### PR TITLE
Added setting to provider gateway ftp client to use extended passive mode.

### DIFF
--- a/cumulus/services/provider-gateway/src/cumulus/provider_gateway/protocols/ftp.clj
+++ b/cumulus/services/provider-gateway/src/cumulus/provider_gateway/protocols/ftp.clj
@@ -35,6 +35,7 @@
   (let [{:keys [host port username password]} config
         port (or port 21)]
     (.setControlEncoding client "UTF-8")
+    (.setUseEPSVwithIPv4 client true)
     (.setConnectTimeout client 30000) ; ms
     (.setDataTimeout client -1) ; forever ms
     (.setControlKeepAliveTimeout client 300) ; seconds


### PR DESCRIPTION
Needed to fix connections issues from ECS.

There is no practical way to create a test for this.