### PR TITLE
Simplify filter of successful stepfunction executions. [run it]

### DIFF
--- a/packages/integration-tests/sfnStep.js
+++ b/packages/integration-tests/sfnStep.js
@@ -92,6 +92,19 @@ class SfnStep {
     return scheduleEvents.map((e) => this.getStepExecutionInstance(executionHistory, e));
   }
 
+
+  /**
+   * Return truthyness of an execution being successful.
+   *
+   * @param {Object} execution - stepFunction execution
+   * @returns {boolean} truthness of the execution being successful.
+   */
+  completedSuccessfulFilter(execution) {
+    return (Object.prototype.hasOwnProperty.call(execution, 'completeEvent')
+            && execution.completeEvent !== null
+            && execution.completeEvent.type === this.successEvent);
+  }
+
   /**
    * Get the output payload from the step, if the step succeeds
    *
@@ -108,18 +121,13 @@ class SfnStep {
     }
 
     // Use the first passed execution, or last execution if none passed
-    let stepExecution = stepExecutions[stepExecutions.length - 1];
-    const passedExecutions = stepExecutions.filter((e) => {
-      if ((e.completeEvent !== null)
-          && ((e.completeEvent === undefined) || !('type' in e.completeEvent))) {
-        console.log(`incomplete Execution discovered found e : ${JSON.stringify(e)}`);
-      }
-      return (typeof e.completeEvent !== 'undefined'
-              && e.completeEvent !== null
-              && e.completeEvent.type === this.successEvent);
-    });
+    let stepExecution;
+    const passedExecutions = stepExecutions.filter((e) => this.completedSuccessfulFilter(e));
     if (passedExecutions && passedExecutions.length > 0) {
       stepExecution = passedExecutions[0];
+    }
+    else {
+      stepExecution = stepExecutions[stepExecutions.length - 1];
     }
 
     if (typeof stepExecution.completeEvent === 'undefined'


### PR DESCRIPTION
**Summary:** 

Addresses cleanup of getStepOutput.

## Changes
No functional changes, pulls out a helper function for filtering valid executions. 

## Test Plan
Things that should succeed before merging.

- [x ] Unit tests
- [x ] Adhoc testing
- [ ] Update CHANGELOG
- [ ] Run `./bin/eslint-ratchet` and verify that eslint errors have not increased
  - [ ] Commit `.eslint-ratchet-high-water-mark` if the score has improved

## Release PR

Reviewers: @laurenfrederick  Not much here, but Pull it, or tell me what you'd change or ignore it.