### PR TITLE
Fix MOD09GQ regular expression.

### DIFF
--- a/docs/workflows/workflow-configuration-how-to.md
+++ b/docs/workflows/workflow-configuration-how-to.md
@@ -36,7 +36,7 @@ buckets:
 
 ### Point to buckets in the workflow configuration
 
-Buckets specified in `app/config.yml` will become part of the `meta` object of the Cumulus message and can be accessed in your workflow configuration. 
+Buckets specified in `app/config.yml` will become part of the `meta` object of the Cumulus message and can be accessed in your workflow configuration.
 
 To use the buckets specified in your config, you can do the following:
 
@@ -80,7 +80,7 @@ DiscoverGranules:
           private: '{$.meta.buckets.private.name}'
 ```
 
-### Using meta and hardcoding 
+### Using meta and hardcoding
 
 Bucket names can be configured using a mixture of hardcoded values and values from the meta. For example, to configure the bucket based on the collection name you could do something like:
 
@@ -108,13 +108,13 @@ A file path can be added as the `url_path` in the collection configuration to sp
   "files": {
     {
       "bucket": "protected",
-      "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf$",
+      "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$",
       "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
       "url_path": "file-example-path"
     },
     {
       "bucket": "private",
-      "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf\\.met$",
+      "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf\\.met$",
       "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf.met"
     }
   }

--- a/example/data/collections/s3_MOD09GQ_006.json
+++ b/example/data/collections/s3_MOD09GQ_006.json
@@ -5,30 +5,30 @@
   "process": "modis",
   "provider_path": "cumulus-test-data/pdrs",
   "duplicateHandling": "replace",
-  "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}$",
+  "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
   "granuleIdExtraction": "(MOD09GQ\\..*)(\\.hdf|\\.cmr|_ndvi\\.jpg)",
   "url_path": "{cmrMetadata.Granule.Collection.ShortName}/{substring(file.name, 0, 3)}",
   "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
   "files": [
     {
       "bucket": "protected",
-      "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf$",
+      "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$",
       "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
       "url_path": "{cmrMetadata.Granule.Collection.ShortName}/{extractYear(cmrMetadata.Granule.Temporal.RangeDateTime.BeginningDateTime)}/{substring(file.name, 0, 3)}"
     },
     {
       "bucket": "private",
-      "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf\\.met$",
+      "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf\\.met$",
       "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf.met"
     },
     {
       "bucket": "protected-2",
-      "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.cmr\\.xml$",
+      "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.cmr\\.xml$",
       "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.cmr.xml"
     },
     {
       "bucket": "public",
-      "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}_ndvi\\.jpg$",
+      "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}_ndvi\\.jpg$",
       "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104_ndvi.jpg"
     }
   ]

--- a/example/spec/ingestGranule/IngestGranuleSuccessSpec.js
+++ b/example/spec/ingestGranule/IngestGranuleSuccessSpec.js
@@ -29,7 +29,7 @@ const config = loadConfig();
 const lambdaStep = new LambdaStep();
 const workflowName = 'IngestGranule';
 
-const granuleRegex = '^MOD09GQ\\.A[\\d]{7}\\.[\\w]{6}\\.006.[\\d]{13}$';
+const granuleRegex = '^MOD09GQ\\.A[\\d]{7}\\.[\\w]{6}\\.006\\.[\\d]{13}$';
 const testDataGranuleId = 'MOD09GQ.A2016358.h13v04.006.2016360104606';
 
 const templatedSyncGranuleFilename = templateFile({

--- a/example/spec/testAPI/APISuccessSpec.js
+++ b/example/spec/testAPI/APISuccessSpec.js
@@ -15,7 +15,7 @@ const {
 } = require('@cumulus/integration-tests');
 const config = loadConfig();
 const taskName = 'IngestGranule';
-const granuleRegex = '^MOD09GQ\\.A[\\d]{7}\\.[\\w]{6}\\.006.[\\d]{13}$';
+const granuleRegex = '^MOD09GQ\\.A[\\d]{7}\\.[\\w]{6}\\.006\\.[\\d]{13}$';
 const testDataGranuleId = 'MOD09GQ.A2016358.h13v04.006.2016360104606';
 const { api: apiTestUtils } = require('@cumulus/integration-tests');
 
@@ -182,4 +182,3 @@ describe('The Cumulus API', () => {
     });
   });
 });
-

--- a/packages/api/lib/testUtils.js
+++ b/packages/api/lib/testUtils.js
@@ -171,7 +171,7 @@ function fakeCollectionFactory() {
     version: '0.0.0',
     provider_path: '/',
     duplicateHandling: 'replace',
-    granuleId: '^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}$',
+    granuleId: '^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$',
     granuleIdExtraction: '(MOD09GQ\\.(.*))\\.hdf',
     sampleFileName: 'MOD09GQ.A2017025.h21v00.006.2017034065104.hdf',
     files: []

--- a/packages/api/tests/data/granule_failed.json
+++ b/packages/api/tests/data/granule_failed.json
@@ -20,28 +20,28 @@
     "collection": {
       "files": [
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
           "bucket": "protected"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf\\.met$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf\\.met$",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf.met",
           "bucket": "private"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.cmr\\.xml$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.cmr\\.xml$",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.cmr.xml",
           "bucket": "public"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}_ndvi\\.jpg$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}_ndvi\\.jpg$",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104_ndvi.jpg",
           "bucket": "public"
         }
       ],
       "name": "MOD09GQ",
-      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}$",
+      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "process": "modis",
       "dataType": "MOD09GQ",
       "granuleIdExtraction": "(MOD09GQ\\..*)(\\.hdf|\\.cmr\\.xml|_[\\w]{1,}\\.jpg)",

--- a/packages/api/tests/data/granule_success.json
+++ b/packages/api/tests/data/granule_success.json
@@ -25,26 +25,26 @@
     "collection": {
       "files": [
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$",
           "s3": "s3://cumulus-devseed-protected/MOD09GQ.A2016358.h13v04.006.2016360104606.hdf",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
           "bucket": "protected",
           "http": "https://g928e05in1.execute-api.us-east-1.amazonaws.com/dev/MOD09GQ.A2016358.h13v04.006.2016360104606.hdf"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf\\.met$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf\\.met$",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf.met",
           "bucket": "private"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.cmr\\.xml$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.cmr\\.xml$",
           "s3": "s3://cumulus-devseed-public/MOD09GQ.A2016358.h13v04.006.2016360104606.cmr.xml",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.cmr.xml",
           "http": "http://cumulus-devseed-public.s3.amazonaws.com/MOD09GQ.A2016358.h13v04.006.2016360104606.cmr.xml",
           "bucket": "public"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}_ndvi\\.jpg$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}_ndvi\\.jpg$",
           "s3": "s3://cumulus-devseed-public/MOD09GQ.A2016358.h13v04.006.2016360104606_ndvi.jpg",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104_ndvi.jpg",
           "http": "http://cumulus-devseed-public.s3.amazonaws.com/MOD09GQ.A2016358.h13v04.006.2016360104606_ndvi.jpg",
@@ -53,7 +53,7 @@
       ],
       "name": "MOD09GQ",
       "granuleIdExtraction": "(MOD09GQ\\..*)(\\.hdf|\\.cmr\\.xml|_[\\w]{1,}\\.jpg)",
-      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}$",
+      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "dataType": "MOD09GQ",
       "process": "modis",
       "provider_path": "/",
@@ -126,7 +126,7 @@
       }
     ],
     "workflow_name": "IngestGranule",
-    "sync_granule_duration": 120, 
+    "sync_granule_duration": 120,
     "post_to_cmr_duration": 100,
     "post_to_cmr_start_time": 1525367493007,
     "sync_granule_end_time": 1525357392010

--- a/packages/api/tests/data/pdr_failure.json
+++ b/packages/api/tests/data/pdr_failure.json
@@ -20,28 +20,28 @@
     "collection": {
       "files": [
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
           "bucket": "protected"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf\\.met$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf\\.met$",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf.met",
           "bucket": "private"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.cmr\\.xml$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.cmr\\.xml$",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.cmr.xml",
           "bucket": "public"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}_ndvi\\.jpg$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}_ndvi\\.jpg$",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104_ndvi.jpg",
           "bucket": "public"
         }
       ],
       "name": "MOD09GQ",
-      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}$",
+      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "process": "modis",
       "dataType": "MOD09GQ",
       "granuleIdExtraction": "(MOD09GQ\\..*)(\\.hdf|\\.cmr\\.xml|_[\\w]{1,}\\.jpg)",

--- a/packages/api/tests/data/pdr_success.json
+++ b/packages/api/tests/data/pdr_success.json
@@ -20,28 +20,28 @@
     "collection": {
       "files": [
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
           "bucket": "protected"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf\\.met$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf\\.met$",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf.met",
           "bucket": "private"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.cmr\\.xml$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.cmr\\.xml$",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.cmr.xml",
           "bucket": "public"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}_ndvi\\.jpg$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}_ndvi\\.jpg$",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104_ndvi.jpg",
           "bucket": "public"
         }
       ],
       "name": "MOD09GQ",
-      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}$",
+      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "process": "modis",
       "dataType": "MOD09GQ",
       "granuleIdExtraction": "(MOD09GQ\\..*)(\\.hdf|\\.cmr\\.xml|_[\\w]{1,}\\.jpg)",

--- a/packages/test-data/cumulus_messages/discover-pdrs.json
+++ b/packages/test-data/cumulus_messages/discover-pdrs.json
@@ -47,27 +47,27 @@
         {
           "bucket": "protected",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf$"
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$"
         },
         {
           "bucket": "private",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf.met",
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf\\.met$"
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf\\.met$"
         },
         {
           "bucket": "public",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.cmr.xml",
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.cmr\\.xml$"
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.cmr\\.xml$"
         },
         {
           "bucket": "public",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104_ndvi.jpg",
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}_ndvi\\.jpg$"
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}_ndvi\\.jpg$"
         }
       ],
       "updatedAt": 1519154288958,
       "createdAt": 1519154288958,
-      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}$",
+      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
       "name": "MOD09GQ"
     },

--- a/packages/test-data/cumulus_messages/discover-s3-granules.json
+++ b/packages/test-data/cumulus_messages/discover-s3-granules.json
@@ -47,27 +47,27 @@
         {
           "bucket": "protected",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf$"
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$"
         },
         {
           "bucket": "private",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf.met",
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf\\.met$"
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf\\.met$"
         },
         {
           "bucket": "public",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.cmr.xml",
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.cmr\\.xml$"
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.cmr\\.xml$"
         },
         {
           "bucket": "public",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104_ndvi.jpg",
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}_ndvi\\.jpg$"
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}_ndvi\\.jpg$"
         }
       ],
       "updatedAt": 1519154288958,
       "createdAt": 1519154288958,
-      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}$",
+      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
       "name": "MOD09GQ"
     },

--- a/packages/test-data/cumulus_messages/parse-pdr.json
+++ b/packages/test-data/cumulus_messages/parse-pdr.json
@@ -39,28 +39,28 @@
     "collection": {
       "files": [
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
           "bucket": "protected"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf\\.met$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf\\.met$",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf.met",
           "bucket": "private"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.cmr\\.xml$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.cmr\\.xml$",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.cmr.xml",
           "bucket": "public"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}_ndvi\\.jpg$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}_ndvi\\.jpg$",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104_ndvi.jpg",
           "bucket": "public"
         }
       ],
       "name": "MOD09GQ",
-      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}$",
+      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "process": "modis",
       "dataType": "MOD09GQ",
       "granuleIdExtraction": "(MOD09GQ\\..*)(\\.hdf|\\.cmr\\.xml|_[\\w]{1,}\\.jpg)",

--- a/packages/test-data/cumulus_messages/pdr-status-check.json
+++ b/packages/test-data/cumulus_messages/pdr-status-check.json
@@ -21,28 +21,28 @@
     "collection": {
       "files": [
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
           "bucket": "protected"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf\\.met$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf\\.met$",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf.met",
           "bucket": "private"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.cmr\\.xml$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.cmr\\.xml$",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.cmr.xml",
           "bucket": "public"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}_ndvi\\.jpg$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}_ndvi\\.jpg$",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104_ndvi.jpg",
           "bucket": "public"
         }
       ],
       "name": "MOD09GQ",
-      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}$",
+      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "process": "modis",
       "dataType": "MOD09GQ",
       "granuleIdExtraction": "(MOD09GQ\\..*)(\\.hdf|\\.cmr\\.xml|_[\\w]{1,}\\.jpg)",

--- a/packages/test-data/cumulus_messages/post-to-cmr.json
+++ b/packages/test-data/cumulus_messages/post-to-cmr.json
@@ -18,26 +18,26 @@
     "collection": {
       "files": [
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$",
           "s3": "s3://cumulus-devseed-protected/MOD09GQ.A2016358.h13v04.006.2016360104606.hdf",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
           "bucket": "protected",
           "http": "https://g928e05in1.execute-api.us-east-1.amazonaws.com/dev/MOD09GQ.A2016358.h13v04.006.2016360104606.hdf"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf\\.met$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf\\.met$",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf.met",
           "bucket": "private"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.cmr\\.xml$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.cmr\\.xml$",
           "http": "http://cumulus-devseed-public.s3.amazonaws.com/MOD09GQ.A2016358.h13v04.006.2016360104606.cmr.xml",
           "s3": "s3://cumulus-devseed-public/MOD09GQ.A2016358.h13v04.006.2016360104606.cmr.xml",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.cmr.xml",
           "bucket": "public"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}_ndvi\\.jpg$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}_ndvi\\.jpg$",
           "http": "http://cumulus-devseed-public.s3.amazonaws.com/MOD09GQ.A2016358.h13v04.006.2016360104606_ndvi.jpg",
           "s3": "s3://cumulus-devseed-public/MOD09GQ.A2016358.h13v04.006.2016360104606_ndvi.jpg",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104_ndvi.jpg",
@@ -46,7 +46,7 @@
       ],
       "name": "MOD09GQ",
       "granuleIdExtraction": "(MOD09GQ\\..*)(\\.hdf|\\.cmr\\.xml|_[\\w]{1,}\\.jpg)",
-      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}$",
+      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "dataType": "MOD09GQ",
       "process": "modis",
       "provider_path": "/",

--- a/packages/test-data/payloads/modis/discover.json
+++ b/packages/test-data/payloads/modis/discover.json
@@ -50,27 +50,27 @@
       "version": "006",
       "process": "modis",
       "provider_path": "/TEST_B/Cumulus/PDR/TEST_CASES",
-      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}$",
+      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
       "granuleIdExtraction": "(MOD09GQ\\.(.*))\\.hdf",
       "files": [
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$",
           "bucket": "protected",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf\\.met$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf\\.met$",
           "bucket": "private",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf.met"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.meta\\.xml$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.meta\\.xml$",
           "bucket": "protected",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.meta.xml"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}_1\\.jpg$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}_1\\.jpg$",
           "bucket": "public",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104_1.jpg"
         }

--- a/packages/test-data/payloads/modis/ingest-checksumfile.json
+++ b/packages/test-data/payloads/modis/ingest-checksumfile.json
@@ -49,27 +49,27 @@
       "version": "006",
       "process": "modis",
       "provider_path": "/MODOPS/MODAPS/EDC/CUMULUS/FPROC/PDR/",
-      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}$",
+      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
       "granuleIdExtraction": "(MOD09GQ\\.(.*))\\.hdf",
       "files": [
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$",
           "bucket": "protected",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf\\.met$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf\\.met$",
           "bucket": "private",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf.met"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.meta\\.xml$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.meta\\.xml$",
           "bucket": "protected",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.meta.xml"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}_1\\.jpg$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}_1\\.jpg$",
           "bucket": "public",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104_1.jpg"
         }

--- a/packages/test-data/payloads/modis/ingest.json
+++ b/packages/test-data/payloads/modis/ingest.json
@@ -52,28 +52,28 @@
       "version": "006",
       "process": "modis",
       "provider_path": "/MODOPS/MODAPS/EDC/CUMULUS/FPROC/PDR/",
-      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}$",
+      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
       "granuleIdExtraction": "(MOD09GQ\\.(.*))\\.hdf",
       "granuleHandling": "replace",
       "files": [
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$",
           "bucket": "protected",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf\\.met$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf\\.met$",
           "bucket": "private",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf.met"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.meta\\.xml$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.meta\\.xml$",
           "bucket": "protected",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.meta.xml"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}_1\\.jpg$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}_1\\.jpg$",
           "bucket": "public",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104_1.jpg"
         }

--- a/packages/test-data/payloads/modis/parse.json
+++ b/packages/test-data/payloads/modis/parse.json
@@ -50,27 +50,27 @@
       "version": "006",
       "process": "modis",
       "provider_path": "/TEST_B/Cumulus/PDR/TEST_CASES",
-      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}$",
+      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
       "granuleIdExtraction": "(MOD09GQ\\.(.*))\\.hdf",
       "files": [
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$",
           "bucket": "protected",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf\\.met$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf\\.met$",
           "bucket": "private",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf.met"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.meta\\.xml$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.meta\\.xml$",
           "bucket": "protected",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.meta.xml"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}_1\\.jpg$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}_1\\.jpg$",
           "bucket": "public",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104_1.jpg"
         }

--- a/packages/test-data/payloads/new-message-schema/discover.json
+++ b/packages/test-data/payloads/new-message-schema/discover.json
@@ -45,27 +45,27 @@
       "version": "006",
       "process": "modis",
       "provider_path": "/TEST_B/Cumulus/PDR/TEST_CASES",
-      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}$",
+      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
       "granuleIdExtraction": "(MOD09GQ\\.(.*))\\.hdf",
       "files": [
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$",
           "bucket": "protected",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf\\.met$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf\\.met$",
           "bucket": "private",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf.met"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.meta\\.xml$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.meta\\.xml$",
           "bucket": "protected",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.meta.xml"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}_1\\.jpg$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}_1\\.jpg$",
           "bucket": "public",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104_1.jpg"
         }

--- a/packages/test-data/payloads/new-message-schema/ingest-checksumfile.json
+++ b/packages/test-data/payloads/new-message-schema/ingest-checksumfile.json
@@ -45,30 +45,30 @@
       "version": "006",
       "process": "modis",
       "provider_path": "/MODOPS/MODAPS/EDC/CUMULUS/FPROC/PDR/",
-      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}$",
+      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
       "granuleIdExtraction": "(MOD09GQ\\.(.*))\\.hdf",
       "files": [
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$",
           "bucket": "protected",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
           "url_path":"/"
         },
         {
-          "regex":  "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf\\.met$",
+          "regex":  "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf\\.met$",
           "bucket": "private",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf.met",
           "url_path":"/"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.meta\\.xml$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.meta\\.xml$",
           "bucket": "protected",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.meta.xml",
           "url_path":"/"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}_1\\.jpg$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}_1\\.jpg$",
           "bucket": "public",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104_1.jpg",
           "url_path":"/"

--- a/packages/test-data/payloads/new-message-schema/ingest.json
+++ b/packages/test-data/payloads/new-message-schema/ingest.json
@@ -47,27 +47,27 @@
       "version": "006",
       "process": "modis",
       "provider_path": "/MODOPS/MODAPS/EDC/CUMULUS/FPROC/PDR/",
-      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}$",
+      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
       "granuleIdExtraction": "(MOD09GQ\\.(.*))\\.hdf",
       "files": [
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$",
           "bucket": "protected",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf\\.met$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf\\.met$",
           "bucket": "private",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf.met"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.meta\\.xml$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.meta\\.xml$",
           "bucket": "protected",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.meta.xml"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}_1\\.jpg$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}_1\\.jpg$",
           "bucket": "public",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104_1.jpg"
         }

--- a/packages/test-data/payloads/new-message-schema/parse.json
+++ b/packages/test-data/payloads/new-message-schema/parse.json
@@ -14,27 +14,27 @@
       "version": "006",
       "process": "modis",
       "provider_path": "/TEST_B/Cumulus/PDR/TEST_CASES",
-      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}$",
+      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
       "granuleIdExtraction": "(MOD09GQ\\.(.*))\\.hdf",
       "files": [
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$",
           "bucket": "protected",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf\\.met$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf\\.met$",
           "bucket": "private",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf.met"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.meta\\.xml$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.meta\\.xml$",
           "bucket": "protected",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.meta.xml"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}_1\\.jpg$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}_1\\.jpg$",
           "bucket": "public",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104_1.jpg"
         }

--- a/tasks/discover-pdrs/tests/fixtures/input.json
+++ b/tasks/discover-pdrs/tests/fixtures/input.json
@@ -14,27 +14,27 @@
       "version": "006",
       "process": "modis",
       "provider_path": "/TEST_B/Cumulus/PDR/TEST_CASES",
-      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}$",
+      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
       "granuleIdExtraction": "(MOD09GQ\\.(.*))\\.hdf",
       "files": [
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$",
           "bucket": "protected",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf\\.met$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf\\.met$",
           "bucket": "private",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf.met"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.meta\\.xml$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.meta\\.xml$",
           "bucket": "protected",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.meta.xml"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}_1\\.jpg$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}_1\\.jpg$",
           "bucket": "public",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104_1.jpg"
         }

--- a/tasks/queue-pdrs/tests/fixtures/input.json
+++ b/tasks/queue-pdrs/tests/fixtures/input.json
@@ -9,27 +9,27 @@
       "version": "006",
       "process": "modis",
       "provider_path": "/TEST_B/Cumulus/PDR/TEST_CASES",
-      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}$",
+      "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
       "granuleIdExtraction": "(MOD09GQ\\.(.*))\\.hdf",
       "files": [
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$",
           "bucket": "protected",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf\\.met$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf\\.met$",
           "bucket": "private",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf.met"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.meta\\.xml$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.meta\\.xml$",
           "bucket": "protected",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.meta.xml"
         },
         {
-          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}_1\\.jpg$",
+          "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}_1\\.jpg$",
           "bucket": "public",
           "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104_1.jpg"
         }

--- a/tests/fixtures/collections.json
+++ b/tests/fixtures/collections.json
@@ -5,27 +5,27 @@
     "dataType": "MOD09GQ",
     "process": "modis",
     "provider_path": "/pdrs/discover-pdrs",
-    "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}$",
+    "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
     "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
     "granuleIdExtraction": "(MOD09GQ\\.(.*))\\.hdf",
     "files": [
       {
-        "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf$",
+        "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$",
         "bucket": "protected",
         "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf"
       },
       {
-        "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf\\.met$",
+        "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf\\.met$",
         "bucket": "private",
         "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf.met"
       },
       {
-        "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.meta\\.xml$",
+        "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.meta\\.xml$",
         "bucket": "protected",
         "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.meta.xml"
       },
       {
-        "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}_1\\.jpg$",
+        "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}_1\\.jpg$",
         "bucket": "public",
         "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104_1.jpg"
       }


### PR DESCRIPTION
In a number of places
```
"^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}"
is used as the regexp but it has an error and should be.
"^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\"
                                      ^^^
```

**Summary:**  replace regexp with one that needs a literal dot in it.

Addresses: Intermittent failures in integration tests when bad granuleId are created during setup.

## Changes

* simply adds escape characters to regexp.

## Test Plan
Things that should succeed before merging.

- [x ] Unit tests
- [ ] Adhoc testing
- [ ] Update CHANGELOG
- [ ] Run `./bin/eslint-ratchet` and verify that eslint errors have not increased
  - [ ] Commit `.eslint-ratchet-high-water-mark` if the score has improved

