### PR TITLE
fix discover-pdr schema

### DIFF
--- a/tasks/discover-pdrs/schemas/config.json
+++ b/tasks/discover-pdrs/schemas/config.json
@@ -31,6 +31,12 @@
       "description": "aws s3 buckets used by this task",
       "type": "string"
     },
+    "collection": {
+      "type": "object",
+      "properties": {
+        "provider_path": { "type": "string"}
+      }
+    },
     "useList": {
       "description": "flag to tell ftp server to use 'LIST' instead of 'STAT'",
       "default": false,

--- a/tasks/discover-pdrs/schemas/config.json
+++ b/tasks/discover-pdrs/schemas/config.json
@@ -31,14 +31,6 @@
       "description": "aws s3 buckets used by this task",
       "type": "string"
     },
-    "collection": {
-      "type": "object",
-      "required": ["name", "granuleIdExtraction"],
-      "properties": {
-        "name": { "type": "string" },
-        "granuleIdExtraction": { "type": "string" }
-      }
-    },
     "useList": {
       "description": "flag to tell ftp server to use 'LIST' instead of 'STAT'",
       "default": false,


### PR DESCRIPTION
**Summary:** Summary of changes

Complete changes from https://github.com/nasa/cumulus/pull/426
Discover-PDR Config Schema was not fully updated when reliance on collections was removed.
Message adapter validation fails to validate the schema currently when collection is null or undefined.