### PR TITLE
Extend wait to find queued failure message.

### DIFF
--- a/example/spec/helpers/kinesisHelpers.js
+++ b/example/spec/helpers/kinesisHelpers.js
@@ -226,7 +226,7 @@ function kinesisEventFromSqsMessage(message) {
   catch (error) {
     console.log('Error parsing KinesisEventFromSqsMessage(message)', JSON.stringify(message));
     console.log(error);
-    kinesisEvent = { identifier: 'Bad Message' };
+    kinesisEvent = { identifier: 'Fake Wrong Message' };
   }
   return kinesisEvent;
 }
@@ -244,14 +244,14 @@ function isTargetMessage(message, recordIdentifier) {
 }
 
 /**
- * Wait until a kinesisRecord appears in an SQS message who's identifier matches the input recordIdentifier.  Wait up to 5 minutes.
+ * Wait until a kinesisRecord appears in an SQS message who's identifier matches the input recordIdentifier.  Wait up to 10 minutes.
  *
  * @param {string} recordIdentifier - random string to match found messages against.
  * @param {string} queueUrl - kinesisFailure SQS url
- * @param {number} maxNumberElapsedPeriods - number of timeout intervals to wait.
+ * @param {number} maxNumberElapsedPeriods - number of timeout intervals (5 seconds) to wait.
  * @returns {Object} - matched Message from SQS.
  */
-async function waitForQueuedRecord(recordIdentifier, queueUrl, maxNumberElapsedPeriods = 60) {
+async function waitForQueuedRecord(recordIdentifier, queueUrl, maxNumberElapsedPeriods = 120) {
   const timeoutInterval = 5000;
   let queuedRecord;
   let elapsedPeriods = 0;
@@ -259,14 +259,13 @@ async function waitForQueuedRecord(recordIdentifier, queueUrl, maxNumberElapsedP
   while (!queuedRecord && elapsedPeriods < maxNumberElapsedPeriods) {
     const messages = await receiveSQSMessages(queueUrl);
     if (messages.length > 0) {
-
       const targetMessage = messages.find((message) => isTargetMessage(message, recordIdentifier));
       if (targetMessage) return targetMessage;
     }
     await timeout(timeoutInterval);
     elapsedPeriods += 1;
   }
-  return {};
+  return { waitForQueuedRecord: 'never found record on queue' };
 }
 
 module.exports = {

--- a/example/spec/kinesisTests/KinesisTestErrorSpec.js
+++ b/example/spec/kinesisTests/KinesisTestErrorSpec.js
@@ -36,6 +36,7 @@ describe('The kinesisConsumer receives a bad record.', () => {
   beforeAll(async () => {
     this.defaultTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 10 * 60 * 1000;
+    this.maxNumberElapsedPeriods = jasmine.DEFAULT_TIMEOUT_INTERVAL / 5000;
     await tryCatchExit(async () => {
       await createOrUseTestStream(streamName);
       console.log(`\nWaiting for active streams: '${streamName}'.`);
@@ -56,7 +57,7 @@ describe('The kinesisConsumer receives a bad record.', () => {
   it('Eventually puts the bad record on the failure queue.', async () => {
     console.log('\nWait for minimum duration of failure process ~3min');
     console.log('\nWait for record on:', failureSqsUrl);
-    const queuedRecord = await waitForQueuedRecord(testRecordIdentifier, failureSqsUrl);
+    const queuedRecord = await waitForQueuedRecord(testRecordIdentifier, failureSqsUrl, this.maxNumberElapsedPeriods);
     this.ReceiptHandle = queuedRecord.ReceiptHandle;
     const queuedKinesisEvent = kinesisEventFromSqsMessage(queuedRecord);
     expect(queuedKinesisEvent).toEqual(badRecord);


### PR DESCRIPTION
Also add explicit max timout to KinesisTestErrorSpec so that if the JASMINE
timeout is extended again, the user will know to extend the number of wait
periods as well.

**Summary:** Extend wait period for failed kinesis messages to get to kinesis failure SQS. 

## Changes
