### PR TITLE
Fix `sqs2sf` ingest limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `@cumulus/ingest/consumer` correctly limits the number of messages being received and processed from SQS. Details:
+  - **Background:** `@cumulus/api` includes a lambda `<stack-name>-sqs2sf` which processes messages from the `<stack-name>-startSF` SQS queue every minute. The `sqs2sf` lambda uses `@cumulus/ingest/consumer` to receive and process messages from SQS.
+  - **Bug:** `@cumulus/ingest/consumer#processMessages` was waiting for any number of messages returned from SQS up to `@cumulus/ingest/consumer`'s `timeLimit` (which defaults to 9 seconds). This resulted in many messages being processed at once - many workflows being processed at once. This drove the error from the CumulusMessageAdapter: `An error occurred (ThrottlingException) when calling the GetExecutionHistory`.
+  - **Fix:** `@cumulus/ingest/consumer#processMessages` processes messages up to `timeLimit` _OR_ once it receives up to `messageLimit` messages. `sqs2sf` is deployed with a [default `messageLimit` of 10](https://github.com/nasa/cumulus/blob/670000c8a821ff37ae162385f921c40956e293f7/packages/deployment/app/config.yml#L147).
+
 ## [v1.9.1] - 2018-08-22
 
 **Please Note** To take advantage of the added granule tracking API functionality, updates are required for the message adapter and its libraries. You should be on the following versions:

--- a/packages/ingest/consumer.js
+++ b/packages/ingest/consumer.js
@@ -35,7 +35,7 @@ class Consume {
 
       // if the function is running for more than the timeLimit, stop it
       const timeElapsed = (Date.now() - this.now);
-      if (timeElapsed > this.timeLimit) {
+      if ((timeElapsed > this.timeLimit) || (counter >= messageLimit)) {
         this.endConsume = true;
       }
     }

--- a/packages/ingest/package.json
+++ b/packages/ingest/package.json
@@ -56,6 +56,7 @@
     "node-forge": "^0.7.1",
     "pino": "^4.7.1",
     "pump": "^3.0.0",
+    "rewire": "^4.0.1",
     "simplecrawler": "^1.1.4",
     "ssh2": "^0.5.5",
     "url-join": "^1.0.0",

--- a/packages/ingest/test/consumer.js
+++ b/packages/ingest/test/consumer.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const rewire = require('rewire');
+const sinon = require('sinon');
+const test = require('ava');
+const consumer = rewire('../consumer');
+const Consume = consumer.Consume;
+
+/**
+ * An asynchronous sleep/wait function
+ *
+ * @param {number} milliseconds - number of milliseconds to sleep
+ * @returns {Promise<undefined>} undefined
+ */
+async function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+const timeLimit = 10;
+const messageLimit = 2;
+class MyTestConsumerClass extends Consume {
+  constructor() {
+    super()
+    this.queueUrl = 'sqs.test';
+    this.messageLimit = messageLimit;
+    this.timeLimit = timeLimit;
+    this.now = Date.now();
+    this.endConsume = false;    
+  }
+}
+
+async function stubReceiveSQSMessages() {
+  await sleep(timeLimit*2);
+  return ['hi'];
+}
+consumer.__set__('receiveSQSMessages', stubReceiveSQSMessages);
+function processFn(msg) {};
+
+const sandbox = sinon.sandbox.create();
+let receiveSpy;
+
+test.afterEach.always(() => sandbox.restore());
+
+test.serial('stops after timelimit', async (t) => {
+  const myTestConsumerClass = new MyTestConsumerClass();
+  receiveSpy = sandbox.spy(myTestConsumerClass, 'processMessage');
+
+  const result = await myTestConsumerClass.processMessages(processFn, messageLimit);
+  t.is(result, 1);
+  t.is(receiveSpy.calledOnce, true);
+});
+
+test.serial('it continues when timeLimit is is greater than time to receive', async (t) => {
+  const myTestConsumerClass = new MyTestConsumerClass();
+  receiveSpy = sandbox.spy(myTestConsumerClass, 'processMessage');
+  myTestConsumerClass.timeLimit = timeLimit*3;
+
+  const result = await myTestConsumerClass.processMessages(processFn, messageLimit);
+  t.is(result, 2);
+  t.is(receiveSpy.calledTwice, true);
+});
+
+test.serial('it stops after messageLimit is reached', async (t) => {
+  const myTestConsumerClass = new MyTestConsumerClass();
+  receiveSpy = sandbox.spy(myTestConsumerClass, 'processMessage');
+  myTestConsumerClass.timeLimit = timeLimit*3;
+  myTestConsumerClass.messageLimit = 1;
+
+  const result = await myTestConsumerClass.processMessages(processFn, messageLimit);
+  t.is(result, 1);
+  t.is(receiveSpy.calledOnce, true);  
+});


### PR DESCRIPTION
**Summary:**

There is a bug in `@cumulus/ingest` where more than `messageLimit` number of messages were being consumed and processed from the `<stack-name>-startSF` SQS queue. Many step functions were being triggered simultaneously by the lambda `<stack-name>-sqs2sf` (which consumes every minute from the `startSF` queue) and resulting in step function failure with the error: `An error occurred (ThrottlingException) when calling the GetExecutionHistory`.

I believe the bug's origin is that the `processMessages` function [continues to loop](https://github.com/nasa/cumulus/blob/f63f5599c9ac3e0d270ff60ded4c05ba466e6d5d/packages/ingest/consumer.js#L27-L41) and makes many calls to receive messages from the queue up to `timeLimit` seconds (which I think defaults to [12 seconds](https://github.com/nasa/cumulus/blob/f63f5599c9ac3e0d270ff60ded4c05ba466e6d5d/packages/api/lambdas/sf-starter.js#L50)).

Steps to replicate:
* Create a `Discover` workflow which uses `DiscoverGranules` and `QueueGranules`
* Create a second `IngestGranules` workflow which uses `SyncGranule`
* The `Discover` workflow should queue messages for the `IngestGranules` workflow as follows:
```yaml
    QueueGranules:
      CumulusConfig:
        ...
        granuleIngestMessageTemplateUri: '{$.meta.templates.IngestGranule}'
        queueUrl: '{$.meta.queues.startSF}'
``` 
* Trigger the Discover workflow with a provider and collection which returns greater than 10 granules (in my scenario it was 105).

<img width="1190" alt="screen shot 2018-08-27 at 3 50 27 pm" src="https://user-images.githubusercontent.com/15016780/44704262-6246d300-aaa3-11e8-9263-0c7047f0599c.png">


**Changes:**

* Update conditional in `packages/ingest/consumer.js#processMessages` to stop consuming messages once `messageLimit` messages have been received.
* Add tests for `packages/ingest/consumer.js#processMessages`.
* Also add, as bonus, tests for `packages/ingest/http.js#list`.

**Test plan:**

- [ ] Unit tests
- [ ] Integration tests
- [x] Adhoc testing
