### PR TITLE
replace short fn format with the long one

### DIFF
--- a/packages/deployment/app/cloudformation.template.yml
+++ b/packages/deployment/app/cloudformation.template.yml
@@ -157,7 +157,8 @@ Resources:
     {{else}}
       MaxCapacity: 10
     {{/if}}
-      ResourceId: !Sub table/{{../../stackName}}-{{@key}}
+      ResourceId: 
+        Fn::Sub: table/{{../../stackName}}-{{@key}}
       RoleARN: {{../../this.iams.scalingRoleArn}}
       ScalableDimension: "dynamodb:table:ReadCapacityUnits"
       ServiceNamespace: dynamodb
@@ -189,7 +190,8 @@ Resources:
     {{else}}
       MaxCapacity: 2
     {{/if}}
-      ResourceId: !Sub table/{{../../stackName}}-{{@key}}
+      ResourceId:
+        Fn::Sub: table/{{../../stackName}}-{{@key}}
       RoleARN: {{../../this.iams.scalingRoleArn}}
       ScalableDimension: "dynamodb:table:WriteCapacityUnits"
       ServiceNamespace: dynamodb
@@ -743,7 +745,8 @@ Resources:
   SecurityGroupSSHinbound:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      GroupId: !Ref 'SecurityGroup'
+      GroupId: 
+        Fn::Ref: 'SecurityGroup'
       IpProtocol: tcp
       FromPort: '22'
       ToPort: '22'
@@ -829,22 +832,23 @@ Resources:
         mount:
           commands:
             01_mount:
-              command: !Sub
-              - |
-                #!/bin/bash -xe
+              command: 
+                Fn::Sub:
+                  - |
+                    #!/bin/bash -xe
 
-                mkdir -p {{ecs.efs.mount}}
-                mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 ${EFSFileSystemId}.efs.${AWS::Region}.amazonaws.com:/ {{ecs.efs.mount}}
-                chmod 777 {{ecs.efs.mount}}
+                    mkdir -p {{ecs.efs.mount}}
+                    mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 ${EFSFileSystemId}.efs.${AWS::Region}.amazonaws.com:/ {{ecs.efs.mount}}
+                    chmod 777 {{ecs.efs.mount}}
 
-                echo '${EFSFileSystemId}.efs.${AWS::Region}.amazonaws.com:/ {{ecs.efs.mount}} nfs4 nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 0 0' | tee -a /etc/fstab
-                mount -a
-                service docker restart
-                start ecs
+                    echo '${EFSFileSystemId}.efs.${AWS::Region}.amazonaws.com:/ {{ecs.efs.mount}} nfs4 nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 0 0' | tee -a /etc/fstab
+                    mount -a
+                    service docker restart
+                    start ecs
 
-              - EFSFileSystemId:
-                  Fn::ImportValue:
-                    !Sub "{{prefix}}-EFSFileSystemId"
+                  - EFSFileSystemId:
+                      Fn::ImportValue:
+                        Fn::Sub: "{{prefix}}-EFSFileSystemId"
         {{/if}}
 
     Properties:

--- a/packages/deployment/iam/cloudformation.template.yml
+++ b/packages/deployment/iam/cloudformation.template.yml
@@ -22,7 +22,8 @@ Resources:
   LambdaApiGatewayRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${ResourcePrefix}-lambda-api-gateway"
+      RoleName: 
+        Fn::Sub: "${ResourcePrefix}-lambda-api-gateway"
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -61,7 +62,8 @@ Resources:
                   - dynamodb:Query
                   - dynamodb:Scan
                   - dynamodb:UpdateItem
-                Resource: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${ResourcePrefix}-*"
+                Resource:
+                  Fn::Sub: "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${ResourcePrefix}-*"
 
               - Effect: Allow
                 Action:
@@ -69,7 +71,8 @@ Resources:
                   - dynamodb:GetShardIterator
                   - dynamodb:DescribeStream
                   - dynamodb:ListStreams
-                Resource: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${ResourcePrefix}-*/stream/*"
+                Resource:
+                  Fn::Sub: "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${ResourcePrefix}-*/stream/*"
 
               - Effect: Allow
                 Action:
@@ -114,7 +117,8 @@ Resources:
                   - sqs:GetQueueUrl
                   - sqs:GetQueueAttributes
                   - sqs:SendMessage
-                Resource: !Sub "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${ResourcePrefix}-*"
+                Resource:
+                  Fn::Sub: "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${ResourcePrefix}-*"
 
               # allow adding/editing/deleting of rules associated with this deployment
               - Effect: Allow
@@ -127,7 +131,8 @@ Resources:
                   - events:DescribeRule
                   - events:PutTargets
                   - events:RemoveTargets
-                Resource: !Sub "arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/${ResourcePrefix}-*"
+                Resource:
+                  Fn::Sub: "arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/${ResourcePrefix}-*"
 
               # Allow state machine interactions
               - Effect: Allow
@@ -141,7 +146,8 @@ Resources:
   LambdaProcessingRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${ResourcePrefix}-lambda-processing"
+      RoleName:
+        Fn::Sub: "${ResourcePrefix}-lambda-processing"
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -215,7 +221,7 @@ Resources:
                 Action:
                   - s3:PutBucketPolicy
                 Resource:
-                  - !Sub "arn:aws:s3:::{{prefix}}-*"
+                  - Fn::Sub: "arn:aws:s3:::{{prefix}}-*"
 
               # Allow access to dynamoDB
               - Effect: Allow
@@ -229,7 +235,8 @@ Resources:
                   - dynamodb:BatchWriteItem
                   - dynamodb:UpdateContinuousBackups
                   - dynamodb:DescribeContinuousBackups
-                Resource: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${ResourcePrefix}-*"
+                Resource:
+                  Fn::Sub: "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${ResourcePrefix}-*"
 
               - Effect: Allow
                 Action:
@@ -237,7 +244,8 @@ Resources:
                   - dynamodb:GetShardIterator
                   - dynamodb:DescribeStream
                   - dynamodb:ListStreams
-                Resource: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${ResourcePrefix}-*/stream/*"
+                Resource:
+                  Fn::Sub: "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${ResourcePrefix}-*/stream/*"
 
               - Effect: Allow
                 Action:
@@ -253,7 +261,8 @@ Resources:
                   - sqs:DeleteMessage
                   - sqs:GetQueueUrl
                   - sqs:GetQueueAttributes
-                Resource: !Sub "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${ResourcePrefix}-*"
+                Resource:
+                  Fn::Sub: "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${ResourcePrefix}-*"
 
               # Allow state machine interactions
               - Effect: Allow
@@ -307,14 +316,15 @@ Resources:
   StepRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${ResourcePrefix}-steprole"
+      RoleName:
+        Fn::Sub: "${ResourcePrefix}-steprole"
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
               Service:
-                - !Sub states.${AWS::Region}.amazonaws.com
+                - Fn::Sub: states.${AWS::Region}.amazonaws.com
             Action: sts:AssumeRole
       Path: "/"
       Policies:
@@ -330,7 +340,7 @@ Resources:
   ECSRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${ResourcePrefix}-ecs"
+      RoleName: Fn::Sub: "${ResourcePrefix}-ecs"
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -423,7 +433,7 @@ Resources:
   DistributionApiRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${ResourcePrefix}-distribution-api-lambda"
+      RoleName: Fn::Sub: "${ResourcePrefix}-distribution-api-lambda"
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -493,7 +503,7 @@ Resources:
   ScalingRole:
     Type: 'AWS::IAM::Role'
     Properties:
-      RoleName: !Sub "${ResourcePrefix}-scaling-role"
+      RoleName: Fn::Sub: "${ResourcePrefix}-scaling-role"
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -521,23 +531,45 @@ Resources:
   CumulusInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
-      InstanceProfileName: !Sub "${ResourcePrefix}-ecs"
+      InstanceProfileName:
+        Fn::Sub: "${ResourcePrefix}-ecs"
       Path: "/"
       Roles:
-        - !Ref ECSRole
+        - Fn::Ref: ECSRole
 
 Outputs:
   CumulusInstanceProfileArn:
-    Value: !GetAtt CumulusInstanceProfile.Arn
+    Value:
+      Fn::GetAtt:
+        - CumulusInstanceProfile
+        - Arn
   EcsRoleArn:
-    Value: !GetAtt ECSRole.Arn
+    Value:
+      Fn::GetAtt:
+        - ECSRole
+        - Arn
   LambdaApiGatewayRoleArn:
-    Value: !GetAtt LambdaApiGatewayRole.Arn
+    Value:
+      Fn::GetAtt:
+        - LambdaApiGatewayRole
+        - Arn
   LambdaProcessingRoleArn:
-    Value: !GetAtt LambdaProcessingRole.Arn
+    Value:
+      Fn::GetAtt:
+        - LambdaProcessingRole
+        - Arn
   DistributionRoleArn:
-    Value: !GetAtt DistributionApiRole.Arn
+    Value:
+      Fn::GetAtt:
+        - DistributionApiRole
+        - Arn
   StepRoleArn:
-    Value: !GetAtt StepRole.Arn
+    Value:
+      Fn::GetAtt:
+        - StepRole
+        - Arn
   ScalingRoleArn:
-    Value: !GetAtt ScalingRole.Arn
+    Value:
+      Fn::GetAtt:
+        - ScalingRole
+        - Arn


### PR DESCRIPTION
**Summary:** Summary of changes

Our yaml parser and lodash merge throw error with the `!Sub` syntax when templates are merged. This PR fixes the issue

## Changes

* replace short fn format with long one

