### PR TITLE
Cloudformation iam template fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Fixed cloudformation template errors in `@cumulus/deployment/`
+  - Replaced references to Fn::Ref: with Ref: 
+  - Moved long form template references to a newline for instance
+  ```
+    RoleName: Fn::Sub: "${ResourcePrefix}-distribution-api-lambda"
+  ```
+
+  ```
+  RoleName: 
+    Fn::Sub: "${ResourcePrefix}-distribution-api-lambda"
+  ````
+    
+  
+
+
 ## [v1.10.0] - 2018-08-31
 
 ### Removed

--- a/packages/deployment/app/cloudformation.template.yml
+++ b/packages/deployment/app/cloudformation.template.yml
@@ -746,7 +746,7 @@ Resources:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
       GroupId: 
-        Fn::Ref: 'SecurityGroup'
+        Ref: 'SecurityGroup'
       IpProtocol: tcp
       FromPort: '22'
       ToPort: '22'

--- a/packages/deployment/iam/cloudformation.template.yml
+++ b/packages/deployment/iam/cloudformation.template.yml
@@ -340,7 +340,8 @@ Resources:
   ECSRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: Fn::Sub: "${ResourcePrefix}-ecs"
+      RoleName: 
+        Fn::Sub: "${ResourcePrefix}-ecs"
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -433,7 +434,8 @@ Resources:
   DistributionApiRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: Fn::Sub: "${ResourcePrefix}-distribution-api-lambda"
+      RoleName: 
+       Fn::Sub: "${ResourcePrefix}-distribution-api-lambda"
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -503,7 +505,8 @@ Resources:
   ScalingRole:
     Type: 'AWS::IAM::Role'
     Properties:
-      RoleName: Fn::Sub: "${ResourcePrefix}-scaling-role"
+      RoleName: 
+        Fn::Sub: "${ResourcePrefix}-scaling-role"
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -535,7 +538,7 @@ Resources:
         Fn::Sub: "${ResourcePrefix}-ecs"
       Path: "/"
       Roles:
-        - Fn::Ref: ECSRole
+        - Ref: ECSRole
 
 Outputs:
   CumulusInstanceProfileArn:


### PR DESCRIPTION
**Summary:** Summary of changes

Fixed a few instances in the iam/cloudformation.template.yml that caused kes compilation to fail due to the inability to parse the long form cloudformation fn/ref syntax when it is found on the same line.

I also changed Fn::Ref: to Ref, as it was an invalid template function.