### PR TITLE
Change shardIterator from LATEST to AT_TIMESTAMP.

### DIFF
--- a/example/spec/helpers/kinesisHelpers.js
+++ b/example/spec/helpers/kinesisHelpers.js
@@ -133,7 +133,10 @@ async function createOrUseTestStream(streamName) {
  * @param  {string} streamName - Name of the stream of interest
  * @returns {string}            - Shard iterator
  */
-async function getShardIterator(streamName) {
+async function getShardIterator(streamName, inputTimeStamp) {
+  let timeStamp = new Date();
+  if (typeof inputTimeStamp !== 'undefined') timeStamp = inputTimeStamp;
+
   const describeStreamParams = {
     StreamName: streamName
   };
@@ -143,7 +146,8 @@ async function getShardIterator(streamName) {
 
   const shardIteratorParams = {
     ShardId: shardId, /* required */
-    ShardIteratorType: 'LATEST',
+    ShardIteratorType: 'AT_TIMESTAMP',
+    Timestamp: timeStamp,
     StreamName: streamName
   };
 

--- a/example/spec/kinesisTests/KinesisTestTriggerSpec.js
+++ b/example/spec/kinesisTests/KinesisTestTriggerSpec.js
@@ -110,12 +110,13 @@ describe('The Cloud Notification Mechanism Kinesis workflow', () => {
 
   describe('Workflow executes successfully', () => {
     let workflowExecution;
-    const workflowSucceedStartTime = new Date();
+    let workflowSucceedStartTime;
 
     beforeAll(async () => {
       await tryCatchExit(async () => {
         console.log(`\nDropping record onto  ${streamName}, recordIdentifier: ${recordIdentifier}.`);
         await putRecordOnStream(streamName, record);
+        workflowSucceedStartTime = new Date();
 
         console.log('Waiting for step function to start...');
         workflowExecution = await waitForTestSf(recordIdentifier, maxWaitTime);
@@ -185,7 +186,7 @@ describe('The Cloud Notification Mechanism Kinesis workflow', () => {
       });
 
       it('writes a message to the response stream', async () => {
-        console.log(`Fetching shard iterator for response stream  '${cnmResponseStreamName}' at ${workflowSucceedStartTime}.`);
+        console.log(`Fetching shard iterator for response stream  '${cnmResponseStreamName}' at ${workflowSucceedStartTime.toISOString()}.`);
         // get shard iterator for the response stream so we can process any new records sent to it
         responseStreamShardIterator = await getShardIterator(cnmResponseStreamName, workflowSucceedStartTime);
 
@@ -202,7 +203,7 @@ describe('The Cloud Notification Mechanism Kinesis workflow', () => {
 
   describe('Workflow fails because TranslateMessage fails', () => {
     let workflowExecution;
-    const workflowFailStartTime = new Date();
+    let workflowFailStartTime;
     const badRecord = { ...record };
     const badRecordIdentifier = randomString();
     badRecord.identifier = badRecordIdentifier;
@@ -212,6 +213,7 @@ describe('The Cloud Notification Mechanism Kinesis workflow', () => {
       await tryCatchExit(async () => {
         console.log(`\nDropping bad record onto ${streamName}, recordIdentifier: ${badRecordIdentifier}.`);
         await putRecordOnStream(streamName, badRecord);
+        workflowFailStartTime = new Date();
 
         console.log('Waiting for step function to start...');
         workflowExecution = await waitForTestSf(badRecordIdentifier, maxWaitTime);
@@ -238,7 +240,7 @@ describe('The Cloud Notification Mechanism Kinesis workflow', () => {
     });
 
     it('writes a failure message to the response stream', async () => {
-      console.log(`Fetching shard iterator for response stream  '${cnmResponseStreamName}' at ${workflowFailStartTime}.`);
+      console.log(`Fetching shard iterator for response stream  '${cnmResponseStreamName}' at ${workflowFailStartTime.toISOString()}.`);
       // get shard iterator for the response stream so we can process any new records sent to it
       responseStreamShardIterator = await getShardIterator(cnmResponseStreamName, workflowFailStartTime);
       const newResponseStreamRecords = await getRecords(responseStreamShardIterator);

--- a/example/spec/kinesisTests/KinesisTestTriggerSpec.js
+++ b/example/spec/kinesisTests/KinesisTestTriggerSpec.js
@@ -191,6 +191,7 @@ describe('The Cloud Notification Mechanism Kinesis workflow', () => {
 
         const newResponseStreamRecords = await getRecords(responseStreamShardIterator);
         const parsedRecords = newResponseStreamRecords.Records.map((r) => JSON.parse(r.Data.toString()));
+        parsedRecords.map((r) => console.log('record:', JSON.stringify(r)));
         const responseRecord = parsedRecords.find((r) => r.identifier === recordIdentifier);
         expect(responseRecord.identifier).toEqual(recordIdentifier);
         expect(responseRecord.response.status).toEqual('SUCCESS');

--- a/example/spec/kinesisTests/KinesisTestTriggerSpec.js
+++ b/example/spec/kinesisTests/KinesisTestTriggerSpec.js
@@ -114,7 +114,7 @@ describe('The Cloud Notification Mechanism Kinesis workflow', () => {
 
     beforeAll(async () => {
       await tryCatchExit(async () => {
-        console.log(`Dropping record onto  ${streamName}, recordIdentifier: ${recordIdentifier}.`);
+        console.log(`\nDropping record onto  ${streamName}, recordIdentifier: ${recordIdentifier}.`);
         await putRecordOnStream(streamName, record);
 
         console.log('Waiting for step function to start...');
@@ -185,11 +185,12 @@ describe('The Cloud Notification Mechanism Kinesis workflow', () => {
       });
 
       it('writes a message to the response stream', async () => {
-        console.log(`Fetching shard iterator for response stream  '${cnmResponseStreamName}'.`);
+        console.log(`Fetching shard iterator for response stream  '${cnmResponseStreamName}' at ${workflowSucceedStartTime}.`);
         // get shard iterator for the response stream so we can process any new records sent to it
         responseStreamShardIterator = await getShardIterator(cnmResponseStreamName, workflowSucceedStartTime);
 
         const newResponseStreamRecords = await getRecords(responseStreamShardIterator);
+        console.log('responseRecords', JSON.stringify(newResponseStreamRecords));
         const parsedRecords = newResponseStreamRecords.Records.map((r) => JSON.parse(r.Data.toString()));
         parsedRecords.map((r) => console.log('record:', JSON.stringify(r)));
         const responseRecord = parsedRecords.find((r) => r.identifier === recordIdentifier);
@@ -209,7 +210,7 @@ describe('The Cloud Notification Mechanism Kinesis workflow', () => {
 
     beforeAll(async () => {
       await tryCatchExit(async () => {
-        console.log(`Dropping bad record onto ${streamName}, recordIdentifier: ${badRecordIdentifier}.`);
+        console.log(`\nDropping bad record onto ${streamName}, recordIdentifier: ${badRecordIdentifier}.`);
         await putRecordOnStream(streamName, badRecord);
 
         console.log('Waiting for step function to start...');
@@ -237,12 +238,13 @@ describe('The Cloud Notification Mechanism Kinesis workflow', () => {
     });
 
     it('writes a failure message to the response stream', async () => {
-      console.log(`Fetching shard iterator for response stream  '${cnmResponseStreamName}'.`);
+      console.log(`Fetching shard iterator for response stream  '${cnmResponseStreamName}' at ${workflowFailStartTime}.`);
       // get shard iterator for the response stream so we can process any new records sent to it
       responseStreamShardIterator = await getShardIterator(cnmResponseStreamName, workflowFailStartTime);
-
       const newResponseStreamRecords = await getRecords(responseStreamShardIterator);
+      console.log('newResponseStreamRecords', newResponseStreamRecords);
       const parsedRecords = newResponseStreamRecords.Records.map((r) => JSON.parse(r.Data.toString()));
+      parsedRecords.map((r) => console.log('response record:', JSON.stringify(r)));
       // TODO(aimee): This should check the record identifier is equal to bad
       // record identifier, but this requires a change to cnmresponse task
       expect(parsedRecords[parsedRecords.length - 1].response.status).toEqual('FAILURE');

--- a/example/spec/kinesisTests/KinesisTestTriggerSpec.js
+++ b/example/spec/kinesisTests/KinesisTestTriggerSpec.js
@@ -120,10 +120,6 @@ describe('The Cloud Notification Mechanism Kinesis workflow', () => {
         console.log('Waiting for step function to start...');
         workflowExecution = await waitForTestSf(recordIdentifier, maxWaitTime);
 
-        console.log(`Fetching shard iterator for response stream  '${cnmResponseStreamName}'.`);
-        // get shard iterator for the response stream so we can process any new records sent to it
-        responseStreamShardIterator = await getShardIterator(cnmResponseStreamName, workflowSucceedStartTime);
-
         console.log(`Waiting for completed execution of ${workflowExecution.executionArn}.`);
         executionStatus = await waitForCompletedExecution(workflowExecution.executionArn);
       });
@@ -189,6 +185,10 @@ describe('The Cloud Notification Mechanism Kinesis workflow', () => {
       });
 
       it('writes a message to the response stream', async () => {
+        console.log(`Fetching shard iterator for response stream  '${cnmResponseStreamName}'.`);
+        // get shard iterator for the response stream so we can process any new records sent to it
+        responseStreamShardIterator = await getShardIterator(cnmResponseStreamName, workflowSucceedStartTime);
+
         const newResponseStreamRecords = await getRecords(responseStreamShardIterator);
         const parsedRecords = newResponseStreamRecords.Records.map((r) => JSON.parse(r.Data.toString()));
         const responseRecord = parsedRecords.find((r) => r.identifier === recordIdentifier);

--- a/travis-ci/select-stack.js
+++ b/travis-ci/select-stack.js
@@ -17,7 +17,7 @@ function determineIntegrationTestStackName(cb) {
     'Lauren Frederick': 'lf',
     laurenfrederick: 'lf',
     yjpa7145: 'mth-2',
-    flamingbear: 'mhs',
+    'Matt Savoie': 'mhs',
     Jkovarik: 'jk',
     'Menno Van Diermen': 'mvd',
     ifestus: 'jc'


### PR DESCRIPTION
**Summary:** Change shardIterator to prevent timeout

Addresses Bug where workflow does not complete in the 5 min after the shardIterator is created and the iterator expires.

* Instead of using a 'LATEST' shardIterator, we mark a timestamp before anything is placed in the cnmResponse Stream.  Then create a shardIterator with that timestamp. allowing us to retrieve the shardIterator right before using it, rather than hoping that the stepfunctions have completed before it's expiration. 

## Test Plan
Things that should succeed before merging.

- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Update CHANGELOG

Reviewers: 