### PR TITLE
Make CMR host configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Added PublishGranule workflow to publish a granule to CMR without full reingest. (ingest-in-place capability)
+- Added option to use environment variable to set CMR host in `@cumulus/cmrjs`.
 
+### Fixed
+
+- `getGranuleId` in `@cumulus/ingest` bug: `getGranuleId` was constructing an error using `filename` which was undefined. The fix replaces `filename` with the `uri` argument.
 
 ## [v1.10.1] - 2018-09-4
 

--- a/packages/cmrjs/index.js
+++ b/packages/cmrjs/index.js
@@ -8,7 +8,8 @@ const {
   ValidationError,
   updateToken,
   getUrl,
-  xmlParseOptions
+  xmlParseOptions,
+  getHost
 } = require('./utils');
 
 
@@ -334,5 +335,6 @@ module.exports = {
   ValidationError,
   CMR,
   getMetadata,
-  getFullMetadata
+  getFullMetadata,
+  getHost
 };

--- a/packages/cmrjs/tests/utils-spec.js
+++ b/packages/cmrjs/tests/utils-spec.js
@@ -4,12 +4,12 @@ const sinon = require('sinon');
 const test = require('ava');
 const publicIp = require('public-ip');
 
-const { getIp } = require('../utils');
+const { getIp, getHost } = require('../utils');
 
 let stub;
 
 test.afterEach(t => {
-  stub.restore();
+  if (stub !== undefined) stub.restore();
 });
 
 test('getIp returns public IP when available', async (t) => {
@@ -30,4 +30,19 @@ test('getIp throws an error when the error is unexpected', async (t) => {
   await getIp().catch((e) => {
     t.is(e.message, errorMessage);
   });
+});
+
+test('getHost returns value according to process.env.CMR_ENVIRONMENT', (t) => {
+  process.env.CMR_ENVIRONMENT = 'OPS';
+  t.is(getHost(), 'cmr.earthdata.nasa.gov');
+  process.env.CMR_ENVIRONMENT = 'SIT';
+  t.is(getHost(), 'cmr.sit.earthdata.nasa.gov');
+  process.env.CMR_ENVIRONMENT = '';
+  t.is(getHost(), 'cmr.uat.earthdata.nasa.gov');
+});
+
+test('getHost returns CMR_HOST when defined', (t) => {
+  const anotherHost = 'cmr.com';
+  process.env.CMR_HOST = anotherHost;
+  t.is(getHost(), anotherHost);
 });

--- a/packages/cmrjs/utils.js
+++ b/packages/cmrjs/utils.js
@@ -39,6 +39,8 @@ const ValidationError = createErrorType('ValidationError');
  */
 function getHost() {
   const env = process.env.CMR_ENVIRONMENT;
+  if (process.env.CMR_HOST) return process.env.CMR_HOST;
+
   let host;
   if (env === 'OPS') {
     host = 'cmr.earthdata.nasa.gov';
@@ -176,6 +178,8 @@ async function updateToken(cmrProvider, clientId, username, password) {
   // Update the saved ECHO token
   // for info on how to add collections to CMR: https://cmr.earthdata.nasa.gov/ingest/site/ingest_api_docs.html#validate-collection
   let response;
+
+  if (process.env.CMR_TOKEN) return process.env.CMR_TOKEN;
 
   try {
     response = await got.post(getUrl('token'), {

--- a/packages/cmrjs/utils.js
+++ b/packages/cmrjs/utils.js
@@ -179,8 +179,6 @@ async function updateToken(cmrProvider, clientId, username, password) {
   // for info on how to add collections to CMR: https://cmr.earthdata.nasa.gov/ingest/site/ingest_api_docs.html#validate-collection
   let response;
 
-  if (process.env.CMR_TOKEN) return process.env.CMR_TOKEN;
-
   try {
     response = await got.post(getUrl('token'), {
       json: true,
@@ -240,5 +238,6 @@ module.exports = {
   updateToken,
   getUrl,
   xmlParseOptions,
-  getIp
+  getIp,
+  getHost
 }

--- a/packages/ingest/granule.js
+++ b/packages/ingest/granule.js
@@ -608,7 +608,7 @@ function selector(type, protocol) {
 function getGranuleId(uri, regex) {
   const match = path.basename(uri).match(regex);
   if (match) return match[1];
-  throw new Error(`Could not determine granule id of ${filename} using ${regex}`);
+  throw new Error(`Could not determine granule id of ${uri} using ${regex}`);
 }
 
 /**

--- a/packages/ingest/test/granule.js
+++ b/packages/ingest/test/granule.js
@@ -19,7 +19,8 @@ const {
   SftpDiscoverGranules,
   S3DiscoverGranules,
   moveGranuleFiles,
-  moveGranuleFile
+  moveGranuleFile,
+  getGranuleId
 } = require('../granule');
 
 
@@ -383,4 +384,17 @@ test('moveGranuleFiles only moves granule files specified with regex', async (t)
     t.is(list.Contents.length, 1);
     t.is(list.Contents[0].Key, 'destination/included-in-move.txt');
   });
+});
+
+test('getGranuleId is successful', (t) => {
+  const uri = 'test.txt';
+  const regex = '(.*).txt';
+  t.is(getGranuleId(uri, regex), 'test');
+});
+
+test('getGranuleId fails', (t) => {
+  const uri = 'test.txt';
+  const regex = '(.*).TXT';
+  const error = t.throws(() => getGranuleId(uri, regex), Error);
+  t.is(error.message, `Could not determine granule id of ${uri} using ${regex}`);
 });

--- a/travis-ci/select-stack.js
+++ b/travis-ci/select-stack.js
@@ -10,7 +10,7 @@ function determineIntegrationTestStackName(cb) {
   if (branch === 'master') return cb('cumulus-from-source');
 
   const stacks = {
-    'abarciauskas-bgse': 'aimee-test',
+    'Aimee Barciauskas': 'aimee-test',
     scisco: 'aj',
     jennyhliu: 'jl',
     kkelly51: 'kk-uat-deployment',


### PR DESCRIPTION
**Summary:** 

Make CMR host configurable

## Changes

* Added option to use environment variable to set CMR host in `@cumulus/cmrjs`.
* `getGranuleId` in `@cumulus/ingest` bug: `getGranuleId` was constructing an error using `filename` which was undefined. The fix replaces `filename` with the `uri` argument.
* Unit tests for the above

## Test Plan

- [x] Unit tests
- [x] Adhoc testing
- [x] Update CHANGELOG
