### PR TITLE
CUMULUS 883 Execution-status Endpoint returns complete message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Added PublishGranule workflow to publish a granule to CMR without full reingest. (ingest-in-place capability)
-
+- `@cumulus/api` `/execution-status` endpoint requests and returns complete execution output if  execution output is stored in S3 due to size.
 
 ## [v1.10.1] - 2018-09-4
 

--- a/example/spec/ingestGranule/IngestGranuleFailureSpec.js
+++ b/example/spec/ingestGranule/IngestGranuleFailureSpec.js
@@ -85,14 +85,14 @@ describe('The Ingest Granule failure workflow', () => {
         const currentEvent = events[i];
 
         if (currentEvent.type === 'TaskStateExited' &&
-        get(currentEvent, 'stateExitedEventDetails.name') === syncGranuleNoVpcTaskName) {
-          syncGranStepOutput = JSON.parse(get(currentEvent, 'stateExitedEventDetails.output'));
+        get(currentEvent, 'name') === syncGranuleNoVpcTaskName) {
+          syncGranStepOutput = get(currentEvent, 'output');
           expect(syncGranStepOutput.exception).toBeTruthy();
 
           // the previous step has the original error thrown from lambda
           const previousEvent = events[i - 1];
           expect(previousEvent.type).toBe('LambdaFunctionFailed');
-          syncGranFailedDetail = previousEvent.lambdaFunctionFailedEventDetails;
+          syncGranFailedDetail = previousEvent;
 
           // get the next task executed
           let nextTask;
@@ -100,8 +100,8 @@ describe('The Ingest Granule failure workflow', () => {
             i += 1;
             const nextEvent = events[i];
             if (nextEvent.type === 'TaskStateEntered' &&
-              get(nextEvent, 'stateEnteredEventDetails.name')) {
-              nextTask = get(nextEvent, 'stateEnteredEventDetails.name');
+              get(nextEvent, 'name')) {
+              nextTask = get(nextEvent, 'name');
             }
           }
 

--- a/example/spec/parsePdr/ParsePdrSuccessSpec.js
+++ b/example/spec/parsePdr/ParsePdrSuccessSpec.js
@@ -195,8 +195,8 @@ describe('Parse PDR workflow', () => {
       for (let i = 0; i < events.length; i += 1) {
         const currentEvent = events[i];
         if (currentEvent.type === 'TaskStateExited' &&
-        get(currentEvent, 'stateExitedEventDetails.name') === checkStatusTaskName) {
-          const output = JSON.parse(get(currentEvent, 'stateExitedEventDetails.output'));
+        get(currentEvent, 'name') === checkStatusTaskName) {
+          const output = get(currentEvent, 'output');
           const isFinished = output.payload.isFinished;
 
           // get the next task executed
@@ -205,8 +205,8 @@ describe('Parse PDR workflow', () => {
             i += 1;
             const nextEvent = events[i];
             if (nextEvent.type === 'TaskStateEntered' &&
-              get(nextEvent, 'stateEnteredEventDetails.name')) {
-              nextTask = get(nextEvent, 'stateEnteredEventDetails.name');
+              get(nextEvent, 'name')) {
+              nextTask = get(nextEvent, 'name');
             }
           }
 

--- a/example/spec/redeployment/WorkflowRedeploySpec.js
+++ b/example/spec/redeployment/WorkflowRedeploySpec.js
@@ -76,9 +76,10 @@ describe('When a workflow', () => {
       });
 
       it('the execution steps show the original workflow steps', () => {
+        console.log(`executionStatus.executionHistory.events ${JSON.stringify(executionStatus.executionHistory.events, null, 2)}`);
         const helloWorldScheduledEvents = executionStatus.executionHistory.events.filter((event) =>
           event.type === 'LambdaFunctionScheduled' &&
-          event.lambdaFunctionScheduledEventDetails.resource.includes('HelloWorld'));
+          event.resource.includes('HelloWorld'));
 
         expect(helloWorldScheduledEvents.length).toEqual(1);
       });

--- a/example/spec/testAPI/APISuccessSpec.js
+++ b/example/spec/testAPI/APISuccessSpec.js
@@ -174,7 +174,7 @@ describe('The Cumulus API', () => {
         workflow: 'PublishGranule'
       });
 
-      const granulePublished = await waitForExist(cmrLink, true, 6, 20000);
+      const granulePublished = await waitForExist(cmrLink, true, 10, 20000);
       expect(granulePublished).toEqual(true);
 
       // Cleanup: remove from CMR

--- a/example/spec/testAPI/APISuccessSpec.js
+++ b/example/spec/testAPI/APISuccessSpec.js
@@ -174,7 +174,7 @@ describe('The Cumulus API', () => {
         workflow: 'PublishGranule'
       });
 
-      const granulePublished = await waitForExist(cmrLink, true, 10, 20000);
+      const granulePublished = await waitForExist(cmrLink, true, 10, 30000);
       expect(granulePublished).toEqual(true);
 
       // Cleanup: remove from CMR

--- a/example/spec/testAPI/ExecutionStatusSpec.js
+++ b/example/spec/testAPI/ExecutionStatusSpec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { difference } = require('lodash');
+const { difference, intersection } = require('lodash');
 const fs = require('fs-extra');
 const { loadConfig } = require('../helpers/testUtils');
 const { getConfigObject } = require('../helpers/configUtils');
@@ -99,23 +99,8 @@ describe('The Cumulus API ExecutionStatus tests. The Ingest workflow', () => {
       // steps with *EventDetails will have the input/output, and also stepname when state is entered/exited
       const stepNames = [];
       executionStatus.executionHistory.events.forEach((event) => {
-        const eventDetailsKey = Object.keys(event).filter((key) => key.endsWith('EventDetails'));
-        // a step has none or one *EventDetails
-        expect(eventDetailsKey.length === 0 || eventDetailsKey.length === 1).toBe(true);
-
-        if (eventDetailsKey.length) {
-          const eventDetail = event[eventDetailsKey[0]];
-          expect(eventDetail.input || eventDetail.output).toBeTruthy();
-
-          if (event.type.endsWith('StateEntered') || event.type.endsWith('StateExited')) {
-            expect(eventDetail.name).toBeTruthy();
-            expect(
-              (event.type.endsWith('StateEntered') && eventDetail.input) ||
-              (event.type.endsWith('StateExited') && eventDetail.output)
-            ).toBeTruthy();
-            stepNames.push(eventDetail.name);
-          }
-        }
+        const eventKeys = Object.keys(event);
+        if (intersection(eventKeys, ['input', 'output']).length === 1) stepNames.push(event.name);
       });
 
       // all the executed steps have *EventDetails

--- a/packages/api/endpoints/execution-status.js
+++ b/packages/api/endpoints/execution-status.js
@@ -5,7 +5,39 @@ const handle = require('../lib/response').handle;
 const { S3, StepFunction } = require('@cumulus/ingest/aws');
 const { inTestMode } = require('@cumulus/common/test-utils');
 
-const handle = require('../lib/response').handle;
+async function fetchRemote(eventMessage) {
+  if (eventMessage.replace) {
+    const file = await S3.get(eventMessage.replace.Bucket, eventMessage.replace.Key);
+    return file.Body.toString();
+  }
+
+  return eventMessage;
+}
+
+async function getEventDetails(event) {
+  let result = Object.assign({}, event);
+  let prop;
+
+  if (event.type.endsWith('StateEntered')) {
+    prop = 'stateEnteredEventDetails';
+  }
+  else if (event.type.endsWith('StateExited')) {
+    prop = 'stateExitedEventDetails';
+  }
+  else if (event.type) {
+    prop = `${event.type.charAt(0).toLowerCase() + event.type.slice(1)}EventDetails`;
+  }
+
+  if (prop && event[prop]) {
+    result = Object.assign(result, event[prop]);
+    delete result[prop];
+  }
+
+  if (result.input) result.input = await fetchRemote(JSON.parse(result.input));
+  if (result.output) result.output = await fetchRemote(JSON.parse(result.output));
+
+  return result;
+}
 
 /**
  * get a single execution status
@@ -18,22 +50,23 @@ function get(event, cb) {
   const arn = _get(event.pathParameters, 'arn');
 
   return StepFunction.getExecutionStatus(arn)
-    .then((status) => {
-      let replace;
+    .then(async (status) => {
+      // if execution output is stored remotely, fetch it from S3 and replace it
       const executionOutput = status.execution.output;
-      if (executionOutput) replace = JSON.parse(executionOutput).replace;
-      if (replace) {
-        return S3.get(replace.Bucket, replace.Key)
-          .then((file) => {
-            /* eslint-disable no-param-reassign */
-            status.execution.output = file.Body.toString();
-            /* eslint-enable no-param-reassign */
-            return cb(null, status);
-          }).catch(cb);
+
+      /* eslint-disable no-param-reassign */
+      if (executionOutput) status.execution.output = await fetchRemote(status.execution.output);
+      /* eslint-enable no-param-reassign */
+
+      const updatedEvents = [];
+      for (let i = 0; i < status.executionHistory.events.length; i += 1) {
+        const sfEvent = status.executionHistory.events[i];
+        updatedEvents.push(getEventDetails(sfEvent));
       }
-      else {
-        cb(null, status);
-      }
+      /* eslint-disable no-param-reassign */
+      status.executionHistory.events = await Promise.all(updatedEvents);
+      /* eslint-enable no-param-reassign */
+      cb(null, status);
     })
     .catch(cb);
 }

--- a/packages/api/endpoints/execution-status.js
+++ b/packages/api/endpoints/execution-status.js
@@ -55,7 +55,7 @@ function get(event, cb) {
       const executionOutput = status.execution.output;
 
       /* eslint-disable no-param-reassign */
-      if (executionOutput) status.execution.output = await fetchRemote(status.execution.output);
+      if (executionOutput) status.execution.output = await fetchRemote(JSON.parse(status.execution.output));
       /* eslint-enable no-param-reassign */
 
       const updatedEvents = [];

--- a/packages/api/endpoints/execution-status.js
+++ b/packages/api/endpoints/execution-status.js
@@ -25,7 +25,9 @@ function get(event, cb) {
       if (replace) {
         S3.get(replace.Bucket, replace.Key)
           .then((file) => {
+            /* eslint-disable no-param-reassign */
             status.execution.output = file.Body.toString();
+            /* eslint-enable no-param-reassign */
             return cb(null, status);
           }).catch(cb);
       }

--- a/packages/api/endpoints/execution-status.js
+++ b/packages/api/endpoints/execution-status.js
@@ -5,6 +5,11 @@ const handle = require('../lib/response').handle;
 const { S3, StepFunction } = require('@cumulus/ingest/aws');
 const { inTestMode } = require('@cumulus/common/test-utils');
 
+/**
+ * fetchRemote fetches remote message from S3
+ * @param  {Object} eventMessage Cumulus Message Adapter message
+ * @return {Object}              Cumulus Messsage Adapter message
+ */
 async function fetchRemote(eventMessage) {
   if (eventMessage.replace) {
     const file = await S3.get(eventMessage.replace.Bucket, eventMessage.replace.Key);
@@ -14,6 +19,15 @@ async function fetchRemote(eventMessage) {
   return eventMessage;
 }
 
+/**
+ * getEventDetails
+ *   - replaces StepFunction-specific keys with input or output keys
+ *   - replaces "replace" key in input or output with message stored on S3
+ * @param  {Object} event StepFunction event object
+ * @return {Object}       StepFunction event object, with SFn keys and
+ *                        "replace" values replaced with "input|output"
+ *                        and message stored on S3, respectively.
+ */
 async function getEventDetails(event) {
   let result = Object.assign({}, event);
   let prop;

--- a/packages/api/endpoints/execution-status.js
+++ b/packages/api/endpoints/execution-status.js
@@ -23,7 +23,7 @@ function get(event, cb) {
       const executionOutput = status.execution.output;
       if (executionOutput) replace = JSON.parse(executionOutput).replace;
       if (replace) {
-        S3.get(replace.Bucket, replace.Key)
+        return S3.get(replace.Bucket, replace.Key)
           .then((file) => {
             /* eslint-disable no-param-reassign */
             status.execution.output = file.Body.toString();

--- a/packages/api/endpoints/execution-status.js
+++ b/packages/api/endpoints/execution-status.js
@@ -19,12 +19,14 @@ function get(event, cb) {
 
   return StepFunction.getExecutionStatus(arn)
     .then((status) => {
-      const replace = status.output.replace;
+      let replace;
+      const executionOutput = status.execution.output;
+      if (executionOutput) replace = JSON.parse(executionOutput).replace;
       if (replace) {
         S3.get(replace.Bucket, replace.Key)
           .then((file) => {
-            const fullStatus = JSON.parse(file.Body);
-            return cb(null, fullStatus);
+            status.execution.output = file.Body.toString();
+            return cb(null, status);
           }).catch(cb);
       }
       else {
@@ -46,3 +48,4 @@ function handler(event, context) {
 }
 
 module.exports = handler;
+

--- a/packages/api/endpoints/execution-status.js
+++ b/packages/api/endpoints/execution-status.js
@@ -1,14 +1,15 @@
 'use strict';
 
 const _get = require('lodash.get');
-const handle = require('../lib/response').handle;
 const { S3, StepFunction } = require('@cumulus/ingest/aws');
 const { inTestMode } = require('@cumulus/common/test-utils');
+const handle = require('../lib/response').handle;
 
 /**
  * fetchRemote fetches remote message from S3
- * @param  {Object} eventMessage Cumulus Message Adapter message
- * @return {Object}              Cumulus Messsage Adapter message
+ *
+ * @param  {Object} eventMessage - Cumulus Message Adapter message
+ * @returns {Object}              Cumulus Messsage Adapter message
  */
 async function fetchRemote(eventMessage) {
   if (eventMessage.replace) {
@@ -23,8 +24,9 @@ async function fetchRemote(eventMessage) {
  * getEventDetails
  *   - replaces StepFunction-specific keys with input or output keys
  *   - replaces "replace" key in input or output with message stored on S3
- * @param  {Object} event StepFunction event object
- * @return {Object}       StepFunction event object, with SFn keys and
+ *
+ * @param  {Object} event - StepFunction event object
+ * @returns {Object}       StepFunction event object, with SFn keys and
  *                        "replace" values replaced with "input|output"
  *                        and message stored on S3, respectively.
  */
@@ -97,4 +99,3 @@ function handler(event, context) {
 }
 
 module.exports = handler;
-

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -77,6 +77,7 @@
     "lodash.range": "^3.2.0",
     "lodash.sample": "4.2.1",
     "nyc": "^11.6.0",
+    "rewire": "^4.0.1",
     "sinon": "^4.5.0",
     "webpack": "~4.5.0",
     "webpack-cli": "~2.0.14",

--- a/packages/api/tests/endpoints/test-endpoints-execution-status.js
+++ b/packages/api/tests/endpoints/test-endpoints-execution-status.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const rewire = require('rewire');
+const test = require('ava');
+
+const executionStatusEndpoint = rewire('../../endpoints/execution-status');
+const { testEndpoint } = require('../../lib/testUtils');
+
+const executionStatusCommon = {
+  executionArn: 'arn:aws:states:us-east-1:xxx:execution:discoverGranulesStateMachine:3ea094d8',
+  stateMachineArn: 'arn:aws:states:us-east-1:xxx:stateMachine:discoverGranulesStateMachine:3ea094d8',
+  name: '3ea094d8',
+  status: 'SUCCEEDED',
+  startDate: 'date',
+  stopDate: 'date'
+};
+
+const cumulusMetaOutput = {
+  cumulus_meta: {
+    state_machine: 'arn:aws:states:us-east-1:xxx:stateMachine:discoverGranulesStateMachine',
+    message_source: 'sfn',
+    workflow_start_time: 1536279498569,
+    execution_name: '3ea094d8',
+    system_bucket: 'cumulus-map-internal'
+  }
+};
+
+const remoteMessageOutput = {
+  ...cumulusMetaOutput,
+  replace: {
+    Bucket: 'cumulus-map-internal',
+    Key: 'events/df37ded5'
+  }
+};
+
+const fullMessageOutput = {
+  ...cumulusMetaOutput,
+  meta: {},
+  payload: {},
+  exception: 'None',
+  workflow_config: {}
+};
+
+const stepFunctionMock = {
+  getExecutionStatus: async function(arn) {
+    return new Promise((resolve, reject) => {
+      const executionStatus = {
+        ...executionStatusCommon,
+        output: arn === 'hasFullMessage' ? fullMessageOutput : remoteMessageOutput
+      };
+      resolve(executionStatus);
+    });
+  }
+};
+
+const s3Mock = {
+  get: async function(bucket, key) {
+    return new Promise((resolve, reject) => {
+      const executionStatus = {
+        ...executionStatusCommon,
+        output: fullMessageOutput
+      };
+      const s3Result = {
+        Body: new Buffer(JSON.stringify(executionStatus))
+      };
+      resolve(s3Result);
+    });
+  }
+};
+
+executionStatusEndpoint.__set__('StepFunction', stepFunctionMock);
+executionStatusEndpoint.__set__('S3', s3Mock);
+  
+test('returns execution status', (t) => {
+  const event = { pathParameters: { arn: 'hasFullMessage' } };
+  return testEndpoint(executionStatusEndpoint, event, (response) => {
+    const executionStatus = JSON.parse(response.body);
+    t.deepEqual(fullMessageOutput, executionStatus.output);
+  });
+});
+
+test('fetches message from S3 when remote message', (t) => {
+  const event = { pathParameters: { arn: 'hasRemoteMessage' } };
+  return testEndpoint(executionStatusEndpoint, event, (response) => {
+    const executionStatus = JSON.parse(response.body);
+    t.deepEqual(fullMessageOutput, executionStatus.output);
+  });
+});
+

--- a/packages/api/tests/endpoints/test-endpoints-execution-status.js
+++ b/packages/api/tests/endpoints/test-endpoints-execution-status.js
@@ -138,7 +138,7 @@ test('returns execution status', (t) => {
   const event = { pathParameters: { arn: 'hasFullMessage' } };
   return testEndpoint(executionStatusEndpoint, event, (response) => {
     const executionStatus = JSON.parse(response.body);
-    t.deepEqual(JSON.stringify(fullMessageOutput), executionStatus.execution.output);
+    t.deepEqual(fullMessageOutput, executionStatus.execution.output);
   });
 });
 

--- a/packages/api/tests/endpoints/test-endpoints-execution-status.js
+++ b/packages/api/tests/endpoints/test-endpoints-execution-status.js
@@ -178,4 +178,3 @@ test('when execution is still running, still returns status and fetches SF execu
     t.deepEqual(expectedResponse, executionStatus);
   });
 });
-

--- a/packages/api/tests/endpoints/test-endpoints-execution-status.js
+++ b/packages/api/tests/endpoints/test-endpoints-execution-status.js
@@ -42,11 +42,11 @@ const fullMessageOutput = {
 };
 
 const stepFunctionMock = {
-  getExecutionStatus: async function(arn) {
-    return new Promise((resolve, reject) => {
+  getExecutionStatus: function (arn) {
+    return new Promise((resolve) => {
       let executionStatus;
       if (arn === 'stillRunning') {
-        executionStatus = { ...executionStatusCommon }
+        executionStatus = { ...executionStatusCommon };
       }
       else {
         executionStatus = {
@@ -64,10 +64,10 @@ const stepFunctionMock = {
 };
 
 const s3Mock = {
-  get: async function(bucket, key) {
-    return new Promise((resolve, reject) => {
+  get: function () {
+    return new Promise((resolve) => {
       const s3Result = {
-        Body: new Buffer(JSON.stringify(fullMessageOutput))
+        Body: Buffer.from(JSON.stringify(fullMessageOutput))
       };
       resolve(s3Result);
     });
@@ -76,7 +76,7 @@ const s3Mock = {
 
 executionStatusEndpoint.__set__('StepFunction', stepFunctionMock);
 executionStatusEndpoint.__set__('S3', s3Mock);
-  
+
 test('returns execution status', (t) => {
   const event = { pathParameters: { arn: 'hasFullMessage' } };
   return testEndpoint(executionStatusEndpoint, event, (response) => {
@@ -103,6 +103,6 @@ test('when execution is still running, still returns status', (t) => {
       stateMachine: {}
     };
     t.deepEqual(expectedResponse, executionStatus);
-  });  
+  });
 });
 

--- a/travis-ci/select-stack.js
+++ b/travis-ci/select-stack.js
@@ -10,7 +10,7 @@ function determineIntegrationTestStackName(cb) {
   if (branch === 'master') return cb('cumulus-from-source');
 
   const stacks = {
-    'abarciauskas-bgse': 'aimee-test',
+    'Aimee Barciauskas': 'aimee-test',
     scisco: 'aj',
     jennyhliu: 'jl',
     kkelly51: 'kk-uat-deployment',


### PR DESCRIPTION
**Summary:**

Addresses [CUMULUS-883: Input/Output incorrect when message is too large](https://bugs.earthdata.nasa.gov/browse/CUMULUS-883)

When the message is too large and is written to S3, the S3 location shows up in SF.describeExecution, but not the message. When the call is made to the SF API in execution-status, if the message is in S3, a call to the S3 location is made and the whole message is sent back.

## Test Plan
Things that should succeed before merging.

- [x] Unit tests
- [x] Adhoc testing
- [x] Update CHANGELOG
- [x] Run `./bin/eslint` and fix eslint
