### PR TITLE
Wait longer for kinesis workflows to finish.

### DIFF
--- a/example/spec/helpers/kinesisHelpers.js
+++ b/example/spec/helpers/kinesisHelpers.js
@@ -182,19 +182,19 @@ async function putRecordOnStream(streamName, record) {
  * Wait for test stepfunction execution to exist.
  *
  * @param {string} recordIdentifier - random string identifying correct execution for test
- * @param {integer} maxWaitTime - maximum time to wait for the correct execution in milliseconds
+ * @param {integer} maxWaitTimeSecs - maximum time to wait for the correct execution in seconds
  * @param {string} firstStep - The name of the first step of the workflow, used to query if the workflow has started.
  * @returns {Object} - {executionArn: <arn>, status: <status>}
  * @throws {Error} - any AWS error, re-thrown from AWS execution or 'Workflow Never Started'.
  */
-async function waitForTestSf(recordIdentifier, maxWaitTime, firstStep = 'SfSnsReport') {
-  let timeWaited = 0;
+async function waitForTestSf(recordIdentifier, maxWaitTimeSecs, firstStep = 'SfSnsReport') {
+  let timeWaitedSecs = 0;
   let workflowExecution;
 
   /* eslint-disable no-await-in-loop */
-  while (timeWaited < maxWaitTime && workflowExecution === undefined) {
+  while (timeWaitedSecs < maxWaitTimeSecs && workflowExecution === undefined) {
     await timeout(waitPeriodMs);
-    timeWaited += waitPeriodMs;
+    timeWaitedSecs += (waitPeriodMs / 1000);
     const executions = await getExecutions();
     // Search all recent executions for target recordIdentifier
     for (const execution of executions) {
@@ -206,7 +206,7 @@ async function waitForTestSf(recordIdentifier, maxWaitTime, firstStep = 'SfSnsRe
     }
   }
   /* eslint-disable no-await-in-loop */
-  if (timeWaited < maxWaitTime) return workflowExecution;
+  if (timeWaitedSecs < maxWaitTimeSecs) return workflowExecution;
   throw new Error('Never found started workflow.');
 }
 

--- a/example/spec/kinesisTests/KinesisTestTriggerSpec.js
+++ b/example/spec/kinesisTests/KinesisTestTriggerSpec.js
@@ -2,7 +2,7 @@
 
 const { s3 } = require('@cumulus/common/aws');
 
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 550000;
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 12 * 60 * 1000;
 
 const {
   LambdaStep,
@@ -85,7 +85,8 @@ const expectedSyncGranulesPayload = {
 // stream. When a record appears on the stream, the kinesisConsumer lambda
 // triggers workflows associated with the kinesis-type rules.
 describe('The Cloud Notification Mechanism Kinesis workflow', () => {
-  const maxWaitTime = 1000 * 60 * 4;
+  const maxWaitForSFExistSecs =  60 * 4;
+  const maxWaitForExecutionSecs = 60 * 8;
   let executionStatus;
   let s3FileHead;
   let responseStreamShardIterator;
@@ -117,14 +118,14 @@ describe('The Cloud Notification Mechanism Kinesis workflow', () => {
         await putRecordOnStream(streamName, record);
 
         console.log('Waiting for step function to start...');
-        workflowExecution = await waitForTestSf(recordIdentifier, maxWaitTime);
+        workflowExecution = await waitForTestSf(recordIdentifier, maxWaitForSFExistSecs);
 
         console.log(`Fetching shard iterator for response stream  '${cnmResponseStreamName}'.`);
         // get shard iterator for the response stream so we can process any new records sent to it
         responseStreamShardIterator = await getShardIterator(cnmResponseStreamName);
 
         console.log(`Waiting for completed execution of ${workflowExecution.executionArn}.`);
-        executionStatus = await waitForCompletedExecution(workflowExecution.executionArn);
+        executionStatus = await waitForCompletedExecution(workflowExecution.executionArn, maxWaitForExecutionSecs);
       });
     });
 
@@ -160,7 +161,7 @@ describe('The Cloud Notification Mechanism Kinesis workflow', () => {
           Bucket: testConfig.buckets.private.name,
           Key: `${filePrefix}/${fileData.name}`
         }).promise();
-        expect(new Date() - s3FileHead.LastModified < maxWaitTime).toBeTruthy();
+        expect(new Date() - s3FileHead.LastModified < maxWaitForSFExistSecs * 1000).toBeTruthy();
       });
     });
 
@@ -214,10 +215,10 @@ describe('The Cloud Notification Mechanism Kinesis workflow', () => {
         responseStreamShardIterator = await getShardIterator(cnmResponseStreamName);
 
         console.log('Waiting for step function to start...');
-        workflowExecution = await waitForTestSf(badRecordIdentifier, maxWaitTime);
+        workflowExecution = await waitForTestSf(badRecordIdentifier, maxWaitForSFExistSecs);
 
         console.log(`Waiting for completed execution of ${workflowExecution.executionArn}.`);
-        executionStatus = await waitForCompletedExecution(workflowExecution.executionArn);
+        executionStatus = await waitForCompletedExecution(workflowExecution.executionArn, maxWaitForExecutionSecs);
       });
     });
 


### PR DESCRIPTION
Fix kinesis timeouts.

**Summary:** Wait longer for things to finish.

Addresses https://travis-ci.org/nasa/cumulus/jobs/430242418

## Changes
Refactor kinesisHelpers' waitForTestSf to take wait time in seconds.
Change default timeout in jasmine tests  to be 12 min.
Update wait for stepfunction use seconds (still 4 min.)
Wait for sf execution to finish for up to 8 min.
