### PR TITLE
Stop on errors immediately in subshell.

### DIFF
--- a/travis-ci/run-integration-tests.sh
+++ b/travis-ci/run-integration-tests.sh
@@ -82,7 +82,7 @@ curl \
 
 rm "${DEPLOYMENT}.lock"
 
-set +e
+set -e
 (
   cd example
   if [ "$USE_NPM_PACKAGES" = "true" ]; then

--- a/travis-ci/run-integration-tests.sh
+++ b/travis-ci/run-integration-tests.sh
@@ -116,6 +116,7 @@ RESULT="$?"
 set -e
 
 # Release the stack
+echo "Release lock ${KEY}"
 DATE=$(date -R)
 STRING_TO_SIGN_PUT="DELETE
 

--- a/travis-ci/run-integration-tests.sh
+++ b/travis-ci/run-integration-tests.sh
@@ -82,8 +82,9 @@ curl \
 
 rm "${DEPLOYMENT}.lock"
 
-set -e
+set +e
 (
+  set -e
   cd example
   if [ "$USE_NPM_PACKAGES" = "true" ]; then
     yarn


### PR DESCRIPTION
**Summary:** exit subshell if any of the deployment steps fail.

Addresses problem of running integration tests on a bad stack.  

It wasn't clear if you stack failed to update or deploy properly because travis always continued to execute the tests. (in fact the only reason this failed was because the deploy tests failed)
https://travis-ci.org/nasa/cumulus/jobs/430302275

~Now if a stack deployment fails, the travis output is clearer.~
~https://travis-ci.org/nasa/cumulus/jobs/430584519~

Now if a step in the deployment fails, we exit from the subshell, but still remove the lock.
https://travis-ci.org/nasa/cumulus/jobs/430680640

asked for @yjpa7145 explicitly since he probably had reasons for `set +e` originally. 
Yes, we want to exit the subshell and clean up the lock.

## Changes
exit from subshell when deployment errors occur, but continue to clean up lock.
