### PR TITLE
Move step function utilities to common

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -93,7 +93,8 @@
       2,
       {
         "code": 100,
-        "ignorePattern": "(https?:|JSON\\.parse|[Uu]rl =)"
+        "ignorePattern": "(https?:|JSON\\.parse|[Uu]rl =)",
+        "ignoreComments": true
       }
     ],
     "arrow-parens": ["error", "always"],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Added `@cumulus/common/step-functions.waitForCompletedExecution()`
+- Added `@cumulus/common/step-functions.getCompletedExecutionStatus()`
 - Added PublishGranule workflow to publish a granule to CMR without full reingest. (ingest-in-place capability)
 - `@cumulus/api` `/execution-status` endpoint requests and returns complete execution output if  execution output is stored in S3 due to size.
 - Added option to use environment variable to set CMR host in `@cumulus/cmrjs`.
+
+### Removed
+
+- Removed `@cumulus/integration-tests.waitForCompletedExecution()`
 
 ### Fixed
 

--- a/example/spec/discoverAndQueuePdrs/DiscoverAndQueuePdrsSuccessSpec.js
+++ b/example/spec/discoverAndQueuePdrs/DiscoverAndQueuePdrsSuccessSpec.js
@@ -1,7 +1,8 @@
+const stepFunctions = require('@cumulus/common/step-functions');
 const { Execution } = require('@cumulus/api/models');
+
 const {
   buildAndExecuteWorkflow,
-  waitForCompletedExecution,
   LambdaStep,
   api: apiTestUtils
 } = require('@cumulus/integration-tests');
@@ -75,7 +76,10 @@ describe('The Discover And Queue PDRs workflow', () => {
 
     beforeAll(async () => {
       parsePdrWorkflowArn = queuePdrsOutput.payload.running[0];
-      parsePdrExecutionStatus = await waitForCompletedExecution(parsePdrWorkflowArn);
+      parsePdrExecutionStatus = await stepFunctions.getCompletedExecutionStatus(
+        parsePdrWorkflowArn,
+        { waitToExist: true }
+      );
     });
 
     it('executes successfully', () => {

--- a/example/spec/discoverGranules/DiscoverGranulesSuccessSpec.js
+++ b/example/spec/discoverGranules/DiscoverGranulesSuccessSpec.js
@@ -1,5 +1,6 @@
+const stepFunctions = require('@cumulus/common/step-functions');
 const { Execution } = require('@cumulus/api/models');
-const { buildAndExecuteWorkflow, LambdaStep, waitForCompletedExecution } = require('@cumulus/integration-tests');
+const { buildAndExecuteWorkflow, LambdaStep } = require('@cumulus/integration-tests');
 
 const { loadConfig } = require('../helpers/testUtils');
 
@@ -78,8 +79,13 @@ describe('The Discover Granules workflow with http Protocol', () => {
 
     beforeAll(async () => {
       ingestGranuleWorkflowArn = queueGranulesOutput.payload.running[0];
+
       console.log('\nwait for ingestGranuleWorkflow', ingestGranuleWorkflowArn);
-      ingestGranuleExecutionStatus = await waitForCompletedExecution(ingestGranuleWorkflowArn);
+
+      ingestGranuleExecutionStatus = await stepFunctions.getCompletedExecutionStatus(
+        ingestGranuleWorkflowArn,
+        { waitToExist: true }
+      );
     });
 
     it('executes successfully', () => {

--- a/example/spec/kinesisTests/KinesisTestTriggerSpec.js
+++ b/example/spec/kinesisTests/KinesisTestTriggerSpec.js
@@ -1,13 +1,11 @@
 'use strict';
 
 const { s3 } = require('@cumulus/common/aws');
+const stepFunctions = require('@cumulus/common/step-functions');
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 550000;
 
-const {
-  LambdaStep,
-  waitForCompletedExecution
-} = require('@cumulus/integration-tests');
+const { LambdaStep } = require('@cumulus/integration-tests');
 const { randomString } = require('@cumulus/common/test-utils');
 
 const { loadConfig } = require('../helpers/testUtils');
@@ -124,7 +122,10 @@ describe('The Cloud Notification Mechanism Kinesis workflow', () => {
         responseStreamShardIterator = await getShardIterator(cnmResponseStreamName);
 
         console.log(`Waiting for completed execution of ${workflowExecution.executionArn}.`);
-        executionStatus = await waitForCompletedExecution(workflowExecution.executionArn);
+        executionStatus = await stepFunctions.getCompletedExecutionStatus(
+          workflowExecution.executionArn,
+          { waitToExist: true }
+        );
       });
     });
 
@@ -217,7 +218,10 @@ describe('The Cloud Notification Mechanism Kinesis workflow', () => {
         workflowExecution = await waitForTestSf(badRecordIdentifier, maxWaitTime);
 
         console.log(`Waiting for completed execution of ${workflowExecution.executionArn}.`);
-        executionStatus = await waitForCompletedExecution(workflowExecution.executionArn);
+        executionStatus = await stepFunctions.getCompletedExecutionStatus(
+          workflowExecution.executionArn,
+          { waitToExist: true }
+        );
       });
     });
 

--- a/example/spec/parsePdr/ParsePdrSuccessSpec.js
+++ b/example/spec/parsePdr/ParsePdrSuccessSpec.js
@@ -1,9 +1,9 @@
 const fs = require('fs');
 const { get } = require('lodash');
 const { Pdr, Execution } = require('@cumulus/api/models');
+const stepFunctions = require('@cumulus/common/step-functions');
 const {
   buildAndExecuteWorkflow,
-  waitForCompletedExecution,
   LambdaStep,
   api: apiTestUtils
 } = require('@cumulus/integration-tests');
@@ -114,7 +114,10 @@ describe('Parse PDR workflow', () => {
 
     beforeAll(async () => {
       ingestGranuleWorkflowArn = queueGranulesOutput.payload.running[0];
-      ingestGranuleExecutionStatus = await waitForCompletedExecution(ingestGranuleWorkflowArn);
+      ingestGranuleExecutionStatus = await stepFunctions.getCompletedExecutionStatus(
+        ingestGranuleWorkflowArn,
+        { waitToExist: true }
+      );
     });
 
     it('executes successfully', () => {

--- a/example/spec/redeployment/LambdaRedeploySpec.js
+++ b/example/spec/redeployment/LambdaRedeploySpec.js
@@ -1,8 +1,8 @@
 'use strict';
 
+const stepFunctions = require('@cumulus/common/step-functions');
 const {
   buildAndStartWorkflow,
-  waitForCompletedExecution,
   LambdaStep
 } = require('@cumulus/integration-tests');
 
@@ -43,7 +43,12 @@ describe('When a workflow', () => {
       );
       updateConfigObject(lambdaConfigFileName, lambdaName, updateConfig);
       await redeploy(config);
-      workflowStatus = await waitForCompletedExecution(workflowExecutionArn);
+
+      workflowStatus = await stepFunctions.getCompletedExecutionStatus(
+        workflowExecutionArn,
+        { waitToExist: true }
+      );
+
       testVersionOutput = await lambdaStep.getStepOutput(
         workflowExecutionArn,
         lambdaName

--- a/example/spec/redeployment/WorkflowRedeploySpec.js
+++ b/example/spec/redeployment/WorkflowRedeploySpec.js
@@ -125,12 +125,12 @@ describe('When a workflow', () => {
         console.log('Finished redeploy() in beforeAll() B'); // Debugging intermittent test failures
 
         // Wait for the execution to reach a non-RUNNING state
-        console.log('Starting stepFunctions.waitForCompletedExecution() in beforeAll() A'); // Debugging intermittent test failures
+        console.log('Starting stepFunctions.waitForCompletedExecution() in beforeAll() B'); // Debugging intermittent test failures
         await stepFunctions.waitForCompletedExecution(
           workflowExecutionArn,
           { waitToExist: true }
         );
-        console.log('Finished stepFunctions.waitForCompletedExecution() in beforeAll() A'); // Debugging intermittent test failures
+        console.log('Finished stepFunctions.waitForCompletedExecution() in beforeAll() B'); // Debugging intermittent test failures
 
         console.log('Starting apiTestUtils.getExecution() in beforeAll() B'); // Debugging intermittent test failures
         workflowStatus = await apiTestUtils.getExecution({

--- a/example/spec/redeployment/WorkflowRedeploySpec.js
+++ b/example/spec/redeployment/WorkflowRedeploySpec.js
@@ -2,10 +2,10 @@
 
 const fs = require('fs');
 const { promisify } = require('util');
+const stepFunctions = require('@cumulus/common/step-functions');
 
 const {
   buildAndStartWorkflow,
-  waitForCompletedExecution,
   api: apiTestUtils
 } = require('@cumulus/integration-tests');
 
@@ -63,9 +63,12 @@ describe('When a workflow', () => {
         await redeploy(config);
         console.log('Finished redeploy() in beforeAll() A'); // Debugging intermittent test failures
 
-        console.log('Starting waitForCompletedExecution() in beforeAll() A'); // Debugging intermittent test failures
-        workflowStatus = await waitForCompletedExecution(workflowExecutionArn);
-        console.log('Finished waitForCompletedExecution() in beforeAll() A'); // Debugging intermittent test failures
+        console.log('Starting stepFunctions.getCompletedExecutionStatus() in beforeAll() A'); // Debugging intermittent test failures
+        workflowStatus = await stepFunctions.getCompletedExecutionStatus(
+          workflowExecutionArn,
+          { waitToExist: true }
+        );
+        console.log('Finished stepFunctions.getCompletedExecutionStatus() in beforeAll() A'); // Debugging intermittent test failures
       },
       15 * 60 * 1000 // Timeout after 15 minutes
     );
@@ -122,9 +125,12 @@ describe('When a workflow', () => {
         console.log('Finished redeploy() in beforeAll() B'); // Debugging intermittent test failures
 
         // Wait for the execution to reach a non-RUNNING state
-        console.log('Starting waitForCompletedExecution() in beforeAll() B'); // Debugging intermittent test failures
-        await waitForCompletedExecution(workflowExecutionArn);
-        console.log('Finished waitForCompletedExecution() in beforeAll() B'); // Debugging intermittent test failures
+        console.log('Starting stepFunctions.waitForCompletedExecution() in beforeAll() A'); // Debugging intermittent test failures
+        await stepFunctions.waitForCompletedExecution(
+          workflowExecutionArn,
+          { waitToExist: true }
+        );
+        console.log('Finished stepFunctions.waitForCompletedExecution() in beforeAll() A'); // Debugging intermittent test failures
 
         console.log('Starting apiTestUtils.getExecution() in beforeAll() B'); // Debugging intermittent test failures
         workflowStatus = await apiTestUtils.getExecution({

--- a/packages/common/.gitignore
+++ b/packages/common/.gitignore
@@ -7,3 +7,4 @@ tmp
 config/authorized_keys
 config/cloudformation.yml
 cache-invalidation/config/runtime_config.json
+/docs/

--- a/packages/common/.npmignore
+++ b/packages/common/.npmignore
@@ -1,1 +1,2 @@
+/docs/
 /tests/

--- a/packages/common/bin/build-docs.sh
+++ b/packages/common/bin/build-docs.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+rm -rf docs
+jsdoc -c jsdoc.conf.json .
+find . -path './docs/*/styles/*' -not -name 'site.cosmo.css' -exec rm {} \;

--- a/packages/common/jsdoc.conf.json
+++ b/packages/common/jsdoc.conf.json
@@ -1,0 +1,41 @@
+{
+  "opts": {
+    "destination": "./docs/",
+    "package": "./package.json",
+    "readme": "./README.md",
+    "recurse": true,
+    "template": "./node_modules/ink-docstrap/template"
+  },
+  "source": {
+    "exclude": [
+      "./node_modules/",
+      "./test/",
+      "./tests/"
+    ]
+  },
+  "tags": {
+    "allowUnknownTags": true
+  },
+  "plugins": ["plugins/markdown"],
+  "templates": {
+    "cleverLinks": false,
+    "collapseSymbols": false,
+    "dateFormat": "ddd MMM Do YYYY",
+    "footer": "",
+    "includeDate": true,
+    "inverseNav": true,
+    "linenums": true,
+    "logoFile": "",
+    "methodHeadingReturns": false,
+    "monospaceLinks": false,
+    "navType": "vertical",
+    "outputSourceFiles": true,
+    "outputSourcePath": true,
+    "protocol": "html://",
+    "theme": "cosmo"
+  },
+  "markdown": {
+    "parser": "gfm",
+    "hardwrap": true
+  }
+}

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "build": "true",
-    "docs": "rm -rf docs && jsdoc -c jsdoc.conf.json .",
+    "docs": "./bin/build-docs.sh",
     "lint": "eslint .",
     "mocha": "mocha test/**/*.js",
     "mocha-coverage": "nyc mocha-webpack test/**/*.js",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -57,6 +57,8 @@
     "mocha": "^5.0.4",
     "mocha-junit-reporter": "^1.11.1",
     "p-retry": "^2.0.0",
+    "p-timeout": "^2.0.1",
+    "p-wait-for": "^2.0.0",
     "promise-retry": "^1.1.1",
     "pump": "^3.0.0",
     "randexp": "^0.4.9",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -20,6 +20,7 @@
   },
   "scripts": {
     "build": "true",
+    "docs": "rm -rf docs && jsdoc -c jsdoc.conf.json .",
     "lint": "eslint .",
     "mocha": "mocha test/**/*.js",
     "mocha-coverage": "nyc mocha-webpack test/**/*.js",
@@ -66,6 +67,7 @@
   },
   "devDependencies": {
     "ava": "^0.25.0",
+    "ink-docstrap": "^1.3.2",
     "nyc": "^11.6.0"
   }
 }

--- a/packages/common/step-functions.js
+++ b/packages/common/step-functions.js
@@ -48,7 +48,7 @@ exports.constructStepFunctionInput = (resources, provider, collection) => {
  *
  * @param {string} executionArn - ARN of the execution
  * @param {Object} [retryOptions] - see the options described [here](https://github.com/tim-kos/node-retry#retrytimeoutsoptions)
- * @returns {Promise<Object>} https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/StepFunctions.html#describeExecution-property
+ * @returns {Promise<Object>} [AWS StepFunctions.describeExecutions response](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/StepFunctions.html#describeExecution-property)
  */
 exports.describeExecution = (executionArn, retryOptions) =>
   pRetry(
@@ -134,7 +134,7 @@ exports.waitForCompletedExecution = async (executionArn, options = {}) => {
  * Wait for a given execution to complete, then return the status
  *
  * @param {string} executionArn - a Step Function Execution ARN
- * @param {Object} options - see {@link waitForCompletedExecution}
+ * @param {Object} options - see {@link module:step-functions.waitForCompletedExecution|waitForCompletedExecution}
  * @returns {Promise<string>} the execution status
  * @throws {TimeoutError}
  */


### PR DESCRIPTION
There were a couple of functions in `@cumulus/integration-tests` that are useful outside of integration tests.  Moved those functions to `@cumulus/common/step-functions`.

The new functions are:
- `@cumulus/common/step-functions.waitForCompletedExecution`
- `@cumulus/common/step-functions.getCompletedExecutionStatus`

Updated the integration tests accordingly.

Added a script to `@cumulus/common` to generate jsdocs for that module.

Improved the documentation of `@cumulus/common/step-functions`