### PR TITLE
CUMULUS-778

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `@cumulus/api` `/execution-status` endpoint requests and returns complete execution output if  execution output is stored in S3 due to size.
 - Added option to use environment variable to set CMR host in `@cumulus/cmrjs`.
+- Added `onDuplicateFilename` field to config for `@cumulus/sync-granule` to allow specifying how duplicate filenames should be handled
 
 ### Fixed
 

--- a/tasks/sync-granule/README.md
+++ b/tasks/sync-granule/README.md
@@ -7,12 +7,17 @@ Download a given granule from a given provider to S3
 ## Message Configuration
 ### Config
 
-| field name | default | values | description
-| --------   | ------- | ---------- | ----------
-| provider   | (required) | | The cumulus-api provider object
-| buckets     | (required) | | Object specifying AWS S3 buckets used by this task
-| downloadBucket      | (required) | | Name of AWS S3 bucket to use when downloading files
-| onDuplicateFilename      | error | <ul><li>`error` - Throws an error on duplicates</li><li>`replace` - Replaces the existing file</li><li>`skip` - Skips the duplicate file</li><li>`version` - Adds a suffix to the duplicate filename to avoid a clash</li></ul> | Specifies how duplicate filenames should be handled
+| field name | type | default | values | description
+| --------   | ------- | ------- | ---------- | ----------
+| buckets | object | (required) | | Object specifying AWS S3 buckets used by this task
+| downloadBucket | string | (required) | | Name of AWS S3 bucket to use when downloading files
+| provider | object | (required) | | The cumulus-api provider object
+| collection | object | | | The cumulus-api collection object
+| fileStagingDir | string | | | Directory used for staging location of files. Default is `file-staging`. Granules are further organized by stack name and collection name making the full path `file-staging/<stack name>/<collection name>`
+| forceDownload | boolean | false | |
+| onDuplicateFilename | string | error | <ul><li>`error` - Throws an error on duplicates</li><li>`replace` - Replaces the existing file</li><li>`skip` - Skips the duplicate file</li><li>`version` - Adds a suffix to the duplicate filename to avoid a clash</li></ul> | Specifies how duplicate filenames should be handled
+| pdr | object | | | Object containing the name and path for a PDR file
+| stack | string | | | The name of the deployment stack to use. Useful as a prefix.
 
 ## What is Cumulus?
 

--- a/tasks/sync-granule/README.md
+++ b/tasks/sync-granule/README.md
@@ -4,6 +4,16 @@
 
 Download a given granule from a given provider to S3
 
+## Message Configuration
+### Config
+
+| field name | default | values | description
+| --------   | ------- | ---------- | ----------
+| provider   | (required) | | The cumulus-api provider object
+| buckets     | (required) | | Object specifying AWS S3 buckets used by this task
+| downloadBucket      | (required) | | Name of AWS S3 bucket to use when downloading files
+| onDuplicateFilename      | error | <ul><li>`error` - Throws an error on duplicates</li><li>`replace` - Replaces the existing file</li><li>`skip` - Skips the duplicate file</li><li>`version` - Adds a suffix to the duplicate filename to avoid a clash</li></ul> | Specifies how duplicate filenames should be handled
+
 ## What is Cumulus?
 
 Cumulus is a cloud-based data ingest, archive, distribution and management prototype for NASA's future Earth science data streams.

--- a/tasks/sync-granule/README.md
+++ b/tasks/sync-granule/README.md
@@ -13,9 +13,9 @@ Download a given granule from a given provider to S3
 | downloadBucket | string | (required) | | Name of AWS S3 bucket to use when downloading files
 | provider | object | (required) | | The cumulus-api provider object
 | collection | object | | | The cumulus-api collection object
-| fileStagingDir | string | | | Directory used for staging location of files. Default is `file-staging`. Granules are further organized by stack name and collection name making the full path `file-staging/<stack name>/<collection name>`
-| forceDownload | boolean | false | |
-| onDuplicateFilename | string | error | <ul><li>`error` - Throws an error on duplicates</li><li>`replace` - Replaces the existing file</li><li>`skip` - Skips the duplicate file</li><li>`version` - Adds a suffix to the duplicate filename to avoid a clash</li></ul> | Specifies how duplicate filenames should be handled
+| fileStagingDir | string | `file-staging` | | Directory used for staging location of files. Granules are further organized by stack name and collection name making the full path `file-staging/<stack name>/<collection name>`
+| forceDownload | boolean | `false` | |
+| onDuplicateFilename | string | `error` | <ul><li>`error` - Throws an error on duplicates</li><li>`replace` - Replaces the existing file</li><li>`skip` - Skips the duplicate file</li><li>`version` - Adds a suffix to the duplicate filename to avoid a clash</li></ul> | Specifies how duplicate filenames should be handled
 | pdr | object | | | Object containing the name and path for a PDR file
 | stack | string | | | The name of the deployment stack to use. Useful as a prefix.
 

--- a/tasks/sync-granule/schemas/config.json
+++ b/tasks/sync-granule/schemas/config.json
@@ -38,7 +38,7 @@
       "patternProperties": {
         "\\S*": {
           "description": "bucket configuration for the key'd bucket",
-          "type": "object", 
+          "type": "object",
           "properties": {
             "name": {
               "type": "string",
@@ -87,6 +87,12 @@
         "name": { "type": "string" },
         "path": { "type": "string" }
       }
+    },
+    "onDuplicateFilename": {
+      "type": "string",
+      "description": "Specifies how duplicate filenames should be handled",
+      "enum": ["replace", "version", "skip", "error"],
+      "default": "error"
     }
   }
 }

--- a/tasks/sync-granule/schemas/config.json
+++ b/tasks/sync-granule/schemas/config.json
@@ -90,7 +90,7 @@
     },
     "onDuplicateFilename": {
       "type": "string",
-      "description": "Specifies how duplicate filenames should be handled",
+      "description": "Specifies how duplicate filenames should be handled. `error` will throw an error that, if not caught, will fail the task/workflow execution. `version` will add a suffix to the duplicate filename to avoid a clash.",
       "enum": ["replace", "version", "skip", "error"],
       "default": "error"
     }


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-778: As a DAAC operator, I want a method for configuring how a workflow's sync granule task's handles files already existing at the target location so I may determine what happens when the same data is encountered twice](https://bugs.earthdata.nasa.gov/browse/CUMULUS-778)

## Changes

* Update `config.json` schema for `sync-granule` task to document new `onDuplicateFilename` parameter
* Update documentation for `sync-granule` task to explain `onDuplicateFilename` parameter, including possible values and their behaviors

