### PR TITLE
Set stopOnSpecFailure to false in jasmine configuration

### DIFF
--- a/example/spec/support/jasmine.json
+++ b/example/spec/support/jasmine.json
@@ -9,7 +9,7 @@
   "helpers": [
     "helpers/**/*.js"
   ],
-  "stopOnSpecFailure": true,
+  "stopOnSpecFailure": false,
   "stopSpecOnExpectationFailure": false,
   "random": false
 }


### PR DESCRIPTION
stopOnSpecFailure causes AfterAll not to run in cases of test failure.   This can result in cleanups not being run and all the issues that implies (garbage left on s3/databases, stacks in inconsistent states).   