### PR TITLE
Fix travis_wait_new to fail if the background command fails

### DIFF
--- a/travis-ci/travis_wait_new
+++ b/travis-ci/travis_wait_new
@@ -19,6 +19,7 @@ cmd="$@"
 
 # running cmd at background
 ${cmd} &
+pid=$!
 
 # ping per minutes
 MINUTES=0
@@ -28,10 +29,14 @@ do
     echo -n -e " \b"  # never leave evidence
 
     if [ ${MINUTES} == ${LIMIT} ]; then
-        break;
+        exit 1;
     fi
 
     MINUTES=$((MINUTES + 1))
 
     sleep 60
 done
+
+# exit with the status code of cmd
+wait $pid
+exit $?


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-XX: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-XXX)

## Changes

* Detailed list or prose of changes
* ...

## Test Plan
Things that should succeed before merging.

- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Update CHANGELOG
- [ ] Run `./bin/eslint-ratchet` and verify that eslint errors have not increased
  - [ ] Commit `.eslint-ratchet-high-water-mark` if the score has improved

## Release PR

If this is a **release** PR, make sure you branch name starts with `release-` prefix, e.g. `release-v-1.1.2`.

Reviewers: @tag-your-friends
