### PR TITLE
Update output order in waitForCompletedExecution

### DIFF
--- a/packages/integration-tests/index.js
+++ b/packages/integration-tests/index.js
@@ -96,6 +96,7 @@ async function waitForCompletedExecution(executionArn, timeout = 600) {
   const stopTime = Date.now() + (timeout * 1000);
   /* eslint-disable no-await-in-loop */
   do {
+    iteration += 1;
     try {
       executionStatus = await getExecutionStatus(executionArn);
     }
@@ -105,14 +106,13 @@ async function waitForCompletedExecution(executionArn, timeout = 600) {
         throw err;
       }
       console.log("Execution does not exist... assuming it's still starting up.");
-      executionStatus = 'RUNNING';
+      executionStatus = 'STARTING';
     }
     if (executionStatus === 'RUNNING') {
-      iteration += 1;
-      if (!(iteration % 12)) console.log('Execution running....'); // Output a 'heartbeat' every minute
-      await sleep(5000);
+      if (!(iteration %12)) console.log('Execution running....'); // Output a 'heartbeat' every minute
     }
-  } while (executionStatus === 'RUNNING' && Date.now() < stopTime);
+    await sleep(5000);
+  } while (['RUNNING', 'STARTING'].includes(executionStatus) && Date.now() < stopTime);
   /* eslint-enable no-await-in-loop */
 
   if (executionStatus === 'RUNNING') {


### PR DESCRIPTION
**Summary:** Minor output/logging fix to integration-test helpers

Addresses [CUMULUS-929](https://bugs.earthdata.nasa.gov/browse/CUMULUS-929)

## Changes

* Updates waitForCompletedExecution output


## Test Plan
Things that should succeed before merging.

- [x] Unit tests
- [x] Adhoc testing
- [x] Update CHANGELOG
- [ ] Run `./bin/eslint-ratchet` and verify that eslint errors have not increased
  - [ ] Commit `.eslint-ratchet-high-water-mark` if the score has improved


