### PR TITLE
CUMULUS-785

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,13 +25,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Updated `@cumulus/sync-granule` task and `Granule.ingestFile` in `@cumulus/ingest` to keep both old and new data when a destination file with different checksum already exists and `duplicateHandling` is `version` (CUMULUS-782)
+- **CUMULUS-778** - Updated config schema and documentation in `@cumulus/sync-granule` to include `duplicateHandling` parameter for specifying how duplicate filenames should be handled
 - **CUMULUS-779** - Updated `@cumulus/sync-granule` to throw `DuplicateFile` error when destination files already exist and `duplicateHandling` is `error`
 - **CUMULUS-780** - Updated `@cumulus/sync-granule` to use `error` as the default for `duplicateHandling` when it is not specified
 - **CUMULUS-780** - Updated `@cumulus/api` to use `error` as the default value for `duplicateHandling` in the `Collection` model
+- **CUMULUS-785** - Updated the config schema and documentation in `@cumulus/move-granules` to include `duplicateHandling` parameter for specifying how duplicate filenames should be handled
 
 ### Fixed
 
-- Updated config schema and documentation in `@cumulus/sync-granule` to include `duplicateHandling` parameter for specifying how duplicate filenames should be handled
 - Updated the config schema in `@cumulus/move-granules` to include the `moveStagedFiles` param.
 - `getGranuleId` in `@cumulus/ingest` bug: `getGranuleId` was constructing an error using `filename` which was undefined. The fix replaces `filename` with the `uri` argument.
 

--- a/tasks/move-granules/README.md
+++ b/tasks/move-granules/README.md
@@ -4,6 +4,20 @@
 
 This lambda function is responsible for moving granule files from a file staging location to their final location.
 
+## Message Configuration
+### Config
+
+| field name | type | default | values | description
+| --------   | ------- | ------- | ---------- | ----------
+| bucket | string | (required) | | Bucket with public/private key for decrypting CMR password
+| buckets | object | (required) | | Object specifying AWS S3 buckets used by this task
+| collection | object | (required) | | The cumulus-api collection object
+| distribution_endpoint | string | (required) | | The API distribution endpoint
+| input_granules | array\<object\> | (required) | | Array of Granule objects to construct output for Cumulus indexer
+| duplicateHandling | string | `error` | <ul><li>`error` - Throws an error on duplicates</li><li>`replace` - Replaces the existing file</li><li>`skip` - Skips the duplicate file</li><li>`version` - Adds a suffix to the duplicate filename to avoid a clash</li></ul> | Specifies how duplicate filenames should be handled
+| granuleIdExtraction | string | | | The regex needed for extracting granuleId from filenames
+| moveStagedFiles | boolean | `true` | | Can set to `false` to skip moving files from the staging location. Defaults to `true`.
+
 ## What is Cumulus?
 
 Cumulus is a cloud-based data ingest, archive, distribution and management prototype for NASA's future Earth science data streams.

--- a/tasks/move-granules/README.md
+++ b/tasks/move-granules/README.md
@@ -14,7 +14,7 @@ This lambda function is responsible for moving granule files from a file staging
 | collection | object | (required) | | The cumulus-api collection object
 | distribution_endpoint | string | (required) | | The API distribution endpoint
 | input_granules | array\<object\> | (required) | | Array of Granule objects to construct output for Cumulus indexer
-| duplicateHandling | string | `error` | <ul><li>`error` - Throws an error on duplicates</li><li>`replace` - Replaces the existing file</li><li>`skip` - Skips the duplicate file</li><li>`version` - Adds a suffix to the duplicate filename to avoid a clash</li></ul> | Specifies how duplicate filenames should be handled
+| duplicateHandling | string | `error` | <ul><li>`error` - Throws an error on duplicates</li><li>`replace` - Replaces the existing file</li><li>`skip` - Skips the duplicate file</li><li>`version` - Adds a suffix to the existing filename to avoid a clash</li></ul> | Specifies how duplicate filenames should be handled
 | granuleIdExtraction | string | | | The regex needed for extracting granuleId from filenames
 | moveStagedFiles | boolean | `true` | | Can set to `false` to skip moving files from the staging location. Defaults to `true`.
 

--- a/tasks/move-granules/schemas/config.json
+++ b/tasks/move-granules/schemas/config.json
@@ -80,7 +80,7 @@
     },
     "duplicateHandling": {
       "type": "string",
-      "description": "Specifies how duplicate filenames should be handled. `error` will throw an error that, if not caught, will fail the task/workflow execution. `version` will add a suffix to the duplicate filename to avoid a clash.",
+      "description": "Specifies how duplicate filenames should be handled. `error` will throw an error that, if not caught, will fail the task/workflow execution. `version` will add a suffix to the existing filename to avoid a clash.",
       "enum": ["replace", "version", "skip", "error"],
       "default": "error"
     }

--- a/tasks/move-granules/schemas/config.json
+++ b/tasks/move-granules/schemas/config.json
@@ -77,6 +77,12 @@
     "moveStagedFiles": {
       "type": "boolean",
       "description": "Can set to false to skip moving files from the staging location. Defaults to true."
+    },
+    "duplicateHandling": {
+      "type": "string",
+      "description": "Specifies how duplicate filenames should be handled. `error` will throw an error that, if not caught, will fail the task/workflow execution. `version` will add a suffix to the duplicate filename to avoid a clash.",
+      "enum": ["replace", "version", "skip", "error"],
+      "default": "error"
     }
   }
 }

--- a/tasks/sync-granule/README.md
+++ b/tasks/sync-granule/README.md
@@ -13,7 +13,7 @@ Download a given granule from a given provider to S3
 | downloadBucket | string | (required) | | Name of AWS S3 bucket to use when downloading files
 | provider | object | (required) | | The cumulus-api provider object
 | collection | object | | | The cumulus-api collection object
-| duplicateHandling | string | `error` | <ul><li>`error` - Throws an error on duplicates</li><li>`replace` - Replaces the existing file</li><li>`skip` - Skips the duplicate file</li><li>`version` - Adds a suffix to the duplicate filename to avoid a clash</li></ul> | Specifies how duplicate filenames should be handled
+| duplicateHandling | string | `error` | <ul><li>`error` - Throws an error on duplicates</li><li>`replace` - Replaces the existing file</li><li>`skip` - Skips the duplicate file</li><li>`version` - Adds a suffix to the existing filename to avoid a clash</li></ul> | Specifies how duplicate filenames should be handled
 | fileStagingDir | string | `file-staging` | | Directory used for staging location of files. Granules are further organized by stack name and collection name making the full path `file-staging/<stack name>/<collection name>`
 | forceDownload | boolean | `false` | |
 | pdr | object | | | Object containing the name and path for a PDR file

--- a/tasks/sync-granule/schemas/config.json
+++ b/tasks/sync-granule/schemas/config.json
@@ -90,7 +90,7 @@
     },
     "duplicateHandling": {
       "type": "string",
-      "description": "Specifies how duplicate filenames should be handled. `error` will throw an error that, if not caught, will fail the task/workflow execution. `version` will add a suffix to the duplicate filename to avoid a clash.",
+      "description": "Specifies how duplicate filenames should be handled. `error` will throw an error that, if not caught, will fail the task/workflow execution. `version` will add a suffix to the existing filename to avoid a clash.",
       "enum": ["replace", "version", "skip", "error"],
       "default": "error"
     }


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-785: Document new duplicateHandling options for moveGranules task](https://bugs.earthdata.nasa.gov/browse/CUMULUS-785)

## Changes

* Update `@cumulus/move-granules` config schema to document new `duplicateHandling` parameter
* Update `@cumulus/move-granules` documentation with new `duplicateHandling` parameter

## Test Plan
Things that should succeed before merging.

- [ ] Update CHANGELOG
