### PR TITLE
Increase wait times for cmr removal.

### DIFF
--- a/example/spec/testAPI/APISuccessSpec.js
+++ b/example/spec/testAPI/APISuccessSpec.js
@@ -128,7 +128,7 @@ describe('The Cumulus API', () => {
       });
 
       // Check that the granule was removed
-      await waitForConceptExistsOutcome(cmrLink, false, 2);
+      await waitForConceptExistsOutcome(cmrLink, false, 3, 4000);
       const doesExist = await conceptExists(cmrLink);
       expect(doesExist).toEqual(false);
     });


### PR DESCRIPTION
86) The Cumulus API
granule id: MOD09GQ.A3708688.d9YFJ9.006.2109584376401

Starting workflow: IngestGranule. Execution ARN arn:aws:states:us-east-1:000000000000:execution:mhs2IngestGranuleStateMachine-O2HTRZ0hOaIt:53ef6a3e-68e8-4c9c-8568-12ab5e500f9e

.   ✔ completes execution with success status

   87) granule endpoint
.      ✔ makes the granule available through the Cumulus API
.      ✔ has the granule with a CMR link
.      ✔ allows reingest and executes with success status
F      ✖ removeFromCMR removes the ingested granule from CMR (1 failure)
.      ✔ applyWorkflow PublishGranule publishes the granule to CMR
.      ✔ can delete the ingested granule from the API

**Summary:** Increases wait duration and number of retries for the integration test
`removeFromCMR removes the ingested granule from CMR`

Addresses failing integration tests.


