### PR TITLE
Make eslint less pedantic about JSDocs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,8 +23,9 @@
   },
   "rules": {
     "indent": [ "error", 2 ],
+
     "require-jsdoc": "off",
-    "valid-jsdoc": [ "error", {
+    "valid-jsdoc": [ "warn", {
       "prefer": {
         "arg": "param",
         "return": "returns"
@@ -40,21 +41,26 @@
         "Regexp": "RegExp",
         "promise": "Promise"
       },
-      "requireReturn": true
+      "requireParamDescription": false,
+      "requireParamType": true,
+      "requireReturn": false,
+      "requireReturnDescription": false,
+      "requireReturnType": true
     }],
-    "jsdoc/check-param-names": "error",
-    "jsdoc/check-tag-names": "error",
+    "jsdoc/check-param-names": "warn",
+    "jsdoc/check-tag-names": "warn",
     "jsdoc/check-types": "off",
-    "jsdoc/newline-after-description": "error",
+    "jsdoc/newline-after-description": "off",
     "jsdoc/require-description-complete-sentence": "off",
     "jsdoc/require-example": "off",
-    "jsdoc/require-hyphen-before-param-description": "error",
-    "jsdoc/require-param": "error",
-    "jsdoc/require-param-description": "error",
-    "jsdoc/require-param-name": "error",
-    "jsdoc/require-param-type": "error",
-    "jsdoc/require-returns-description": "error",
-    "jsdoc/require-returns-type": "error",
+    "jsdoc/require-hyphen-before-param-description": "off",
+    "jsdoc/require-param": "off",
+    "jsdoc/require-param-description": "off",
+    "jsdoc/require-param-name": "warn",
+    "jsdoc/require-param-type": "off",
+    "jsdoc/require-returns-description": "off",
+    "jsdoc/require-returns-type": "off",
+
     "generator-star-spacing": "off",
     "import/no-extraneous-dependencies": "off",
     "import/newline-after-import": "off",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,31 @@ If you want to submit your own contributions, follow these steps:
 
 We ask that you follow these guidelines with your contributions:
 
+### Documenation
+
+Anything exported by a module must be documented using [JSDoc](http://usejsdoc.org/).
+
+The following JSDoc rules are enforced by our [eslint](https://eslint.org/)
+configuration:
+
+- Use the `@param` tag instead of `@arg`
+- Use the `@returns` tag instead of `@return`
+- Preferred param types:
+  - "boolean" instead of "Boolean"
+  - "number" instead of "Number"
+  - "string" instead of "String"
+  - "Object" instead of "object"
+  - "Array" instead of "array"
+  - "Date" instead of "date"
+  - "RegExp" instead of "regex" or "Regexp"
+  - "Promise" instead of "promise"
+- `@param` tags should have a type and a name. Example:
+  `@param {string} username`
+- Functions that explicitly return should have a `@returns` tag that has a type.
+  Example: `@returns {string}`
+- Parameter names must match those in the function declaration
+- Tags must be valid [JSDoc 3 Block Tags](http://usejsdoc.org/#block-tags)
+
 ### Tests
 
 All of the automated tests for this project need to pass before your submission will be accepted. You can run `npm test` in the command line after making changes to verify that the tests pass. If you add new functionality, please consider adding tests for that functionality as well.


### PR DESCRIPTION
As discussed in today's architecture meeting, adding information to the CONTRIBUTING document about expectations for JSDocs, and then relaxing eslint's JSDoc checks.