### PR TITLE
Cumulus 924 add logging to kinesis consumer

### DIFF
--- a/example/spec/testAPI/APISuccessSpec.js
+++ b/example/spec/testAPI/APISuccessSpec.js
@@ -135,7 +135,7 @@ describe('The Cumulus API', () => {
       });
 
       // Check that the granule was removed
-      await waitForConceptExistsOutcome(cmrLink, false, 2);
+      await waitForConceptExistsOutcome(cmrLink, false, 10, 4000);
       const doesExist = await conceptExists(cmrLink);
       expect(doesExist).toEqual(false);
     });

--- a/packages/api/lambdas/kinesis-consumer.js
+++ b/packages/api/lambdas/kinesis-consumer.js
@@ -156,6 +156,7 @@ function processRecord(record, fromSNS) {
 
   try {
     eventObject = JSON.parse(dataString);
+    log.debug('processRecord eventObject', eventObject);
   }
   catch (err) {
     log.error('Caught error parsing JSON:');


### PR DESCRIPTION
**Summary:**  

Increases time to wait in tests for cmr to remove a granule. [fixes Integration Tests.]
Adds a log when kinesis consumer processes an object for debugging convenience.


