### PR TITLE
Cumulus 955 add times to jasmine suite output

### DIFF
--- a/example/spec/helpers/reporters/consoleReporter.js
+++ b/example/spec/helpers/reporters/consoleReporter.js
@@ -1,7 +1,7 @@
 const JasmineConsoleReporter = require('jasmine-console-reporter');
 
 const consoleReporter = new JasmineConsoleReporter({
-  colors: 1, // (0|false)|(1|true)|2
+  colors: 2, // (0|false)|(1|true)|2
   cleanStack: 1, // (0|false)|(1|true)|2|3
   verbosity: 4, // (0|false)|1|2|(3|true)|4
   listStyle: 'indent', // "flat"|"indent"

--- a/example/spec/helpers/reporters/suiteTimeReporter.js
+++ b/example/spec/helpers/reporters/suiteTimeReporter.js
@@ -1,0 +1,16 @@
+const SuiteTimeReporter = function () {
+  const suiteTimers = {};
+  return {
+    suiteStarted: (result) => {
+      suiteTimers[result.description] = (new Date()).valueOf();
+    },
+    suiteDone: (result) => {
+      const duration = (new Date()).valueOf() - suiteTimers[result.description];
+      console.log(`\nsuiteDone: ${duration / 1000.0} secs "${result.description}"`);
+    }
+  };
+};
+
+const suiteTimeReporter = new SuiteTimeReporter();
+
+jasmine.getEnv().addReporter(suiteTimeReporter);


### PR DESCRIPTION
**Summary:** Adds custom reporter to jasmine that outputs the duration of each test suite (describes).

Addresses [CUMULUS-955: display suite durations](https://bugs.earthdata.nasa.gov/browse/CUMULUS-955)

## Changes

* Adds custom reporter to display the time each suite takes as it exits.
* Changes ansi codes to travis to display jasmine output in color.
