### PR TITLE
Run API test in parallel where possible

### DIFF
--- a/packages/api/models/base.js
+++ b/packages/api/models/base.js
@@ -4,8 +4,29 @@ const deprecate = require('depd')('@cumulus/api/Manager');
 const Ajv = require('ajv');
 const cloneDeep = require('lodash.clonedeep');
 const aws = require('@cumulus/common/aws');
+const pWaitFor = require('p-wait-for');
+const { inTestMode } = require('@cumulus/common/test-utils');
 const { errorify } = require('../lib/utils');
 const { RecordDoesNotExist } = require('../lib/errors');
+
+async function enableStream(tableName) {
+  const params = {
+    TableName: tableName,
+    StreamSpecification: {
+      StreamEnabled: true,
+      StreamViewType: 'NEW_AND_OLD_IMAGES'
+    }
+  };
+
+  await aws.dynamodb().updateTable(params).promise();
+
+  await pWaitFor(
+    async () =>
+      aws.dynamodb().describeTable({ TableName: tableName }).promise()
+        .then((response) => response.TableStatus !== 'UPDATING'),
+    { interval: 5 * 1000 }
+  );
+}
 
 async function createTable(tableName, hash, range = null) {
   const params = {
@@ -21,10 +42,6 @@ async function createTable(tableName, hash, range = null) {
     ProvisionedThroughput: {
       ReadCapacityUnits: 5,
       WriteCapacityUnits: 5
-    },
-    StreamSpecification: {
-      StreamEnabled: true,
-      StreamViewType: 'NEW_AND_OLD_IMAGES'
     }
   };
 
@@ -42,6 +59,9 @@ async function createTable(tableName, hash, range = null) {
 
   const output = await aws.dynamodb().createTable(params).promise();
   await aws.dynamodb().waitFor('tableExists', { TableName: tableName }).promise();
+
+  if (!inTestMode()) await enableStream(tableName);
+
   return output;
 }
 
@@ -129,6 +149,15 @@ class Manager {
    */
   deleteTable() {
     return deleteTable(this.tableName);
+  }
+
+  /**
+   * Enable DynamoDB streams on the table
+   *
+   * @returns {Promise} resolves when streams are enabled
+   */
+  enableStream() {
+    return enableStream(this.tableName);
   }
 
   /**

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -10,16 +10,18 @@
     "cumulus-api": "./bin/cli.js"
   },
   "scripts": {
-    "test": "ava --serial --fail-fast",
-    "test-coverage": "nyc ava",
+    "test": "ava && ava --serial tests/serial/",
+    "test-coverage": "nyc npm test",
     "build": "webpack",
     "watch": "webpack --progress -w",
     "prepublishOnly": "PRODUCTION=true npm run build"
   },
   "ava": {
-    "files": "tests/**/*.js",
-    "fail-fast": true,
-    "serial": true
+    "files": [
+      "tests/**/*.js",
+      "!tests/serial/**/*.js"
+    ],
+    "fail-fast": true
   },
   "nyc": {
     "exclude": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -76,6 +76,7 @@
     "node-forge": "^0.7.1",
     "p-limit": "^1.2.0",
     "p-retry": "^2.0.0",
+    "p-wait-for": "https://github.com/yjpa7145/p-wait-for.git#StopChecksAfterTimeout",
     "querystring": "^0.2.0",
     "split2": "^2.2.0",
     "uuid": "^3.2.1"

--- a/packages/api/tests/serial/cli/test-es-cli.js
+++ b/packages/api/tests/serial/cli/test-es-cli.js
@@ -3,10 +3,10 @@
 const test = require('ava');
 const get = require('lodash.get');
 
-const { Search } = require('../../es/search');
-const { bootstrapElasticSearch } = require('../../lambdas/bootstrap');
-const es = require('../../bin/es');
-const mappings = require('../../models/mappings.json');
+const { Search } = require('../../../es/search');
+const { bootstrapElasticSearch } = require('../../../lambdas/bootstrap');
+const es = require('../../../bin/es');
+const mappings = require('../../../models/mappings.json');
 
 const esIndex = 'cumulus-1';
 const indexAlias = 'cumulus-1-alias';

--- a/packages/api/tests/serial/endpoints/collections.js
+++ b/packages/api/tests/serial/endpoints/collections.js
@@ -4,18 +4,18 @@ const test = require('ava');
 const sinon = require('sinon');
 const aws = require('@cumulus/common/aws');
 const { randomString } = require('@cumulus/common/test-utils');
-const models = require('../../models');
-const bootstrap = require('../../lambdas/bootstrap');
-const collectionsEndpoint = require('../../endpoints/collections');
+const models = require('../../../models');
+const bootstrap = require('../../../lambdas/bootstrap');
+const collectionsEndpoint = require('../../../endpoints/collections');
 const {
   fakeCollectionFactory,
   fakeUserFactory,
   testEndpoint
-} = require('../../lib/testUtils');
-const EsCollection = require('../../es/collections');
-const { Search } = require('../../es/search');
-const assertions = require('../../lib/assertions');
-const { RecordDoesNotExist } = require('../../lib/errors');
+} = require('../../../lib/testUtils');
+const EsCollection = require('../../../es/collections');
+const { Search } = require('../../../es/search');
+const assertions = require('../../../lib/assertions');
+const { RecordDoesNotExist } = require('../../../lib/errors');
 
 process.env.CollectionsTable = randomString();
 process.env.UsersTable = randomString();

--- a/packages/api/tests/serial/endpoints/executions.js
+++ b/packages/api/tests/serial/endpoints/executions.js
@@ -3,17 +3,17 @@
 const test = require('ava');
 const aws = require('@cumulus/common/aws');
 const { randomString } = require('@cumulus/common/test-utils');
-const models = require('../../models');
-const bootstrap = require('../../lambdas/bootstrap');
-const executionEndpoint = require('../../endpoints/executions');
-const indexer = require('../../es/indexer');
+const models = require('../../../models');
+const bootstrap = require('../../../lambdas/bootstrap');
+const executionEndpoint = require('../../../endpoints/executions');
+const indexer = require('../../../es/indexer');
 const {
   testEndpoint,
   fakeExecutionFactory,
   fakeUserFactory
-} = require('../../lib/testUtils');
-const { Search } = require('../../es/search');
-const assertions = require('../../lib/assertions');
+} = require('../../../lib/testUtils');
+const { Search } = require('../../../es/search');
+const assertions = require('../../../lib/assertions');
 
 // create all the variables needed across this test
 let esClient;

--- a/packages/api/tests/serial/endpoints/granules.js
+++ b/packages/api/tests/serial/endpoints/granules.js
@@ -10,16 +10,16 @@ const { randomString } = require('@cumulus/common/test-utils');
 const xml2js = require('xml2js');
 const { xmlParseOptions } = require('@cumulus/cmrjs/utils');
 
-const assertions = require('../../lib/assertions');
-const models = require('../../models');
-const bootstrap = require('../../lambdas/bootstrap');
-const handleRequest = require('../../endpoints/granules');
-const indexer = require('../../es/indexer');
+const assertions = require('../../../lib/assertions');
+const models = require('../../../models');
+const bootstrap = require('../../../lambdas/bootstrap');
+const handleRequest = require('../../../endpoints/granules');
+const indexer = require('../../../es/indexer');
 const {
   fakeGranuleFactoryV2,
   fakeUserFactory
-} = require('../../lib/testUtils');
-const { Search } = require('../../es/search');
+} = require('../../../lib/testUtils');
+const { Search } = require('../../../es/search');
 
 const createBucket = (Bucket) => aws.s3().createBucket({ Bucket }).promise();
 

--- a/packages/api/tests/serial/endpoints/pdrs.js
+++ b/packages/api/tests/serial/endpoints/pdrs.js
@@ -3,17 +3,17 @@
 const test = require('ava');
 const aws = require('@cumulus/common/aws');
 const { randomString } = require('@cumulus/common/test-utils');
-const models = require('../../models');
-const bootstrap = require('../../lambdas/bootstrap');
-const pdrEndpoint = require('../../endpoints/pdrs');
-const indexer = require('../../es/indexer');
+const models = require('../../../models');
+const bootstrap = require('../../../lambdas/bootstrap');
+const pdrEndpoint = require('../../../endpoints/pdrs');
+const indexer = require('../../../es/indexer');
 const {
   testEndpoint,
   fakePdrFactory,
   fakeUserFactory
-} = require('../../lib/testUtils');
-const { Search } = require('../../es/search');
-const assertions = require('../../lib/assertions');
+} = require('../../../lib/testUtils');
+const { Search } = require('../../../es/search');
+const assertions = require('../../../lib/assertions');
 
 const pdrS3Key = (stackName, bucket, pdrName) => `${process.env.stackName}/pdrs/${pdrName}`;
 

--- a/packages/api/tests/serial/endpoints/reconciliation-reports.js
+++ b/packages/api/tests/serial/endpoints/reconciliation-reports.js
@@ -3,13 +3,13 @@
 const test = require('ava');
 const aws = require('@cumulus/common/aws');
 const { randomString } = require('@cumulus/common/test-utils');
-const reconciliationReportEndpoint = require('../../endpoints/reconciliation-reports');
+const reconciliationReportEndpoint = require('../../../endpoints/reconciliation-reports');
 const {
   fakeUserFactory,
   testEndpoint
-} = require('../../lib/testUtils');
-const assertions = require('../../lib/assertions');
-const models = require('../../models');
+} = require('../../../lib/testUtils');
+const assertions = require('../../../lib/assertions');
+const models = require('../../../models');
 
 process.env.invoke = 'granule-reconciliation-reports';
 process.env.stackName = 'test-stack';

--- a/packages/api/tests/serial/endpoints/rules.js
+++ b/packages/api/tests/serial/endpoints/rules.js
@@ -4,15 +4,15 @@ const test = require('ava');
 const cloneDeep = require('lodash.clonedeep');
 const aws = require('@cumulus/common/aws');
 const { randomString } = require('@cumulus/common/test-utils');
-const bootstrap = require('../../lambdas/bootstrap');
-const models = require('../../models');
-const rulesEndpoint = require('../../endpoints/rules');
+const bootstrap = require('../../../lambdas/bootstrap');
+const models = require('../../../models');
+const rulesEndpoint = require('../../../endpoints/rules');
 const {
   fakeUserFactory,
   testEndpoint
-} = require('../../lib/testUtils');
-const { Search } = require('../../es/search');
-const assertions = require('../../lib/assertions');
+} = require('../../../lib/testUtils');
+const { Search } = require('../../../es/search');
+const assertions = require('../../../lib/assertions');
 
 const esIndex = randomString();
 

--- a/packages/api/tests/serial/es/test-db-indexer.js
+++ b/packages/api/tests/serial/es/test-db-indexer.js
@@ -9,17 +9,17 @@ const {
   util: { noop }
 } = require('@cumulus/common');
 
-const models = require('../../models');
-const { Search } = require('../../es/search');
-const bootstrap = require('../../lambdas/bootstrap');
-const dbIndexer = require('../../lambdas/db-indexer');
+const models = require('../../../models');
+const { Search } = require('../../../es/search');
+const bootstrap = require('../../../lambdas/bootstrap');
+const dbIndexer = require('../../../lambdas/db-indexer');
 const {
   fakeCollectionFactory,
   fakeGranuleFactory,
   fakeExecutionFactory,
   fakeFilesFactory,
   deleteAliases
-} = require('../../lib/testUtils');
+} = require('../../../lib/testUtils');
 
 let esClient;
 const seq = new Set(); // to keep track of processed records in the stream

--- a/packages/api/tests/serial/es/test-db-indexer.js
+++ b/packages/api/tests/serial/es/test-db-indexer.js
@@ -110,10 +110,18 @@ test.before(async () => {
   fileModel = new models.FileClass();
   executionModel = new models.Execution();
 
-  await collectionModel.createTable();
-  await granuleModel.createTable();
-  await fileModel.createTable();
-  await executionModel.createTable();
+  await Promise.all([
+    collectionModel.createTable(),
+    executionModel.createTable(),
+    fileModel.createTable(),
+    granuleModel.createTable()
+  ]);
+
+  await Promise.all([
+    collectionModel.enableStream(),
+    executionModel.enableStream(),
+    granuleModel.enableStream()
+  ]);
 
   // bootstrap the esIndex
   esClient = await Search.es();

--- a/packages/api/tests/serial/es/test-es-indexer-log.js
+++ b/packages/api/tests/serial/es/test-es-indexer-log.js
@@ -4,11 +4,11 @@ const test = require('ava');
 const fs = require('fs');
 const path = require('path');
 const { randomString } = require('@cumulus/common/test-utils');
-const { deleteAliases } = require('../../lib/testUtils');
-const indexer = require('../../es/indexer');
-const { Search } = require('../../es/search');
-const queries = require('../../es/queries');
-const { bootstrapElasticSearch } = require('../../lambdas/bootstrap');
+const { deleteAliases } = require('../../../lib/testUtils');
+const indexer = require('../../../es/indexer');
+const { Search } = require('../../../es/search');
+const queries = require('../../../es/queries');
+const { bootstrapElasticSearch } = require('../../../lambdas/bootstrap');
 
 const esIndex = randomString();
 process.env.ES_INDEX = esIndex;
@@ -26,7 +26,7 @@ test.after.always(async () => {
 
 test.serial('indexing log messages', async (t) => {
   // input log events
-  const inputtxt = fs.readFileSync(path.join(__dirname, '../data/log_events_input.txt'), 'utf8');
+  const inputtxt = fs.readFileSync(path.join(__dirname, '../../data/log_events_input.txt'), 'utf8');
   const event = JSON.parse(JSON.parse(inputtxt.toString()));
   const response = await indexer.indexLog(esClient, event.logEvents);
   t.false(response.errors);
@@ -35,7 +35,7 @@ test.serial('indexing log messages', async (t) => {
   await esClient.indices.refresh();
   // console.log(JSON.stringify(response, null, 2));
   // expected result in elastic search
-  const estxt = fs.readFileSync(path.join(__dirname, '../data/log_events_expected.json'), 'utf8');
+  const estxt = fs.readFileSync(path.join(__dirname, '../../data/log_events_expected.json'), 'utf8');
   const expected = JSON.parse(estxt.toString());
   // records are in elasticsearch
   const records = await esClient.mget({

--- a/packages/api/tests/serial/es/test-es-indexer.js
+++ b/packages/api/tests/serial/es/test-es-indexer.js
@@ -13,15 +13,15 @@ const {
   util: { noop }
 } = require('@cumulus/common');
 
-const indexer = require('../../es/indexer');
-const { Search } = require('../../es/search');
-const models = require('../../models');
-const { fakeGranuleFactory, fakeCollectionFactory, deleteAliases } = require('../../lib/testUtils');
-const { bootstrapElasticSearch } = require('../../lambdas/bootstrap');
-const granuleSuccess = require('../data/granule_success.json');
-const granuleFailure = require('../data/granule_failed.json');
-const pdrFailure = require('../data/pdr_failure.json');
-const pdrSuccess = require('../data/pdr_success.json');
+const indexer = require('../../../es/indexer');
+const { Search } = require('../../../es/search');
+const models = require('../../../models');
+const { fakeGranuleFactory, fakeCollectionFactory, deleteAliases } = require('../../../lib/testUtils');
+const { bootstrapElasticSearch } = require('../../../lambdas/bootstrap');
+const granuleSuccess = require('../../data/granule_success.json');
+const granuleFailure = require('../../data/granule_failed.json');
+const pdrFailure = require('../../data/pdr_failure.json');
+const pdrSuccess = require('../../data/pdr_success.json');
 
 const esIndex = randomString();
 process.env.bucket = randomString();
@@ -662,7 +662,7 @@ test.serial('reingest a granule', async (t) => {
 test.serial('pass a sns message to main handler', async (t) => {
   const txt = fs.readFileSync(path.join(
     __dirname,
-    '../data/sns_message_granule.txt'
+    '../../data/sns_message_granule.txt'
   ), 'utf8');
 
   const event = JSON.parse(JSON.parse(txt.toString()));
@@ -693,7 +693,7 @@ test.serial('pass a sns message to main handler', async (t) => {
 test.serial('pass a sns message to main handler with parse info', async (t) => {
   const txt = fs.readFileSync(path.join(
     __dirname,
-    '../data/sns_message_parse_pdr.txt'
+    '../../data/sns_message_parse_pdr.txt'
   ), 'utf8');
 
   const event = JSON.parse(JSON.parse(txt.toString()));
@@ -721,7 +721,7 @@ test.serial('pass a sns message to main handler with parse info', async (t) => {
 
 test.serial('pass a sns message to main handler with discoverpdr info', async (t) => {
   const txt = fs.readFileSync(path.join(
-    __dirname, '../data/sns_message_discover_pdr.txt'
+    __dirname, '../../data/sns_message_discover_pdr.txt'
   ), 'utf8');
 
   const event = JSON.parse(JSON.parse(txt.toString()));

--- a/travis-ci/run-api-unit-tests.sh
+++ b/travis-ci/run-api-unit-tests.sh
@@ -3,6 +3,7 @@
 set -e
 
 (
+  set -e
   cd packages/api
-  ./node_modules/.bin/nyc ./node_modules/.bin/ava
+  npm run test-coverage
 )


### PR DESCRIPTION
Moves test files that can't be run in parallel to a `tests/serial` directory.  All of the other tests are run in parallel, then the tests in `tests/serial` are run in serial.

In local testing I saw tests go from taking 313 seconds down to 172 seconds.