### PR TITLE
Remove references to e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,5 +58,4 @@ jobs:
               cd packages/api
               ./node_modules/.bin/ava --serial
               cd ../..
-              yarn e2e
             fi

--- a/README.md
+++ b/README.md
@@ -83,10 +83,6 @@ Run the test commands next
     $ export LOCALSTACK_HOST=localhost
     $ yarn test
 
-Run end to end tests with
-
-    $ yarn e2e
-
 ### Integration Tests
 
 For more information please [read this](docs/development/integration-tests.md).


### PR DESCRIPTION
**Summary:**

* Remove reference to `yarn e2e` from `README.md`
* Remove reference to `yarn e2e` from `.circleci/config.yml`

- [ ] Unit tests
- [ ] Adhoc testing
