### PR TITLE
CUMULUS-965 use eslint overrides

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -119,5 +119,49 @@
 
     "unicorn/filename-case": "off",
     "unicorn/prefer-spread": "off"
-  }
+  },
+  "overrides": [
+    {
+      "files": [
+        "packages/api/migrations/**/*.js"
+      ],
+      "rules": {
+        "no-console": "off"
+      }
+    },
+    {
+      "files": [
+        "packages/deployment/**/*.js"
+      ],
+      "rules": {
+        "no-console": "off"
+      }
+    },
+    {
+      "files": [
+        "**/bin/**/*.js"
+      ],
+      "rules": {
+        "no-console": "off"
+      }
+    },
+    {
+      "files": [
+        "**/test/**/*.js",
+        "**/tests/**/*.js"
+      ],
+      "rules": {
+        "no-console": "off",
+        "no-param-reassign": "off"
+      }
+    },
+    {
+      "files": [
+        "**/spec/**/*.js"
+      ],
+      "rules": {
+        "no-console": "off"
+      }
+    }
+  ]
 }

--- a/bin/.eslintrc.json
+++ b/bin/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "no-console": "off"
-  }
-}

--- a/example/spec/.eslintrc.json
+++ b/example/spec/.eslintrc.json
@@ -1,7 +1,6 @@
 {
   "rules": {
     "max-len": "off",
-    "no-console": "off",
     "operator-linebreak": [2, "after"]
   },
   "env": {

--- a/packages/api/bin/.eslintrc.json
+++ b/packages/api/bin/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "no-console": "off"
-  }
-}

--- a/packages/api/migrations/.eslintrc.json
+++ b/packages/api/migrations/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "no-console": "off"
-  }
-}

--- a/packages/api/tests/.eslintrc.json
+++ b/packages/api/tests/.eslintrc.json
@@ -1,8 +1,0 @@
-{
-  "rules": {
-    "max-len": "off",
-    "no-param-reassign": "off",
-    "no-restricted-syntax": "off",
-    "max-statements": "off"
-  }
-}

--- a/packages/api/tests/lambdas/create-reconciliation-report.js
+++ b/packages/api/tests/lambdas/create-reconciliation-report.js
@@ -277,12 +277,23 @@ test.serial('A valid reconciliation report is generated when there are extra Dyn
     granuleId: randomString()
   }));
 
-  const extraDbFile1 = { bucket: sample(dataBuckets), key: randomString(), granuleId: randomString() };
-  const extraDbFile2 = { bucket: sample(dataBuckets), key: randomString(), granuleId: randomString() };
+  const extraDbFile1 = {
+    bucket: sample(dataBuckets),
+    key: randomString(),
+    granuleId: randomString()
+  };
+  const extraDbFile2 = {
+    bucket: sample(dataBuckets),
+    key: randomString(),
+    granuleId: randomString()
+  };
 
   // Store the files to S3 and DynamoDB
   await storeFilesToS3(matchingFiles);
-  await storeFilesToDynamoDb(t.context.filesTableName, matchingFiles.concat([extraDbFile1, extraDbFile2]));
+  await storeFilesToDynamoDb(
+    t.context.filesTableName,
+    matchingFiles.concat([extraDbFile1, extraDbFile2])
+  );
 
   const event = {
     dataBuckets,
@@ -334,12 +345,23 @@ test.serial('A valid reconciliation report is generated when there are both extr
 
   const extraS3File1 = { bucket: sample(dataBuckets), key: randomString() };
   const extraS3File2 = { bucket: sample(dataBuckets), key: randomString() };
-  const extraDbFile1 = { bucket: sample(dataBuckets), key: randomString(), granuleId: randomString() };
-  const extraDbFile2 = { bucket: sample(dataBuckets), key: randomString(), granuleId: randomString() };
+  const extraDbFile1 = {
+    bucket: sample(dataBuckets),
+    key: randomString(),
+    granuleId: randomString()
+  };
+  const extraDbFile2 = {
+    bucket: sample(dataBuckets),
+    key: randomString(),
+    granuleId: randomString()
+  };
 
   // Store the files to S3 and DynamoDB
   await storeFilesToS3(matchingFiles.concat([extraS3File1, extraS3File2]));
-  await storeFilesToDynamoDb(t.context.filesTableName, matchingFiles.concat([extraDbFile1, extraDbFile2]));
+  await storeFilesToDynamoDb(
+    t.context.filesTableName,
+    matchingFiles.concat([extraDbFile1, extraDbFile2])
+  );
 
   const event = {
     dataBuckets,

--- a/packages/api/tests/serial/endpoints/granules.js
+++ b/packages/api/tests/serial/endpoints/granules.js
@@ -531,11 +531,13 @@ test.serial('DELETE deleting an existing unpublished granule', async (t) => {
   t.is(detail, 'Record deleted');
 
   // verify the files are deleted
+  /* eslint-disable no-await-in-loop */
   for (let i = 0; i < newGranule.files.length; i += 1) {
     const file = newGranule.files[i];
     const parsed = aws.parseS3Uri(file.filename);
-    t.false(await aws.fileExists(parsed.Bucket, parsed.Key)); // eslint-disable-line no-await-in-loop
+    t.false(await aws.fileExists(parsed.Bucket, parsed.Key));
   }
+  /* eslint-enable no-await-in-loop */
 
   await deleteBuckets([
     buckets.protected.name,
@@ -617,14 +619,20 @@ test.serial('move a granule with no .cmr.xml file', async (t) => {
       t.is(body.status, 'SUCCESS');
       t.is(body.action, 'move');
 
-      await aws.s3().listObjects({ Bucket: bucket, Prefix: destinationFilepath }).promise().then((list) => {
+      await aws.s3().listObjects({
+        Bucket: bucket,
+        Prefix: destinationFilepath
+      }).promise().then((list) => {
         t.is(list.Contents.length, 2);
         list.Contents.forEach((item) => {
           t.is(item.Key.indexOf(destinationFilepath), 0);
         });
       });
 
-      await aws.s3().listObjects({ Bucket: thirdBucket, Prefix: destinationFilepath }).promise().then((list) => {
+      await aws.s3().listObjects({
+        Bucket: thirdBucket,
+        Prefix: destinationFilepath
+      }).promise().then((list) => {
         t.is(list.Contents.length, 1);
         list.Contents.forEach((item) => {
           t.is(item.Key.indexOf(destinationFilepath), 0);
@@ -724,7 +732,10 @@ test.serial('move a file and update metadata', async (t) => {
   t.is(body.status, 'SUCCESS');
   t.is(body.action, 'move');
 
-  const list = await aws.s3().listObjects({ Bucket: bucket, Prefix: destinationFilepath }).promise();
+  const list = await aws.s3().listObjects({
+    Bucket: bucket,
+    Prefix: destinationFilepath
+  }).promise();
   t.is(list.Contents.length, 1);
   list.Contents.forEach((item) => {
     t.is(item.Key.indexOf(destinationFilepath), 0);
@@ -734,7 +745,10 @@ test.serial('move a file and update metadata', async (t) => {
   t.is(list2.Contents.length, 1);
   t.is(newGranule.files[1].filepath, list2.Contents[0].Key);
 
-  const file = await aws.s3().getObject({ Bucket: buckets.public.name, Key: newGranule.files[1].filepath }).promise();
+  const file = await aws.s3().getObject({
+    Bucket: buckets.public.name,
+    Key: newGranule.files[1].filepath
+  }).promise();
   await aws.recursivelyDeleteS3Bucket(buckets.public.name);
   return new Promise((resolve, reject) => {
     xml2js.parseString(file.Body, xmlParseOptions, (err, data) => {

--- a/packages/api/tests/serial/endpoints/pdrs.js
+++ b/packages/api/tests/serial/endpoints/pdrs.js
@@ -62,7 +62,12 @@ test.before(async () => {
 
   // create fake granule records
   fakePdrs = ['completed', 'failed'].map(fakePdrFactory);
-  await Promise.all(fakePdrs.map((pdr) => pdrModel.create(pdr).then((record) => indexer.indexPdr(esClient, record, esIndex))));
+  await Promise.all(
+    fakePdrs.map(
+      (pdr) => pdrModel.create(pdr)
+        .then((record) => indexer.indexPdr(esClient, record, esIndex))
+    )
+  );
 });
 
 test.after.always(async () => {

--- a/packages/api/tests/serial/es/test-es-indexer.js
+++ b/packages/api/tests/serial/es/test-es-indexer.js
@@ -372,6 +372,7 @@ test.serial('indexing a collection record', async (t) => {
 
 test.serial('indexing collection records with different versions', async (t) => {
   const name = randomString();
+  /* eslint-disable no-await-in-loop */
   for (let i = 1; i < 11; i += 1) {
     const version = `00${i}`;
     const key = `key${i}`;
@@ -382,10 +383,11 @@ test.serial('indexing collection records with different versions', async (t) => 
       [`${key}`]: value
     };
 
-    const r = await indexer.indexCollection(esClient, collection, esIndex); // eslint-disable-line no-await-in-loop
+    const r = await indexer.indexCollection(esClient, collection, esIndex);
     // make sure record is created
     t.is(r.result, 'created');
   }
+  /* eslint-enable no-await-in-loop */
 
   await esClient.indices.refresh();
   // check each record exists and is not affected by other collections

--- a/packages/common/tests/.eslintrc.json
+++ b/packages/common/tests/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "no-param-reassign": "off"
-  }
-}

--- a/packages/deployment/.eslintrc.json
+++ b/packages/deployment/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "no-console": "off"
-  }
-}

--- a/packages/deployment/test/.eslintrc.json
+++ b/packages/deployment/test/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "no-param-reassign": "off"
-  }
-}

--- a/packages/ingest/test/.eslintrc.json
+++ b/packages/ingest/test/.eslintrc.json
@@ -1,6 +1,0 @@
-{
-  "rules": {
-    "require-jsdoc": "off",
-    "no-param-reassign": "off"
-  }
-}

--- a/packages/integration-tests/.eslintrc.json
+++ b/packages/integration-tests/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "no-console": "off"
-  }
-}

--- a/packages/logger/tests/.eslintrc.json
+++ b/packages/logger/tests/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "no-param-reassign": "off"
-  }
-}

--- a/tasks/discover-granules/tests/.eslintrc.json
+++ b/tasks/discover-granules/tests/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "require-jsdoc": "off"
-  }
-}

--- a/tasks/discover-pdrs/tests/.eslintrc.json
+++ b/tasks/discover-pdrs/tests/.eslintrc.json
@@ -1,6 +1,0 @@
-{
-  "rules": {
-    "no-param-reassign": "off",
-    "require-jsdoc": "off"
-  }
-}

--- a/tasks/move-granules/tests/.eslintrc.json
+++ b/tasks/move-granules/tests/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "no-param-reassign": "off"
-  }
-}

--- a/tasks/parse-pdr/tests/.eslintrc.json
+++ b/tasks/parse-pdr/tests/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "no-param-reassign": "off"
-  }
-}

--- a/tasks/queue-granules/tests/.eslintrc.json
+++ b/tasks/queue-granules/tests/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "no-param-reassign": "off"
-  }
-}

--- a/tasks/queue-pdrs/tests/.eslintrc.json
+++ b/tasks/queue-pdrs/tests/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "no-param-reassign": "off"
-  }
-}

--- a/tasks/sf-sns-report/tests/.eslintrc.json
+++ b/tasks/sf-sns-report/tests/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "no-param-reassign": "off"
-  }
-}

--- a/tasks/sync-granule/tests/.eslintrc.json
+++ b/tasks/sync-granule/tests/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "no-param-reassign": "off"
-  }
-}


### PR DESCRIPTION
We use slightly different `eslint` rules in our test directories.  Mainly, we allow writing to the console, and we allow writing to function params (which is how `ava` manages test context).  Until now we've been creating `.eslintrc.json` files in each test directory to accomplish that.  This PR moves those changes into the main `.eslintrc.json` file so that we 1) don't need all of those separate files and 2) won't need to create them in any new test directories we create.

This also allows for some other directory-specific lint configs, such as allowing writing to the console from `bin` scripts and migrations.

Removing the directory-specific `.eslintrc.json` files also revealed a few minor lint warnings, which are also addressed here.