### PR TITLE
CUMULUS-965 Load test-data in tasks more safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- **CUMULUS-965**
+  - Add `@cumulus/test-data.loadJSONTestData()`,
+    `@cumulus/test-data.loadTestData()`, and
+    `@cumulus/test-data.streamTestData()` to safely load test data. These
+    functions should be used instead of using `require()` to load test data,
+    which could lead to tests interferring with each other.
+
 ## [v1.10.3] - 2018-10-31
 
 ### Added

--- a/packages/test-data/index.js
+++ b/packages/test-data/index.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { promisify } = require('util');
+
+const readFile = promisify(fs.readFile);
+
+const testDataPath = (name) => path.join(__dirname, name);
+
+/**
+ * Read test data in as a string
+ *
+ * @param {string} name - the path to the test data
+ * @returns {Promise<string>} the test data as a string
+ */
+const loadTestData = (name) => {
+  const filePath = testDataPath(name);
+  return readFile(filePath, 'utf8');
+};
+
+/**
+ * Read and parse JSON-formatted test data
+ *
+ * @param {string} name - the path to the test data
+ * @returns {Promise} the test data parsed into Javascript
+ */
+const loadJSONTestData = (name) => loadTestData(name).then(JSON.parse);
+
+/**
+ * Get a stream containing test data
+ *
+ * @param {string} name - the path to the test data
+ * @returns {Stream} the test data as a writable stream
+ */
+const streamTestData = (name) => {
+  const filePath = testDataPath(name);
+  return fs.createReadStream(filePath);
+};
+
+module.exports = {
+  loadJSONTestData,
+  loadTestData,
+  streamTestData
+};

--- a/packages/test-data/package.json
+++ b/packages/test-data/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "https://github.com/nasa/cumulus"
   },
+  "engines": {
+    "node": ">=8.10.0"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\"",
     "build": "echo \"Nothing to build\""

--- a/tasks/.deprecated/discover-s3-granules/index.js
+++ b/tasks/.deprecated/discover-s3-granules/index.js
@@ -3,6 +3,7 @@
 const { listS3Objects } = require('@cumulus/common/aws');
 const cumulusMessageAdapter = require('@cumulus/cumulus-message-adapter-js');
 const { justLocalRun } = require('@cumulus/common/local-helpers');
+const { loadJSONTestData } = require('@cumulus/test-data');
 
 /**
 * filterByFileType
@@ -120,7 +121,7 @@ function handler(event, context, callback) {
 exports.handler = handler;
 
 // use node index.js local to invoke this
-justLocalRun(() => {
-  const payload = require('@cumulus/test-data/cumulus_messages/discover-s3-granules.json'); // eslint-disable-line global-require, max-len
+justLocalRun(async () => {
+  const payload = await loadJSONTestData('cumulus_messages/discover-s3-granules.json');
   handler(payload, {}, (e, r) => console.log(e, r));
 });

--- a/tasks/discover-granules/package.json
+++ b/tasks/discover-granules/package.json
@@ -46,7 +46,6 @@
   "devDependencies": {
     "ava": "^0.25.0",
     "fs-extra": "^5.0.0",
-    "lodash.clonedeep": "^4.5.0",
     "nyc": "^11.6.0",
     "webpack": "~4.5.0",
     "webpack-cli": "~2.0.14"

--- a/tasks/discover-pdrs/index.js
+++ b/tasks/discover-pdrs/index.js
@@ -6,6 +6,7 @@ const pdr = require('@cumulus/ingest/pdr');
 const errors = require('@cumulus/common/errors');
 const log = require('@cumulus/common/log');
 const local = require('@cumulus/common/local-helpers');
+const { loadJSONTestData } = require('@cumulus/test-data');
 
 /**
  * Discover PDRs
@@ -106,7 +107,7 @@ function handler(event, context, callback) {
 exports.handler = handler;
 
 // use node index.js local to invoke this
-local.justLocalRun(() => {
-  const payload = require('@cumulus/test-data/cumulus_messages/discover-pdrs.json'); // eslint-disable-line global-require, max-len
+local.justLocalRun(async () => {
+  const payload = await loadJSONTestData('cumulus_messages/discover-pdrs.json');
   handler(payload, {}, (e, r) => console.log(e, r));
 });

--- a/tasks/discover-pdrs/tests/force.js
+++ b/tasks/discover-pdrs/tests/force.js
@@ -5,10 +5,8 @@ const path = require('path');
 const os = require('os');
 const fs = require('fs-extra');
 const { RemoteResourceError } = require('@cumulus/common/errors');
-const cloneDeep = require('lodash.clonedeep');
 
-const { discoverPdrs } = require('../index');
-const input = require('./fixtures/input.json');
+const { discoverPdrs } = require('..');
 
 const { recursivelyDeleteS3Bucket, s3, uploadS3Files } = require('@cumulus/common/aws');
 const {
@@ -17,8 +15,15 @@ const {
   validateOutput
 } = require('@cumulus/common/test-utils');
 
+test.beforeEach(async (t) => {
+  const inputPath = path.join(__dirname, 'fixtures', 'input.json');
+  const rawInput = await fs.readFile(inputPath, 'utf8');
+  t.context.event = JSON.parse(rawInput);
+});
+
 test('test pdr discovery with force=false', async (t) => {
-  const event = cloneDeep(input);
+  const { event } = t.context;
+
   event.config.bucket = randomString();
   event.config.stack = randomString();
   event.config.collection.provider_path = '/pdrs/discover-pdrs';
@@ -73,7 +78,8 @@ test('test pdr discovery with force=false', async (t) => {
 });
 
 test('test pdr discovery with force=true', async (t) => {
-  const event = cloneDeep(input);
+  const { event } = t.context;
+
   event.config.bucket = randomString();
   event.config.stack = randomString();
   event.config.collection.provider_path = '/pdrs/discover-pdrs';

--- a/tasks/discover-pdrs/tests/index.js
+++ b/tasks/discover-pdrs/tests/index.js
@@ -4,10 +4,8 @@ const test = require('ava');
 const path = require('path');
 const fs = require('fs-extra');
 const { FTPError, RemoteResourceError } = require('@cumulus/common/errors');
-const cloneDeep = require('lodash.clonedeep');
 
-const { discoverPdrs } = require('../index');
-const input = require('./fixtures/input.json');
+const { discoverPdrs } = require('..');
 
 const { recursivelyDeleteS3Bucket, s3 } = require('@cumulus/common/aws');
 const {
@@ -17,8 +15,14 @@ const {
   validateOutput
 } = require('@cumulus/common/test-utils');
 
+test.beforeEach(async (t) => {
+  const inputPath = path.join(__dirname, 'fixtures', 'input.json');
+  const rawInput = await fs.readFile(inputPath, 'utf8');
+  t.context.input = JSON.parse(rawInput);
+});
+
 test('test pdr discovery with FTP assuming all PDRs are new', async (t) => {
-  const event = cloneDeep(input);
+  const event = t.context.input;
   event.config.bucket = randomString();
   event.config.collection.provider_path = '/pdrs/discover-pdrs';
   event.config.useList = true;
@@ -60,7 +64,7 @@ test('test pdr discovery with FTP invalid user/pass', async (t) => {
     password: 'testpass'
   };
 
-  const newPayload = cloneDeep(input);
+  const newPayload = t.context.input;
   newPayload.config.provider = provider;
   newPayload.input = {};
 
@@ -89,7 +93,7 @@ test('test pdr discovery with FTP connection refused', async (t) => {
     password: 'testpass'
   };
 
-  const newPayload = cloneDeep(input);
+  const newPayload = t.context.input;
   newPayload.config.provider = provider;
   newPayload.input = {};
 
@@ -111,7 +115,7 @@ test('test pdr discovery with FTP assuming some PDRs are new', async (t) => {
     password: 'testpass'
   };
 
-  const newPayload = cloneDeep(input);
+  const newPayload = t.context.input;
   newPayload.config.useList = true;
   newPayload.config.provider = provider;
   newPayload.config.collection.provider_path = '/pdrs/discover-pdrs';
@@ -162,7 +166,7 @@ test('test pdr discovery with HTTP assuming some PDRs are new', async (t) => {
     const newPdrs = pdrFilenames.slice(1);
 
     // Build the event
-    const event = cloneDeep(input);
+    const event = t.context.input;
     event.config.bucket = internalBucketName;
     event.config.provider = {
       id: 'MODAPS',
@@ -221,7 +225,7 @@ test('test pdr discovery with SFTP assuming some PDRs are new', async (t) => {
     const newPdrs = pdrFilenames.slice(1);
 
     // Build the event
-    const event = cloneDeep(input);
+    const event = t.context.input;
     event.config.bucket = internalBucketName;
     event.config.provider = {
       id: 'MODAPS',

--- a/tasks/parse-pdr/index.js
+++ b/tasks/parse-pdr/index.js
@@ -7,6 +7,7 @@ const errors = require('@cumulus/common/errors');
 const pdr = require('@cumulus/ingest/pdr');
 const log = require('@cumulus/common/log');
 const { justLocalRun } = require('@cumulus/common/local-helpers');
+const { loadJSONTestData } = require('@cumulus/test-data');
 
 /**
 * Parse a PDR
@@ -88,8 +89,8 @@ function handler(event, context, callback) {
 exports.handler = handler;
 
 // use node index.js local to invoke this
-justLocalRun(() => {
-  const payload = require('@cumulus/test-data/cumulus_messages/parse-pdr.json'); // eslint-disable-line global-require, max-len
+justLocalRun(async () => {
+  const payload = await loadJSONTestData('cumulus_messages/parse-pdr.json');
   handler(payload, {}, (e, r) => {
     console.log(JSON.stringify(r, null, '\t')); // eslint-disable-line no-console
   });

--- a/tasks/post-to-cmr/index.js
+++ b/tasks/post-to-cmr/index.js
@@ -6,6 +6,7 @@ const { justLocalRun } = require('@cumulus/common/local-helpers');
 const { getCmrFiles } = require('@cumulus/ingest/granule');
 const { publish } = require('@cumulus/ingest/cmr');
 const log = require('@cumulus/common/log');
+const { loadJSONTestData } = require('@cumulus/test-data');
 
 /**
  * Builds the output of the post-to-cmr task
@@ -103,7 +104,7 @@ function handler(event, context, callback) {
 exports.handler = handler;
 
 // use node index.js local to invoke this
-justLocalRun(() => {
-  const payload = require('@cumulus/test-data/cumulus_messages/post-to-cmr.json'); // eslint-disable-line global-require, max-len
+justLocalRun(async () => {
+  const payload = await loadJSONTestData('cumulus_messages/post-to-cmr.json');
   handler(payload, {}, (e, r) => log.info(e, r));
 });


### PR DESCRIPTION
- Add `@cumulus/test-data.loadJSONTestData()`, `@cumulus/test-data.loadTestData()`, and `@cumulus/test-data.streamTestData()` to safely load test data. These functions should be used instead of using `require()` to load test data, which could lead to tests interferring with each other.
- Update tests in the `tasks` directory to not `require()` JSON
