### PR TITLE
CUMULUS-656 Remove concurrency limit from pdr-status-check

### DIFF
--- a/tasks/pdr-status-check/package.json
+++ b/tasks/pdr-status-check/package.json
@@ -40,14 +40,12 @@
     "@cumulus/cumulus-message-adapter-js": "^1.0.4",
     "@cumulus/ingest": "^1.10.3",
     "@cumulus/test-data": "^1.10.2",
-    "lodash.get": "^4.4.2",
-    "p-map": "^2.0.0"
+    "lodash.get": "^4.4.2"
   },
   "devDependencies": {
     "ava": "^0.25.0",
     "lodash.isequal": "^4.5.0",
     "lodash.some": "^4.6.0",
-    "moment": "^2.22.1",
     "nyc": "^11.6.0",
     "proxyquire": "^2.0.0",
     "sinon": "^4.5.0",

--- a/tasks/pdr-status-check/tests/index.js
+++ b/tasks/pdr-status-check/tests/index.js
@@ -3,14 +3,11 @@
 const isEqual = require('lodash.isequal');
 const some = require('lodash.some');
 const test = require('ava');
-const moment = require('moment');
 const aws = require('@cumulus/common/aws');
 const {
-  randomString,
   validateInput,
   validateOutput
 } = require('@cumulus/common/test-utils');
-const { sleep } = require('@cumulus/common/util');
 
 const { checkPdrStatuses } = require('..');
 
@@ -135,50 +132,4 @@ test.serial('returns the correct results in the nominal case', async (t) => {
       `${JSON.stringify(expectedItem)} not found in ${JSON.stringify(output.failed)}`
     );
   });
-});
-
-test.serial('test concurrency limit setting on sfn api calls', async (t) => {
-  process.env.CONCURRENCY = 20;
-
-  const running = [];
-  const uuid = randomString();
-  for (let i = 0; i < 200; i += 1) running[i] = `${uuid}:${i}`;
-
-  const event = {
-    input: {
-      running,
-      pdr: { name: 'test.PDR', path: 'test-path' }
-    }
-  };
-
-  await validateInput(t, event.input);
-
-  const sfn = aws.sfn();
-
-  let output;
-  let startTime;
-  try {
-    sfn.describeExecution = ({ executionArn }) => ({
-      promise: () =>
-        sleep(100)
-          .then(() => ({ executionArn, status: 'SUCCEEDED' }))
-    });
-
-    startTime = moment();
-    output = await checkPdrStatuses(event);
-  }
-  finally {
-    delete sfn.describeExecution;
-  }
-
-  await validateOutput(t, output);
-  t.true(output.isFinished);
-
-  // the sf api execution time would be approximately:
-  // ((# of executions)/(# of concurrency) ) * (function execution time)
-  // (200/20) * 100 = 1000
-  // add 100ms for other operations
-  const endTime = moment();
-  const timeEscaped = moment.duration(endTime.diff(startTime)).as('milliseconds');
-  t.true(timeEscaped >= 900 && timeEscaped <= 1100);
 });


### PR DESCRIPTION
The PDR Status Check task was setting a concurrency limit on calls to StepFunction.describeExecution.  @Jkovarik and I talked it over and decided that, with the StepFunction library now supporting retries when throttling exceptions occur, the concurrency limit in the task was not necessary.