### PR TITLE
Allow creation of unassigned objects in tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -152,6 +152,7 @@
       ],
       "rules": {
         "no-console": "off",
+        "no-new": "off",
         "no-param-reassign": "off"
       }
     },

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ jobs:
       install:
         - ./travis-ci/fetch-cache.sh
         - npm install
+        - ln -s /dev/stdout ./lerna-debug.log
         - npm run bootstrap-no-build
       script: npm run lint
       after_failure: ./travis-ci/travis_wait_new 50 ./travis-ci/cleanup-integration-tests.sh
@@ -43,6 +44,7 @@ jobs:
       install:
         - ./travis-ci/fetch-cache.sh
         - npm install
+        - ln -s /dev/stdout ./lerna-debug.log
         - npm run bootstrap-no-build
         - ./travis-ci/start-local-services.sh
       script: ./node_modules/.bin/nyc ./node_modules/.bin/lerna run test --ignore @cumulus/api
@@ -58,6 +60,7 @@ jobs:
       install:
         - ./travis-ci/fetch-cache.sh
         - npm install
+        - ln -s /dev/stdout ./lerna-debug.log
         - npm run bootstrap-no-build
         - ./travis-ci/start-local-services.sh
       script: ./travis-ci/run-api-unit-tests.sh
@@ -69,6 +72,7 @@ jobs:
       install:
         - ./travis-ci/fetch-cache.sh
         - npm install
+        - ln -s /dev/stdout ./lerna-debug.log
         - npm run bootstrap-no-build
       script: ./travis-ci/travis_wait_new 50 ./travis-ci/init-integration-tests.sh
       after_failure: ./travis-ci/travis_wait_new 50 ./travis-ci/cleanup-integration-tests.sh
@@ -79,6 +83,7 @@ jobs:
       install:
         - ./travis-ci/fetch-cache.sh
         - npm install
+        - ln -s /dev/stdout ./lerna-debug.log
         - npm run bootstrap-no-build
       script: ./travis-ci/travis_wait_new 50 ./travis-ci/run-integration-tests.sh
       after_failure: ./travis-ci/travis_wait_new 50 ./travis-ci/cleanup-integration-tests.sh
@@ -89,6 +94,7 @@ jobs:
       install:
         - ./travis-ci/fetch-cache.sh
         - npm install
+        - ln -s /dev/stdout ./lerna-debug.log
         - npm run bootstrap-no-build
       script: ./travis-ci/travis_wait_new 50 ./travis-ci/run-redeployment-tests.sh
       after_failure: ./travis-ci/travis_wait_new 50 ./travis-ci/cleanup-integration-tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ jobs:
         - npm install
         - ln -s /dev/stdout ./lerna-debug.log
         - npm run bootstrap-no-build
+        - echo 'BOOTSTRAP FINISHED'
       script: npm run lint
       after_failure: ./travis-ci/travis_wait_new 50 ./travis-ci/cleanup-integration-tests.sh
 
@@ -47,6 +48,7 @@ jobs:
         - ln -s /dev/stdout ./lerna-debug.log
         - npm run bootstrap-no-build
         - ./travis-ci/start-local-services.sh
+        - echo 'BOOTSTRAP FINISHED'
       script: ./node_modules/.bin/nyc ./node_modules/.bin/lerna run test --ignore @cumulus/api
       after_failure: ./travis-ci/travis_wait_new 50 ./travis-ci/cleanup-integration-tests.sh
 
@@ -63,6 +65,7 @@ jobs:
         - ln -s /dev/stdout ./lerna-debug.log
         - npm run bootstrap-no-build
         - ./travis-ci/start-local-services.sh
+        - echo 'BOOTSTRAP FINISHED'
       script: ./travis-ci/run-api-unit-tests.sh
       after_failure: ./travis-ci/travis_wait_new 50 ./travis-ci/cleanup-integration-tests.sh
 
@@ -74,6 +77,7 @@ jobs:
         - npm install
         - ln -s /dev/stdout ./lerna-debug.log
         - npm run bootstrap-no-build
+        - echo 'BOOTSTRAP FINISHED'
       script: ./travis-ci/travis_wait_new 50 ./travis-ci/init-integration-tests.sh
       after_failure: ./travis-ci/travis_wait_new 50 ./travis-ci/cleanup-integration-tests.sh
 
@@ -85,6 +89,7 @@ jobs:
         - npm install
         - ln -s /dev/stdout ./lerna-debug.log
         - npm run bootstrap-no-build
+        - echo 'BOOTSTRAP FINISHED'
       script: ./travis-ci/travis_wait_new 50 ./travis-ci/run-integration-tests.sh
       after_failure: ./travis-ci/travis_wait_new 50 ./travis-ci/cleanup-integration-tests.sh
 
@@ -96,6 +101,7 @@ jobs:
         - npm install
         - ln -s /dev/stdout ./lerna-debug.log
         - npm run bootstrap-no-build
+        - echo 'BOOTSTRAP FINISHED'
       script: ./travis-ci/travis_wait_new 50 ./travis-ci/run-redeployment-tests.sh
       after_failure: ./travis-ci/travis_wait_new 50 ./travis-ci/cleanup-integration-tests.sh
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "nyc lerna run test --concurrency 2",
     "bootstrap": "lerna bootstrap --npm-client=npm --hoist",
     "ybootstrap": "lerna bootstrap",
-    "bootstrap-no-build": "lerna bootstrap --ignore-scripts --npm-client=npm --hoist --loglevel silly",
+    "bootstrap-no-build": "lerna bootstrap --ignore-scripts --npm-client=npm --hoist --loglevel verbose",
     "update": "lerna publish --skip-git --skip-npm",
     "publish": "lerna publish --skip-git --repo-version $VERSION --yes --npm-client=npm",
     "clean": "lerna clean",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "nyc lerna run test --concurrency 2",
     "bootstrap": "lerna bootstrap --npm-client=npm --hoist",
     "ybootstrap": "lerna bootstrap",
-    "bootstrap-no-build": "lerna bootstrap --ignore-scripts --npm-client=npm --hoist",
+    "bootstrap-no-build": "lerna bootstrap --ignore-scripts --npm-client=npm --hoist --loglevel silly",
     "update": "lerna publish --skip-git --skip-npm",
     "publish": "lerna publish --skip-git --repo-version $VERSION --yes --npm-client=npm",
     "clean": "lerna clean",

--- a/packages/api/tests/lib/EarthdataLogin.js
+++ b/packages/api/tests/lib/EarthdataLogin.js
@@ -16,7 +16,7 @@ test.beforeEach(() => {
 
 test('The EarthdataLogin constructor throws a TypeError if clientId is not specified', (t) => {
   const err = t.throws(() => {
-    new EarthdataLogin({ // eslint-disable-line no-new
+    new EarthdataLogin({
       clientPassword: 'client-password',
       earthdataLoginUrl: 'http://www.example.com',
       redirectUri: 'http://www.example.com/cb'
@@ -29,7 +29,7 @@ test('The EarthdataLogin constructor throws a TypeError if clientId is not speci
 
 test('The EarthdataLogin constructor throws a TypeError if clientPassword is not specified', (t) => {
   const err = t.throws(() => {
-    new EarthdataLogin({ // eslint-disable-line no-new
+    new EarthdataLogin({
       clientId: 'client-id',
       earthdataLoginUrl: 'http://www.example.com',
       redirectUri: 'http://www.example.com/cb'
@@ -42,7 +42,7 @@ test('The EarthdataLogin constructor throws a TypeError if clientPassword is not
 
 test('The EarthdataLogin constructor throws a TypeError if earthdataLoginUrl is not specified', (t) => {
   const err = t.throws(() => {
-    new EarthdataLogin({ // eslint-disable-line no-new
+    new EarthdataLogin({
       clientId: 'client-id',
       clientPassword: 'client-password',
       redirectUri: 'http://www.example.com/cb'
@@ -55,7 +55,7 @@ test('The EarthdataLogin constructor throws a TypeError if earthdataLoginUrl is 
 
 test('The EarthdataLogin constructor throws a TypeError if earthdataLoginUrl is not a valid URL', (t) => {
   t.throws(() => {
-    new EarthdataLogin({ // eslint-disable-line no-new
+    new EarthdataLogin({
       clientId: 'client-id',
       clientPassword: 'client-password',
       earthdataLoginUrl: 'asdf',
@@ -67,7 +67,7 @@ test('The EarthdataLogin constructor throws a TypeError if earthdataLoginUrl is 
 
 test('The EarthdataLogin constructor throws a TypeError if redirectUri is not specified', (t) => {
   const err = t.throws(() => {
-    new EarthdataLogin({ // eslint-disable-line no-new
+    new EarthdataLogin({
       clientId: 'client-id',
       clientPassword: 'client-password',
       earthdataLoginUrl: 'http://www.example.com'
@@ -80,7 +80,7 @@ test('The EarthdataLogin constructor throws a TypeError if redirectUri is not sp
 
 test('The EarthdataLogin constructor throws a TypeError if redirectUri is not a valid URL', (t) => {
   t.throws(() => {
-    new EarthdataLogin({ // eslint-disable-line no-new
+    new EarthdataLogin({
       clientId: 'client-id',
       clientPassword: 'client-password',
       earthdataLoginUrl: 'http://www.example.com',

--- a/packages/api/tests/lib/GoogleOAuth2.js
+++ b/packages/api/tests/lib/GoogleOAuth2.js
@@ -6,7 +6,7 @@ const GoogleOAuth2 = require('../../lib/GoogleOAuth2');
 
 test('The GoogleOAuth2 constructor throws a TypeError if googleOAuth2Client is not specified', (t) => {
   const err = t.throws(() => {
-    new GoogleOAuth2(null, {});// eslint-disable-line no-new
+    new GoogleOAuth2(null, {});
   },
   TypeError);
 
@@ -15,7 +15,7 @@ test('The GoogleOAuth2 constructor throws a TypeError if googleOAuth2Client is n
 
 test('The GoogleOAuth2 constructor throws a TypeError if googlePlusPeopleClient is not specified', (t) => {
   const err = t.throws(() => {
-    new GoogleOAuth2({}, null);// eslint-disable-line no-new
+    new GoogleOAuth2({}, null);
   },
   TypeError);
 

--- a/packages/api/tests/models/test-async-operation-model.js
+++ b/packages/api/tests/models/test-async-operation-model.js
@@ -52,7 +52,7 @@ test.after.always(async () => {
 
 test('The AsyncOperation constructor requires that stackName be specified', (t) => {
   try {
-    new AsyncOperation({ // eslint-disable-line no-new
+    new AsyncOperation({
       systemBucket: 'asdf',
       tableName: 'asdf'
     });
@@ -66,7 +66,7 @@ test('The AsyncOperation constructor requires that stackName be specified', (t) 
 
 test('The AsyncOperation constructor requires that systemBucket be specified', (t) => {
   try {
-    new AsyncOperation({ // eslint-disable-line no-new
+    new AsyncOperation({
       stackName: 'asdf',
       tableName: 'asdf'
     });


### PR DESCRIPTION
The eslint `no-new` rule prohibits creation of new objects that are not used.  This typically makes sense, but there are cases in tests (primarily when testing constructors) where we do want the ability to create an object without assigning it.

This PR disables the `no-new` rule in tests.