### PR TITLE
Allow kes to add new custom ressource

### DIFF
--- a/packages/api/config/lambdas.yml
+++ b/packages/api/config/lambdas.yml
@@ -135,7 +135,6 @@ CustomBootstrap:
   source: 'node_modules/@cumulus/api/dist/'
   envs:
     internal: '{{system_bucket}}'
-    stackName: '{{stackName}}'
 
 InRegionS3Policy:
   handler: index.inRegionS3Policy
@@ -170,7 +169,6 @@ CreateReconciliationReport:
   source: 'node_modules/@cumulus/api/dist/'
   envs:
     systemBucket: '{{system_bucket}}'
-    stackName: '{{stackName}}'
     filesTableName:
       function: Ref
       value: FilesTableDynamoDB


### PR DESCRIPTION
The reason is that stackName is included by default in all lambda functions
and by deleting the stackName from lambda config file kes will be able to merge the project and cumulus the CF.templates.
I jave also deleted the contaminated workspace.xml