### PR TITLE
Cumulus 775 instance meta api endpoint

### DIFF
--- a/packages/api/config/api_default.yml
+++ b/packages/api/config/api_default.yml
@@ -480,3 +480,20 @@ ApiBulkDeleteDefault:
       value: AsyncOperationTaskDefinition
     stackName: '{{parent.stackName}}'
     systemBucket: '{{parent.bucket}}'
+
+ApiInstanceMetaDefault:
+  handler: index.instanceMeta
+  apiRole: true
+  source: 'node_modules/@cumulus/api/dist/'
+  envs:
+    cmr_provider: '{{parent.cmr.provider}}'
+    UsersTable:
+      function: Ref
+      value: UsersTableDynamoDB
+
+  apiGateway:
+    # Default paths
+    - api: backend
+      path: instanceMeta
+      method: get
+      cors: true

--- a/packages/api/config/api_v1.yml
+++ b/packages/api/config/api_v1.yml
@@ -477,3 +477,20 @@ ApiBulkDeleteV1:
       value: AsyncOperationTaskDefinition
     stackName: '{{parent.stackName}}'
     systemBucket: '{{parent.bucket}}'
+
+ApiInstanceMetaV1:
+  handler: index.instanceMeta
+  apiRole: true
+  source: 'node_modules/@cumulus/api/dist/'
+  envs:
+    cmr_provider: '{{parent.cmr.provider}}'
+    UsersTable:
+      function: Ref
+      value: UsersTableDynamoDB
+
+  apiGateway:
+    # Default paths
+    - api: backend
+      path: v1/instanceMeta
+      method: get
+      cors: true

--- a/packages/api/config/api_v1.yml
+++ b/packages/api/config/api_v1.yml
@@ -431,7 +431,7 @@ ApiReconciliationReportV1:
       cors: true
       api: backend
 
-AsyncOperationsV1:
+ApiAsyncOperationsV1:
   handler: index.asyncOperations
   apiRole: true
   source: 'node_modules/@cumulus/api/dist/'

--- a/packages/api/endpoints/instance-meta.js
+++ b/packages/api/endpoints/instance-meta.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const { handle } = require('../lib/response');
+
+
+function instanceMetadata(event, cb) {
+
+  return cb(null, {
+    instanceMetadata: {
+      CMR_PROVIDER: process.env.cmr_provider,
+      CMR_ENVIRONMENT: process.env.CMR_ENVIRONMENT || 'UAT'
+    }
+  });
+}
+
+function handler(event, context) {
+  const checkAuth = true;
+  return handle(event, context, checkAuth, (cb) => {
+    return instanceMetadata(event, cb);
+  });
+}
+
+module.exports = handler;

--- a/packages/api/endpoints/instance-meta.js
+++ b/packages/api/endpoints/instance-meta.js
@@ -4,7 +4,6 @@ const { handle } = require('../lib/response');
 
 
 function instanceMetadata(event, cb) {
-
   return cb(null, {
     cmr: {
       provider: process.env.cmr_provider,
@@ -15,9 +14,7 @@ function instanceMetadata(event, cb) {
 
 function handler(event, context) {
   const checkAuth = true;
-  return handle(event, context, checkAuth, (cb) => {
-    return instanceMetadata(event, cb);
-  });
+  return handle(event, context, checkAuth, (cb) => instanceMetadata(event, cb));
 }
 
 module.exports = handler;

--- a/packages/api/endpoints/instance-meta.js
+++ b/packages/api/endpoints/instance-meta.js
@@ -6,9 +6,9 @@ const { handle } = require('../lib/response');
 function instanceMetadata(event, cb) {
 
   return cb(null, {
-    instanceMetadata: {
-      CMR_PROVIDER: process.env.cmr_provider,
-      CMR_ENVIRONMENT: process.env.CMR_ENVIRONMENT || 'UAT'
+    cmr: {
+      provider: process.env.cmr_provider,
+      environment: process.env.CMR_ENVIRONMENT || 'UAT'
     }
   });
 }

--- a/packages/api/index.js
+++ b/packages/api/index.js
@@ -4,6 +4,7 @@ exports.asyncOperations = require('./endpoints/async-operations');
 exports.token = require('./endpoints/token').handleApiGatewayRequest;
 exports.collections = require('./endpoints/collections');
 exports.granules = require('./endpoints/granules');
+exports.instanceMeta = require('./endpoints/instance-meta');
 exports.logs = require('./endpoints/logs');
 exports.pdrs = require('./endpoints/pdrs');
 exports.providers = require('./endpoints/providers');

--- a/packages/api/tests/endpoints/test-instance-meta.js
+++ b/packages/api/tests/endpoints/test-instance-meta.js
@@ -3,6 +3,7 @@
 const test = require('ava');
 
 const { randomString } = require('@cumulus/common/test-utils');
+const assertions = require('../../lib/assertions');
 const models = require('../../models');
 const {
   fakeUserFactory,
@@ -44,5 +45,28 @@ test('GET returns expected metadata', (t) => {
         CMR_ENVIRONMENT: CMR_ENVIRONMENT
       }
     });
+  });
+});
+
+test('GET with unauthorized user returns an unauthorized response', async (t) => {
+  const request = {
+    httpMethod: 'GET',
+    headers: {
+      Authorization: 'Bearer ThisIsAnInvalidAuthorizationToken'
+    }
+  };
+  return testEndpoint(instanceMetaEndpoint, request, (response) => {
+    assertions.isUnauthorizedUserResponse(t, response);
+  });
+});
+
+test('GET without without an Authorization header returns an Authorization Missing response', async (t) => {
+  const request = {
+    httpMethod: 'GET',
+    headers: {}
+  };
+
+  return testEndpoint(instanceMetaEndpoint, request, (response) => {
+    assertions.isAuthorizationMissingResponse(t, response);
   });
 });

--- a/packages/api/tests/endpoints/test-instance-meta.js
+++ b/packages/api/tests/endpoints/test-instance-meta.js
@@ -40,9 +40,9 @@ test('GET returns expected metadata', (t) => {
   return testEndpoint(instanceMetaEndpoint, request, (response) => {
     const body = JSON.parse(response.body);
     t.deepEqual(body, {
-      instanceMetadata: {
-        CMR_PROVIDER: CMR_PROVIDER,
-        CMR_ENVIRONMENT: CMR_ENVIRONMENT
+      cmr: {
+        provider: CMR_PROVIDER,
+        environment: CMR_ENVIRONMENT
       }
     });
   });

--- a/packages/api/tests/endpoints/test-instance-meta.js
+++ b/packages/api/tests/endpoints/test-instance-meta.js
@@ -48,7 +48,7 @@ test('GET returns expected metadata', (t) => {
   });
 });
 
-test('GET with unauthorized user returns an unauthorized response', async (t) => {
+test('GET with invalid access token returns an unauthorized response', async (t) => {
   const request = {
     httpMethod: 'GET',
     headers: {

--- a/packages/api/tests/endpoints/test-instance-meta.js
+++ b/packages/api/tests/endpoints/test-instance-meta.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const test = require('ava');
+
+const { randomString } = require('@cumulus/common/test-utils');
+const models = require('../../models');
+const {
+  fakeUserFactory,
+  testEndpoint
+} = require('../../lib/testUtils');
+const instanceMetaEndpoint = require('../../endpoints/instance-meta');
+
+const CMR_ENVIRONMENT = randomString();
+const CMR_PROVIDER = randomString();
+let userModel;
+let authHeaders;
+
+test.before(async () => {
+  process.env.UsersTable = randomString();
+  userModel = new models.User();
+  await userModel.createTable();
+
+  process.env.CMR_ENVIRONMENT = CMR_ENVIRONMENT;
+  process.env.cmr_provider = CMR_PROVIDER;
+
+
+  const authToken = (await userModel.create(fakeUserFactory())).password;
+  authHeaders = {
+    Authorization: `Bearer ${authToken}`
+  };
+});
+
+test('GET returns expected metadata', (t) => {
+  const request = {
+    httpMethod: 'GET',
+    headers: authHeaders
+  };
+
+  return testEndpoint(instanceMetaEndpoint, request, (response) => {
+    const body = JSON.parse(response.body);
+    t.deepEqual(body, {
+      instanceMetadata: {
+        CMR_PROVIDER: CMR_PROVIDER,
+        CMR_ENVIRONMENT: CMR_ENVIRONMENT
+      }
+    });
+  });
+});


### PR DESCRIPTION
**Summary:** Adds new API endpoint to provide information about the running cumulus instance itself.


Addresses [CUMULUS-775: Provide CMR information to dashboard via API](https://bugs.earthdata.nasa.gov/browse/CUMULUS-775)

## Changes

* Adds endpoint `instanceMeta` that returns json response of information about the cumulus instance including the cmr_provider and CMR_ENVIRONMENT.

PR for documentation:  https://github.com/nasa/cumulus-api/pull/249

## Test Plan
Things that should succeed before merging.

- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Update CHANGELOG
