### PR TITLE
Cumulus 775 allow params in get host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Added new IAM policy for migration lambda
 - **CUMULUS-775**
   - Adds a instance metadata endpoint to the `@cumulus/api` package.
+  - Adds a new convenience function `hostId` to the `@cumulus/cmrjs` to help build environment specific cmr urls.
   - Fixed `@cumulus/cmrjs.searchConcept` to search and return CMR results.
   - Modified `@cumulus/cmrjs.CMR.searchGranule` and `@cumulus/cmrjs.CMR.searchCollection` to include CMR's provider as a default parameter to searches.
 - **CUMULUS-965**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Added migration_4 to migrate/update exisitng Kinesis rules to have a log event mapping
   - Added new IAM policy for migration lambda
 - **CUMULUS-775**
+  - Adds a instance metadata endpoint to the `@cumulus/api` package.
   - Fixed `@cumulus/cmrjs.searchConcept` to search and return CMR results.
   - Modified `@cumulus/cmrjs.CMR.searchGranule` and `@cumulus/cmrjs.CMR.searchCollection` to include CMR's provider as a default parameter to searches.
 - **CUMULUS-965**

--- a/packages/cmrjs/package.json
+++ b/packages/cmrjs/package.json
@@ -34,6 +34,7 @@
     "@cumulus/common": "^1.10.3",
     "got": "^8.3.0",
     "lodash.property": "^4.4.2",
+    "lodash.get": "^4.4.2",
     "public-ip": "^2.3.5",
     "xml2js": "^0.4.19"
   },

--- a/packages/cmrjs/tests/test-utils-spec.js
+++ b/packages/cmrjs/tests/test-utils-spec.js
@@ -4,7 +4,7 @@ const sinon = require('sinon');
 const test = require('ava');
 const publicIp = require('public-ip');
 
-const { getIp, getHost } = require('../utils');
+const { getIp, getHost, hostId } = require('../utils');
 
 let stub;
 
@@ -39,6 +39,24 @@ test('getHost returns value according to process.env.CMR_ENVIRONMENT', (t) => {
   t.is(getHost(), 'cmr.sit.earthdata.nasa.gov');
   process.env.CMR_ENVIRONMENT = '';
   t.is(getHost(), 'cmr.uat.earthdata.nasa.gov');
+});
+
+test('getHost returns value according passed parameter', (t) => {
+  const param = { CMR_ENVIRONMENT: 'OPS' };
+  t.is(getHost(param), 'cmr.earthdata.nasa.gov');
+  param.CMR_ENVIRONMENT = 'SIT';
+  t.is(getHost(param), 'cmr.sit.earthdata.nasa.gov');
+  param.CMR_ENVIRONMENT = 'literally anything else';
+  t.is(getHost(param), 'cmr.uat.earthdata.nasa.gov');
+});
+
+test('hostId returns expected pieces of cmr url', (t) => {
+  let env = 'OPS';
+  t.is(hostId(env), '');
+  env = 'SIT';
+  t.is(hostId(env), 'sit');
+  env = 'any other thing';
+  t.is(hostId(env), 'uat');
 });
 
 test('getHost returns CMR_HOST when defined', (t) => {

--- a/packages/cmrjs/utils.js
+++ b/packages/cmrjs/utils.js
@@ -34,11 +34,17 @@ const ValidationError = createErrorType('ValidationError');
  * value for CMR_ENVIRONMENT environment variable. Defaults
  * to the uat cmr
  *
+ * @param {Object} environment - process env like object
+ * @param {string} environment.CMR_ENVIRONMENT - [optional] CMR environment to
+ *              use valid arguments are ['OPS', 'SIT', 'UAT'], anything that is
+ *              not 'OPS' or 'SIT' will be interpreted as 'UAT'
+ * @param {string} environment.CMR_HOST [optional] explicit host to return, if
+ *              this has a value, it overrides any values for CMR_ENVIRONMENT
  * @returns {string} the cmr host address
  */
-function getHost() {
-  const env = process.env.CMR_ENVIRONMENT;
-  if (process.env.CMR_HOST) return process.env.CMR_HOST;
+function getHost(environment = process.env) {
+  const env = environment.CMR_ENVIRONMENT;
+  if (environment.CMR_HOST) return environment.CMR_HOST;
 
   let host;
   if (env === 'OPS') {

--- a/packages/cmrjs/utils.js
+++ b/packages/cmrjs/utils.js
@@ -1,6 +1,8 @@
 const got = require('got');
+const _get = require('lodash.get');
 const publicIp = require('public-ip');
 const xml2js = require('xml2js');
+
 
 /**
  * Overrides the Error class
@@ -30,6 +32,21 @@ const createErrorType = (name, ParentType = Error) => {
 const ValidationError = createErrorType('ValidationError');
 
 /**
+ * Returns the environment specific identifier for the input cmr environment.
+ * @param {string} env - cmr environment ['OPS', 'SIT', 'UAT']
+ * @returns {string} - value to use to build correct cmr url for environment.
+ */
+function hostId(env) {
+  const id = {
+    OPS: '',
+    SIT: 'sit',
+    UAT: 'uat'
+  };
+  return _get(id, env, 'uat');
+}
+
+
+/**
  * Determines the appropriate CMR host endpoint based on a given
  * value for CMR_ENVIRONMENT environment variable. Defaults
  * to the uat cmr
@@ -46,20 +63,9 @@ function getHost(environment = process.env) {
   const env = environment.CMR_ENVIRONMENT;
   if (environment.CMR_HOST) return environment.CMR_HOST;
 
-  let host;
-  if (env === 'OPS') {
-    host = 'cmr.earthdata.nasa.gov';
-  }
-  else if (env === 'SIT') {
-    host = 'cmr.sit.earthdata.nasa.gov';
-  }
-  else {
-    host = 'cmr.uat.earthdata.nasa.gov';
-  }
-
+  const host = ['cmr', hostId(env), 'earthdata.nasa.gov'].filter((d) => d).join('.');
   return host;
 }
-
 
 const xmlParseOptions = {
   ignoreAttrs: true,
@@ -209,11 +215,12 @@ async function updateToken(cmrProvider, clientId, username, password) {
 }
 
 module.exports = {
-  validate,
   ValidationError,
-  updateToken,
-  getUrl,
-  xmlParseOptions,
+  getHost,
   getIp,
-  getHost
+  getUrl,
+  hostId,
+  updateToken,
+  validate,
+  xmlParseOptions
 };


### PR DESCRIPTION
**Summary:**  backwards compatable refactor to let cmrjs.getHost to take input parameter.

Addresses [CUMULUS-775: cmrjs package needs](https://bugs.earthdata.nasa.gov/browse/CUMULUS-775)

## Changes

* Lifts process.env into the default input parameter to allow library users easy access to the getHost function. 
