### PR TITLE
Cumulus 658 upgrade wait for test execution start

### DIFF
--- a/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
@@ -420,13 +420,13 @@ describe('The S3 Ingest Granules workflow', () => {
 
         it('overwrites granule files', async () => {
           // Await reingest completion
-          const reingestGranuleExecution = await waitForTestExecutionStart(
+          const reingestGranuleExecution = await waitForTestExecutionStart({
             workflowName,
-            config.stackName,
-            config.bucket,
-            isExecutionForGranuleId,
-            { granuleId: inputPayload.granules[0].granuleId }
-          );
+            stackName: config.stackName,
+            bucket: config.bucket,
+            findExecutionFn: isExecutionForGranuleId,
+            findExecutionFnParams: { granuleId: inputPayload.granules[0].granuleId }
+          });
 
           console.log(`Wait for completed execution ${reingestGranuleExecution.executionArn}`);
 
@@ -487,13 +487,13 @@ describe('The S3 Ingest Granules workflow', () => {
           workflow: 'PublishGranule'
         });
 
-        const publishGranuleExecution = await waitForTestExecutionStart(
-          'PublishGranule',
-          config.stackName,
-          config.bucket,
-          isExecutionForGranuleId,
-          { granuleId: inputPayload.granules[0].granuleId }
-        );
+        const publishGranuleExecution = await waitForTestExecutionStart({
+          workflowName: 'PublishGranule',
+          stackName: config.stackName,
+          bucket: config.bucket,
+          findExecutionFn: isExecutionForGranuleId,
+          findExecutionFnParams: { granuleId: inputPayload.granules[0].granuleId }
+        });
 
         console.log(`Wait for completed execution ${publishGranuleExecution.executionArn}`);
 

--- a/example/spec/parallel/syncGranule/SyncGranuleSuccessSpec.js
+++ b/example/spec/parallel/syncGranule/SyncGranuleSuccessSpec.js
@@ -215,13 +215,13 @@ describe('The Sync Granules workflow', () => {
 
     it('overwrites granule files', async () => {
       // Await reingest completion
-      const reingestGranuleExecution = await waitForTestExecutionStart(
+      const reingestGranuleExecution = await waitForTestExecutionStart({
         workflowName,
-        config.stackName,
-        config.bucket,
-        isExecutionForGranuleId,
-        { granuleId: inputPayload.granules[0].granuleId }
-      );
+        stackName: config.stackName,
+        bucket: config.bucket,
+        findExecutionFn: isExecutionForGranuleId,
+        findExecutionFnParams: { granuleId: inputPayload.granules[0].granuleId }
+      });
 
       console.log(`Wait for completed execution ${reingestGranuleExecution.executionArn}`);
 

--- a/example/spec/parallel/testAPI/ruleSpec.js
+++ b/example/spec/parallel/testAPI/ruleSpec.js
@@ -63,14 +63,14 @@ describe('When I create a scheduled rule via the Cumulus API', () => {
 
   describe('The scheduled rule kicks off a workflow', () => {
     beforeAll(async () => {
-      execution = await waitForTestExecutionStart(
-        scheduledHelloWorldRule.workflow,
-        config.stackName,
-        config.bucket,
-        (taskInput, params) =>
+      execution = await waitForTestExecutionStart({
+        workflowName: scheduledHelloWorldRule.workflow,
+        stackName: config.stackName,
+        bucket: config.bucket,
+        findExecutionFn: (taskInput, params) =>
           taskInput.meta.triggerRule && (taskInput.meta.triggerRule === params.ruleName),
-        { ruleName: scheduledRuleName }
-      );
+        findExecutionFnParams: { ruleName: scheduledRuleName }
+      });
 
       console.log(`Scheduled Execution ARN: ${execution.executionArn}`);
     });
@@ -91,16 +91,16 @@ describe('When I create a scheduled rule via the Cumulus API', () => {
     });
 
     it('does not kick off a scheduled workflow', () => {
-      waitForTestExecutionStart(
-        scheduledHelloWorldRule.workflow,
-        config.stackName,
-        config.bucket,
-        (taskInput, params) =>
+      waitForTestExecutionStart({
+        workflowName: scheduledHelloWorldRule.workflow,
+        stackName: config.stackName,
+        bucket: config.bucket,
+        findExecutionFn: (taskInput, params) =>
           taskInput.meta.triggerRule &&
             (taskInput.meta.triggerRule === params.ruleName) &&
             (taskInput.cumulus_meta.execution_name !== params.execution.name),
-        { ruleName: scheduledRuleName, execution }
-      ).catch((err) => expect(err.message).toEqual('Never found started workflow'));
+        findExecutionFnParams: { ruleName: scheduledRuleName, execution }
+      }).catch((err) => expect(err.message).toEqual('Never found started workflow'));
     });
   });
 });

--- a/example/spec/parallel/testAPI/ruleSpec.js
+++ b/example/spec/parallel/testAPI/ruleSpec.js
@@ -71,14 +71,14 @@ describe('When I create a scheduled rule via the Cumulus API', () => {
 
     it('does not kick off a workflow', () => {
       try {
-        waitForTestExecutionStart(
-          scheduledHelloWorldRule.workflow,
-          config.stackName,
-          config.bucket,
-          (taskInput, params) =>
+        waitForTestExecutionStart({
+          workflowName: scheduledHelloWorldRule.workflow,
+          stackName: config.stackName,
+          bucket: config.bucket,
+          findExecutionFn: (taskInput, params) =>
             taskInput.meta.triggerRule && (taskInput.meta.triggerRule === params.ruleName),
-          { ruleName: scheduledRuleName }
-        );
+          findExecutionFnParams: { ruleName: scheduledRuleName }
+        });
       }
       catch (err) {
         expect(err.message).toEqual('Never found started workflow.');
@@ -136,7 +136,13 @@ describe('When I create a one-time rule via the Cumulus API', () => {
     beforeAll(async () => {
       console.log(`Waiting for execution of ${helloWorldRule.workflow} triggered by rule`);
 
-      execution = await waitForTestExecutionStart(helloWorldRule.workflow, config.stackName, config.bucket, isWorkflowTriggeredByRule, { rule: createdCheck });
+      execution = await waitForTestExecutionStart({
+        workflowName: helloWorldRule.workflow,
+        stackName: config.stackName,
+        bucket: config.bucket,
+        findExecutionFn: isWorkflowTriggeredByRule,
+        findExecutionFnParams: { rule: createdCheck }
+      });
       console.log(`Execution ARN: ${execution.executionArn}`);
     });
 
@@ -164,7 +170,13 @@ describe('When I create a one-time rule via the Cumulus API', () => {
       });
 
       console.log(`Waiting for new execution of ${helloWorldRule.workflow} triggered by rerun of rule`);
-      const updatedExecution = await waitForTestExecutionStart(helloWorldRule.workflow, config.stackName, config.bucket, isWorkflowTriggeredByRule, { rule: updatedCheck });
+      const updatedExecution = await waitForTestExecutionStart({
+        workflowName: helloWorldRule.workflow,
+        stackName: config.stackName,
+        bucket: config.bucket,
+        findExecutionFn: isWorkflowTriggeredByRule,
+        findExecutionFnParams: { rule: updatedCheck }
+      });
       const updatedTaskInput = await lambdaStep.getStepInput(updatedExecution.executionArn, 'SfSnsReport');
       expect(updatedExecution).not.toBeNull();
       expect(updatedTaskInput.meta.triggerRule).toEqual(updatedCheck);

--- a/packages/integration-tests/index.js
+++ b/packages/integration-tests/index.js
@@ -657,26 +657,28 @@ async function getExecutions(workflowName, stackName, bucket, maxExecutionResult
  * Wait for the execution that matches the criteria in the compare function to begin
  * The compare function should take 2 arguments: taskInput and params
  *
- * @param {string} workflowName - workflow name to find execution for
- * @param {string} stackName - stack name
- * @param {string} bucket - bucket name
- * @param {function} findExecutionFn - function that takes the taskInput and findExecutionFnParams
- * and returns a boolean indicating whether or not this is the correct instance of the workflow
- * @param {Object} findExecutionFnParams - params to be passed into findExecutionFn
- * @param {integer} maxWaitSeconds - Set a custom wait time in seconds
+ * @param {Object} options
+ * @param {string} options.workflowName - workflow name to find execution for
+ * @param {string} options.stackName - stack name
+ * @param {string} options.bucket - bucket name
+ * @param {function} options.findExecutionFn - function that takes the taskInput and
+ * findExecutionFnParams and returns a boolean indicating whether or not this is the correct
+ * instance of the workflow
+ * @param {Object} options.findExecutionFnParams - params to be passed into findExecutionFn
+ * @param {integer} options.maxWaitSeconds - an optional custom wait time in seconds
  * @returns {undefined} - none
  */
-async function waitForTestExecutionStart(
+async function waitForTestExecutionStart({
   workflowName,
   stackName,
   bucket,
   findExecutionFn,
   findExecutionFnParams,
-  maxWaitSeconds = maxWaitForStartedExecutionSecs
-) {
+  maxWaitSeconds
+}) {
   let timeWaitedSecs = 0;
   /* eslint-disable no-await-in-loop */
-  while (timeWaitedSecs < maxWaitSeconds) {
+  while (timeWaitedSecs < maxWaitSeconds ? maxWaitSeconds : maxWaitForStartedExecutionSecs) {
     await sleep(waitPeriodMs);
     timeWaitedSecs += (waitPeriodMs / 1000);
     const executions = await getExecutions(workflowName, stackName, bucket);


### PR DESCRIPTION
**Summary:**

Changed the definition of `waitForTestExecutionStart` to take a parameter object instead of ordered parameters. This should make messing up the order of parameters a bit more difficult.

## Changes

* Pass parameter object into `waitForTestExecutionStart`
* Update calls to `waitForTestExecutionStart` to pass a parameter object.

## Test Plan
Things that should succeed before merging.

- [x] Unit tests
- [x] Integration tests
