### PR TITLE
Fix failing master build due to resource name length

### DIFF
--- a/example/spec/parallel/testAPI/ruleSpec.js
+++ b/example/spec/parallel/testAPI/ruleSpec.js
@@ -40,7 +40,7 @@ function isWorkflowTriggeredByRule(taskInput, params) {
 
 describe('When I create a scheduled rule via the Cumulus API', () => {
   let execution;
-  const scheduledRuleName = timestampedName('SchedHelloWorldIntegrationTestRule');
+  const scheduledRuleName = timestampedName('SchedHelloWorldIntTestRule');
   const scheduledHelloWorldRule = {
     name: scheduledRuleName,
     workflow: 'HelloWorldWorkflow',


### PR DESCRIPTION
**Summary:** Fixes a resource name length error we ran into in the `cumulus-from-source` stack.

`"1 validation error detected: Value 'test-src-integration-custom-SchedHelloWorldIntegrationTestRule_1542244894182' at 'name' failed to satisfy constraint: Member must have length less than or equal to 64"`

## Changes

* Shorten the name of Scheduled Rule Name in `example/spec/parallel/testAPI/ruleSpec.js`

## Test Plan
Things that should succeed before merging.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Adhoc testing
- [ ] Update CHANGELOG
- [ ] Run `./bin/eslint-ratchet` and verify that eslint errors have not increased
  - [ ] Commit `.eslint-ratchet-high-water-mark` if the score has improved