### PR TITLE
Shorten scheduled rule name in ruleSpec integration test

### DIFF
--- a/example/spec/parallel/testAPI/ruleSpec.js
+++ b/example/spec/parallel/testAPI/ruleSpec.js
@@ -40,7 +40,7 @@ function isWorkflowTriggeredByRule(taskInput, params) {
 
 describe('When I create a scheduled rule via the Cumulus API', () => {
   let execution;
-  const scheduledRuleName = timestampedName('SchedHelloWorldIntTestRule');
+  const scheduledRuleName = timestampedName('SchedHelloWorldTest');
   const scheduledHelloWorldRule = {
     name: scheduledRuleName,
     workflow: 'HelloWorldWorkflow',


### PR DESCRIPTION
**Summary:** Shorten SchedRuleName length in `ruleSpec.js` api tests.
## Changes

* Shorten SchedRuleName length in `ruleSpec.js` api tests.

## Test Plan
Things that should succeed before merging.

- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Update CHANGELOG
- [ ] Run `./bin/eslint-ratchet` and verify that eslint errors have not increased
  - [ ] Commit `.eslint-ratchet-high-water-mark` if the score has improved
