### PR TITLE
fix SNSRuleSpec rule name

### DIFF
--- a/example/spec/parallel/testAPI/snsRuleSpec.js
+++ b/example/spec/parallel/testAPI/snsRuleSpec.js
@@ -20,7 +20,7 @@ const {
 const lambdaStep = new LambdaStep();
 const SNS = sns();
 const config = loadConfig();
-const ruleName = timestampedName(`${config.stackName}_SnsRuleIntegrationTestRule`);
+const ruleName = timestampedName('SnsRuleIntegrationTestRule');
 const snsTopicName = timestampedName(`${config.stackName}_SnsRuleIntegrationTestTopic`);
 const newValueTopicName = timestampedName(`${config.stackName}_SnsRuleValueChangeTestTopic`);
 const consumerName = `${config.stackName}-messageConsumer`;


### PR DESCRIPTION
As @ifestus pointed out to me, including the stack name in the rule name can cause rule creation to fail when the rule name's length is >64 characters. This PR fixes unnecessary inclusion of config.stackName in the rule name. The rule is contained in the stack, so there is no chance for collision, such as there is with the SNS topic names. 
As the topics are still unique, any subscriptions will be created with a stack-specific name. Lambda permissions will not, but they are set on the lambda contained within the stack, so there is no chance for collision there.