### PR TITLE
CUMULUS-952 Add ability to specify ecs docker repository

### DIFF
--- a/example/app/config.yml
+++ b/example/app/config.yml
@@ -56,6 +56,8 @@ default:
   params:
     - name: CmrPassword
       value: '{{CMR_PASSWORD}}'
+    - name: DockerRepoUrl
+      value: '{{DOCKER_REPO_URL}}'
     - name: DockerEmail
       value: '{{DOCKER_EMAIL}}'
     - name: DockerPassword

--- a/packages/deployment/app/cloudformation.template.yml
+++ b/packages/deployment/app/cloudformation.template.yml
@@ -15,6 +15,11 @@ Parameters:
     Description: 'Email used to login to a private docker repository (not required)'
     Default: NoValue
     NoEcho: true
+  DockerRepoUrl:
+    Type: String
+    Description: 'Url of docker repository to log into (not required)'
+    Default: 'https://index.docker.io/v1/'
+    NoEcho: true
 
 Resources:
 
@@ -819,9 +824,8 @@ Resources:
                     echo ECS_CLUSTER=${CumulusECSCluster} >> /etc/ecs/ecs.config
                     echo ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION=1m >> /etc/ecs/ecs.config
 
-                {{#if ecs.docker}}
                     echo ECS_ENGINE_AUTH_TYPE=docker >> /etc/ecs/ecs.config
-                    echo 'ECS_ENGINE_AUTH_DATA={"https://index.docker.io/v1/":{"username":"{{ecs.docker.username}}","password": "${Password}","email":"${Email}"}}' >> /etc/ecs/ecs.config
+                    echo 'ECS_ENGINE_AUTH_DATA={"${RepoUrl}":{"username":"{{ecs.docker.username}}","password": "${Password}","email":"${Email}"}}' >> /etc/ecs/ecs.config
                     echo 'DOCKER_STORAGE_OPTIONS="${!DOCKER_STORAGE_OPTIONS} --storage-driver {{ecs.docker.storageDriver}}"' >> /etc/sysconfig/docker-storage
                     {{#ifEquals ecs.docker.storageDriver "devicemapper"}}
                     echo 'OPTIONS="${!OPTIONS} --storage-opt dm.basesize={{ecs.volumeSize}}G"' >> /etc/sysconfig/docker
@@ -831,9 +835,8 @@ Resources:
                       Ref: DockerPassword
                     Email:
                       Ref: DockerEmail
-                {{else}}
-                  - Example: value
-                {{/if}}
+                    RepoUrl:
+                      Ref: DockerRepoUrl
 
           {{# if ecs.efs.mount }}
           packages:


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-952: ecs.docker configuration causing authentication issues](https://bugs.earthdata.nasa.gov/browse/CUMULUS-952)

## Changes

* Add the ability to specify `DOCKER_REPO_URL` in `.env`.

## Test Plan
Things that should succeed before merging.

- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Update CHANGELOG
- [ ] Run `./bin/eslint-ratchet` and verify that eslint errors have not increased
  - [ ] Commit `.eslint-ratchet-high-water-mark` if the score has improved
