### PR TITLE
CUMULUS-1006 Fix internal server error in version endpoint

### DIFF
--- a/packages/api/endpoints/version.js
+++ b/packages/api/endpoints/version.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { buildLambdaProxyResponse } = require('../lib/response');
+const { OkResponse } = require('../lib/responses');
 const pckg = require('../package.json');
 
 /**
@@ -10,12 +10,14 @@ const pckg = require('../package.json');
  * @function handler
  * @returns {type} HTTP response in json format
  */
-function handler() {
-  const response = {
-    response_version: 'v1',
-    api_version: pckg.version
-  };
-  return buildLambdaProxyResponse({ body: response });
+async function handler() {
+  return new OkResponse({
+    json: true,
+    body: {
+      response_version: 'v1',
+      api_version: pckg.version
+    }
+  });
 }
 
 module.exports = handler;

--- a/packages/api/lib/responses.js
+++ b/packages/api/lib/responses.js
@@ -98,6 +98,16 @@ class LambdaProxyResponse {
 }
 exports.LambdaProxyResponse = LambdaProxyResponse;
 
+class OkResponse extends LambdaProxyResponse {
+  constructor(params = {}) {
+    super({
+      ...params,
+      statusCode: 200
+    });
+  }
+}
+exports.OkResponse = OkResponse;
+
 class TemporaryRedirectResponse extends LambdaProxyResponse {
   constructor(params = {}) {
     super({

--- a/packages/api/tests/endpoints/version.js
+++ b/packages/api/tests/endpoints/version.js
@@ -1,17 +1,15 @@
 'use strict';
 
 const test = require('ava');
-const versionEndpont = require('../../endpoints/version');
-const { LambdaProxyResponse } = require('../../lib/responses');
+const versionEndpoint = require('../../endpoints/version');
 const pckg = require('../../package.json');
 
-test('returns expected response', (t) => {
-  const actualResponse = versionEndpont({});
-  const expectedResponse = new LambdaProxyResponse({
-    body: {
-      response_version: 'v1',
-      api_version: pckg.version
-    }
-  });
-  t.deepEqual(actualResponse, expectedResponse);
+test('returns expected response', async (t) => {
+  const response = await versionEndpoint();
+
+  t.is(response.statusCode, 200);
+
+  const body = JSON.parse(response.body);
+  t.is(body.response_version, 'v1');
+  t.is(body.api_version, pckg.version);
 });


### PR DESCRIPTION
The version API endpoint was returning internal server errors.  This was because the handler was returning a response, but was not returning a Promise or invoking the callback (the two ways that Lambda expects a response).