### PR TITLE
CUMULUS-952 Add ability to specify ecs repository authentication type

### DIFF
--- a/docs/workflows/developing-workflow-tasks.md
+++ b/docs/workflows/developing-workflow-tasks.md
@@ -28,7 +28,7 @@ ECS activities require a docker image. The docker image is defined as part of th
     publicIp: true
     docker:
       username: cumulususer
-      repoHost: dockerhub
+      registry: dockerhub
     services:
       EcsTaskHelloWorld:
         image: cumuluss/cumulus-ecs-task:1.2.3
@@ -37,9 +37,9 @@ ECS activities require a docker image. The docker image is defined as part of th
         count: 1
 ```
 
-### Specifying Repository Host (ECR | Dockerhub)
+### Specifying a Docker Registry (ECR | Dockerhub)
 
-Cumulus currently supports two methods of pulling images from a hosted repository by setting the `ecs.docker.repoHost` attribute to either `ecr` or `dockerhub`. `dockerhub` is the default value.
+Cumulus currently supports two methods of pulling images from a hosted repository by setting the `ecs.docker.registry` attribute to either `ecr` or `dockerhub`. `dockerhub` is the default value.
 
 *ecr* will use the IAM role attached to the instance (defined in `packages/deployment/iam/cloudformation.template.yml` under `ECSRole`) to authenticate against a repository hosted in [AWS ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/what-is-ecr.html). Using this method will still allow instances to pull images from *public* dockerhub repositories *without authentication.*
 

--- a/docs/workflows/developing-workflow-tasks.md
+++ b/docs/workflows/developing-workflow-tasks.md
@@ -19,7 +19,7 @@ You can also develop your own lambda function, read more on the [Lambda Function
 
 ECS activities require a docker image. The docker image is defined as part of the ECS cluster definition in your deployments `config.yml`, e.g.:
 
-```
+```yaml
   ecs:
     instanceType: t2.small
     desiredInstances: 1
@@ -28,6 +28,7 @@ ECS activities require a docker image. The docker image is defined as part of th
     publicIp: true
     docker:
       username: cumulususer
+      repoHost: dockerhub
     services:
       EcsTaskHelloWorld:
         image: cumuluss/cumulus-ecs-task:1.2.3
@@ -35,3 +36,13 @@ ECS activities require a docker image. The docker image is defined as part of th
         memory: 1500
         count: 1
 ```
+
+### Specifying Repository Host (ECR | Dockerhub)
+
+Cumulus currently supports two methods of pulling images from a hosted repository by setting the `ecs.docker.repoHost` attribute to either `ecr` or `dockerhub`.
+
+*ecr* will use the IAM role attached to the instance (defined in `packages/deployment/iam/cloudformation.template.yml` under `ECSRole`) to authenticate against a repository hosted in AWS ECR. Using this method will still allow instances to pull images from *public* dockerhub repositories *without authentication.*
+
+*dockerhub* will use `ecs.docker.username` from `app/config.yml` and the `DOCKER_PASSWORD` and `DOCKER_EMAIL` environment varaibles (if they exist) to authenticate against the public `dockerhub` endpoint.
+
+More on `dockerhub` authentication can be found in [aws documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/private-auth-container-instances.html) under `docker` Authentication Format.

--- a/docs/workflows/developing-workflow-tasks.md
+++ b/docs/workflows/developing-workflow-tasks.md
@@ -39,10 +39,10 @@ ECS activities require a docker image. The docker image is defined as part of th
 
 ### Specifying Repository Host (ECR | Dockerhub)
 
-Cumulus currently supports two methods of pulling images from a hosted repository by setting the `ecs.docker.repoHost` attribute to either `ecr` or `dockerhub`.
+Cumulus currently supports two methods of pulling images from a hosted repository by setting the `ecs.docker.repoHost` attribute to either `ecr` or `dockerhub`. `dockerhub` is the default value.
 
-*ecr* will use the IAM role attached to the instance (defined in `packages/deployment/iam/cloudformation.template.yml` under `ECSRole`) to authenticate against a repository hosted in AWS ECR. Using this method will still allow instances to pull images from *public* dockerhub repositories *without authentication.*
+*ecr* will use the IAM role attached to the instance (defined in `packages/deployment/iam/cloudformation.template.yml` under `ECSRole`) to authenticate against a repository hosted in [AWS ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/what-is-ecr.html). Using this method will still allow instances to pull images from *public* dockerhub repositories *without authentication.*
 
-*dockerhub* will use `ecs.docker.username` from `app/config.yml` and the `DOCKER_PASSWORD` and `DOCKER_EMAIL` environment varaibles (if they exist) to authenticate against the public `dockerhub` endpoint.
+*dockerhub* will use `ecs.docker.username` specified in `app/config.yml` and the `DOCKER_PASS` and `DOCKER_EMAIL` environment varaibles (if they exist or from `app/.env`) to authenticate against the public `dockerhub` endpoint.
 
 More on `dockerhub` authentication can be found in [aws documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/private-auth-container-instances.html) under `docker` Authentication Format.

--- a/example/app/config.yml
+++ b/example/app/config.yml
@@ -436,6 +436,10 @@ mvd-dev:
 jc:
   stackName: jc
   stackNameNoDash: jc
+  ecs:
+    docker:
+      username: cumulususer
+      authType: iam
 
 mhs:
   stackName: mhs

--- a/example/app/config.yml
+++ b/example/app/config.yml
@@ -457,7 +457,7 @@ jc:
             value: HelloWorldLambdaFunction
     docker:
       username: cumulususer
-      repoHost: ecr
+      registry: ecr
 
 mhs:
   stackName: mhs

--- a/example/app/config.yml
+++ b/example/app/config.yml
@@ -79,7 +79,7 @@ default:
       username: cumulususer
     services:
       EcsTaskHelloWorld:
-        image: cumuluss/cumulus-ecs-task
+        image: cumuluss/cumulus-ecs-task:1.2.3
         cpu: 400
         memory: 700
         count: 1
@@ -457,7 +457,7 @@ jc:
             value: HelloWorldLambdaFunction
     docker:
       username: cumulususer
-      authType: iam
+      repoHost: ecr
 
 mhs:
   stackName: mhs

--- a/example/app/config.yml
+++ b/example/app/config.yml
@@ -79,7 +79,7 @@ default:
       username: cumulususer
     services:
       EcsTaskHelloWorld:
-        image: cumuluss/cumulus-ecs-task:1.2.3
+        image: cumuluss/cumulus-ecs-task
         cpu: 400
         memory: 700
         count: 1
@@ -437,6 +437,24 @@ jc:
   stackName: jc
   stackNameNoDash: jc
   ecs:
+    services:
+      EcsTaskHelloWorld:
+        image: 596205514787.dkr.ecr.us-east-1.amazonaws.com/cumulus-dev-testing:latest
+        cpu: 400
+        memory: 700
+        count: 1
+        envs:
+          AWS_DEFAULT_REGION:
+            function: Fn::Sub
+            value: '${AWS::Region}'
+        commands:
+          - cumulus-ecs-task
+          - '--activityArn'
+          - function: Ref
+            value: EcsTaskHelloWorldActivity
+          - '--lambdaArn'
+          - function: Ref
+            value: HelloWorldLambdaFunction
     docker:
       username: cumulususer
       authType: iam

--- a/packages/deployment/app/cloudformation.template.yml
+++ b/packages/deployment/app/cloudformation.template.yml
@@ -823,7 +823,7 @@ Resources:
                     echo 'OPTIONS="${!OPTIONS} --storage-opt dm.basesize={{ecs.volumeSize}}G"' >> /etc/sysconfig/docker
                     {{/ifEquals}}
 
-                {{#ifEquals ecs.docker.authType "default"}}
+                {{#ifEquals ecs.docker.repoHost "dockerhub"}}
                     echo ECS_ENGINE_AUTH_TYPE=docker >> /etc/ecs/ecs.config
                     echo 'ECS_ENGINE_AUTH_DATA={"https://index.docker.io/v1/":{"username":"{{ecs.docker.username}}","password": "${Password}","email":"${Email}"}}' >> /etc/ecs/ecs.config
 

--- a/packages/deployment/app/cloudformation.template.yml
+++ b/packages/deployment/app/cloudformation.template.yml
@@ -823,7 +823,7 @@ Resources:
                     echo 'OPTIONS="${!OPTIONS} --storage-opt dm.basesize={{ecs.volumeSize}}G"' >> /etc/sysconfig/docker
                     {{/ifEquals}}
 
-                {{#ifEquals ecs.docker.authType 'default'}}
+                {{#ifEquals ecs.docker.authType "default"}}
                     echo ECS_ENGINE_AUTH_TYPE=docker >> /etc/ecs/ecs.config
                     echo 'ECS_ENGINE_AUTH_DATA={"https://index.docker.io/v1/":{"username":"{{ecs.docker.username}}","password": "${Password}","email":"${Email}"}}' >> /etc/ecs/ecs.config
 

--- a/packages/deployment/app/cloudformation.template.yml
+++ b/packages/deployment/app/cloudformation.template.yml
@@ -818,14 +818,14 @@ Resources:
                     #!/bin/bash
                     echo ECS_CLUSTER=${CumulusECSCluster} >> /etc/ecs/ecs.config
                     echo ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION=1m >> /etc/ecs/ecs.config
-
-                {{#if ecs.docker}}
-                    echo ECS_ENGINE_AUTH_TYPE=docker >> /etc/ecs/ecs.config
-                    echo 'ECS_ENGINE_AUTH_DATA={"https://index.docker.io/v1/":{"username":"{{ecs.docker.username}}","password": "${Password}","email":"${Email}"}}' >> /etc/ecs/ecs.config
                     echo 'DOCKER_STORAGE_OPTIONS="${!DOCKER_STORAGE_OPTIONS} --storage-driver {{ecs.docker.storageDriver}}"' >> /etc/sysconfig/docker-storage
                     {{#ifEquals ecs.docker.storageDriver "devicemapper"}}
                     echo 'OPTIONS="${!OPTIONS} --storage-opt dm.basesize={{ecs.volumeSize}}G"' >> /etc/sysconfig/docker
                     {{/ifEquals}}
+
+                {{#ifEquals ecs.docker.authType 'default'}}
+                    echo ECS_ENGINE_AUTH_TYPE=docker >> /etc/ecs/ecs.config
+                    echo 'ECS_ENGINE_AUTH_DATA={"https://index.docker.io/v1/":{"username":"{{ecs.docker.username}}","password": "${Password}","email":"${Email}"}}' >> /etc/ecs/ecs.config
 
                   - Password:
                       Ref: DockerPassword

--- a/packages/deployment/app/cloudformation.template.yml
+++ b/packages/deployment/app/cloudformation.template.yml
@@ -833,7 +833,7 @@ Resources:
                       Ref: DockerEmail
                 {{else}}
                   - Example: value
-                {{/if}}
+                {{/ifEquals}}
 
           {{# if ecs.efs.mount }}
           packages:

--- a/packages/deployment/app/cloudformation.template.yml
+++ b/packages/deployment/app/cloudformation.template.yml
@@ -823,7 +823,7 @@ Resources:
                     echo 'OPTIONS="${!OPTIONS} --storage-opt dm.basesize={{ecs.volumeSize}}G"' >> /etc/sysconfig/docker
                     {{/ifEquals}}
 
-                {{#ifEquals ecs.docker.repoHost "dockerhub"}}
+                {{#ifEquals ecs.docker.registry "dockerhub"}}
                     echo ECS_ENGINE_AUTH_TYPE=docker >> /etc/ecs/ecs.config
                     echo 'ECS_ENGINE_AUTH_DATA={"https://index.docker.io/v1/":{"username":"{{ecs.docker.username}}","password": "${Password}","email":"${Email}"}}' >> /etc/ecs/ecs.config
 

--- a/packages/deployment/app/config.yml
+++ b/packages/deployment/app/config.yml
@@ -108,8 +108,8 @@ default:
             function: Fn::Sub
             value: '${AWS::Region}'
     docker:
-      # Expected auth types are 'default' and 'iam'
-      authType: default
+      # Allowed repoHost values are 'dockerhub' and 'ecr'
+      repoHost: dockerhub
       storageDriver: overlay2
 
   es:

--- a/packages/deployment/app/config.yml
+++ b/packages/deployment/app/config.yml
@@ -111,8 +111,8 @@ default:
             function: Fn::Sub
             value: '${AWS::Region}'
     docker:
-      # Allowed repoHost values are 'dockerhub' and 'ecr'
-      repoHost: dockerhub
+      # Allowed registry values are 'dockerhub' and 'ecr'
+      registry: dockerhub
       storageDriver: overlay2
 
   es:

--- a/packages/deployment/app/config.yml
+++ b/packages/deployment/app/config.yml
@@ -108,6 +108,8 @@ default:
             function: Fn::Sub
             value: '${AWS::Region}'
     docker:
+      # Expected auth types are 'default' and 'iam'
+      authType: default
       storageDriver: overlay2
 
   es:


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-952: ecs.docker configuration causing authentication issues](https://bugs.earthdata.nasa.gov/browse/CUMULUS-952)

## Changes

* Add the ability to specify `ecs.docker.authType` - `default` will attempt to authenticate to `dockerhub` and `iam` will not.

## Discussion
This solution is a bit of a band-aide for this ticket. If a user specifies `default` as their `authType`, nothing is different from our current implementation. However, if a user specifies `iam`, we won't set up `ECS_ENGINE_AUTH_DATA` [when defining ECS instances](https://github.com/nasa/cumulus/blob/b02f671b2c8eed1e277c5b83405096a3bb3bb0ae/packages/deployment/app/cloudformation.template.yml#L826). This means that if a user wants to use their ECS repository through an IAM policy attached to an ECS instance (so they set `authType: iam`), they won't be able to access private repositories in dockerhub. That said, they should still be able to access public repos.

I think there's a next step here to allow for more granule control over docker repositories in our deployments. It seems plausible to me that a user would want to pull images from multiple private Docker repositories. Docker and ecs already support setting up multiple repositories in `ECS_ENGINE_AUTH_DATA`.

## Test Plan
Things that should succeed before merging.

- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Update CHANGELOG
- [ ] Run `./bin/eslint-ratchet` and verify that eslint errors have not increased
  - [ ] Commit `.eslint-ratchet-high-water-mark` if the score has improved
