### PR TITLE
Cumulus 1050 add config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **CUMULUS-793** - Updated the granule move PUT request in `@cumulus/api` to reject the move with a 409 status code if one or more of the files already exist at the destination location
 
 ### Added
+- **CUMULUS-1050**
+  - Separated configuration flags for originalPayload/finalPayload cleanup such that they can be set to different retention times
 - **CUMULUS-798**
   - Added daily Executions cleanup CloudWatch event that triggers cleanExecutions lambda
   - Added cleanExecutions lambda that removes finalPayload/originalPayload field entries for records older than configured timeout value (execution_payload_retention_period), with a default of 30 days

--- a/packages/api/config/lambdas.yml
+++ b/packages/api/config/lambdas.yml
@@ -140,7 +140,10 @@ cleanExecutions:
   source: 'node_modules/@cumulus/api/dist/'
   namedLambdaDeadLetterQueue: true
   envs:
-    executionPayloadRetentionPeriod: '{{execution_payload_retention_period}}'
+    nonCompleteExecutionPayloadTimeout: '{{non_complete_execution_payload_timeout}}'
+    completeExecutionPayloadTimeout: '{{complete_execution_payload_timeout}}'
+    nonCompleteExecutionPayloadTimeoutDisable: '{{non_complete_execution_payload_disable}}'
+    completeExecutionPayloadTimeoutDisable: '{{complete_execution_payload_disable}}'
     ExecutionsTable:
       function: Ref
       value: ExecutionsTableDynamoDB

--- a/packages/api/lambdas/cleanExecutions.js
+++ b/packages/api/lambdas/cleanExecutions.js
@@ -27,8 +27,6 @@ async function cleanExecutionPayloads(ExecutionModel) {
     originalValue: process.env.completeExecutionPayloadTimeout
   }];
 
-
-
   configuration.forEach((timeout) => {
     if (!Number.isInteger(timeout.value)) {
       throw new TypeError(`Invalid number of days specified in configuration for ${timeout.name}: ${timeout.originalValue}`);

--- a/packages/api/lambdas/cleanExecutions.js
+++ b/packages/api/lambdas/cleanExecutions.js
@@ -9,6 +9,10 @@ async function cleanExecutionPayloads(ExecutionModel) {
   completeDisable = JSON.parse(completeDisable);
   nonCompleteDisable = JSON.parse(nonCompleteDisable);
 
+  if (completeDisable && nonCompleteDisable) {
+    return [];
+  }
+
   const nonCompleteTimeout = parseInt(process.env.nonCompleteExecutionPayloadTimeout, 10);
   const completeTimeout = parseInt(process.env.completeExecutionPayloadTimeout, 10);
 
@@ -23,9 +27,7 @@ async function cleanExecutionPayloads(ExecutionModel) {
     originalValue: process.env.completeExecutionPayloadTimeout
   }];
 
-  if (completeDisable && nonCompleteDisable) {
-    return [];
-  }
+
 
   configuration.forEach((timeout) => {
     if (!Number.isInteger(timeout.value)) {

--- a/packages/api/models/executions.js
+++ b/packages/api/models/executions.js
@@ -84,7 +84,6 @@ class Execution extends Manager {
     const limit = pLimit(concurrencyLimit);
 
     const updatePromises = oldExecutionRows.Items.map((row) => limit(() => {
-      debugger;
       if (row.status === 'completed' && !disableComplete && row.updatedAt <= completeMaxAgeMseconds) {
         return this.update({ arn: row.arn }, {}, ['originalPayload', 'finalPayload']);
       }

--- a/packages/api/models/executions.js
+++ b/packages/api/models/executions.js
@@ -84,10 +84,10 @@ class Execution extends Manager {
     const limit = pLimit(concurrencyLimit);
 
     const updatePromises = oldExecutionRows.Items.map((row) => limit(() => {
-      if (row.status === 'completed' && !disableComplete && row.updatedAt <= completeMaxMs) {
+      if (!disableComplete && row.status === 'completed' && row.updatedAt <= completeMaxMs) {
         return this.update({ arn: row.arn }, {}, ['originalPayload', 'finalPayload']);
       }
-      if (!(row.status === 'completed') && !disableNonComplete && row.updatedAt <= nonCompleteMaxMs) {
+      if (!disableNonComplete && !(row.status === 'completed') && row.updatedAt <= nonCompleteMaxMs) {
         return this.update({ arn: row.arn }, {}, ['originalPayload', 'finalPayload']);
       }
       return Promise.resolve();

--- a/packages/api/models/executions.js
+++ b/packages/api/models/executions.js
@@ -52,17 +52,24 @@ class Execution extends Manager {
   }
 
   /**
-   * Scan the Executions table ahd remove originalPayload/finalPayload records from the table
+   * Scan the Executions table and remove originalPayload/finalPayload records from the table
    *
-   * @param {integer} maxAgeDays - Maximum number of days a record may have payload entries
+   * @param {integer} completeMaxDays - Maximum number of days a completed
+   *   record may have payload entries
+   * @param {integer} nonCompleteMaxDays - Maximum number of days a non-completed
+   *   record may have payload entries
+   * @param {boolean} disableComplete - Disable removal of completed execution
+   *   payloads
+   * @param {boolean} disableNonComplete - Disable removal of execution payloads for
+   *   statuses other than 'completed'
    * @returns {Promise<Array>} - Execution table objects that were updated
    */
-  async removeOldPayloadRecords(maxAgeDays) {
-    if (!process.env.executionPayloadTimeout === 'disabled') {
-      return [];
-    }
-    // DB uses milliseconds.  Convert to days for the expiration comparison value
-    const expiryDate = Date.now() - (1000 * 3600 * 24 * maxAgeDays);
+  async removeOldPayloadRecords(completeMaxDays, nonCompleteMaxDays,
+    disableComplete, disableNonComplete) {
+    const msPerDay = 1000 * 3600 * 24;
+    const completeMaxAgeMseconds = Date.now() - (msPerDay * completeMaxDays);
+    const nonCompleteMaxAgeMseconds = Date.now() - (msPerDay * nonCompleteMaxDays);
+    const expiryDate = completeMaxDays < nonCompleteMaxDays ? completeMaxAgeMseconds : nonCompleteMaxAgeMseconds;
     const executionNames = { '#updatedAt': 'updatedAt' };
     const executionValues = { ':expiryDate': expiryDate };
     const filter = '#updatedAt <= :expiryDate and (attribute_exists(originalPayload) or attribute_exists(finalPayload))';
@@ -76,7 +83,16 @@ class Execution extends Manager {
     const concurrencyLimit = process.env.CONCURRENCY || 10;
     const limit = pLimit(concurrencyLimit);
 
-    const updatePromises = oldExecutionRows.Items.map((row) => limit(() => this.update({ arn: row.arn }, {}, ['originalPayload', 'finalPayload'])));
+    const updatePromises = oldExecutionRows.Items.map((row) => limit(() => {
+      debugger;
+      if (row.status === 'completed' && !disableComplete && row.updatedAt <= completeMaxAgeMseconds) {
+        return this.update({ arn: row.arn }, {}, ['originalPayload', 'finalPayload']);
+      }
+      if (!(row.status === 'completed') && !disableNonComplete && row.updatedAt <= nonCompleteMaxAgeMseconds) {
+        return this.update({ arn: row.arn }, {}, ['originalPayload', 'finalPayload']);
+      }
+      return Promise.resolve();
+    }));
     return Promise.all(updatePromises);
   }
 

--- a/packages/api/tests/lambdas/test-cleanExecutions.js
+++ b/packages/api/tests/lambdas/test-cleanExecutions.js
@@ -8,30 +8,51 @@ const { cleanExecutionPayloads } = require('../../lambdas/cleanExecutions');
 const removeRecordsStub = sinon.spy();
 
 class executionModel {
-  removeOldPayloadRecords(value) {
-    return removeRecordsStub(value);
+  removeOldPayloadRecords(...value) {
+    return removeRecordsStub(...value);
   }
 }
 
-test.serial('Function is called with passed in number of days', async (t) => {
-  process.env.executionPayloadRetentionPeriod = 100;
-  await cleanExecutionPayloads(executionModel);
-  t.truthy(removeRecordsStub.calledWith(100));
+test.beforeEach(() => {
+  process.env.completeExecutionPayloadTimeoutDisable = false;
+  process.env.nonCompleteExecutionPayloadTimeoutDisable = false;
 });
 
-test.serial('Function returns empty set if passed in value is disabled', async (t) => {
-  process.env.executionPayloadRetentionPeriod = 'disabled';
+test.serial('Function is called with correct timeout values', async (t) => {
+  process.env.completeExecutionPayloadTimeout = 100;
+  process.env.nonCompleteExecutionPayloadTimeout = 50;
+  await cleanExecutionPayloads(executionModel);
+  t.truthy(removeRecordsStub.calledWith(100, 50, false, false));
+});
+
+test.serial('Function returns empty array if passed in values are disabled', async (t) => {
+  process.env.completeExecutionPayloadTimeout = 100;
+  process.env.nonCompleteExecutionPayloadTimeout = 50;
+  process.env.completeExecutionPayloadTimeoutDisable = true;
+  process.env.nonCompleteExecutionPayloadTimeoutDisable = true;
   const actual = await cleanExecutionPayloads(executionModel);
   const expected = [];
   t.deepEqual(actual, expected);
 });
 
-test.serial('Function throws error if passed invalid RetentionPeriod', async (t) => {
-  process.env.executionPayloadRetentionPeriod = 'testValue';
+test.serial('Function throws error if passed invalid complete timeout', async (t) => {
+  process.env.nonCompleteExecutionPayloadTimeout = 100;
+  process.env.completeExecutionPayloadTimeout = 'notaninteger';
   let actual;
   await cleanExecutionPayloads(executionModel).catch((e) => {
     actual = e.message;
   });
-  const expected = 'Invalid number of days specified for executionPayloadRetentionPeriod env variable. It must be a number: testValue';
+  const expected = 'Invalid number of days specified in configuration for completeExecutionPayloadTimeout: notaninteger';
+  t.is(actual, expected);
+});
+
+test.serial('Function throws error if passed invalid non-complete timeout', async (t) => {
+  process.env.nonCompleteExecutionPayloadTimeout = 'notaninteger';
+  process.env.completeExecutionPayloadTimeout = 100;
+  let actual;
+  await cleanExecutionPayloads(executionModel).catch((e) => {
+    actual = e.message;
+  });
+  const expected = 'Invalid number of days specified in configuration for nonCompleteExecutionPayloadTimeout: notaninteger';
   t.is(actual, expected);
 });

--- a/packages/common/tests/aws.js
+++ b/packages/common/tests/aws.js
@@ -107,7 +107,7 @@ test('pullStepFunctionEvent returns original message if message not on S3', asyn
       execution_name: 'execution'
     },
     meta: {
-      bucket: 'test bucket',
+      bucket: 'test bucket'
     }
   };
 

--- a/packages/deployment/app/config.yml
+++ b/packages/deployment/app/config.yml
@@ -4,8 +4,8 @@ default:
 
   urs_url: https://uat.urs.earthdata.nasa.gov
 
-  non_complete_execution_payload_timeout: 30
-  complete_execution_payload_timeout: 10
+  non_complete_execution_payload_timeout: 30 ## days
+  complete_execution_payload_timeout: 10     ## days
   complete_execution_payload_disable: false
   non_complete_execution_payload_disable: false
 

--- a/packages/deployment/app/config.yml
+++ b/packages/deployment/app/config.yml
@@ -4,8 +4,10 @@ default:
 
   urs_url: https://uat.urs.earthdata.nasa.gov
 
-
-  execution_payload_retention_period: 30 ## days
+  non_complete_execution_payload_timeout: 30
+  complete_execution_payload_timeout: 10
+  complete_execution_payload_disable: false
+  non_complete_execution_payload_disable: false
 
   oauth:
     provider: earthdata


### PR DESCRIPTION
Update execution cleanup to allow cleanup to evaluate completed status
and 'other' status execution records separately so that non-complete
execution records may retain their payload history for a different
amount of time.

**Summary:**

Separated configuration flags for originalPayload/finalPayload cleanup such that they can be set to different retention times

Addresses [CUMULUS-1050](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1050)

## Changes
(see Summary)

## Test Plan
Things that should succeed before merging.

- [x] Unit tests
- [x] Adhoc testing
- [x] Update CHANGELOG
