### PR TITLE
Remove useless DLQs

### DIFF
--- a/packages/api/config/lambdas.yml
+++ b/packages/api/config/lambdas.yml
@@ -200,11 +200,9 @@ KinesisInboundEventLogger:
   timeout: 300
   memory: 512
   source: 'node_modules/@cumulus/api/dist/'
-  namedLambdaDeadLetterQueue: true
 
 KinesisOutboundEventLogger:
   handler: index.logger
   timeout: 300
   memory: 512
   source: 'node_modules/@cumulus/api/dist'
-  namedLambdaDeadLetterQueue: true


### PR DESCRIPTION
During development of 975 these were added and left in in error.
DLQ will not provide useful functionality for sync calls 