### PR TITLE
Use NGAP Permissions boundaries by default, fix travis releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ stages:
   - name: unit test and stack deployment
   - name: integration tests
   - name: redeployment integration tests
-    if: (type != pull_request AND branch = master) OR commit_message =~ \[run-redeploy-tests\] OR (type != pull_request AND tag =~ ^v\d+)
+    if: (type != pull_request AND branch = master) OR commit_message =~ \[run-redeploy-tests\] OR (type != pull_request AND tag =~ ^v\d+.*)
   - name: cleanup integration tests
   - name: deploy
     if: type != pull_request AND tag =~ ^v\d+
@@ -146,3 +146,4 @@ jobs:
 branches:
   only:
     - master
+    - ^v\d+.*  # To build tag pushes for releases

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -32,7 +32,7 @@ Add a link reference for the github "compare" view at the bottom of the CHANGELO
 
 ### 4. Update example/package.json
 
-Update example/package.json to point to the new Cumulus packages.
+Update example/package.json to point to the new Cumulus packages. If this is a backport, pin the version of the Cumulus packages to the specific version being released. Do not use `^` or `~`.
 
 ### 5. Cut new version of Cumulus Documentation
 
@@ -43,6 +43,8 @@ git add .
 ```
 
 Where `${release_version}` corresponds to the version tag `v1.2.3`, for example.
+
+Note: This is for 1.10.3 or later.
 
 ### 6. Create a pull request against the master branch
 

--- a/example/iam/config.yml
+++ b/example/iam/config.yml
@@ -4,6 +4,8 @@ default:
 
   system_bucket: '{{buckets.internal.name}}'
 
+  useNgapPermissionBoundary: true
+
   buckets:
     internal:
       name: cumulus-test-sandbox-internal


### PR DESCRIPTION
**Summary:** Turn on permissions boundary by default to prep for NGAP 2.0 switch

Addresses [CUMULUS-919](https://bugs.earthdata.nasa.gov/browse/CUMULUS-919)

## Changes

* For IAM deployment, change `useNgapPermissionsBoundary` to be true in the example package by default
* Fix travis to properly build tags
* Update release README with lessons learned

## Test Plan
Things that should succeed before merging.

- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Update CHANGELOG
- [ ] Run `./bin/eslint-ratchet` and verify that eslint errors have not increased
  - [ ] Commit `.eslint-ratchet-high-water-mark` if the score has improved

## Release PR

If this is a **release** PR, make sure you branch name starts with `release-` prefix, e.g. `release-v-1.1.2`.

Reviewers: @tag-your-friends
