### PR TITLE
make unreliable startSfSpec tests pending

### DIFF
--- a/example/spec/parallel/startSF/startSfSpec.js
+++ b/example/spec/parallel/startSF/startSfSpec.js
@@ -81,6 +81,7 @@ describe('the sf-starter lambda function', () => {
     });
 
     it('that has messages', async () => {
+      pending('until SQS provides a reliable getNumberOfMessages function');
       const { Attributes } = await sqs().getQueueAttributes(qAttrParams).promise();
       expect(Attributes.ApproximateNumberOfMessages).toBe(initialMessageCount.toString());
     });
@@ -99,8 +100,9 @@ describe('the sf-starter lambda function', () => {
     });
 
     it('up to its message limit', async () => {
+      pending('until SQS provides a way to confirm a given message/set of messages was deleted');
       const { Attributes } = await sqs().getQueueAttributes(qAttrParams).promise();
-      const numOfMessages = parseInt(Attributes.ApproximateNumberOfMessages, 10); // sqs returns number as string
+      const numOfMessages = parseInt(Attributes.ApproximateNumberOfMessages, 10); // sometimes returns 30 due to nature of SQS, failing test
       expect(numOfMessages).toBe(initialMessageCount - messagesConsumed);
     });
 


### PR DESCRIPTION
**Summary:** Summary of changes

SQS due to its distributed nature does not guarantee that `approximateNumberOfMessages` is an up-to-date reflection of the number of visible and non-deleted messages in the queue, nor does it provide a way to confirm if a message was deleted via the messageId, nor even that a deletion is certain. This presents a problem because we cannot test message deletion with certainty, and it may result in receiving a message twice, which would trigger a workflow twice. SQS notes that `You should ensure that your application is idempotent, so that receiving a message more than once does not cause issues.` For now to reduce intermittent test issues I am marking those tests as pending.