### PR TITLE
Cumulus 1063 fix build

### DIFF
--- a/packages/api/webpack.config.js
+++ b/packages/api/webpack.config.js
@@ -5,7 +5,7 @@ let devtool = 'inline-source-map';
 
 if(process.env.PRODUCTION) {
   mode = 'production',
-  devtool = false  
+  devtool = false
 }
 
 module.exports = {
@@ -19,7 +19,21 @@ module.exports = {
   externals: [
     'aws-sdk',
     'electron',
-    {'formidable': 'url'}
+    {
+      'formidable': 'url',
+      'sqlite3': 'sqlite3',
+      'mariasql': 'mariasql',
+      'mssql': 'mssql',
+      'mssql/lib/base': 'mssql/lib/base',
+      'mssql/package.json': 'mssql/package/json',
+      'mysql2': 'mysql2',
+      'tedious': 'tedious',
+      'oracle': 'oracle',
+      'strong-oracle': 'strong-oracle',
+      'oracledb': 'oracledb',
+      'pg': 'pg',
+      'pg-query-stream': 'pg-query-stream'
+    },
   ],
   devtool,
   target: 'node'

--- a/packages/api/webpack.config.js
+++ b/packages/api/webpack.config.js
@@ -3,9 +3,9 @@ const path = require('path');
 let mode = 'development';
 let devtool = 'inline-source-map';
 
-if(process.env.PRODUCTION) {
-  mode = 'production',
-  devtool = false
+if (process.env.PRODUCTION) {
+  mode = 'production';
+  devtool = false;
 }
 
 module.exports = {
@@ -20,20 +20,20 @@ module.exports = {
     'aws-sdk',
     'electron',
     {
-      'formidable': 'url',
-      'sqlite3': 'sqlite3',
-      'mariasql': 'mariasql',
-      'mssql': 'mssql',
+      formidable: 'url',
+      sqlite3: 'sqlite3',
+      mariasql: 'mariasql',
+      mssql: 'mssql',
       'mssql/lib/base': 'mssql/lib/base',
       'mssql/package.json': 'mssql/package/json',
-      'mysql2': 'mysql2',
-      'tedious': 'tedious',
-      'oracle': 'oracle',
+      mysql2: 'mysql2',
+      tedious: 'tedious',
+      oracle: 'oracle',
       'strong-oracle': 'strong-oracle',
-      'oracledb': 'oracledb',
-      'pg': 'pg',
+      oracledb: 'oracledb',
+      pg: 'pg',
       'pg-query-stream': 'pg-query-stream'
-    },
+    }
   ],
   devtool,
   target: 'node'

--- a/packages/integration-tests/webpack.config.js
+++ b/packages/integration-tests/webpack.config.js
@@ -3,9 +3,9 @@ const path = require('path');
 let mode = 'development';
 let devtool = 'inline-source-map';
 
-if(process.env.PRODUCTION) {
-  mode = 'production',
-  devtool = false
+if (process.env.PRODUCTION) {
+  mode = 'production';
+  devtool = false;
 }
 
 module.exports = {
@@ -20,19 +20,19 @@ module.exports = {
     'aws-sdk',
     'electron',
     {
-     'formidable': 'url',
-     'sqlite3': 'sqlite3',
-     'mariasql': 'mariasql',
-     'mssql': 'mssql',
-     'mssql/lib/base': 'mssql/lib/base',
-     'mssql/package.json': 'mssql/package/json',
-     'mysql2': 'mysql2',
-     'tedious': 'tedious',
-     'oracle': 'oracle',
-     'strong-oracle': 'strong-oracle',
-     'oracledb': 'oracledb',
-     'pg': 'pg',
-     'pg-query-stream': 'pg-query-stream'
+      formidable: 'url',
+      sqlite3: 'sqlite3',
+      mariasql: 'mariasql',
+      mssql: 'mssql',
+      'mssql/lib/base': 'mssql/lib/base',
+      'mssql/package.json': 'mssql/package/json',
+      mysql2: 'mysql2',
+      tedious: 'tedious',
+      oracle: 'oracle',
+      'strong-oracle': 'strong-oracle',
+      oracledb: 'oracledb',
+      pg: 'pg',
+      'pg-query-stream': 'pg-query-stream'
     }
   ],
   devtool,

--- a/packages/integration-tests/webpack.config.js
+++ b/packages/integration-tests/webpack.config.js
@@ -19,7 +19,21 @@ module.exports = {
   externals: [
     'aws-sdk',
     'electron',
-    {'formidable': 'url'}
+    {
+     'formidable': 'url',
+     'sqlite3': 'sqlite3',
+     'mariasql': 'mariasql',
+     'mssql': 'mssql',
+     'mssql/lib/base': 'mssql/lib/base',
+     'mssql/package.json': 'mssql/package/json',
+     'mysql2': 'mysql2',
+     'tedious': 'tedious',
+     'oracle': 'oracle',
+     'strong-oracle': 'strong-oracle',
+     'oracledb': 'oracledb',
+     'pg': 'pg',
+     'pg-query-stream': 'pg-query-stream'
+    }
   ],
   devtool,
   target: 'node'

--- a/tasks/test-processing/webpack.config.js
+++ b/tasks/test-processing/webpack.config.js
@@ -5,7 +5,7 @@ let devtool = 'inline-source-map';
 
 if(process.env.PRODUCTION) {
   mode = 'production',
-  devtool = false  
+  devtool = false
 }
 
 module.exports = {
@@ -19,7 +19,21 @@ module.exports = {
   externals: [
     'aws-sdk',
     'electron',
-    {'formidable': 'url'}
+    {
+      'formidable': 'url',
+      'sqlite3': 'sqlite3',
+      'mariasql': 'mariasql',
+      'mssql': 'mssql',
+      'mssql/lib/base': 'mssql/lib/base',
+      'mssql/package.json': 'mssql/package/json',
+      'mysql2': 'mysql2',
+      'tedious': 'tedious',
+      'oracle': 'oracle',
+      'strong-oracle': 'strong-oracle',
+      'oracledb': 'oracledb',
+      'pg': 'pg',
+      'pg-query-stream': 'pg-query-stream'
+    }
   ],
   devtool,
   target: 'node'

--- a/tasks/test-processing/webpack.config.js
+++ b/tasks/test-processing/webpack.config.js
@@ -3,9 +3,9 @@ const path = require('path');
 let mode = 'development';
 let devtool = 'inline-source-map';
 
-if(process.env.PRODUCTION) {
-  mode = 'production',
-  devtool = false
+if (process.env.PRODUCTION) {
+  mode = 'production';
+  devtool = false;
 }
 
 module.exports = {
@@ -20,18 +20,18 @@ module.exports = {
     'aws-sdk',
     'electron',
     {
-      'formidable': 'url',
-      'sqlite3': 'sqlite3',
-      'mariasql': 'mariasql',
-      'mssql': 'mssql',
+      formidable: 'url',
+      sqlite3: 'sqlite3',
+      mariasql: 'mariasql',
+      mssql: 'mssql',
       'mssql/lib/base': 'mssql/lib/base',
       'mssql/package.json': 'mssql/package/json',
-      'mysql2': 'mysql2',
-      'tedious': 'tedious',
-      'oracle': 'oracle',
+      mysql2: 'mysql2',
+      tedious: 'tedious',
+      oracle: 'oracle',
       'strong-oracle': 'strong-oracle',
-      'oracledb': 'oracledb',
-      'pg': 'pg',
+      oracledb: 'oracledb',
+      pg: 'pg',
       'pg-query-stream': 'pg-query-stream'
     }
   ],


### PR DESCRIPTION
Add knex db externals to test/api package.

Externals entries need to be added to webpack for all of the possible
database external requirements that *aren't* included in the api
package.json.

This is due to oddness in the way knex is referencing said libraries,
see commentary at : https://github.com/tgriesser/knex/issues/1128