### PR TITLE
CUMULUS-1070: Use CMR clientId in all CMR requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 `@cumulus/ingest/granule` functions: `publish`, `getGranuleId`, `getXMLMetadataAsString`, `getMetadataBodyAndTags`, `parseXmlString`, `getCmrFiles`, `postS3Object`, `contructOnlineAccessUrls`, `updateMetadata`, extracted and moved to `@cumulus/cmrjs`
 `getGranuleId`, `getCmrFiles`, `publish`, `updateMetadata` removed from `@cumulus/ingest/granule` and added to `@cumulus/cmrjs`;
 `@cumulus/ingest` test files renamed.
+- **CUMULUS-1070**
+  - Add `'Client-Id'` header to all `@cumulus/cmrjs` requests (made via `searchConcept`, `ingestConcept`, and `deleteConcept`).
+  - Updated `cumulus/example/app/config.yml` entry for `cmr.clientId` to use stackName for easier CMR-side identification. 
 
 ## [v1.11.0] - 2018-11-30
 

--- a/example/app/config.yml
+++ b/example/app/config.yml
@@ -125,7 +125,7 @@ default:
   cmr:
     username: '{{CMR_USERNAME}}'
     provider: CUMULUS
-    clientId: CUMULUS
+    clientId: 'cumulus-core-{{stackName}}'
     password: '{{CMR_PASSWORD}}'
 
   stepFunctions: !!files [

--- a/packages/cmrjs/cmr.js
+++ b/packages/cmrjs/cmr.js
@@ -213,7 +213,7 @@ class CMR {
    * @returns {Promise.<Object>} the CMR response
    */
   async ingestCollection(xml) {
-    const headers = this.getHeaders(this.getToken());
+    const headers = this.getHeaders(await this.getToken());
     return ingestConcept('collection', xml, 'Collection.DataSetId', this.provider, headers);
   }
 
@@ -224,7 +224,7 @@ class CMR {
    * @returns {Promise.<Object>} the CMR response
    */
   async ingestGranule(xml) {
-    const headers = this.getHeaders(this.getToken());
+    const headers = this.getHeaders(await this.getToken());
     return ingestConcept('granule', xml, 'Granule.GranuleUR', this.provider, headers);
   }
 
@@ -235,7 +235,7 @@ class CMR {
    * @returns {Promise.<Object>} the CMR response
    */
   async deleteCollection(datasetID) {
-    const headers = this.getHeaders(this.getToken());
+    const headers = this.getHeaders(await this.getToken());
     return deleteConcept('collection', datasetID, headers);
   }
 
@@ -246,7 +246,7 @@ class CMR {
    * @returns {Promise.<Object>} the CMR response
    */
   async deleteGranule(granuleUR) {
-    const headers = this.getHeaders(this.getToken());
+    const headers = this.getHeaders(await this.getToken());
     return deleteConcept('granules', granuleUR, this.provider, headers);
   }
 

--- a/packages/cmrjs/index.js
+++ b/packages/cmrjs/index.js
@@ -3,6 +3,7 @@
 const got = require('got');
 const { parseString } = require('xml2js');
 const {
+  searchConcept,
   ingestConcept,
   deleteConcept,
   CMR
@@ -70,6 +71,7 @@ async function getFullMetadata(cmrLink) {
 }
 
 module.exports = {
+  searchConcept,
   ingestConcept,
   deleteConcept,
   getUrl,


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-1070: Use CMR clientId in all CMR requests](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1070)

## Changes

* Added `Client-Id` headers to all requests made with the `CMR` class from `cmrjs`.
* Tests for header inclusion with request.

## Test Plan
Things that should succeed before merging.

- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Update CHANGELOG
- [ ] Run `./bin/eslint-ratchet` and verify that eslint errors have not increased
  - [ ] Commit `.eslint-ratchet-high-water-mark` if the score has improved

## Release PR

If this is a **release** PR, make sure you branch name starts with `release-` prefix, e.g. `release-v-1.1.2`.

Reviewers: @tag-your-friends
