### PR TITLE
changelog note about CMR action item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+**Please Note**
+- Ensure your `app/config.yml` has a `clientId` specified in the `cmr` section. This will allow CMR to identify your requests for better support and metrics.
+  - For an example, please see [the example config](https://github.com/nasa/cumulus/blob/1c7e2bf41b75da9f87004c4e40fbcf0f39f56794/example/app/config.yml#L128).
+
 ### Changed
 
 - CUMULUS-678


### PR DESCRIPTION
Discussed 1070 with Catalino, he pointed out it would be good for the changelog to include an action item notifying DAACs to ensure they have a `clientId` in their `cmr` config. This PR adds that note.