### PR TITLE
Cumulus 678 unify api and tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `reconcileCMRMetadata` added to `@cumulus/cmrjs` to update metadata record with new file locations.
   `@cumulus/common/errors` adds two new error types `CMRMetaFileNotFound` and `InvalidArgument`.
   `@cumulus/common/test-utils` adds new function `randomId` to create a random string with id to help in debugging.
+  `@cumulus/common/BucketsConfig` adds a new helper class `BucketsConfig` for working with bucket stack configuration and bucket names.
+  `@cumulus/common/aws` adds new fucntion `s3PutObjectTagging` as a convenience for the aws  [s3().putObjectTagging](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObjectTagging-property) function.
+  `metadataObjectFromCMRXMLFile` added to `@cumulus/cmrjs` to read and parse CMR XML file from s3.
 
 ### Changed
 - CUMULUS-678
+  `tasks/move-granules` simplified and refactored to use  functionality from cmrjs.
   `ingest/granules.moveGranuleFiles` now just moves granule files and returns a list of the updated files. Updating metadata now handled by `@cumulus/cmrjs/reconcileCMRMetadata`.
   `move-granules.updateGranuleMetadata` refactored and bugs fixed in the case of a file matching multiple collection.files.regexps.
+  `getCmrXmlFiles` simplified and now only returns an object with the cmrfilename and the granuleId.
 
 - **CUMULUS-1049** Updated `Retrieve Execution Status API` in `@cumulus/api`: If the execution doesn't exist in Step Function API, Cumulus API returns the execution status information from the database.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `@cumulus/common/test-utils` adds new function `randomId` to create a random string with id to help in debugging.
   `@cumulus/common/BucketsConfig` adds a new helper class `BucketsConfig` for working with bucket stack configuration and bucket names.
   `@cumulus/common/aws` adds new fucntion `s3PutObjectTagging` as a convenience for the aws  [s3().putObjectTagging](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObjectTagging-property) function.
-  `metadataObjectFromCMRXMLFile` added to `@cumulus/cmrjs` to read and parse CMR XML file from s3.
+  `@cumulus/cmrjs` Adds:
+      - `constructOnlineAccessUrls` - Create list of correct URLs for echo10 metadata.
+	  -	`isECHO10File` - Identify an echo10 metadata file.
+      - `metadataObjectFromCMRXMLFile` Read and parse CMR XML file from s3.
+      - `updateEcho10XMLMetadata` Modify a cmr.xml file with updated information.
+      - `updateCMRMetadata` Modify a cmr metadata file with updated information.
+	  - `publishECHO10XML2CMR` Posts XML CMR data to CMR service.
+	  - `reconcileCMRMetadata` Reconciles cmr metadata file after a file moves.
+
 
 ### Changed
 - CUMULUS-678

--- a/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
@@ -147,6 +147,7 @@ describe('The S3 Ingest Granules workflow', () => {
     expectedPayload = loadFileWithUpdatedGranuleIdPathAndCollection(templatedOutputPayloadFilename, granuleId, testDataFolder, newCollectionId);
     expectedPayload.granules[0].dataType += testSuffix;
 
+    console.log('Start SuccessExecution');
     workflowExecution = await buildAndExecuteWorkflow(
       config.stackName,
       config.bucket,
@@ -156,6 +157,7 @@ describe('The S3 Ingest Granules workflow', () => {
       inputPayload
     );
 
+    console.log('Start FailingExecution');
     failingWorkflowExecution = await buildAndExecuteWorkflow(
       config.stackName,
       config.bucket,

--- a/packages/api/models/granules.js
+++ b/packages/api/models/granules.js
@@ -150,7 +150,7 @@ class Granule extends Manager {
   }
 
   /**
-   * Move a granule's files to destination locations specified
+   * Move a granule's files to destinations specified
    *
    * @param {Object} g - the granule record object
    * @param {Array<{regex: string, bucket: string, filepath: string}>} destinations

--- a/packages/cmrjs/cmr-utils.js
+++ b/packages/cmrjs/cmr-utils.js
@@ -147,13 +147,9 @@ async function getCmrXMLFiles(input, granuleIdExtraction) {
   await Promise.all(input.map(async (filename) => {
     if (isECHO10File(filename)) {
       const metadataObject = await metadataObjectFromCMRXMLFile(filename);
-      const tags = await getS3ObjectTags(filename);
-
       const cmrFileObject = {
         filename,
-        metadataObject,
         granuleId: getGranuleId(filename, granuleIdExtraction),
-        s3Tags: tags.TagSet
       };
 
       files.push(cmrFileObject);
@@ -333,6 +329,7 @@ module.exports = {
   getGranuleId,
   getCmrXMLFiles,
   isECHO10File,
+  metadataObjectFromCMRXMLFile,
   publishECHO10XML2CMR,
   reconcileCMRMetadata,
   updateCMRMetadata,

--- a/packages/cmrjs/cmr-utils.js
+++ b/packages/cmrjs/cmr-utils.js
@@ -254,7 +254,6 @@ function getCreds() {
  * @returns {Promise} returns promised updated metadata object.
  */
 async function updateEcho10XMLMetadata(cmrFile, files, distEndpoint, buckets) {
-
   const urls = constructOnlineAccessUrls(files, distEndpoint, buckets);
 
   // add/replace the OnlineAccessUrls
@@ -267,7 +266,11 @@ async function updateEcho10XMLMetadata(cmrFile, files, distEndpoint, buckets) {
   const builder = new xml2js.Builder();
   const xml = builder.buildObject(metadataObject);
 
-  await aws.promiseS3Upload({ Bucket: cmrFile.bucket, Key: cmrFile.filepath, Body: xml });
+  const tags = await aws.s3GetObjectTagging(cmrFile.bucket, cmrFile.filepath);
+  const tagsQueryString = aws.s3TagSetToQueryString(tags.TagSet);
+  await aws.promiseS3Upload({
+    Bucket: cmrFile.bucket, Key: cmrFile.filepath, Body: xml, Tagging: tagsQueryString
+  });
   return metadataObject;
 }
 

--- a/packages/cmrjs/cmr-utils.js
+++ b/packages/cmrjs/cmr-utils.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+const _set = require('lodash.set');
 const { promisify } = require('util');
 const urljoin = require('url-join');
 const xml2js = require('xml2js');
@@ -260,14 +261,8 @@ async function updateEcho10XMLMetadata(granuleId, cmrFile, files, distEndpoint) 
   const metadataObject = await metadataObjectFromCMRXMLFile(cmrFile.filename);
   const metadataGranule = metadataObject.Granule;
 
-  const updatedGranule = {};
-  Object.keys(metadataGranule).forEach((key) => {
-    if (key === 'OnlineResources' || key === 'Orderable') {
-      updatedGranule.OnlineAccessURLs = {};
-    }
-    updatedGranule[key] = metadataGranule[key];
-  });
-  updatedGranule.OnlineAccessURLs.OnlineAccessURL = urls;
+  const updatedGranule = { ...metadataGranule };
+  _set(updatedGranule, 'OnlineAccessURLs.OnlineAccessURL', urls);
   metadataObject.Granule = updatedGranule;
   const builder = new xml2js.Builder();
   const xml = builder.buildObject(metadataObject);

--- a/packages/cmrjs/cmr-utils.js
+++ b/packages/cmrjs/cmr-utils.js
@@ -235,7 +235,8 @@ function getCreds() {
 }
 
 /**
- * Modifies CMR ECHO10 XML metadata file with files' URLs updated to their new locations.
+ * After files are moved, this function creates new online access URLs and then updates
+ * the S3 ECHO10 CMR XML file with this information.
  *
  * @param {Object} cmrFile - cmr xml file object to be updated
  * @param {Array<Object>} files - array of file objects

--- a/packages/cmrjs/cmr-utils.js
+++ b/packages/cmrjs/cmr-utils.js
@@ -186,14 +186,15 @@ function constructOnlineAccessUrls(files, distEndpoint, buckets) {
 
   files.forEach((file) => {
     const urlObj = {};
+    const bucketType = buckets.type(file.bucket);
 
-    if (buckets.type(file.bucket) === 'protected') {
+    if (bucketType === 'protected') {
       const extension = urljoin(file.bucket, `${file.filepath}`);
       urlObj.URL = urljoin(distEndpoint, extension);
       urlObj.URLDescription = 'File to download';
       urls.push(urlObj);
     }
-    else if (buckets.type(file.bucket) === 'public') {
+    else if (bucketType === 'public') {
       urlObj.URL = `https://${file.bucket}.s3.amazonaws.com/${file.filepath}`;
       urlObj.URLDescription = 'File to download';
       urls.push(urlObj);

--- a/packages/cmrjs/cmr-utils.js
+++ b/packages/cmrjs/cmr-utils.js
@@ -274,7 +274,8 @@ async function updateEcho10XMLMetadata(cmrFile, files, distEndpoint, buckets) {
  * @param {Array<Object>} files - array of file objects
  * @param {string} distEndpoint - distribution enpoint from config
  * @param {boolean} published - indicate if publish is needed
- * @returns {Promise} returns promise to upload updated cmr file
+ * @returns {Promise} returns promise to publish metadata to CMR Service
+ *                    or resolved promise if published === false.
  */
 async function updateCMRMetadata(granuleId, cmrFile, files, distEndpoint, published) {
   log.debug(`cmrjs.updateCMRMetadata granuleId ${granuleId}, cmrMetadata file ${cmrFile.filename}`);
@@ -290,7 +291,7 @@ async function updateCMRMetadata(granuleId, cmrFile, files, distEndpoint, publis
         metadataObject: theMetadata,
         granuleId: granuleId
       };
-      await publishECHO10XML2CMR(cmrFileObject, creds, process.env.bucket, process.env.stackName);
+      return publishECHO10XML2CMR(cmrFileObject, creds, process.env.bucket, process.env.stackName);
     }
     return Promise.resolve();
   }

--- a/packages/cmrjs/cmr-utils.js
+++ b/packages/cmrjs/cmr-utils.js
@@ -250,7 +250,7 @@ function getCreds() {
  * @param {Object} cmrFile - cmr xml file object to be updated
  * @param {Array<Object>} files - array of file objects
  * @param {string} distEndpoint - distribution endpoint from config
- * @returns {Promise} returns promise to upload updated cmr file
+ * @returns {Promise} returns promised updated metadata object.
  */
 async function updateEcho10XMLMetadata(granuleId, cmrFile, files, distEndpoint) {
   const buckets = new BucketsConfig(await bucketsConfigDefaults());
@@ -272,7 +272,6 @@ async function updateEcho10XMLMetadata(granuleId, cmrFile, files, distEndpoint) 
   const builder = new xml2js.Builder();
   const xml = builder.buildObject(metadataObject);
 
-
   await aws.promiseS3Upload({ Bucket: cmrFile.bucket, Key: cmrFile.filepath, Body: xml });
   return metadataObject;
 }
@@ -293,7 +292,7 @@ async function updateCMRMetadata(granuleId, cmrFile, files, distEndpoint, publis
   if (isECHO10File(cmrFile.filename)) {
     const theMetadata = await updateEcho10XMLMetadata(granuleId, cmrFile, files, distEndpoint);
     if (published) {
-      // post meta file to CMR
+      // post metadata Object to CMR
       const creds = getCreds();
       const cmrFileObject = {
         filename: cmrFile.filename,

--- a/packages/cmrjs/cmr-utils.js
+++ b/packages/cmrjs/cmr-utils.js
@@ -94,11 +94,6 @@ async function getXMLMetadataAsString(xmlFilePath) {
   return obj.Body.toString();
 }
 
-async function getS3ObjectTags(objectFilePath) {
-  const { Bucket, Key } = aws.parseS3Uri(objectFilePath);
-  return aws.s3GetObjectTagging(Bucket, Key);
-}
-
 /**
  * Parse an xml string
  *
@@ -144,7 +139,7 @@ const metadataObjectFromCMRXMLFile = async (cmrFilename) => {
 function getCmrXMLFiles(input, granuleIdExtraction) {
   const files = [];
 
-  input.map((filename) => {
+  input.forEach((filename) => {
     if (isECHO10File(filename)) {
       const cmrFileObject = {
         filename,

--- a/packages/cmrjs/cmr-utils.js
+++ b/packages/cmrjs/cmr-utils.js
@@ -247,14 +247,14 @@ function getCreds() {
 /**
  * Modifies CMR ECHO10 XML metadata file with files' URLs updated to their new locations.
  *
- * @param {string} granuleId - granuleId
  * @param {Object} cmrFile - cmr xml file object to be updated
  * @param {Array<Object>} files - array of file objects
  * @param {string} distEndpoint - distribution endpoint from config
+ * @param {BucketsConfig} buckets - stack BucketConfig instance
  * @returns {Promise} returns promised updated metadata object.
  */
-async function updateEcho10XMLMetadata(granuleId, cmrFile, files, distEndpoint) {
-  const buckets = new BucketsConfig(await bucketsConfigDefaults());
+async function updateEcho10XMLMetadata(cmrFile, files, distEndpoint, buckets) {
+
   const urls = constructOnlineAccessUrls(files, distEndpoint, buckets);
 
   // add/replace the OnlineAccessUrls

--- a/packages/cmrjs/cmr-utils.js
+++ b/packages/cmrjs/cmr-utils.js
@@ -285,7 +285,8 @@ async function updateCMRMetadata(granuleId, cmrFile, files, distEndpoint, publis
   log.debug(`cmrjs.updateCMRMetadata granuleId ${granuleId}, cmrMetadata file ${cmrFile.filename}`);
 
   if (isECHO10File(cmrFile.filename)) {
-    const theMetadata = await updateEcho10XMLMetadata(granuleId, cmrFile, files, distEndpoint);
+    const buckets = new BucketsConfig(await bucketsConfigDefaults());
+    const theMetadata = await updateEcho10XMLMetadata(cmrFile, files, distEndpoint, buckets);
     if (published) {
       // post metadata Object to CMR
       const creds = getCreds();
@@ -328,7 +329,9 @@ module.exports = {
   constructOnlineAccessUrls,
   getGranuleId,
   getCmrXMLFiles,
+  isECHO10File,
   publishECHO10XML2CMR,
   reconcileCMRMetadata,
-  updateCMRMetadata
+  updateCMRMetadata,
+  updateEcho10XMLMetadata
 };

--- a/packages/cmrjs/cmr-utils.js
+++ b/packages/cmrjs/cmr-utils.js
@@ -141,20 +141,18 @@ const metadataObjectFromCMRXMLFile = async (cmrFilename) => {
  * @returns {Promise<Array>} promise resolves to an array of objects
  * that includes CMR xmls uris and granuleIds
  */
-async function getCmrXMLFiles(input, granuleIdExtraction) {
+function getCmrXMLFiles(input, granuleIdExtraction) {
   const files = [];
 
-  await Promise.all(input.map(async (filename) => {
+  input.map((filename) => {
     if (isECHO10File(filename)) {
-      const metadataObject = await metadataObjectFromCMRXMLFile(filename);
       const cmrFileObject = {
         filename,
-        granuleId: getGranuleId(filename, granuleIdExtraction),
+        granuleId: getGranuleId(filename, granuleIdExtraction)
       };
-
       files.push(cmrFileObject);
     }
-  }));
+  });
 
   return files;
 }
@@ -259,6 +257,7 @@ async function updateEcho10XMLMetadata(cmrFile, files, distEndpoint, buckets) {
   const updatedGranule = { ...metadataGranule };
   _set(updatedGranule, 'OnlineAccessURLs.OnlineAccessURL', urls);
   metadataObject.Granule = updatedGranule;
+
   const builder = new xml2js.Builder();
   const xml = builder.buildObject(metadataObject);
 

--- a/packages/cmrjs/cmr-utils.js
+++ b/packages/cmrjs/cmr-utils.js
@@ -152,17 +152,6 @@ async function getCmrXMLFiles(input, granuleIdExtraction) {
   return files;
 }
 
-async function postS3Object(destination, options) {
-  await aws.promiseS3Upload(
-    { Bucket: destination.bucket, Key: destination.key, Body: destination.body }
-  );
-  if (options) {
-    const s3 = aws.s3();
-    await s3.deleteObject(options).promise();
-  }
-}
-
-
 /**
  * Retrieve the stack's bucket configuration from s3 and return the bucket configuration object.
  *
@@ -240,7 +229,6 @@ function getCmrFileObjs(files) {
   return files.filter((file) => isCMRFile(file));
 }
 
-
 const updateUMMGMetadata = async () => {
   const NotImplemented = errors.CreateErrorType('NotImplemented');
   throw new NotImplemented('not yet.');
@@ -295,8 +283,7 @@ const updateEcho10XMLMetadata = async (granuleId, cmrFile, files, distEndpoint, 
     };
     await publishECHO10XML2CMR(cmrFileObject, creds, process.env.bucket, process.env.stackName);
   }
-
-  return postS3Object({ bucket: cmrFile.bucket, key: cmrFile.filepath, body: xml });
+  return aws.promiseS3Upload({ Bucket: cmrFile.bucket, Key: cmrFile.filepath, Body: xml });
 };
 
 /**

--- a/packages/cmrjs/cmr-utils.js
+++ b/packages/cmrjs/cmr-utils.js
@@ -97,7 +97,6 @@ async function getS3ObjectTags(objectFilePath) {
   return aws.s3GetObjectTagging(Bucket, Key);
 }
 
-
 /**
  * Parse an xml string
  *
@@ -107,7 +106,6 @@ async function getS3ObjectTags(objectFilePath) {
 async function parseXmlString(xml) {
   return (promisify(xml2js.parseString))(xml, xmlParseOptions);
 }
-
 
 const isECHO10File = (filename) => filename.endsWith('cmr.xml');
 const isUMMGFile = (filename) => filename.endsWith('cmr.json');
@@ -122,7 +120,6 @@ function isCMRFile(fileobject) {
   const cmrfilename = fileobject.name || fileobject.filename || '';
   return isECHO10File(cmrfilename) || isUMMGFile(cmrfilename);
 }
-
 
 /**
  * return metadata object from cmr echo10 XML file.
@@ -179,8 +176,10 @@ async function bucketConfig(bucket, stackName) {
   return JSON.parse(bucketsString.Body);
 }
 
-/** Return the stack's buckets from S3 */
-const defaultBuckets = async () => bucketConfig(process.env.bucket, process.env.stackName);
+/** Return the stack's buckets object read from from S3 */
+async function defaultBuckets() {
+  return bucketConfig(process.env.bucket, process.env.stackName);
+}
 
 /**
  * Construct a list of online access urls.
@@ -232,20 +231,22 @@ function getCmrFileObjs(files) {
   return files.filter((file) => isCMRFile(file));
 }
 
-const updateUMMGMetadata = async () => {
+async function updateUMMGMetadata() {
   const NotImplemented = errors.CreateErrorType('NotImplemented');
   throw new NotImplemented('not yet.');
-};
+}
 
 /** helper to build an CMR credential object
  * @returns {Object} object to create CMR instance.
 */
-const getCreds = () => ({
-  provider: process.env.cmr_provider,
-  clientId: process.env.cmr_client_id,
-  username: process.env.cmr_username,
-  password: process.env.cmr_password
-});
+function getCreds() {
+  return {
+    provider: process.env.cmr_provider,
+    clientId: process.env.cmr_client_id,
+    username: process.env.cmr_username,
+    password: process.env.cmr_password
+  };
+}
 
 /**
  * Modifies cmr Echo10 xml metadata file with files' URLs updated to their new locations.
@@ -257,7 +258,7 @@ const getCreds = () => ({
  * @param {boolean} published - indicate if publish is needed
  * @returns {Promise} returns promise to upload updated cmr file
  */
-const updateEcho10XMLMetadata = async (granuleId, cmrFile, files, distEndpoint, published) => {
+async function updateEcho10XMLMetadata(granuleId, cmrFile, files, distEndpoint, published) {
   const urls = await constructOnlineAccessUrls(files, distEndpoint);
 
   // add/replace the OnlineAccessUrls
@@ -286,7 +287,7 @@ const updateEcho10XMLMetadata = async (granuleId, cmrFile, files, distEndpoint, 
   const builder = new xml2js.Builder();
   const xml = builder.buildObject(metadataObject);
   return aws.promiseS3Upload({ Bucket: cmrFile.bucket, Key: cmrFile.filepath, Body: xml });
-};
+}
 
 /**
  * Modifies cmr metadata file with file's URLs updated to their new locations.

--- a/packages/cmrjs/cmr.js
+++ b/packages/cmrjs/cmr.js
@@ -201,6 +201,7 @@ class CMR {
     const headers = {
       'Client-Id': this.clientId,
       'Content-type': 'application/echo10+xml'
+      // ummg: 'application/vnd.nasa.cmr.umm+json;version=1.4'  TODO [MHS, 2019-01-08]
     };
     if (token) headers['Echo-Token'] = token;
     return headers;

--- a/packages/cmrjs/index.js
+++ b/packages/cmrjs/index.js
@@ -20,8 +20,11 @@ const {
   constructOnlineAccessUrls,
   getGranuleId,
   getCmrXMLFiles,
+  isECHO10File,
+  metadataObjectFromCMRXMLFile,
   publishECHO10XML2CMR,
   reconcileCMRMetadata,
+  updateEcho10XMLMetadata,
   updateCMRMetadata
 } = require('./cmr-utils');
 
@@ -85,9 +88,12 @@ module.exports = {
   getUrl,
   hostId,
   ingestConcept,
+  isECHO10File,
+  metadataObjectFromCMRXMLFile,
   publishECHO10XML2CMR,
   reconcileCMRMetadata,
   searchConcept,
   updateCMRMetadata,
+  updateEcho10XMLMetadata,
   updateToken
 };

--- a/packages/cmrjs/index.js
+++ b/packages/cmrjs/index.js
@@ -17,6 +17,7 @@ const {
   hostId
 } = require('./utils');
 const {
+  constructOnlineAccessUrls,
   getGranuleId,
   getCmrXMLFiles,
   publishECHO10XML2CMR,
@@ -74,6 +75,7 @@ async function getFullMetadata(cmrLink) {
 module.exports = {
   CMR,
   ValidationError,
+  constructOnlineAccessUrls,
   deleteConcept,
   getCmrXMLFiles,
   getFullMetadata,

--- a/packages/cmrjs/package.json
+++ b/packages/cmrjs/package.json
@@ -36,6 +36,7 @@
     "got": "^8.3.0",
     "lodash.get": "^4.4.2",
     "lodash.property": "^4.4.2",
+    "lodash.set": "^4.3.2",
     "public-ip": "^2.3.5",
     "url-join": "^1.0.0",
     "xml2js": "^0.4.19"

--- a/packages/cmrjs/package.json
+++ b/packages/cmrjs/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "ava",
     "test-coverage": "nyc ava",
-    "debug" : "NODE_ENV=test node --inspect-brk node_modules/ava/profile.js --serial tests/*.js"
+    "debug": "NODE_ENV=test node --inspect-brk node_modules/ava/profile.js --serial tests/*.js"
   },
   "ava": {
     "files": "tests/*.js",

--- a/packages/cmrjs/tests/test-constructonlineaccessurls.js
+++ b/packages/cmrjs/tests/test-constructonlineaccessurls.js
@@ -17,7 +17,7 @@ test.beforeEach((t) => {
   t.context.buckets = new BucketsConfig(t.context.bucketConfig);
 });
 
-test('returns correct url for protected data', async (t) => {
+test('returns correct url for protected data', (t) => {
   const endpoint = 'https://endpoint';
   const testFiles = [
     {
@@ -32,12 +32,12 @@ test('returns correct url for protected data', async (t) => {
     }
   ];
 
-  const actual = await constructOnlineAccessUrls(testFiles, endpoint, t.context.buckets);
+  const actual = constructOnlineAccessUrls(testFiles, endpoint, t.context.buckets);
 
   t.deepEqual(actual, expected);
 });
 
-test('Returns correct url for public data.', async (t) => {
+test('Returns correct url for public data.', (t) => {
   const endpoint = 'https://endpoint';
   const testFiles = [
     {
@@ -52,13 +52,13 @@ test('Returns correct url for public data.', async (t) => {
     }
   ];
 
-  const actual = await constructOnlineAccessUrls(testFiles, endpoint, t.context.buckets);
+  const actual = constructOnlineAccessUrls(testFiles, endpoint, t.context.buckets);
 
   t.deepEqual(actual, expected);
 });
 
 
-test('Returns nothing for private data.', async (t) => {
+test('Returns nothing for private data.', (t) => {
   const endpoint = 'https://endpoint';
   const testFiles = [
     {
@@ -68,12 +68,12 @@ test('Returns nothing for private data.', async (t) => {
   ];
   const expected = [];
 
-  const actual = await constructOnlineAccessUrls(testFiles, endpoint, t.context.buckets);
+  const actual = constructOnlineAccessUrls(testFiles, endpoint, t.context.buckets);
 
   t.deepEqual(actual, expected);
 });
 
-test('Works for a list of files.', async (t) => {
+test('Works for a list of files.', (t) => {
   const endpoint = 'https://endpoint';
   const testFiles = [
     {
@@ -101,7 +101,7 @@ test('Works for a list of files.', async (t) => {
     }
   ];
 
-  const actual = await constructOnlineAccessUrls(testFiles, endpoint, t.context.buckets);
+  const actual = constructOnlineAccessUrls(testFiles, endpoint, t.context.buckets);
 
   t.deepEqual(actual, expected);
 });

--- a/packages/cmrjs/tests/test-constructonlineaccessurls.js
+++ b/packages/cmrjs/tests/test-constructonlineaccessurls.js
@@ -1,8 +1,8 @@
 const test = require('ava');
-const sinon = require('sinon');
 const rewire = require('rewire');
 
 const { randomId } = require('@cumulus/common/test-utils');
+const { BucketsConfig } = require('@cumulus/common');
 
 const cmrUtils = rewire('../cmr-utils');
 
@@ -14,12 +14,7 @@ test.beforeEach((t) => {
     protected: { name: randomId('protected'), type: 'protected' },
     public: { name: randomId('public'), type: 'public' }
   };
-  const fake = sinon.fake.returns(t.context.bucketConfig);
-  t.context.restore = cmrUtils.__set__('bucketConfig', fake);
-});
-
-test.afterEach((t) => {
-  t.context.restore();
+  t.context.buckets = new BucketsConfig(t.context.bucketConfig);
 });
 
 test('returns correct url for protected data', async (t) => {
@@ -37,7 +32,7 @@ test('returns correct url for protected data', async (t) => {
     }
   ];
 
-  const actual = await constructOnlineAccessUrls(testFiles, endpoint);
+  const actual = await constructOnlineAccessUrls(testFiles, endpoint, t.context.buckets);
 
   t.deepEqual(actual, expected);
 });
@@ -57,7 +52,7 @@ test('Returns correct url for public data.', async (t) => {
     }
   ];
 
-  const actual = await constructOnlineAccessUrls(testFiles, endpoint);
+  const actual = await constructOnlineAccessUrls(testFiles, endpoint, t.context.buckets);
 
   t.deepEqual(actual, expected);
 });
@@ -73,7 +68,7 @@ test('Returns nothing for private data.', async (t) => {
   ];
   const expected = [];
 
-  const actual = await constructOnlineAccessUrls(testFiles, endpoint);
+  const actual = await constructOnlineAccessUrls(testFiles, endpoint, t.context.buckets);
 
   t.deepEqual(actual, expected);
 });
@@ -106,7 +101,7 @@ test('Works for a list of files.', async (t) => {
     }
   ];
 
-  const actual = await constructOnlineAccessUrls(testFiles, endpoint);
+  const actual = await constructOnlineAccessUrls(testFiles, endpoint, t.context.buckets);
 
   t.deepEqual(actual, expected);
 });

--- a/packages/cmrjs/tests/test-reconcilecmrmetadata.js
+++ b/packages/cmrjs/tests/test-reconcilecmrmetadata.js
@@ -9,6 +9,20 @@ const { log, errors } = require('@cumulus/common');
 const { randomId } = require('@cumulus/common/test-utils');
 
 
+function expectedCreds() {
+  process.env.cmr_provider = randomId('cmr_provider');
+  process.env.cmr_client_id = randomId('cmr_client_id');
+  process.env.cmr_username = randomId('cmr_username');
+  process.env.cmr_password = randomId('cmr_password');
+
+  return {
+    provider: process.env.cmr_provider,
+    clientId: process.env.cmr_client_id,
+    username: process.env.cmr_username,
+    password: process.env.cmr_password
+  };
+}
+
 test.beforeEach((t) => {
   t.context.granId = randomId('granuleId');
   t.context.distEndpoint = randomId('https://example.com/');
@@ -65,17 +79,53 @@ test('reconcileCMRMetadata logs an error if multiple metadatafiles present.', as
 });
 
 
-test('reconcileCMRMetadata calls updateEcho10XMLMetadata if xml metadata present', async (t) => {
+test('reconcileCMRMetadata calls updateEcho10XMLMetadata but not publishECHO10XML2CMR if xml metadata present and publish is false', async (t) => {
   const updatedFiles = [{ filename: 'anotherfile' }, { filename: 'cmrmeta.cmr.xml' }];
-  const { granId, distEndpoint, pub } = t.context;
+  const { granId, distEndpoint } = t.context;
+  const pub = false;
   const fakeCall = sinon.fake.resolves(true);
   const restore = cmrUtils.__set__('updateEcho10XMLMetadata', fakeCall);
 
-  const results = await cmrUtils.reconcileCMRMetadata(granId, updatedFiles, distEndpoint, pub);
+  const fakeCall2 = sinon.fake.resolves({});
+  const restore2 = cmrUtils.__set__('publishECHO10XML2CMR', fakeCall2);
 
-  t.true(results);
-  t.true(fakeCall.calledOnceWith(granId, updatedFiles[1], updatedFiles, distEndpoint, pub));
+  await cmrUtils.reconcileCMRMetadata(granId, updatedFiles, distEndpoint, pub);
+
+  t.true(fakeCall.calledOnceWith(granId, updatedFiles[1], updatedFiles, distEndpoint));
+  t.true(fakeCall2.notCalled);
   restore();
+  restore2();
+});
+
+test('reconcileCMRMetadata calls updateEcho10XMLMetadata and publishECHO10XML2CMR if xml metadata present and publish is true', async (t) => {
+  const updatedFiles = [{ filename: 'anotherfile' }, { filename: 'cmrmeta.cmr.xml' }];
+  const { granId, distEndpoint, pub } = t.context;
+
+  const fakeMetadataObject = { fake: 'metadata' };
+
+  const fakeCall = sinon.fake.resolves(fakeMetadataObject);
+  const restore = cmrUtils.__set__('updateEcho10XMLMetadata', fakeCall);
+
+  const fakeCall2 = sinon.fake.resolves({});
+  const restore2 = cmrUtils.__set__('publishECHO10XML2CMR', fakeCall2);
+
+  const bucket = randomId('bucket');
+  const stackName = randomId('stack');
+  process.env.bucket = bucket;
+  process.env.stackName = stackName;
+  const testCreds = expectedCreds();
+  const expectedMetadata = {
+    filename: 'cmrmeta.cmr.xml',
+    metadataObject: fakeMetadataObject,
+    granuleId: granId
+  };
+
+  await cmrUtils.reconcileCMRMetadata(granId, updatedFiles, distEndpoint, pub);
+
+  t.true(fakeCall.calledOnceWith(granId, updatedFiles[1], updatedFiles, distEndpoint));
+  t.true(fakeCall2.calledOnceWith(expectedMetadata, testCreds, bucket, stackName));
+  restore();
+  restore2();
 });
 
 test('reconcileCMRMetadata calls updateUMMGMetadata if json metadata present', async (t) => {

--- a/packages/cmrjs/tests/test-reconcilecmrmetadata.js
+++ b/packages/cmrjs/tests/test-reconcilecmrmetadata.js
@@ -4,12 +4,12 @@ const rewire = require('rewire');
 
 const cmrUtils = rewire('../cmr-utils');
 
-const { log, BucketsConfig } = require('@cumulus/common');
+const { log } = require('@cumulus/common');
 
 const { randomId } = require('@cumulus/common/test-utils');
 
 
-function expectedCreds() {
+function setTestCredentials() {
   process.env.cmr_provider = randomId('cmr_provider');
   process.env.cmr_client_id = randomId('cmr_client_id');
   process.env.cmr_username = randomId('cmr_username');
@@ -123,7 +123,7 @@ test('reconcileCMRMetadata calls updateEcho10XMLMetadata and publishECHO10XML2CM
   const stackName = randomId('stack');
   process.env.bucket = bucket;
   process.env.stackName = stackName;
-  const testCreds = expectedCreds();
+  const testCreds = setTestCredentials();
   const expectedMetadata = {
     filename: 'cmrmeta.cmr.xml',
     metadataObject: fakeMetadataObject,

--- a/packages/cmrjs/tests/test-reconcilecmrmetadata.js
+++ b/packages/cmrjs/tests/test-reconcilecmrmetadata.js
@@ -4,7 +4,7 @@ const rewire = require('rewire');
 
 const cmrUtils = rewire('../cmr-utils');
 
-const log = require('@cumulus/common/log');
+const { log, errors } = require('@cumulus/common');
 
 const { randomId } = require('@cumulus/common/test-utils');
 
@@ -89,4 +89,17 @@ test('reconcileCMRMetadata calls updateUMMGMetadata if json metadata present', a
   t.true(results);
   t.true(fakeCall.calledOnceWith());
   restore();
+});
+
+test('updateCMRMetadata file throws error if incorrect cmrfile provided', async (t) => {
+  const updatedFiles = [{ filename: 'anotherfile' }, { filename: 'cmrmeta.cmr.json' }];
+  const badCMRFile = { filename: 'notreallycmrfile' };
+  const { granId, distEndpoint, pub } = t.context;
+  const updateCMRMetadata = cmrUtils.__get__('updateCMRMetadata');
+
+  const error = await t.throws(
+    updateCMRMetadata(granId, badCMRFile, updatedFiles, distEndpoint, pub)
+  );
+  t.is(error.name, 'CMRMetaFileNotFound');
+  t.is(error.message, 'Invalid CMR filetype passed to updateCMRMetadata');
 });

--- a/packages/common/BucketsConfig.js
+++ b/packages/common/BucketsConfig.js
@@ -2,6 +2,10 @@
 
 const isUndefined = require('lodash.isundefined');
 
+const { createErrorType } = require('./errors');
+
+const BucketsConfigError = createErrorType('BucketsConfigError');
+
 /**
  * Class representing cumulus bucket configuration.
  */
@@ -27,6 +31,9 @@ class BucketsConfig {
    */
   type(bucketName) {
     const key = this.key(bucketName);
+    if (!key) {
+      throw new BucketsConfigError(`bucketName ${bucketName} not found in config ${JSON.stringify(this.buckets)}`);
+    }
     return this.buckets[key].type;
   }
 
@@ -37,6 +44,9 @@ class BucketsConfig {
    */
   bucket(bucketName) {
     const key = this.key(bucketName);
+    if (!key) {
+      throw new BucketsConfigError(`bucketName ${bucketName} not found in config ${JSON.stringify(this.buckets)}`);
+    }
     return this.buckets[key];
   }
 

--- a/packages/common/BucketsConfig.js
+++ b/packages/common/BucketsConfig.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const isUndefined = require('lodash.isundefined');
+
+/**
+ * Class representing cumulus bucket configuration.
+ */
+class BucketsConfig {
+  constructor(bucketsJsonObject) {
+    this.buckets = bucketsJsonObject;
+  }
+
+  /**
+   * returns key into this.buckets who's object has `name` bucketName
+   * @param {string} bucketName
+   * @returns {string} desired bucket's key value.
+   */
+  key(bucketName) {
+    return Object.keys(this.buckets)
+      .find((bucketKey) => bucketName === this.buckets[bucketKey].name);
+  }
+
+  /**
+   * Return bucket type for bucketName
+   * @param {string} bucketName
+   * @returns {string} matching bucket's type
+   */
+  type(bucketName) {
+    const key = this.key(bucketName);
+    return this.buckets[key].type;
+  }
+
+  /**
+   * returns bucket object who's name field matches bucketName
+   * @param {string} bucketName
+   * @returns {Object} bucket object
+   */
+  bucket(bucketName) {
+    const key = this.key(bucketName);
+    return this.buckets[key];
+  }
+
+  /**
+   * returns true if bucketName is found in any attatched bucket objects.
+   * @param {string} bucketName
+   * @returns {boolean} truthyness of this bucket existing in the configuration
+   */
+  exists(bucketName) {
+    return !isUndefined(this.key(bucketName));
+  }
+
+  /**
+   * returns true if configKey is found on the top-level config.
+   * @param {string} configKey
+   * @returns {boolean} truthyness of this key existing in the configuration
+   */
+  keyExists(configKey) {
+    return Object.keys(this.buckets).includes(configKey);
+  }
+
+  /**
+   * returns name of bucket attatched to top-level config at configKey.
+   * @param {string} configKey
+   * @returns {string} name of bucket at key.
+   */
+  nameByKey(configKey) {
+    return this.buckets[configKey].name;
+  }
+}
+
+
+module.exports = BucketsConfig;

--- a/packages/common/aws.js
+++ b/packages/common/aws.js
@@ -279,6 +279,19 @@ exports.headObject = (bucket, key) =>
 exports.s3GetObjectTagging = (bucket, key) =>
   exports.s3().getObjectTagging({ Bucket: bucket, Key: key }).promise();
 
+
+/**
+* Puts object Tagging in S3
+* https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObjectTagging-property
+*
+* @param {string} bucket - name of bucket
+* @param {string} key - key for object (filepath + filename)
+* @param {Object} tagging - tagging object
+* @returns {Promise} - returns response from `S3.getObjectTagging` as a promise
+**/
+exports.s3PutObjectTagging = (bucket, key, tagging) =>
+  exports.s3().putObjectTagging({ Bucket: bucket, Key: key, Tagging: tagging }).promise();
+
 /**
 * Get an object from S3
 *

--- a/packages/common/index.js
+++ b/packages/common/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 exports.aws = require('./aws');
+exports.BucketsConfig = require('./BucketsConfig');
 exports.cliUtils = require('./cli-utils');
 exports.CloudFormationGateway = require('./CloudFormationGateway');
 exports.CollectionConfigStore = require('./collection-config-store').CollectionConfigStore;

--- a/packages/common/index.js
+++ b/packages/common/index.js
@@ -12,3 +12,4 @@ exports.stringUtils = require('./string');
 exports.testUtils = require('./test-utils');
 exports.util = require('./util');
 exports.keyPairProvider = require('./key-pair-provider');
+exports.errors = require('./errors');

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -58,6 +58,7 @@
     "lodash.isnumber": "^3.0.3",
     "lodash.isobject": "^3.0.2",
     "lodash.isstring": "^4.0.1",
+    "lodash.isundefined": "^3.0.1",
     "lodash.kebabcase": "^4.1.1",
     "lodash.range": "^3.2.0",
     "mocha": "^5.0.4",

--- a/packages/common/tests/test-BucketsConfig.js
+++ b/packages/common/tests/test-BucketsConfig.js
@@ -22,6 +22,20 @@ test('bucket keys are found by bucketName', (t) => {
   t.is(actual, expected);
 });
 
+test('throws error if bucket missing from bucketsConfig', (t) => {
+  const missingBucketName = 'does-not-exist';
+  const Bucket = new BucketsConfig(bucketConfig);
+  const theError = t.throws(() => Bucket.bucket(missingBucketName));
+  t.regex(theError.message, /bucketName does-not-exist/);
+});
+
+test('throws error if try to get type of non-existing bucket', (t) => {
+  const missingBucketName = 'does-not-exist';
+  const Bucket = new BucketsConfig(bucketConfig);
+  const theError = t.throws(() => Bucket.type(missingBucketName));
+  t.regex(theError.message, /bucketName does-not-exist/);
+});
+
 test('bucket types are found by bucketName', (t) => {
   const bucketName = 'a-shared-bucket';
   const Bucket = new BucketsConfig(bucketConfig);

--- a/packages/common/tests/test-BucketsConfig.js
+++ b/packages/common/tests/test-BucketsConfig.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const test = require('ava');
+
+const BucketsConfig = require('../BucketsConfig');
+
+const bucketConfig = {
+  private: { type: 'private', name: 'a-private-bucket' },
+  public: { type: 'public', name: 'a-public-bucket' },
+  protected: { type: 'protected', name: 'a-protected-bucket' },
+  shared: { type: 'shared', name: 'a-shared-bucket' },
+  internal: { type: 'internal', name: 'an-internal-bucket' }
+};
+
+test('bucket keys are found by bucketName', (t) => {
+  const bucketName = 'a-protected-bucket';
+  const Bucket = new BucketsConfig(bucketConfig);
+  const expected = 'protected';
+
+  const actual = Bucket.key(bucketName);
+
+  t.is(actual, expected);
+});
+
+test('bucket types are found by bucketName', (t) => {
+  const bucketName = 'a-shared-bucket';
+  const Bucket = new BucketsConfig(bucketConfig);
+  const expected = 'shared';
+
+  const actual = Bucket.type(bucketName);
+
+  t.is(actual, expected);
+});
+
+test('bucket object are found by bucketName', (t) => {
+  const bucketName = 'an-internal-bucket';
+  const Bucket = new BucketsConfig(bucketConfig);
+  const expected = {
+    type: 'internal',
+    name: 'an-internal-bucket'
+  };
+
+  const actual = Bucket.bucket(bucketName);
+
+  t.deepEqual(actual, expected);
+});
+
+
+test('checks a bucket existence in config', (t) => {
+  const existsName = 'a-public-bucket';
+  const doesNotExistName = 'not-included-bucket';
+  const Bucket = new BucketsConfig(bucketConfig);
+
+  t.truthy(Bucket.exists(existsName));
+  t.falsy(Bucket.exists(doesNotExistName));
+});
+
+test('checks a bucket key\'s existence in config', (t) => {
+  const existsKey = 'internal';
+  const doesNotExistKey = 'not-included-key';
+  const Bucket = new BucketsConfig(bucketConfig);
+
+  t.truthy(Bucket.keyExists(existsKey));
+  t.falsy(Bucket.keyExists(doesNotExistKey));
+});

--- a/tasks/move-granules/index.js
+++ b/tasks/move-granules/index.js
@@ -5,23 +5,21 @@ const { DuplicateFile, InvalidArgument } = require('@cumulus/common/errors');
 const get = require('lodash.get');
 const clonedeep = require('lodash.clonedeep');
 const flatten = require('lodash.flatten');
+const path = require('path');
+
 const {
   getRenamedS3File, unversionFilename,
   moveGranuleFile, renameS3FileWithTimestamp
 } = require('@cumulus/ingest/granule');
+
 const {
   getCmrXMLFiles,
-  getGranuleId
-} = require('@cumulus/cmrjs');
-const {
-  // TODO [MHS, 2019-01-08] refactor to not use in here, or added to
-  // cmrjs. (2019-01-10: this will actuall depend on if we have unified the
-  // calls to updateCMRMetadata or make separate calls to xml and json.
+  getGranuleId,
   isECHO10File,
   metadataObjectFromCMRXMLFile,
   updateEcho10XMLMetadata
-} = require('@cumulus/cmrjs/cmr-utils');
-const path = require('path');
+} = require('@cumulus/cmrjs');
+
 const {
   aws: {
     buildS3Uri,
@@ -354,7 +352,7 @@ async function moveGranules(event) {
 
   // Get list of cmr file objects from the input Array of S3 filenames (in
   // staging location after processing)
-  const cmrFiles = await getCmrXMLFiles(inputFileList, regex);
+  const cmrFiles = getCmrXMLFiles(inputFileList, regex);
 
   // create granules object for cumulus indexer
   const allGranules = addInputFilesToGranules(inputFileList, inputGranules, regex);

--- a/tasks/move-granules/index.js
+++ b/tasks/move-granules/index.js
@@ -27,6 +27,8 @@ const {
     deleteS3Object,
     parseS3Uri,
     promiseS3Upload,
+    s3GetObjectTagging,
+    s3PutObjectTagging,
     s3ObjectExists,
     s3TagSetToQueryString
   },
@@ -161,6 +163,63 @@ function updateGranuleMetadata(granulesObject, collection, cmrFiles, buckets) {
 }
 
 /**
+ * Moves CMR file ignoring any duplicate handling directives.
+ *
+ * @param {Object} file - cmr fileobject
+ * @param {Object} sourceBucket - sourceBucket for the stack
+ * @param {BucketsConfig} buckets - BucketsConfig instance.
+ */
+async function moveCmrFileRequest(file, sourceBucket, buckets) {
+  log.debug('entered moveCmrFileRequest');
+  log.debug(`moveCmrFileRequest file: ${JSON.stringify(file)}`);
+  const fileStagingDir = file.fileStagingDir || 'file-staging';
+  let source;
+  let target;
+  let tagging;
+  try {
+    source = {
+      Bucket: sourceBucket,
+      Key: `${fileStagingDir}/${file.name}`
+    };
+    log.debug('source...', source);
+    target = {
+      Bucket: file.bucket,
+      Key: file.filepath
+    };
+    log.debug('target...', target);
+
+
+    try {
+      log.debug('before tagging');
+      tagging = await s3GetObjectTagging(sourceBucket, `${fileStagingDir}/${file.name}`);
+      log.debug('tagging');
+    }
+    catch (error) {
+      log.debug('the error', error);
+      tagging = { TagSet: [] };
+    }
+  }
+  catch (error) {
+    log.debug('inside big catch');
+    throw error;
+  }
+  // the file moved to destination
+  const fileMoved = clonedeep(file);
+
+  log.debug('getting options');
+  const options = (buckets.type(file.bucket).match('public')) ? { ACL: 'public-read' } : null;
+
+  log.debug('cmrmove: source', source);
+  log.debug('cmrmove: target', target);
+  log.debug('cmrmove: options', options);
+  await moveGranuleFile(source, target, options);
+  if (tagging.TagSet.length > 0) {
+    await s3PutObjectTagging(file.bucket, file.filepath, tagging);
+  }
+  return [fileMoved];
+}
+
+/**
  * move file from source bucket to target location, and return the file moved.
  * In case of 'version' duplicateHandling, also return the renamed files.
  *
@@ -200,6 +259,7 @@ async function moveFileRequest(file, sourceBucket, duplicateHandling, buckets) {
   if (s3ObjAlreadyExists && duplicateHandling === 'skip') return [fileMoved];
 
   const options = (buckets.type(file.bucket).match('public')) ? { ACL: 'public-read' } : null;
+  log.debug(`options: ${options}`);
 
   // compare the checksum of the existing file and new file, and handle them accordingly
   if (s3ObjAlreadyExists && duplicateHandling === 'version') {
@@ -217,22 +277,32 @@ async function moveFileRequest(file, sourceBucket, duplicateHandling, buckets) {
     }
   }
   else {
+    log.debug(`exists and duplicateHandling is ${duplicateHandling}`);
+    log.debug(`source ${JSON.stringify(source, null, 2)}`);
+    log.debug(`target ${JSON.stringify(target, null, 2)}`);
     await moveGranuleFile(source, target, options);
+    log.debug('Finished Moving existing/replace.');
   }
 
   const renamedFiles = (duplicateHandling === 'version')
     ? await getRenamedS3File(target.Bucket, target.Key) : [];
 
   // return both file moved and renamed files
+  log.debug(`fileMoved: ${JSON.stringify(fileMoved, null, 2)}`);
+  log.debug(`renamedFiles: ${JSON.stringify(renamedFiles, null, 2)}`);
   return [fileMoved]
-    .concat(renamedFiles.map((f) => ({
-      bucket: file.bucket,
-      name: path.basename(f.Key),
-      filename: buildS3Uri(f.Bucket, f.Key),
-      filepath: f.Key,
-      fileSize: f.fileSize,
-      url_path: file.url_path
-    })));
+    .concat(renamedFiles.map((f) => {
+      log.debug(`anon: ${JSON.stringify(f)}`);
+      log.debug(`f.bucket ${f.Bucket}, file.bucket ${file.bucket}`);
+      return {
+        bucket: f.Bucket,
+        name: path.basename(f.Key),
+        filename: buildS3Uri(f.Bucket, f.Key),
+        filepath: f.Key,
+        fileSize: f.fileSize,
+        url_path: file.url_path
+      };
+    }));
 }
 
 /**
@@ -250,15 +320,16 @@ async function moveFilesForAllGranules(granulesObject, sourceBucket, duplicateHa
     const granule = granulesObject[granuleKey];
     const cmrFileFormat = /.*\.cmr\.xml$/;
     const filesToMove = granule.files.filter((file) => !file.name.match(cmrFileFormat));
-    const cmrFile = granule.files.filter((file) => file.name.match(cmrFileFormat));
-
+    const cmrFiles = granule.files.filter((file) => file.name.match(cmrFileFormat));
+    log.debug('filesToMove: ', filesToMove);
     const filesMoved = await Promise.all(
       filesToMove.map((file) => moveFileRequest(file, sourceBucket, duplicateHandling, buckets))
     );
-    granule.files = flatten(filesMoved).concat(cmrFile);
+    granule.files = flatten(filesMoved).concat(flatten(cmrFiles));
   });
 
   await Promise.all(moveFileRequests);
+  log.debug('exiting moveFilesForAllGranules');
   return granulesObject;
 }
 
@@ -272,41 +343,9 @@ async function moveFilesForAllGranules(granulesObject, sourceBucket, duplicateHa
  * @param {BucketsConfig} buckets - Stack BucketsConfig instance
  */
 async function updateCMRFileAccessURLs(cmrFile, files, distEndpoint, buckets) {
-  const metadataGranule = get(cmrFile, 'metadataObject.Granule');
-
-  const urls = await constructOnlineAccessUrls(files, distEndpoint, buckets);
-
-  const updatedGranule = {};
-  Object.keys(metadataGranule).forEach((key) => {
-    if (key === 'OnlineResources' || key === 'Orderable') {
-      updatedGranule.OnlineAccessURLs = {};
-    }
-    updatedGranule[key] = metadataGranule[key];
-  });
-  updatedGranule.OnlineAccessURLs.OnlineAccessURL = urls;
-  /* eslint-disable no-param-reassign */
-  cmrFile.metadataObject.Granule = updatedGranule;
-  /* eslint-enable no-param-reassign */
-  const builder = new xml2js.Builder();
-  const xml = builder.buildObject(cmrFile.metadataObject);
-
-
   const updatedCmrFile = files.find((f) => isECHO10File(f.filename));
-  // S3 upload only accepts tag query strings, so reduce tags to query string.
-  const tagsQueryString = s3TagSetToQueryString(cmrFile.s3Tags);
-  const params = {
-    Bucket: updatedCmrFile.bucket,
-    Key: updatedCmrFile.filepath,
-    Body: xml,
-    Tagging: tagsQueryString
-  };
-  if (buckets.type(updatedCmrFile.bucket).match('public')) {
-    params.ACL = 'public-read';
-  }
-  await promiseS3Upload(params);
-  // clean up old CmrFile after uploading new one
-  const { Bucket, Key } = parseS3Uri(cmrFile.filename);
-  await deleteS3Object(Bucket, Key);
+  await moveGranuleFile(parseS3Uri(cmrFile.filename), parseS3Uri(updatedCmrFile.filename));
+  return updateEcho10XMLMetadata(updatedCmrFile, files, distEndpoint, buckets);
 }
 
 /**
@@ -350,6 +389,14 @@ function duplicateHandlingType(event) {
   return duplicateHandling;
 }
 
+async function validateInputObjects(fileList) {
+  log.debug(`validating fileList ${JSON.stringify(fileList)}`);
+  const validFiles = await Promise.all(fileList.map((file) => s3ObjectExists(parseS3Uri(file))));
+  if (!validFiles.every((vf) => vf === true)) {
+    throw new Error('some files in input filelist missing.');
+  }
+};
+
 /**
  * Move Granule files to final Location
  * See the schemas directory for detailed input and output schemas
@@ -384,15 +431,28 @@ async function moveGranules(event) {
   const duplicateHandling = duplicateHandlingType(event);
 
   const input = get(event, 'input', []);
+  log.debug('moveGranules input: ', JSON.stringify(input));
+
+  try {
+    await validateInputObjects(input);
+  }
+  catch (error) {
+    log.error(`input objects do not exist ${JSON.stringify(input)}`);
+    throw error;
+  }
 
   // Get list of cmr file objects from the input Array of S3 filenames (in
   // staging location after processing)
   const cmrFiles = await getCmrXMLFiles(input, regex);
+  log.debug('the found cmrFiles:', JSON.stringify(cmrFiles));
 
   // create granules object for cumulus indexer
+  log.debug(`input granules: ${JSON.stringify(inputGranules)}`);
   const allGranules = addInputFilesToGranules(input, inputGranules, regex);
+  log.debug(`allGranules ${JSON.stringify(allGranules)}`);
 
   const granulesToMove = updateGranuleMetadata(allGranules, collection, cmrFiles, buckets);
+  log.debug(`granulesToMove, ${JSON.stringify(granulesToMove)}`);
 
   // allows us to disable moving the files
   let movedGranules;
@@ -401,13 +461,15 @@ async function moveGranules(event) {
     movedGranules = await moveFilesForAllGranules(
       granulesToMove, bucket, duplicateHandling, buckets
     );
+    log.debug(`movedGranules, ${JSON.stringify(movedGranules)}`);
     // update cmr.xml files with correct online access urls
     await updateEachCmrFileAccessURLs(cmrFiles, movedGranules, distEndpoint, buckets);
   }
   else {
     // TODO [MHS, 2019-01-08] This is the behavior in v1.10.4, but I'm not sure
     // it's what we want. Validate with someone.  It updates all of the file
-    // location metadata, but doesn't move the files to those locations.
+    // location metadata, but doesn't move the files to those locations.  Seems
+    // bad to me.
     movedGranules = granulesToMove;
   }
 

--- a/tasks/move-granules/index.js
+++ b/tasks/move-granules/index.js
@@ -357,11 +357,12 @@ async function moveGranules(event) {
   // create granules object for cumulus indexer
   const allGranules = addInputFilesToGranules(inputFileList, inputGranules, regex);
 
-  const granulesToMove = await updateGranuleMetadata(allGranules, collection, cmrFiles, buckets);
-
-  // allows us to disable moving the files
+  let granulesToMove;
   let movedGranules;
+  // allows us to disable moving the files
   if (moveStagedFiles) {
+    granulesToMove = await updateGranuleMetadata(allGranules, collection, cmrFiles, buckets);
+
     // move files from staging location to final location
     movedGranules = await moveFilesForAllGranules(
       granulesToMove, bucket, duplicateHandling, buckets
@@ -370,11 +371,7 @@ async function moveGranules(event) {
     await updateEachCmrFileAccessURLs(cmrFiles, movedGranules, distEndpoint, buckets);
   }
   else {
-    // TODO [MHS, 2019-01-08] This is the behavior in v1.10.4, but I'm not sure
-    // it's what we want. Validate with someone.  It updates all of the file
-    // location metadata, but doesn't move the files to those locations.  Seems
-    // bad to me.
-    movedGranules = granulesToMove;
+    movedGranules = allGranules;
   }
 
   return {

--- a/tasks/move-granules/index.js
+++ b/tasks/move-granules/index.js
@@ -129,13 +129,14 @@ async function updateGranuleMetadata(granulesObject, collection, cmrFiles, bucke
     const updatedFiles = [];
     updatedGranules[granuleId] = { ...granulesObject[granuleId] };
 
+    const cmrFile = cmrFiles.find((f) => f.granuleId === granuleId);
+    const cmrMetadata = cmrFile ? await metadataObjectFromCMRXMLFile(cmrFile.filename) : {};
+
     await Promise.all(granulesObject[granuleId].files.map(async (file) => {
       const match = fileSpecs.filter((cf) => unversionFilename(file.name).match(cf.regex));
       validateMatch(match, buckets, file);
 
       const URLPathTemplate = file.url_path || match[0].url_path || collection.url_path || '';
-      const cmrFile = cmrFiles.find((f) => f.granuleId === granuleId);
-      const cmrMetadata = cmrFile ? await metadataObjectFromCMRXMLFile(cmrFile.filename) : {};
       const urlPath = urlPathTemplate(URLPathTemplate, {
         file,
         granule: granulesObject[granuleId],

--- a/tasks/move-granules/index.js
+++ b/tasks/move-granules/index.js
@@ -268,24 +268,8 @@ async function updateCmrFileAccessURLs(cmrFiles, granulesObject, distEndpoint, b
   await Promise.all(cmrFiles.map(async (cmrFile) => {
     const metadataGranule = get(cmrFile, 'metadataObject.Granule');
     const granule = granulesObject[cmrFile.granuleId];
-    const urls = await constructOnlineAccessUrls(granule.files, distEndpoint, buckets);
-    // Populates onlineAcessUrls with all public and protected files
 
-    // granule.files.forEach((file) => {
-    //   const urlObj = {};
-    //   if (file.bucket.type.match('protected')) {
-    //     const extension = urljoin(file.bucket.name, file.filepath);
-    //     urlObj.URL = urljoin(distEndpoint, extension);
-    //     urlObj.URLDescription = 'File to download';
-    //     urls.push(urlObj);
-    //     log.info(`protected file: ${JSON.stringify(file)},\nurl: ${JSON.stringify(urlObj)}`);
-    //   }
-    //   else if (file.bucket.type.match('public')) {
-    //     urlObj.URL = `https://${file.bucket.name}.s3.amazonaws.com/${file.filepath}`;
-    //     urlObj.URLDescription = 'File to download';
-    //     urls.push(urlObj);
-    //   }
-    // });
+    const urls = await constructOnlineAccessUrls(granule.files, distEndpoint, buckets);
 
     const updatedGranule = {};
     Object.keys(metadataGranule).forEach((key) => {
@@ -297,7 +281,7 @@ async function updateCmrFileAccessURLs(cmrFiles, granulesObject, distEndpoint, b
     updatedGranule.OnlineAccessURLs.OnlineAccessURL = urls;
     /* eslint-disable no-param-reassign */
     cmrFile.metadataObject.Granule = updatedGranule;
-
+    /* eslint-enable no-param-reassign */
     const builder = new xml2js.Builder();
     const xml = builder.buildObject(cmrFile.metadataObject);
 

--- a/tasks/move-granules/index.js
+++ b/tasks/move-granules/index.js
@@ -295,7 +295,7 @@ async function updateCmrFileAccessURLs(cmrFiles, granulesObject, distEndpoint) {
 
     const builder = new xml2js.Builder();
     const xml = builder.buildObject(cmrFile.metadataObject);
-    cmrFile.metadata = xml;
+
     /* eslint-enable no-param-reassign */
     const updatedCmrFile = granule.files.find((f) => f.filename.match(/.*\.cmr\.xml$/));
     // S3 upload only accepts tag query strings, so reduce tags to query string.

--- a/tasks/move-granules/tests/test-index.js
+++ b/tasks/move-granules/tests/test-index.js
@@ -156,7 +156,7 @@ test.serial('Should update filenames with updated S3 URLs.', async (t) => {
 
   const output = await moveGranules(newPayload);
   const outputFilenames = output.granules[0].files.map((f) => f.filename);
-  t.deepEqual(expectedFilenames, outputFilenames);
+  t.deepEqual(expectedFilenames.sort(), outputFilenames.sort());
 });
 
 test.serial('Should preserve object tags.', async (t) => {
@@ -315,7 +315,7 @@ test.serial('when duplicateHandling is "version", keep both data if different', 
   await uploadFiles(newPayload.input, t.context.stagingBucket);
   let output = await moveGranules(newPayload);
   const existingFileNames = output.granules[0].files.map((f) => f.filename);
-  t.deepEqual(expectedFilenames, existingFileNames);
+  t.deepEqual(expectedFilenames.sort(), existingFileNames.sort());
 
   const outputHdfFile = existingFileNames.filter((f) => f.endsWith('.hdf'))[0];
   const existingHdfFileInfo = await headObject(
@@ -398,7 +398,7 @@ test.serial('When duplicateHandling is "skip", does not overwrite or create new.
   await uploadFiles(newPayload.input, t.context.stagingBucket);
   let output = await moveGranules(newPayload);
   const existingFileNames = output.granules[0].files.map((f) => f.filename);
-  t.deepEqual(expectedFilenames, existingFileNames);
+  t.deepEqual(expectedFilenames.sort(), existingFileNames.sort());
 
   const outputHdfFile = existingFileNames.filter((f) => f.endsWith('.hdf'))[0];
   const existingHdfFileInfo = await headObject(
@@ -418,7 +418,7 @@ test.serial('When duplicateHandling is "skip", does not overwrite or create new.
 
   output = await moveGranules(newPayload);
   const currentFileNames = output.granules[0].files.map((f) => f.filename);
-  t.deepEqual(expectedFilenames, currentFileNames);
+  t.deepEqual(expectedFilenames.sort(), currentFileNames.sort());
 
   // does not overwrite
   const currentHdfFileInfo = await headObject(
@@ -450,7 +450,7 @@ async function granuleFilesOverwrittenTest(t, duplicateHandling, forceDuplicateO
   let output = await moveGranules(newPayload);
   await validateOutput(t, output);
   const existingFileNames = output.granules[0].files.map((f) => f.filename);
-  t.deepEqual(expectedFilenames, existingFileNames);
+  t.deepEqual(expectedFilenames.sort(), existingFileNames.sort());
 
   const existingFilesMetadata = await getFilesMetadata(output.granules[0].files);
 

--- a/tasks/post-to-cmr/index.js
+++ b/tasks/post-to-cmr/index.js
@@ -4,8 +4,11 @@ const cloneDeep = require('lodash.clonedeep');
 const get = require('lodash.get');
 const cumulusMessageAdapter = require('@cumulus/cumulus-message-adapter-js');
 const { justLocalRun } = require('@cumulus/common/local-helpers');
-const { getCmrXMLFiles, publishECHO10XML2CMR } = require('@cumulus/cmrjs');
-const { metadataObjectFromCMRXMLFile } = require('@cumulus/cmrjs/cmr-utils');
+const {
+  getCmrXMLFiles,
+  metadataObjectFromCMRXMLFile,
+  publishECHO10XML2CMR
+} = require('@cumulus/cmrjs');
 const log = require('@cumulus/common/log');
 const { loadJSONTestData } = require('@cumulus/test-data');
 
@@ -79,8 +82,8 @@ async function postToCMR(event) {
     });
   });
 
-  // get cmr files
-  const cmrFiles = await getCmrXMLFiles(allFiles, regex);
+  // get cmr files and metadata
+  const cmrFiles = getCmrXMLFiles(allFiles, regex);
   const updatedCMRFiles = await addMetadataObjects(cmrFiles);
 
   // post all meta files to CMR

--- a/tasks/post-to-cmr/package.json
+++ b/tasks/post-to-cmr/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "test": "ava",
     "test-coverage": "nyc ava",
+    "debug" : "NODE_ENV=test node --inspect-brk node_modules/ava/profile.js --serial tests/*.js",
     "build": "rm -rf dist && mkdir dist && cp -R schemas dist/ && webpack",
     "watch": "rm -rf dist && mkdir dist && cp -R schemas dist/ && webpack --progress -w",
     "prepublishOnly": "PRODUCTION=true npm run build"


### PR DESCRIPTION
**Summary:** Modifications to make the move-granules lambda function call the @cumulus/cmrjs package.  

These are in order to more easily add UMMG json support to the software for both api moves and move-granules lambda tasks.

Addresses [CUMULUS-678: UMMG](https://bugs.earthdata.nasa.gov/browse/CUMULUS-678)

## Changes

  `@cumulus/common/BucketsConfig` adds a new helper class `BucketsConfig` for working with bucket stack configuration and bucket names.
  `@cumulus/common/aws` adds new fucntion `s3PutObjectTagging` as a convenience for the aws  [s3().putObjectTagging](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObjectTagging-property) function.
  `@cumulus/cmrjs` Adds:
      - `constructOnlineAccessUrls` - Create list of correct URLs for echo10 metadata.
	  -	`isECHO10File` - Identify an echo10 metadata file.
      - `metadataObjectFromCMRXMLFile` Read and parse CMR XML file from s3.
      - `updateEcho10XMLMetadata` Modify a cmr.xml file with updated information.
      - `updateCMRMetadata` Modify a cmr metadata file with updated information.
	  - `publishECHO10XML2CMR` Posts XML CMR data to CMR service.
	  - `reconcileCMRMetadata` Reconciles cmr metadata file after a file moves.


### Changed
- CUMULUS-678
  `tasks/move-granules` simplified and refactored to use  functionality from cmrjs.
  `ingest/granules.moveGranuleFiles` now just moves granule files and returns a list of the updated files. Updating metadata now handled by `@cumulus/cmrjs/reconcileCMRMetadata`.
  `move-granules.updateGranuleMetadata` refactored and bugs fixed in the case of a file matching multiple collection.files.regexps.
  `getCmrXmlFiles` simplified and now only returns an object with the cmrfilename and the granuleId.

## Test Plan
Things that should succeed before merging.

- [ x] Unit tests
- [x] Adhoc testing
- [x] Update CHANGELOG
