### PR TITLE
upgrade lerna to v3.10.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "eslint-plugin-lodash": "^2.7.0",
     "eslint-plugin-node": "^7.0.1",
     "eslint-plugin-unicorn": "^4.0.3",
-    "lerna": "^2.9.0",
+    "lerna": "^3.10.7",
     "nyc": "^11.6.0",
     "simple-git": "^1.96.0"
   },


### PR DESCRIPTION
**Summary:**   Upgrade lerna library to handle bug https://github.com/lerna/lerna/issues/1413

Addresses [CUMULUS-678:](https://bugs.earthdata.nasa.gov/browse/CUMULUS-678)

## Changes
## Test Plan

Tested that unit tests fail appropriately when a package test fails. 
https://travis-ci.org/nasa/cumulus/builds/484050951
as opposed to 
https://travis-ci.org/nasa/cumulus/jobs/484035650#L1269-L1287
- [x ] Unit tests
- [x ] Adhoc testing
