### PR TITLE
Deprecates exposed functions (ingest|search|delete)Concept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - **CUMULUS-1049** Updated `Retrieve Execution Status API` in `@cumulus/api`: If the execution doesn't exist in Step Function API, Cumulus API returns the execution status information from the database.
 
+### Deprecated
+`@cmrjs/ingestConcept`, instead use the CMR object methods. `@cmrjs/CMR.ingestGranule` or `@cmrjs/CMR.ingestCollection`
+`@cmrjs/searchConcept`, instead use the CMR object methods. `@cmrjs/CMR.searchGranules` or `@cmrjs/CMR.searchCollections`
+`@cmrjs/deleteConcept`, instead use the CMR object methods. `@cmrjs/CMR.deleteGranule` or `@cmrjs/CMR.deleteCollection`
+
+
+
 ## [v1.11.1] - 2018-12-18
 
 **Please Note**


### PR DESCRIPTION
These functions should never have been exposed via the @cmrjs library, but we still
wanted the functions to be useable.  In order to deprecate, while keeping the
functionality, deprecation wrappers were added to call through to new private
functions.

**Summary:** No functional changes, just deprecates functions from @cmrjs library while retaining the functionality for the CMR class.

Addresses [CUMULUS-768](https://bugs.earthdata.nasa.gov/browse/CUMULUS-768)

