### PR TITLE
[MAAP] Add ECS and other permissions to StepRole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
       - `updateCMRMetadata` Modify a cmr metadata file with updated information.
 	  - `publishECHO10XML2CMR` Posts XML CMR data to CMR service.
 	  - `reconcileCMRMetadata` Reconciles cmr metadata file after a file moves.
+- Adds some ECS and other permissions to StepRole to enable running ECS tasks from a workflow
 
 
 ### Changed

--- a/packages/deployment/iam/cloudformation.template.yml
+++ b/packages/deployment/iam/cloudformation.template.yml
@@ -539,6 +539,38 @@ Resources:
                 Action:
                   - lambda:InvokeFunction
                 Resource: "*"
+                - Effect: Allow
+                Action:
+                  - ecr:*
+                  - cloudtrail:LookupEvents
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                - ecs:RunTask
+                Resource:
+                - "*"
+              - Effect: Allow
+                Action:
+                - ecs:StopTask
+                - ecs:DescribeTasks
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                - events:PutTargets
+                - events:PutRule
+                - events:DescribeRule
+                Resource:
+                - arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForECSTaskRule
+              - Effect: Allow
+                Action:
+                  - autoscaling:Describe*
+                  - cloudwatch:*
+                  - logs:*
+                  - sns:*
+                  - iam:GetPolicy
+                  - iam:GetPolicyVersion
+                  - iam:GetRole
+                Resource: "*"
 
   ECSRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
**Summary:** Enable running Fargate tasks on ECS from a workflow by adding some ECS and other permissions to StepRole

## Changes

* StepRole needs additional permissions in order to run Fargate tasks on ECS from a Cumulus workflow
* Used those provided in the IAM example from the AWS docs for [Manage a Container Task](https://docs.aws.amazon.com/step-functions/latest/dg/sample-project-container-task-notification.html), with some generalized permissions for simplification

## Test Plan
Things that should succeed before merging.

- [x] Unit tests
- [x] Adhoc testing
- [x] Update CHANGELOG
- [ ] Run `./bin/eslint-ratchet` and verify that eslint errors have not increased
  - [ ] Commit `.eslint-ratchet-high-water-mark` if the score has improved

@abarciauskas-bgse @markdboyd 