### PR TITLE
Fix mutation bug in granules model

### DIFF
--- a/packages/api/lib/utils.js
+++ b/packages/api/lib/utils.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const get = require('lodash.get');
+const isInteger = require('lodash.isinteger');
 const isObject = require('lodash.isobject');
 
 function errorify(err) {
@@ -71,10 +72,10 @@ function extractDate(payload, dateField) {
  * @returns {Integer} - sum of granule file sizes in bytes
  */
 function getGranuleProductVolume(granuleFiles) {
-  const fileSizes = granuleFiles.map((file) => file.fileSize)
-    .filter((size) => size);
-
-  return fileSizes.reduce((a, b) => a + b);
+  return granuleFiles
+    .map((f) => f.fileSize)
+    .filter(isInteger)
+    .reduce((a, b) => a + b);
 }
 
 /**
@@ -89,7 +90,6 @@ function findCaseInsensitiveKey(obj, keyArg) {
   const keys = Object.keys(obj);
   return keys.find((key) => key.toLowerCase() === keyArg.toLowerCase());
 }
-exports.findCaseInsensitiveKey = findCaseInsensitiveKey;
 
 /**
  * Find a property value in an object in a case-insensitive manner
@@ -101,10 +101,13 @@ exports.findCaseInsensitiveKey = findCaseInsensitiveKey;
 function findCaseInsensitiveValue(obj, keyArg) {
   return obj[findCaseInsensitiveKey(obj, keyArg)];
 }
-exports.findCaseInsensitiveValue = findCaseInsensitiveValue;
 
-module.exports.errorify = errorify;
-module.exports.parseException = parseException;
-module.exports.deconstructCollectionId = deconstructCollectionId;
-module.exports.extractDate = extractDate;
-module.exports.getGranuleProductVolume = getGranuleProductVolume;
+module.exports = {
+  deconstructCollectionId,
+  errorify,
+  extractDate,
+  findCaseInsensitiveKey,
+  findCaseInsensitiveValue,
+  getGranuleProductVolume,
+  parseException
+};

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -68,6 +68,7 @@
     "lodash.has": "^4.5.2",
     "lodash.iserror": "^3.1.1",
     "lodash.isfunction": "^3.0.9",
+    "lodash.isinteger": "^4.0.4",
     "lodash.isnumber": "^3.0.3",
     "lodash.isobject": "^3.0.2",
     "lodash.isstring": "^4.0.1",

--- a/packages/api/tests/serial/es/test-es-indexer.js
+++ b/packages/api/tests/serial/es/test-es-indexer.js
@@ -99,9 +99,11 @@ test.after.always(async () => {
 });
 
 test.serial('creating a successful granule record', async (t) => {
+  const mockedFileSize = 12345;
+
   // Stub out headobject S3 call used in api/models/granules.js,
   // so we don't have to create artifacts
-  sinon.stub(aws, 'headObject').resolves({ ContentLength: 12345 });
+  sinon.stub(aws, 'headObject').resolves({ ContentLength: mockedFileSize });
 
   const granule = granuleSuccess.payload.granules[0];
   const collection = granuleSuccess.meta.collection;
@@ -109,11 +111,14 @@ test.serial('creating a successful granule record', async (t) => {
 
   const collectionId = constructCollectionId(collection.name, collection.version);
 
-
   // check the record exists
   const record = records[0];
 
-  t.deepEqual(record.files, granule.files);
+  t.deepEqual(
+    record.files,
+    // If fileSize is not set, default it to `mockedFileSize`
+    granule.files.map((f) => ({ fileSize: mockedFileSize, ...f }))
+  );
   t.is(record.status, 'completed');
   t.is(record.collectionId, collectionId);
   t.is(record.granuleId, granule.granuleId);

--- a/packages/common/aws.js
+++ b/packages/common/aws.js
@@ -261,13 +261,23 @@ exports.downloadS3File = (s3Obj, filepath) => {
 /**
 * Get an object header from S3
 *
-* @param {string} bucket - name of bucket
-* @param {string} key - key for object (filepath + filename)
+* @param {string} Bucket - name of bucket
+* @param {string} Key - key for object (filepath + filename)
 * @returns {Promise} - returns response from `S3.headObject` as a promise
 **/
+exports.headObject = (Bucket, Key) =>
+  exports.s3().headObject({ Bucket, Key }).promise();
 
-exports.headObject = (bucket, key) =>
-  exports.s3().headObject({ Bucket: bucket, Key: key }).promise();
+/**
+ * Get the size of an S3Object, in bytes
+ *
+ * @param {string} bucket - S3 bucket
+ * @param {string} key - S3 key
+ * @returns {Promise<integer>} - object size, in bytes
+ */
+exports.getObjectSize = (bucket, key) =>
+  exports.headObject(bucket, key)
+    .then((response) => response.ContentLength);
 
 /**
 * Get object Tagging from S3


### PR DESCRIPTION
The `addMissingFileSizes(files)` method in the API's granule model class was mutating its argument, which meant that the `createGranulesFromSns(payload)` method was mutating _its_ argument, which was modifying the payload passed to `indexer.granule(payload)`.

This was causing unexpected behavior, since there was not an expectation that the payload would be modified in this case.