### PR TITLE
Changes to generify cmrjs interactions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `@cumulus/common/BucketsConfig` adds a new helper class `BucketsConfig` for working with bucket stack configuration and bucket names.
   `@cumulus/common/aws` adds new function `s3PutObjectTagging` as a convenience for the aws  [s3().putObjectTagging](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObjectTagging-property) function.
   `@cumulus/cmrjs` Adds:
-      - `isECHO10File` - Identify an echo10 metadata file.
-      - `metadataObjectFromCMRXMLFile` Read and parse CMR XML file from s3.
-      - `updateEcho10XMLMetadata` Modify a cmr.xml file with updated information.
-      - `updateCMRMetadata` Modify a cmr metadata file with updated information.
-	  - `publishECHO10XML2CMR` Posts XML CMR data to CMR service.
+      - `isCMRFile` - Identify an echo10(xml) or UMMG(json) metadata file.
+      - `metadataObjectFromCMRFile` Read and parse CMR XML file from s3.
+      - `updateCMRMetadata` Modify a cmr metadata (xml/json) file with updated information.
+	  - `publish2CMR` Posts XML or UMMG CMR data to CMR service.
 	  - `reconcileCMRMetadata` Reconciles cmr metadata file after a file moves.
 - Adds some ECS and other permissions to StepRole to enable running ECS tasks from a workflow
 - Added Apache logs to cumulus api and distribution lambdas

--- a/packages/api/tests/serial/endpoints/test-granules.js
+++ b/packages/api/tests/serial/endpoints/test-granules.js
@@ -9,8 +9,7 @@ const { sfn } = require('@cumulus/common/aws');
 const aws = require('@cumulus/common/aws');
 const { CMR } = require('@cumulus/cmrjs');
 const {
-  metadataObjectFromCMRJSONFile,
-  metadataObjectFromCMRXMLFile
+  metadataObjectFromCMRFile
 } = require('@cumulus/cmrjs/cmr-utils');
 const { DefaultProvider } = require('@cumulus/common/key-pair-provider');
 const { randomString, randomId } = require('@cumulus/common/test-utils');
@@ -671,7 +670,7 @@ test.serial('move a file and update ECHO10 xml metadata', async (t) => {
     }
     return putObject({ Bucket: file.bucket, Key: file.filepath, Body: metadata });
   }));
-  const originalXML = await metadataObjectFromCMRXMLFile(newGranule.files[1].filename);
+  const originalXML = await metadataObjectFromCMRFile(newGranule.files[1].filename);
 
   const destinationFilepath = `${process.env.stackName}/moved_granules`;
   const destinations = [
@@ -716,7 +715,7 @@ test.serial('move a file and update ECHO10 xml metadata', async (t) => {
   t.is(list2.Contents.length, 1);
   t.is(newGranule.files[1].filepath, list2.Contents[0].Key);
 
-  const xmlObject = await metadataObjectFromCMRXMLFile(newGranule.files[1].filename);
+  const xmlObject = await metadataObjectFromCMRFile(newGranule.files[1].filename);
 
   const newUrls = xmlObject.Granule.OnlineAccessURLs.OnlineAccessURL.map((obj) => obj.URL);
   const newDestination = `${process.env.DISTRIBUTION_ENDPOINT}${destinations[0].bucket}/${destinations[0].filepath}/${newGranule.files[0].name}`;
@@ -810,7 +809,7 @@ test.serial('move a file and update its UMM-G JSON metadata', async (t) => {
   t.is(newGranule.files[1].filepath, list2.Contents[0].Key);
 
   // CMR UMMG JSON has been updated with the location of the moved file.
-  const ummgObject = await metadataObjectFromCMRJSONFile(newGranule.files[1].filename);
+  const ummgObject = await metadataObjectFromCMRFile(newGranule.files[1].filename);
   const updatedURLs = ummgObject.RelatedUrls.map((urlObj) => urlObj.URL);
   const newDestination = `${process.env.DISTRIBUTION_ENDPOINT}${destinations[0].bucket}/${destinations[0].filepath}/${newGranule.files[0].name}`;
   t.true(updatedURLs.includes(newDestination));

--- a/packages/cmrjs/cmr-utils.js
+++ b/packages/cmrjs/cmr-utils.js
@@ -19,6 +19,21 @@ const { omit } = require('@cumulus/common/util');
 const { CMR } = require('./cmr');
 const { getUrl, xmlParseOptions } = require('./utils');
 
+const isECHO10File = (filename) => filename.endsWith('cmr.xml');
+const isUMMGFile = (filename) => filename.endsWith('cmr.json');
+const isCMRFilename = (filename) => isECHO10File(filename) || isUMMGFile(filename);
+
+/**
+ * Returns True if this object can be determined to be a cmrMetadata object.
+ *
+ * @param {Object} fileobject
+ * @returns {boolean} true if object references cmr metadata.
+ */
+function isCMRFile(fileobject) {
+  const cmrfilename = fileobject.name || fileobject.filename || '';
+  return isCMRFilename(cmrfilename);
+}
+
 
 /**
  * Instantiates a CMR instance for ingest of metadata
@@ -83,17 +98,20 @@ async function publishECHO10XML2CMR(cmrFile, creds, systemBucket, stack) {
 
 /**
  *
- * @param {Object} ummgMetadata - UMM Granule json object
+ * @param {Object} cmrPublishObject -
+ * @param {string} cmrPublishObject.filename - the cmr filename
+ * @param {Object} cmrPublishObject.metadataObject - the UMMG JSON cmr metadata
+ * @param {Object} cmrPublishObject.granuleId - the metadata's granuleId
  * @param {Object} creds - credentials needed to post to CMR service
  * @param {string} systemBucket - bucket containing crypto keypair.
  * @param {string} stack - stack deployment name
  */
-async function publishUMMGJSON2CMR(ummgMetadata, creds, systemBucket, stack) {
+async function publishUMMGJSON2CMR(cmrPublishObject, creds, systemBucket, stack) {
   const cmr = await getCMRInstance(creds, systemBucket, stack);
 
-  const granuleId = ummgMetadata.GranuleUR;
+  const granuleId = cmrPublishObject.metadataObject.GranuleUR;
 
-  const res = await cmr.ingestUMMGranule(ummgMetadata);
+  const res = await cmr.ingestUMMGranule(cmrPublishObject.metadataObject);
   const conceptId = res.result['concept-id'];
 
   log.info(`Published UMMG ${granuleId} to the CMR. conceptId: ${conceptId}`);
@@ -104,6 +122,30 @@ async function publishUMMGJSON2CMR(ummgMetadata, creds, systemBucket, stack) {
     link: `${getUrl('search')}granules.json?concept_id=${res.result['concept-id']}`
   };
 }
+
+/**
+ * Determines what type of metadata object and posts either ECHO10XML or UMMG
+ * JSON data to CMR.
+ *
+ * @param {Object} cmrPublishObject -
+ * @param {string} cmrPublishObject.filename - the cmr filename
+ * @param {Object} cmrPublishObject.metadataObject - the UMMG JSON cmr metadata
+ * @param {Object} cmrPublishObject.granuleId - the metadata's granuleId
+ * @param {Object} creds - credentials needed to post to CMR service
+ * @param {string} systemBucket - bucket containing crypto keypair.
+ * @param {string} stack - stack deployment name
+ */
+async function publish2CMR(cmrPublishObject, creds, systemBucket, stack) {
+  // choose xml or json and do the things.
+  if (isECHO10File(cmrPublishObject.filename)) {
+    return publishECHO10XML2CMR(cmrPublishObject, creds, systemBucket, stack);
+  }
+  if (isUMMGFile(cmrPublishObject.filename)) {
+    return publishUMMGJSON2CMR(cmrPublishObject, creds, systemBucket, stack);
+  }
+  throw new Error(`invalid cmrPublishObject passed to publis2CMR ${JSON.stringify(cmrPublishObject)}`);
+}
+
 
 // 2018-12-12 This doesn't belong in cmrjs, but should be resolved by
 // https://bugs.earthdata.nasa.gov/browse/CUMULUS-1086
@@ -145,24 +187,10 @@ async function parseXmlString(xml) {
   return (promisify(xml2js.parseString))(xml, xmlParseOptions);
 }
 
-const isECHO10File = (filename) => filename.endsWith('cmr.xml');
-const isUMMGFile = (filename) => filename.endsWith('cmr.json');
-
-/**
- * Returns True if this object can be determined to be a cmrMetadata object.
- *
- * @param {Object} fileobject
- * @returns {boolean} true if object references cmr metadata.
- */
-function isCMRFile(fileobject) {
-  const cmrfilename = fileobject.name || fileobject.filename || '';
-  return isECHO10File(cmrfilename) || isUMMGFile(cmrfilename);
-}
-
 /**
  * return UMMG metadata object from CMR UMM-G json file
  * @param {string} cmrFilename - s3 path to json file
- * @returns {Object} CMR UMMG metadata object
+ * @returns {Promise<Object>} CMR UMMG metadata object
  */
 async function metadataObjectFromCMRJSONFile(cmrFilename) {
   const { Bucket, Key } = aws.parseS3Uri(cmrFilename);
@@ -173,26 +201,42 @@ async function metadataObjectFromCMRJSONFile(cmrFilename) {
 /**
  * return metadata object from cmr echo10 XML file.
  * @param {string} cmrFilename
- * @returns {Object} cmr xml metadata as object.
+ * @returns {Promise<Object>} cmr xml metadata as object.
  */
 async function metadataObjectFromCMRXMLFile(cmrFilename) {
   const metadata = await getXMLMetadataAsString(cmrFilename);
   return parseXmlString(metadata);
 }
 
+
 /**
- * returns a list of CMR xml file objects
+ * Return cmr metadata object from a CMR Echo10XML file or CMR UMMG File.
+ * @param {string} cmrFilename - s3 path to cmr file
+ * @returns {Promise<Object>} - metadata object from the file.
+ */
+async function metadataObjectFromCMRFile(cmrFilename) {
+  if (isECHO10File(cmrFilename)) {
+    return metadataObjectFromCMRXMLFile(cmrFilename);
+  }
+  if (isUMMGFile(cmrFilename)) {
+    return metadataObjectFromCMRJSONFile(cmrFilename);
+  }
+  throw new Error(`cannot return metdata from invalid cmrFilename: ${cmrFilename}`);
+}
+
+/**
+ * Returns a list of CMR ECHO10 xml or UMMG JSON file objects.
  *
  * @param {Array} input - an Array of S3 uris
  * @param {string} granuleIdExtraction - a regex for extracting granule IDs
- * @returns {Promise<Array>} promise resolves to an array of objects
- * that includes CMR xmls uris and granuleIds
+ * @returns {Array} array of objects
+ * that includes CMR xml/json URIs and granuleIds
  */
 function getCmrFiles(input, granuleIdExtraction) {
   const files = [];
 
   input.forEach((filename) => {
-    if (isECHO10File(filename)) {
+    if (isCMRFilename(filename)) {
       const cmrFileObject = {
         filename,
         granuleId: getGranuleId(filename, granuleIdExtraction)
@@ -425,38 +469,33 @@ async function updateCMRMetadata(
   log.debug(`cmrjs.updateCMRMetadata granuleId ${granuleId}, cmrMetadata file ${cmrFile.filename}`);
   const buckets = inBuckets || new BucketsConfig(await bucketsConfigDefaults());
   const cmrCredentials = (published) ? getCreds() : {};
+  let theMetadata;
 
   if (isECHO10File(cmrFile.filename)) {
-    const theMetadata = await updateEcho10XMLMetadata(cmrFile, files, distEndpoint, buckets);
-    if (published) {
-      // post metadata Object to CMR
-      const cmrFileObject = {
-        filename: cmrFile.filename,
-        metadataObject: theMetadata,
-        granuleId: granuleId
-      };
-      return publishECHO10XML2CMR(
-        cmrFileObject,
-        cmrCredentials,
-        process.env.system_bucket,
-        process.env.stackName
-      );
-    }
-    return Promise.resolve();
+    theMetadata = await updateEcho10XMLMetadata(cmrFile, files, distEndpoint, buckets);
   }
-  if (isUMMGFile(cmrFile.filename)) {
-    const ummgMetadata = await updateUMMGMetadata(cmrFile, files, distEndpoint, buckets);
-    if (published) {
-      return publishUMMGJSON2CMR(
-        ummgMetadata,
-        cmrCredentials,
-        process.env.system_bucket,
-        process.env.stackName
-      );
-    }
-    return Promise.resolve();
+  else if (isUMMGFile(cmrFile.filename)) {
+    theMetadata = await updateUMMGMetadata(cmrFile, files, distEndpoint, buckets);
   }
-  throw new errors.CMRMetaFileNotFound('Invalid CMR filetype passed to updateCMRMetadata');
+  else {
+    throw new errors.CMRMetaFileNotFound('Invalid CMR filetype passed to updateCMRMetadata');
+  }
+
+  if (published) {
+    // post metadata Object to CMR
+    const cmrPublishObject = {
+      filename: cmrFile.filename,
+      metadataObject: theMetadata,
+      granuleId: granuleId
+    };
+    return publish2CMR(
+      cmrPublishObject,
+      cmrCredentials,
+      process.env.system_bucket,
+      process.env.stackName
+    );
+  }
+  return Promise.resolve();
 }
 
 /**
@@ -480,13 +519,11 @@ async function reconcileCMRMetadata(granuleId, updatedFiles, distEndpoint, publi
 
 
 module.exports = {
-  getGranuleId,
   getCmrFiles,
-  isECHO10File,
-  metadataObjectFromCMRJSONFile,
-  metadataObjectFromCMRXMLFile,
-  publishECHO10XML2CMR,
+  getGranuleId,
+  isCMRFile,
+  metadataObjectFromCMRFile,
+  publish2CMR,
   reconcileCMRMetadata,
-  updateCMRMetadata,
-  updateEcho10XMLMetadata
+  updateCMRMetadata
 };

--- a/packages/cmrjs/index.js
+++ b/packages/cmrjs/index.js
@@ -20,11 +20,10 @@ const {
 const {
   getGranuleId,
   getCmrFiles,
-  isECHO10File,
-  metadataObjectFromCMRXMLFile,
-  publishECHO10XML2CMR,
+  isCMRFile,
+  metadataObjectFromCMRFile,
+  publish2CMR,
   reconcileCMRMetadata,
-  updateEcho10XMLMetadata,
   updateCMRMetadata
 } = require('./cmr-utils');
 
@@ -88,12 +87,11 @@ module.exports = {
   getUrl,
   hostId,
   ingestConcept,
-  isECHO10File,
-  metadataObjectFromCMRXMLFile,
-  publishECHO10XML2CMR,
+  isCMRFile,
+  metadataObjectFromCMRFile,
+  publish2CMR,
   reconcileCMRMetadata,
   searchConcept,
   updateCMRMetadata,
-  updateEcho10XMLMetadata,
   updateToken
 };

--- a/packages/cmrjs/tests/cmr-utils/test-reconcilecmrmetadata.js
+++ b/packages/cmrjs/tests/cmr-utils/test-reconcilecmrmetadata.js
@@ -174,6 +174,12 @@ test('reconcileCMRMetadata calls updateUMMGMetadata and publishUMMGJSON2CMR if i
   const fakePublishUMMGJSON2CMR = sinon.fake.resolves({ });
   const restorePublishUMMGJSON2CMR = cmrUtils.__set__('publishUMMGJSON2CMR', fakePublishUMMGJSON2CMR);
 
+  const publishObject = {
+    filename: jsonCMRFile.filename,
+    metadataObject: { fake: 'metadata' },
+    granuleId: granId
+  };
+
   const buckets = new BucketsConfig(defaultBucketsConfig);
   const systemBucket = randomId('systembucket');
   const stackName = randomId('stackname');
@@ -189,7 +195,7 @@ test('reconcileCMRMetadata calls updateUMMGMetadata and publishUMMGJSON2CMR if i
     fakeUpdateUMMGMetadata.calledOnceWithExactly(jsonCMRFile, updatedFiles, distEndpoint, buckets)
   );
   t.true(
-    fakePublishUMMGJSON2CMR.calledOnceWithExactly({ fake: 'metadata' }, testCreds, systemBucket, stackName)
+    fakePublishUMMGJSON2CMR.calledOnceWithExactly(publishObject, testCreds, systemBucket, stackName)
   );
 
   // cleanup
@@ -214,7 +220,11 @@ test('updateCMRMetadata file throws error if incorrect cmrfile provided', async 
 });
 
 test('publishUMMGJSON2CMR calls ingestUMMGranule with ummgMetadata via valid CMR object', async (t) => {
-  const ummgMetadata = { fake: 'metadata', GranuleUR: 'fakeGranuleID' };
+  const cmrPublishObject = {
+    filename: 'cmrfilename',
+    metadataObject: { fake: 'metadata', GranuleUR: 'fakeGranuleID' },
+    granuleId: 'fakeGranuleID'
+  };
   const creds = setTestCredentials();
   const systemBucket = process.env.system_bucket;
   const stackName = process.env.stackName;
@@ -226,7 +236,7 @@ test('publishUMMGJSON2CMR calls ingestUMMGranule with ummgMetadata via valid CMR
 
   // Act
   try {
-    await publishUMMGJSON2CMR(ummgMetadata, creds, systemBucket, stackName);
+    await publishUMMGJSON2CMR(cmrPublishObject, creds, systemBucket, stackName);
   }
   catch (error) {
     console.log(error);
@@ -237,7 +247,7 @@ test('publishUMMGJSON2CMR calls ingestUMMGranule with ummgMetadata via valid CMR
   t.true(cmrFake.calledOnceWithExactly(
     creds.provider, creds.clientId, creds.username, creds.password
   ));
-  t.true(ingestFake.calledOnceWithExactly(ummgMetadata));
+  t.true(ingestFake.calledOnceWithExactly(cmrPublishObject.metadataObject));
 
   // Cleanup
   restoreCMR();

--- a/tasks/post-to-cmr/index.js
+++ b/tasks/post-to-cmr/index.js
@@ -6,8 +6,8 @@ const cumulusMessageAdapter = require('@cumulus/cumulus-message-adapter-js');
 const { justLocalRun } = require('@cumulus/common/local-helpers');
 const {
   getCmrFiles,
-  metadataObjectFromCMRXMLFile,
-  publishECHO10XML2CMR
+  metadataObjectFromCMRFile,
+  publish2CMR
 } = require('@cumulus/cmrjs');
 const log = require('@cumulus/common/log');
 const { loadJSONTestData } = require('@cumulus/test-data');
@@ -41,7 +41,7 @@ function buildOutput(results, granulesObject) {
 async function addMetadataObjects(cmrFiles) {
   const updatedCMRFiles = [];
   const objectPromises = cmrFiles.map(async (cmrFile) => {
-    const metadataObject = await metadataObjectFromCMRXMLFile(cmrFile.filename);
+    const metadataObject = await metadataObjectFromCMRFile(cmrFile.filename);
     const updatedFile = Object.assign({}, { ...cmrFile }, { metadataObject: metadataObject });
     updatedCMRFiles.push(updatedFile);
   });
@@ -66,7 +66,7 @@ async function postToCMR(event) {
   // We have to post the metadata file for the output granules.
   // First we check if there is an output file.
   const config = get(event, 'config');
-  const bucket = get(config, 'bucket'); // the name of the bucket with private/public keys
+  const systemBucket = get(config, 'bucket'); // the name of the bucket with private/public keys
   const stack = get(config, 'stack'); // the name of the deployment stack
   const input = get(event, 'input', []);
   const process = get(config, 'process');
@@ -88,7 +88,7 @@ async function postToCMR(event) {
 
   // post all meta files to CMR
   const publishRequests = updatedCMRFiles.map((cmrFile) => (
-    publishECHO10XML2CMR(cmrFile, creds, bucket, stack)
+    publish2CMR(cmrFile, creds, systemBucket, stack)
   ));
   const results = await Promise.all(publishRequests);
 


### PR DESCRIPTION
Use the functions that work with xml or json everywhere.

**Summary:** replaces XML or JSON specific CMR functions with generic versions that work with either echo10 xml files or UMMG v1.4 json files

Addresses [CUMULUS-678: UMMG JSON metadata](https://bugs.earthdata.nasa.gov/browse/CUMULUS-678)

## Changes

* Removes XML specific functions for generic ones
  - `isECHO10File` =>  `isCMRFile`
  - `metadataObjectFromCMRXMLFile` => `metadataObjectFromCMRFile`
  - `updateEcho10XMLMetadata` => `updateCMRMetadata`
  - `publishECHO10XML2CMR` => `publish2CMR`

* Simplifies updateCMRMetadata by changing the shape of the metadata passed to publishUMMGJSON2CMR from just the metadata to a object with a metadataObject key that matches the publishECHO10XML2CMR shape and calling publish2CMR directly.



## Test Plan
Things that should succeed before merging.

- [X] Unit tests
- [X] Adhoc testing
- [X] Update CHANGELOG
