### PR TITLE
Removing refreshToken schema requirement for Oauth

### DIFF
--- a/packages/api/models/schemas.js
+++ b/packages/api/models/schemas.js
@@ -4,7 +4,7 @@ module.exports.accessToken = {
   title: 'Access Token Object',
   description: 'Cumulus API AccessToken Table schema',
   type: 'object',
-  required: ['accessToken', 'refreshToken'],
+  required: ['accessToken'],
   additionalProperties: false,
   properties: {
     accessToken: {

--- a/packages/api/tests/endpoints/token.js
+++ b/packages/api/tests/endpoints/token.js
@@ -141,7 +141,6 @@ test.serial('GET /token with no refreshToken in the response', async (t) => {
     accessToken: 'my-access-token',
     expirationTime: 12345
   };
-  const jwtToken = createJwtToken(getAccessTokenResponse);
 
   const stub = sinon.stub(
     EarthdataLoginClient.prototype,
@@ -153,7 +152,7 @@ test.serial('GET /token with no refreshToken in the response', async (t) => {
     .query({
       code: 'my-authorization-code',
       scope: 'my-scope',
-      state: 'my-state',
+      state: 'my-state'
     })
     .set('Accept', 'application/json')
     .expect(307);

--- a/packages/api/tests/endpoints/token.js
+++ b/packages/api/tests/endpoints/token.js
@@ -135,6 +135,34 @@ test.serial('GET /token with a code but no state returns the access token', asyn
   stub.restore();
 });
 
+test.serial('GET /token with no refreshToken in the response', async (t) => {
+  const getAccessTokenResponse = {
+    username: 'my-username',
+    accessToken: 'my-access-token',
+    expirationTime: 12345
+  };
+  const jwtToken = createJwtToken(getAccessTokenResponse);
+
+  const stub = sinon.stub(
+    EarthdataLoginClient.prototype,
+    'getAccessToken'
+  ).callsFake(async () => getAccessTokenResponse);
+
+  const response = await request(app)
+    .get('/token')
+    .query({
+      code: 'my-authorization-code',
+      scope: 'my-scope',
+      state: 'my-state',
+    })
+    .set('Accept', 'application/json')
+    .expect(307);
+
+  t.is(response.status, 307);
+  t.regex(response.headers.location, /my-state\?token\=/);
+  stub.restore();
+});
+
 test.serial('GET /token with a code and state results in a redirect to that state', async (t) => {
   const getAccessTokenResponse = fakeAccessTokenFactory();
 


### PR DESCRIPTION
## Summary

Oauth with Google currently throw an error after the accessToken expires after 1st authorization. You can reproduce this with an Cumulus instance running Google Oauth by:
 * Log in with Google account
 * Log out of dashboard
 * Immediately log back in with same Google Account

You should see an error message, on 1.11.2 it looks like:
```
{
statusCode: 401,
error: "Unauthorized",
message: "The record has validation errors"
}
```

Fixes #829

## Changes

* Removes refreshToken as a requirement in the oauth schema
* Adds a test to capture this situation

## Test Plan
Things that should succeed before merging.

- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Update CHANGELOG
- [ ] Run `./bin/eslint-ratchet` and verify that eslint errors have not increased
- [ ] Commit `.eslint-ratchet-high-water-mark` if the score has improved