### PR TITLE
CUMULUS-671: Verify Earthdata login for distribution logs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-**Please Note**
-- If you are using the `@cumulus/post-to-cmr` task in your workflow and specifying the metadata format to post using the `cmrFileType` config property, you must update that workflow step to use the `cmrMetadataFormat` config property instead and re-deploy
-
 ### Added
 
+- **CUMULUS-671**
+  - Added `@packages/integration-tests/api/distribution/getDistributionApiS3SignedUrl()` to return the S3 signed URL for a file protected by the distribution API
 - **CUMULUS-672**
-  - Added `cmrMetadataFormat` and `cmrConceptId` to output for individual granules from `@cumulus/post-to-cmr`. `cmrMetadataFormat` will default to value from workflow configuration, if provided, otherwise it will attempt to read the `cmrMetadataFormat` generated in `@cumulus/cmrjs/publish2CMR`
+  - Added `cmrMetadataFormat` and `cmrConceptId` to output for individual granules from `@cumulus/post-to-cmr`. `cmrMetadataFormat` will be read from the `cmrMetadataFormat` generated for each granule in `@cumulus/cmrjs/publish2CMR()`
   - Added helpers to `@packages/integration-tests/api/distribution`:
-    - `getDistributionApiFileStream` returns a stream to download files protected by the distribution API
-    - `getDistributionFileUrl` constructs URLs for requesting files from the distribution API
+    - `getDistributionApiFileStream()` returns a stream to download files protected by the distribution API
+    - `getDistributionFileUrl()` constructs URLs for requesting files from the distribution API
 
 - CUMULUS-1171
   - Added `@cumulus/common` API documentation to `packages/common/docs/API.md`
@@ -36,7 +35,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - **CUMULUS-672**
-  - `@cumulus/post-to-cmr` now looks in `config.cmrMetadataFormat` instead of `config.cmrFileType` to determine the type of metadata to post to CMR
   - Changed `@cumulus/integration-tests/api/EarthdataLogin.getEarthdataLoginRedirectResponse` to `@cumulus/integration-tests/api/EarthdataLogin.getEarthdataAccessToken`. The new function returns an access response from Earthdata login, if successful.
   - `@cumulus/integration-tests/cmr/getOnlineResources` now accepts an object of options, including `cmrMetadataFormat`. Based on the `cmrMetadataFormat`, the function will correctly retrieve the online resources for each metadata format (ECHO10, UMM-G)
 

--- a/docs/ems_reporting.md
+++ b/docs/ems_reporting.md
@@ -33,8 +33,8 @@ logging will work.
 
 When enabling server access logging, the "Target bucket" should be set to your
 stack's internal bucket. The "Target prefix" should be set to
-"<STACK_NAME>/ems-distribution/s3-server-access-logs/", where "<STACK_NAME>" is
-replaced with the name of your Cumulus stack.
+"<STACK_NAME>/ems-distribution/s3-server-access-logs/" (include trailing slash),
+where "<STACK_NAME>" is replaced with the name of your Cumulus stack.
 
 A scheduled Lambda task will run nightly that collects distribution events and
 builds an EMS distribution report.

--- a/example/spec/distributionAPI/distributionSpec.js
+++ b/example/spec/distributionAPI/distributionSpec.js
@@ -100,9 +100,8 @@ describe('Distribution API', () => {
       accessToken = accessTokenResponse.accessToken;
 
       // Compare checksum of downloaded file with expected checksum.
-      const downloadChecksum = await getFileChecksumFromStream(
-        getDistributionApiFileStream(fileUrl, accessToken)
-      );
+      const fileStream = await getDistributionApiFileStream(fileUrl, accessToken);
+      const downloadChecksum = await getFileChecksumFromStream(fileStream);
       expect(downloadChecksum).toEqual(fileChecksum);
     });
   });

--- a/example/spec/ingestGranule/IngestUMMGSuccessSpec.js
+++ b/example/spec/ingestGranule/IngestUMMGSuccessSpec.js
@@ -35,6 +35,7 @@ const {
   granulesApi: granulesApiTestUtils,
   EarthdataLogin: { getEarthdataAccessToken },
   distributionApi: {
+    getDistributionApiS3SignedUrl,
     getDistributionApiFileStream,
     getDistributionFileUrl
   }
@@ -174,7 +175,7 @@ describe('The S3 Ingest Granules workflow configured to ingest UMM-G', () => {
         collectionModel.delete(collection),
         providerModel.delete(provider),
         executionModel.delete({ arn: workflowExecution.executionArn }),
-        granulesApiTestUtils.deleteGranule({
+        granulesApiTestUtils.removePublishedGranule({
           prefix: config.stackName,
           granuleId: inputPayload.granules[0].granuleId
         })
@@ -260,8 +261,20 @@ describe('The S3 Ingest Granules workflow configured to ingest UMM-G', () => {
       granule = postToCmrOutput.payload.granules[0];
       files = granule.files;
 
-      onlineResources = await getOnlineResources(granule);
+      const result = await Promise.all([
+        getOnlineResources(granule),
+        // Login with Earthdata and get access token.
+        getEarthdataAccessToken({
+          redirectUri: process.env.DISTRIBUTION_REDIRECT_ENDPOINT,
+          requestOrigin: process.env.DISTRIBUTION_ENDPOINT
+        })
+      ]);
+
+      onlineResources = result[0];
       resourceURLs = onlineResources.map((resource) => resource.URL);
+
+      const accessTokenResponse = result[1];
+      accessToken = accessTokenResponse.accessToken;
     });
 
     afterAll(async () => {
@@ -318,14 +331,17 @@ describe('The S3 Ingest Granules workflow configured to ingest UMM-G', () => {
       expect(resourceURLs.includes(cumulusDocUrl)).toBe(true);
     });
 
-    it('downloads the requested science file for authorized requests', async () => {
-      // Login with Earthdata and get access token.
-      const accessTokenResponse = await getEarthdataAccessToken({
-        redirectUri: process.env.DISTRIBUTION_REDIRECT_ENDPOINT,
-        requestOrigin: process.env.DISTRIBUTION_ENDPOINT
+    it('includes the Earthdata login ID for requests to protected science files', async () => {
+      const distributionUrl = getDistributionFileUrl({
+        bucket: files[0].bucket,
+        key: files[0].filepath
       });
-      accessToken = accessTokenResponse.accessToken;
+      const s3SignedUrl = await getDistributionApiS3SignedUrl(distributionUrl, accessToken);
+      const earthdataLoginParam = new URL(s3SignedUrl).searchParams.get('x-EarthdataLoginUsername');
+      expect(earthdataLoginParam).toEqual(process.env.EARTHDATA_USERNAME);
+    });
 
+    it('downloads the requested science file for authorized requests', async () => {
       const scienceFileUrls = resourceURLs.filter(isUMMGScienceUrl);
       console.log('scienceFileUrls: ', scienceFileUrls);
 
@@ -346,7 +362,7 @@ describe('The S3 Ingest Granules workflow configured to ingest UMM-G', () => {
                 bucket: file.bucket,
                 key: file.filepath
               });
-              fileStream = getDistributionApiFileStream(fileUrl, accessToken);
+              fileStream = await getDistributionApiFileStream(fileUrl, accessToken);
             }
             else if (bucketsConfig.type(file.bucket) === 'public') {
               fileStream = got.stream(url);

--- a/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
@@ -43,6 +43,7 @@ const {
   waitForCompletedExecution,
   EarthdataLogin: { getEarthdataAccessToken },
   distributionApi: {
+    getDistributionApiS3SignedUrl,
     getDistributionApiFileStream,
     getDistributionFileUrl
   }
@@ -210,7 +211,7 @@ describe('The S3 Ingest Granules workflow', () => {
         providerModel.delete(provider),
         executionModel.delete({ arn: workflowExecution.executionArn }),
         executionModel.delete({ arn: failingWorkflowExecution.executionArn }),
-        granulesApiTestUtils.deleteGranule({
+        granulesApiTestUtils.removePublishedGranule({
           prefix: config.stackName,
           granuleId: inputPayload.granules[0].granuleId
         })
@@ -342,8 +343,21 @@ describe('The S3 Ingest Granules workflow', () => {
 
       granule = postToCmrOutput.payload.granules[0];
       files = granule.files;
-      cmrResource = await getOnlineResources(granule);
+
+      const result = await Promise.all([
+        getOnlineResources(granule),
+        // Login with Earthdata and get access token.
+        getEarthdataAccessToken({
+          redirectUri: process.env.DISTRIBUTION_REDIRECT_ENDPOINT,
+          requestOrigin: process.env.DISTRIBUTION_ENDPOINT
+        })
+      ]);
+
+      cmrResource = result[0];
       resourceURLs = cmrResource.map((resource) => resource.href);
+
+      const accessTokenResponse = result[1];
+      accessToken = accessTokenResponse.accessToken;
     });
 
     afterAll(async () => {
@@ -386,14 +400,17 @@ describe('The S3 Ingest Granules workflow', () => {
       expect(resourceURLs.includes(s3CredsUrl)).toBe(true);
     });
 
-    it('downloads the requested science file for authorized requests', async () => {
-      // Login with Earthdata and get access token.
-      const accessTokenResponse = await getEarthdataAccessToken({
-        redirectUri: process.env.DISTRIBUTION_REDIRECT_ENDPOINT,
-        requestOrigin: process.env.DISTRIBUTION_ENDPOINT
+    it('includes the Earthdata login ID for requests to protected science files', async () => {
+      const distributionUrl = getDistributionFileUrl({
+        bucket: files[0].bucket,
+        key: files[0].filepath
       });
-      accessToken = accessTokenResponse.accessToken;
+      const s3SignedUrl = await getDistributionApiS3SignedUrl(distributionUrl, accessToken);
+      const earthdataLoginParam = new URL(s3SignedUrl).searchParams.get('x-EarthdataLoginUsername');
+      expect(earthdataLoginParam).toEqual(process.env.EARTHDATA_USERNAME);
+    });
 
+    it('downloads the requested science file for authorized requests', async () => {
       const scienceFileUrls = resourceURLs
         .filter((url) =>
           (url.startsWith(process.env.DISTRIBUTION_ENDPOINT) ||
@@ -418,7 +435,7 @@ describe('The S3 Ingest Granules workflow', () => {
                 bucket: file.bucket,
                 key: file.filepath
               });
-              fileStream = getDistributionApiFileStream(fileUrl, accessToken);
+              fileStream = await getDistributionApiFileStream(fileUrl, accessToken);
             }
             else if (bucketsConfig.type(file.bucket) === 'public') {
               fileStream = got.stream(url);

--- a/example/workflows/sips.yml
+++ b/example/workflows/sips.yml
@@ -229,7 +229,6 @@ IngestAndPublishGranule:
         process: '{$.cumulus_meta.process}'
         input_granules: '{$.meta.input_granules}'
         granuleIdExtraction: '{$.meta.collection.granuleIdExtraction}'
-        cmrMetadataFormat: '{$.meta.cmrMetadataFormat}'
       Type: Task
       Resource: ${PostToCmrLambdaFunction.Arn}
       Catch:

--- a/packages/api/lambdas/ems-distribution-report.js
+++ b/packages/api/lambdas/ems-distribution-report.js
@@ -206,7 +206,7 @@ async function generateDistributionReport(params) {
   const s3Objects = (await aws.listS3ObjectsV2({ Bucket: logsBucket, Prefix: logsPrefix }))
     .map((s3Object) => ({ Bucket: logsBucket, Key: s3Object.Key }));
 
-  log.info(`Found ${s3Objects} log files in S3`);
+  log.info(`Found ${s3Objects.length} log files in S3`);
 
   // Fetch all distribution events from S3
   const allDistributionEvents = flatten(await pMap(

--- a/packages/api/tests/models/test-granules-model.js
+++ b/packages/api/tests/models/test-granules-model.js
@@ -343,7 +343,11 @@ test('scan() will translate old-style granule files into the new schema', async 
   }).promise();
 
   const granuleModel = new Granule();
-  const scanResponse = await granuleModel.scan();
+  const scanResponse = await granuleModel.scan({
+    names: { '#granuleId': 'granuleId' },
+    filter: '#granuleId = :granuleId',
+    values: { ':granuleId': granule.granuleId }
+  });
 
   t.deepEqual(
     scanResponse.Items[0].files[0],

--- a/packages/cmrjs/cmr-utils.js
+++ b/packages/cmrjs/cmr-utils.js
@@ -17,7 +17,12 @@ const { DefaultProvider } = require('@cumulus/common/key-pair-provider');
 const { omit } = require('@cumulus/common/util');
 
 const { CMR } = require('./cmr');
-const { getUrl, xmlParseOptions } = require('./utils');
+const {
+  getUrl,
+  xmlParseOptions,
+  ummVersion,
+  ummVersionToMetadataFormat
+} = require('./utils');
 
 function getS3KeyOfFile(file) {
   if (file.filename) return aws.parseS3Uri(file.filename).Key;
@@ -136,6 +141,7 @@ async function publishUMMGJSON2CMR(cmrPublishObject, creds, systemBucket, stack)
   return {
     granuleId,
     conceptId,
+    metadataFormat: ummVersionToMetadataFormat(ummVersion(cmrPublishObject.metadataObject)),
     link: `${getUrl('search')}granules.json?concept_id=${conceptId}`
   };
 }

--- a/packages/cmrjs/tests/test-utils.js
+++ b/packages/cmrjs/tests/test-utils.js
@@ -10,6 +10,7 @@ const {
   getHost,
   hostId,
   ummVersion,
+  ummVersionToMetadataFormat,
   validateUMMG
 } = require('../utils');
 
@@ -99,6 +100,14 @@ test('ummVersion returns default version 1.4 if object has no metadata specifica
   const actual = ummVersion(metadata);
 
   t.is('1.4', actual);
+});
+
+test('ummVersionToMetadataFormat returns correct metadata format for UMM-G versions', (t) => {
+  let actual = ummVersionToMetadataFormat('1.4');
+  t.is('umm_json_v1_4', actual);
+
+  actual = ummVersionToMetadataFormat('1.5');
+  t.is('umm_json_v1_5', actual);
 });
 
 test('validateUMMG calls post with correct metadata version when metadata version available', async (t) => {

--- a/packages/cmrjs/utils.js
+++ b/packages/cmrjs/utils.js
@@ -104,6 +104,16 @@ function ummVersion(umm) {
 }
 
 /**
+ * Transform UMM version number to metadata format string.
+ *
+ * @param {string} versionNumber - UMM version string in decimal format (e.g. 1.4)
+ * @returns {string} UMM-G metadata format string (e.g. umm_json_v1_4)
+ */
+function ummVersionToMetadataFormat(versionNumber, ummFormat = 'json') {
+  return `umm_${ummFormat}_v${versionNumber.replace('.', '_')}`;
+}
+
+/**
  * Posts a given xml string to the validate endpoint of the CMR
  * and returns the results
  *
@@ -245,6 +255,7 @@ module.exports = {
   getUrl,
   hostId,
   ummVersion,
+  ummVersionToMetadataFormat,
   updateToken,
   validate,
   validateUMMG,

--- a/packages/integration-tests/api/granules.js
+++ b/packages/integration-tests/api/granules.js
@@ -150,11 +150,26 @@ async function moveGranule({ prefix, granuleId, destinations }) {
   }
 }
 
+/**
+ * Removed a granule from CMR and delete from Cumulus via the API
+ *
+ * @param {Object} params - params
+ * @param {string} params.prefix - the prefix configured for the stack
+ * @param {string} params.granuleId - a granule ID
+ * @returns {Promise<Object>} - the delete confirmation from the API
+ */
+async function removePublishedGranule({ prefix, granuleId }) {
+  // pre-delete: Remove the granule from CMR
+  await removeFromCMR({ prefix, granuleId });
+  return deleteGranule({ prefix, granuleId });
+};
+
 module.exports = {
   getGranule,
   reingestGranule,
   removeFromCMR,
   applyWorkflow,
   deleteGranule,
-  moveGranule
+  moveGranule,
+  removePublishedGranule
 };

--- a/tasks/post-to-cmr/index.js
+++ b/tasks/post-to-cmr/index.js
@@ -19,12 +19,10 @@ const { loadJSONTestData } = require('@cumulus/test-data');
  *
  * @param {Array} results - list of results returned by publish function
  * @param {Array} granules - list of granules
- * @param {string} cmrMetadataFormat - CMR metadata format
- *  (echo10, umm_json_v1_4, umm_json_v1_5)
  *
  * @returns {Array} an updated array of granules
  */
-function buildOutput(results, granules, cmrMetadataFormat) {
+function buildOutput(results, granules) {
   const resultsByGranuleId = keyBy(results, 'granuleId');
 
   return granules.map((granule) => {
@@ -37,7 +35,7 @@ function buildOutput(results, granules, cmrMetadataFormat) {
       cmrLink: result.link,
       cmrConceptId: result.conceptId,
       published: true,
-      cmrMetadataFormat: cmrMetadataFormat || result.metadataFormat
+      cmrMetadataFormat: result.metadataFormat
     });
   });
 }
@@ -100,8 +98,7 @@ async function postToCMR(event) {
     process: event.config.process,
     granules: buildOutput(
       results,
-      event.input.granules,
-      event.config.cmrMetadataFormat
+      event.input.granules
     )
   };
 }


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-671: As a DAAC, I want to associate HTTPS data access with Earthdata Login ids so I may understand who is accessing my data](https://bugs.earthdata.nasa.gov/browse/CUMULUS-671)

In addition to the integration tests, I also manually verified that Earthdata login usernames appear in S3 access logs and EMS distribution reports when access logging is enabled for protected buckets. Further detail is provided on the ticket.

## Changes

* Add tests to `IngestUMMGSuccessSpec.js` and `IngestGranuleSuccessSpec.js` to verify that S3 signed URL redirects from distribution API include Earthdata login in the query string

## PR Checklist

- [x] Update CHANGELOG
- [x] Adhoc testing
- [x] Integration tests
