### PR TITLE
[CUMULUS-668] s3credentials url should be in resourceUrls

### DIFF
--- a/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
@@ -344,6 +344,7 @@ describe('The S3 Ingest Granules workflow', () => {
       files = granule.files;
       cmrResource = await getOnlineResources(granule);
       resourceURLs = cmrResource.map((resource) => resource.href);
+      console.log('cmrResource: ', JSON.stringify(cmrResource));
     });
 
     afterAll(async () => {

--- a/packages/cmrjs/cmr-utils.js
+++ b/packages/cmrjs/cmr-utils.js
@@ -540,7 +540,7 @@ async function updateEcho10XMLMetadata(cmrFile, files, distEndpoint, buckets) {
   );
 
   _set(updatedGranule, 'OnlineAccessURLs.OnlineAccessURL', mergedOnlineAccessURLs);
-  _set(updatedGranule, 'ResourceURLs.ResourceURL', mergedResourceURLs);
+  _set(updatedGranule, 'OnlineResources.OnlineResource', mergedResourceURLs);
   metadataObject.Granule = updatedGranule;
 
   const builder = new xml2js.Builder();

--- a/packages/cmrjs/cmr-utils.js
+++ b/packages/cmrjs/cmr-utils.js
@@ -345,15 +345,15 @@ function constructOnlineAccessUrls({
  *
  * @param {string} distEndpoint - distribution endpoint
  * @param {string} s3CredsEndpoint - Optional endpoint for acquiring temporary s3 creds
- * @returns {Array<{URL: string, URLDescription: string, Type: string}>}
+ * @returns {Array<{URL: string, Description: string, Type: string}>}
  *   returns the list of online access url objects
  */
-function constructResourceUrls(distEndpoint, s3CredsEndpoint = 's3credentials') {
+function constructOnlineResourceUrls(distEndpoint, s3CredsEndpoint = 's3credentials') {
   const credsUrl = urljoin(distEndpoint, s3CredsEndpoint);
   const s3CredentialsObject = getS3CredentialsObject(credsUrl);
   const resourceUrls = [s3CredentialsObject];
 
-  return resourceUrls.map((urlObj) => omit(urlObj, 'Description'));
+  return resourceUrls.map((urlObj) => omit(urlObj, 'URLDescription'));
 }
 
 /**
@@ -509,7 +509,7 @@ function getCreds() {
 async function updateEcho10XMLMetadata(cmrFile, files, distEndpoint, buckets) {
   let newOnlineAccessURLs = constructOnlineAccessUrls({ files, distEndpoint, buckets });
   newOnlineAccessURLs = newOnlineAccessURLs.map((urlObj) => omit(urlObj, ['Type', 'Description']));
-  const newResourceURLs = constructResourceUrls(distEndpoint);
+  const newResourceURLs = constructOnlineResourceUrls(distEndpoint);
   const removedOnlineAccessURLs = onlineAccessURLsToRemove(files, buckets);
 
   // add/replace the OnlineAccessUrls
@@ -519,7 +519,7 @@ async function updateEcho10XMLMetadata(cmrFile, files, distEndpoint, buckets) {
 
   const updatedGranule = { ...metadataGranule };
   let originalOnlineAccessURLs = _get(metadataGranule, 'OnlineAccessURLs.OnlineAccessURL', []);
-  let originalResourceURLs = _get(metadataGranule, 'ResourceURLs.ResourceURL', []);
+  let originalResourceURLs = _get(metadataGranule, 'OnlineResources.OnlineResource', []);
 
   // If there is only one OnlineAccessURL in the file, it comes back as an object and not an array
   if (!Array.isArray(originalOnlineAccessURLs)) {

--- a/packages/cmrjs/cmr-utils.js
+++ b/packages/cmrjs/cmr-utils.js
@@ -357,7 +357,7 @@ function constructResourceUrls(distEndpoint, s3CredsEndpoint = 's3credentials') 
 }
 
 /**
- * Construct a list of online access urls.
+ * Construct a list of UMMG related urls
  *
  * @param {Object} params - input parameters
  * @param {Array<Object>} params.files - array of file objects

--- a/packages/cmrjs/tests/cmr-utils/test-constructonlineaccessurls.js
+++ b/packages/cmrjs/tests/cmr-utils/test-constructonlineaccessurls.js
@@ -39,7 +39,6 @@ test('returns correct url for protected data', (t) => {
       URLDescription: 'File to download',
       Type: 'GET DATA'
     },
-    s3CredentialsEndpointObject
   ];
 
   const actual = constructOnlineAccessUrls({
@@ -66,7 +65,6 @@ test('Returns correct url object for public data.', (t) => {
       URLDescription: 'File to download',
       Type: 'GET DATA'
     },
-    s3CredentialsEndpointObject
   ];
 
   const actual = constructOnlineAccessUrls({
@@ -87,15 +85,13 @@ test('Returns empty list for private data.', (t) => {
       bucket: privateBucket
     }
   ];
-  const expected = [s3CredentialsEndpointObject];
-
   const actual = constructOnlineAccessUrls({
     files: movedFiles,
     distEndpoint: endpoint,
     buckets: t.context.buckets
   });
 
-  t.deepEqual(actual, expected);
+  t.deepEqual(actual, []);
 });
 
 test('returns an array of correct url objects given a list of moved files.', (t) => {
@@ -127,7 +123,6 @@ test('returns an array of correct url objects given a list of moved files.', (t)
       URLDescription: 'File to download',
       Type: 'GET DATA'
     },
-    s3CredentialsEndpointObject
   ];
 
   const actual = constructOnlineAccessUrls({

--- a/packages/cmrjs/tests/cmr-utils/test-constructonlineaccessurls.js
+++ b/packages/cmrjs/tests/cmr-utils/test-constructonlineaccessurls.js
@@ -13,7 +13,7 @@ const getS3CredentialsObject = cmrUtils.__get__('getS3CredentialsObject');
 const sortByURL = (a, b) => a.URL < b.URL;
 
 const endpoint = 'https://endpoint';
-const s3CredentialsEndpointObject = getS3CredentialsObject(`${endpoint}/s3credentials`);
+// const s3CredentialsEndpointObject = getS3CredentialsObject(`${endpoint}/s3credentials`);
 
 
 test.beforeEach((t) => {
@@ -38,7 +38,7 @@ test('returns correct url for protected data', (t) => {
       Description: 'File to download',
       URLDescription: 'File to download',
       Type: 'GET DATA'
-    },
+    }
   ];
 
   const actual = constructOnlineAccessUrls({
@@ -64,7 +64,7 @@ test('Returns correct url object for public data.', (t) => {
       Description: 'File to download',
       URLDescription: 'File to download',
       Type: 'GET DATA'
-    },
+    }
   ];
 
   const actual = constructOnlineAccessUrls({
@@ -122,7 +122,7 @@ test('returns an array of correct url objects given a list of moved files.', (t)
       Description: 'File to download',
       URLDescription: 'File to download',
       Type: 'GET DATA'
-    },
+    }
   ];
 
   const actual = constructOnlineAccessUrls({

--- a/packages/cmrjs/tests/cmr-utils/test-constructurls.js
+++ b/packages/cmrjs/tests/cmr-utils/test-constructurls.js
@@ -184,7 +184,7 @@ test('constructRelatedUrls returns expected array when called with file list', (
 });
 
 test('constructRelatedUrls returns expected array when called with an empty file list', (t) => {
-  const movedFiles = []
+  const movedFiles = [];
   const expected = [omit(s3CredentialsEndpointObject, 'URLDescription')];
 
   const actual = constructRelatedUrls({

--- a/packages/cmrjs/tests/cmr-utils/test-constructurls.js
+++ b/packages/cmrjs/tests/cmr-utils/test-constructurls.js
@@ -3,17 +3,20 @@ const rewire = require('rewire');
 
 const { randomId } = require('@cumulus/common/test-utils');
 const { BucketsConfig } = require('@cumulus/common');
+const { omit } = require('@cumulus/common/util');
 
 const cmrUtils = rewire('../../cmr-utils');
 
 const constructOnlineAccessUrls = cmrUtils.__get__('constructOnlineAccessUrls');
+const constructResourceUrls = cmrUtils.__get__('constructResourceUrls');
+const constructRelatedUrls = cmrUtils.__get__('constructRelatedUrls');
 const getS3CredentialsObject = cmrUtils.__get__('getS3CredentialsObject');
 
 
 const sortByURL = (a, b) => a.URL < b.URL;
 
 const endpoint = 'https://endpoint';
-// const s3CredentialsEndpointObject = getS3CredentialsObject(`${endpoint}/s3credentials`);
+const s3CredentialsEndpointObject = getS3CredentialsObject(`${endpoint}/s3credentials`);
 
 
 test.beforeEach((t) => {
@@ -132,4 +135,63 @@ test('returns an array of correct url objects given a list of moved files.', (t)
   });
 
   t.deepEqual(actual.sort(sortByURL), expected.sort(sortByURL));
+});
+
+test('constructResourceUrls returns expected array of echo10xml resource urls', (t) => {
+  const expected = [omit(s3CredentialsEndpointObject, 'Description')];
+  const actual = constructResourceUrls(endpoint);
+
+  t.deepEqual(expected, actual);
+});
+
+test('constructRelatedUrls returns expected array when called with file list', (t) => {
+  const movedFiles = [
+    {
+      key: 'hidden/secretfile.gpg',
+      bucket: t.context.bucketConfig.private.name
+    },
+    {
+      key: 'path/publicfile.jpg',
+      bucket: t.context.bucketConfig.public.name
+    },
+    {
+      key: 'another/path/protected.hdf',
+      bucket: t.context.bucketConfig.protected.name
+    }
+  ];
+
+  const expected = [
+    {
+      URL: `${endpoint}/${t.context.bucketConfig.protected.name}/another/path/protected.hdf`,
+      Description: 'File to download',
+      Type: 'GET DATA'
+    },
+    {
+      URL: `https://${t.context.bucketConfig.public.name}.s3.amazonaws.com/path/publicfile.jpg`,
+      Description: 'File to download',
+      Type: 'GET DATA'
+    },
+    omit(s3CredentialsEndpointObject, 'URLDescription')
+  ];
+
+  const actual = constructRelatedUrls({
+    files: movedFiles,
+    distEndpoint: endpoint,
+    buckets: t.context.buckets
+  });
+
+  t.deepEqual(actual.sort(sortByURL), expected.sort(sortByURL));
+});
+
+test('constructRelatedUrls returns expected array when called with an empty file list', (t) => {
+  const movedFiles = []
+  const expected = [omit(s3CredentialsEndpointObject, 'URLDescription')];
+
+  const actual = constructRelatedUrls({
+    files: movedFiles,
+    distEndpoint: endpoint,
+    buckets: t.context.buckets
+  });
+
+  t.deepEqual(actual, expected);
 });


### PR DESCRIPTION
**Summary:** s3credentials url is currently being added to `onlineAccessUrls` when coming from an ECHO10XML file, which is incorrect. It should be placed into `resourceUrls`. 

Addresses [CUMULUS-668: As a same-region cloud user / service, I want to discover granule S3 URLs through the CMR so I may know where to download the data](https://bugs.earthdata.nasa.gov/browse/CUMULUS-668)

## Changes

* Split `constructOnlineAccessUrls` into three functions: `constructResourceUrls`, `constructRelatedUrls`, `constructOnlineAccessUrls`.

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

