### PR TITLE
CUMULUS-1187: Fix bug reading duplicate handling from collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- **CUMULUS-1187** - Added `@cumulus/ingest/granule/duplicateHandlingType()` to determine how duplicate files should be handled in an ingest workflow
 - **CUMULUS-672**
   - Added `cmrMetadataFormat` and `cmrConceptId` to output for individual granules from `@cumulus/post-to-cmr`. `cmrMetadataFormat` will default to value from workflow configuration, if provided, otherwise it will attempt to read the `cmrMetadataFormat` generated in `@cumulus/cmrjs/publish2CMR`
   - Added helpers to `@packages/integration-tests/api/distribution`:

--- a/packages/api/tests/models/test-granules-model.js
+++ b/packages/api/tests/models/test-granules-model.js
@@ -343,7 +343,11 @@ test('scan() will translate old-style granule files into the new schema', async 
   }).promise();
 
   const granuleModel = new Granule();
-  const scanResponse = await granuleModel.scan();
+  const scanResponse = await granuleModel.scan({
+    names: { '#granuleId': 'granuleId' },
+    filter: '#granuleId = :granuleId',
+    values: { ':granuleId': granule.granuleId }
+  });
 
   t.deepEqual(
     scanResponse.Items[0].files[0],

--- a/packages/ingest/granule.js
+++ b/packages/ingest/granule.js
@@ -841,7 +841,6 @@ function isFileRenamed(filename) {
   return (filename.match(suffixRegex) !== null);
 }
 
-
 /**
  * Returns the input filename stripping off any versioned timestamp.
  *
@@ -850,6 +849,30 @@ function isFileRenamed(filename) {
  */
 function unversionFilename(filename) {
   return isFileRenamed(filename) ? filename.split('.').slice(0, -1).join('.') : filename;
+}
+
+/**
+ * Returns a directive on how to act when duplicate files are encountered.
+ *
+ * @param {Object} event - lambda function event.
+ * @param {Object} event.config - the config object
+ * @param {Object} event.config.collection - collection object.
+
+ * @returns {string} - duplicate handling directive.
+ */
+function duplicateHandlingType(event) {
+  const config = get(event, 'config');
+  const collection = get(config, 'collection');
+
+  let duplicateHandling = get(config, 'duplicateHandling', get(collection, 'duplicateHandling', 'error'));
+
+  const forceDuplicateOverwrite = get(event, 'cumulus_config.cumulus_context.forceDuplicateOverwrite', false);
+
+  log.debug(`Configured duplicateHandling value: ${duplicateHandling}, forceDuplicateOverwrite ${forceDuplicateOverwrite}`);
+
+  if (forceDuplicateOverwrite === true) duplicateHandling = 'replace';
+
+  return duplicateHandling;
 }
 
 module.exports.selector = selector;
@@ -870,3 +893,4 @@ module.exports.moveGranuleFile = moveGranuleFile;
 module.exports.moveGranuleFiles = moveGranuleFiles;
 module.exports.renameS3FileWithTimestamp = renameS3FileWithTimestamp;
 module.exports.generateMoveFileParams = generateMoveFileParams;
+module.exports.duplicateHandlingType = duplicateHandlingType;

--- a/packages/ingest/granule.js
+++ b/packages/ingest/granule.js
@@ -5,6 +5,7 @@ const fs = require('fs-extra');
 const cloneDeep = require('lodash.clonedeep');
 const flatten = require('lodash.flatten');
 const groupBy = require('lodash.groupby');
+const get = require('lodash.get');
 const moment = require('moment');
 const omit = require('lodash.omit');
 const os = require('os');

--- a/tasks/move-granules/index.js
+++ b/tasks/move-granules/index.js
@@ -315,7 +315,7 @@ async function updateEachCmrFileAccessURLs(cmrFiles, granulesObject, distEndpoin
  */
 function duplicateHandlingType(event) {
   const config = get(event, 'config');
-  const collection = get(event, 'collection');
+  const collection = get(config, 'collection');
 
   let duplicateHandling = get(config, 'duplicateHandling', get(collection, 'duplicateHandling', 'error'));
 

--- a/tasks/move-granules/index.js
+++ b/tasks/move-granules/index.js
@@ -8,8 +8,11 @@ const flatten = require('lodash.flatten');
 const path = require('path');
 
 const {
-  getRenamedS3File, unversionFilename,
-  moveGranuleFile, renameS3FileWithTimestamp
+  getRenamedS3File,
+  unversionFilename,
+  moveGranuleFile,
+  renameS3FileWithTimestamp,
+  duplicateHandlingType
 } = require('@cumulus/ingest/granule');
 
 const {
@@ -302,30 +305,6 @@ async function updateEachCmrFileAccessURLs(cmrFiles, granulesObject, distEndpoin
       granuleId, updatedCmrFile, granule.files, distEndpoint, publish, bucketsConfig
     );
   }));
-}
-
-/**
- * Returns a directive on how to act when duplicate files are encountered.
- *
- * @param {Object} event - lambda function event.
- * @param {Object} event.config - the config object
- * @param {Object} event.config.collection - collection object.
-
- * @returns {string} - duplicate handling directive.
- */
-function duplicateHandlingType(event) {
-  const config = get(event, 'config');
-  const collection = get(config, 'collection');
-
-  let duplicateHandling = get(config, 'duplicateHandling', get(collection, 'duplicateHandling', 'error'));
-
-  const forceDuplicateOverwrite = get(event, 'cumulus_config.cumulus_context.forceDuplicateOverwrite', false);
-
-  log.debug(`Configured duplicateHandling value: ${duplicateHandling}, forceDuplicateOverwrite ${forceDuplicateOverwrite}`);
-
-  if (forceDuplicateOverwrite === true) duplicateHandling = 'replace';
-
-  return duplicateHandling;
 }
 
 /**

--- a/tasks/move-granules/tests/test-index.js
+++ b/tasks/move-granules/tests/test-index.js
@@ -59,7 +59,7 @@ function buildPayload(t) {
       file.filename = buildS3Uri(t.context.stagingBucket, parseS3Uri(file.filename).Key);
     });
   });
-  debugger;
+
   return newPayload;
 }
 

--- a/tasks/move-granules/tests/test-index.js
+++ b/tasks/move-granules/tests/test-index.js
@@ -477,7 +477,7 @@ function setupDuplicateHandlingConfig(t, duplicateHandling, forceDuplicateOverwr
   return payload;
 }
 
-function setDuplicateHandlingCollection(t, duplicateHandling) {
+function setupDuplicateHandlingCollection(t, duplicateHandling) {
   const payload = buildPayload(t);
   set(payload, 'config.collection.duplicateHandling', duplicateHandling);
   return payload;
@@ -559,6 +559,6 @@ test.serial('when duplicateHandling is "replace" and forceDuplicateOverwrite is 
 });
 
 test.serial('when duplicateHandling is specified as "replace" via collection, do overwrite files', async (t) => {
-  const payload = setDuplicateHandlingCollection(t, 'replace');
+  const payload = setupDuplicateHandlingCollection(t, 'replace');
   await granuleFilesOverwrittenTest(t, payload);
 });

--- a/tasks/move-granules/tests/test-index.js
+++ b/tasks/move-granules/tests/test-index.js
@@ -59,6 +59,7 @@ function buildPayload(t) {
       file.filename = buildS3Uri(t.context.stagingBucket, parseS3Uri(file.filename).Key);
     });
   });
+  debugger;
   return newPayload;
 }
 
@@ -469,11 +470,20 @@ test.serial('When duplicateHandling is "skip", does not overwrite or create new.
   });
 });
 
-async function granuleFilesOverwrittenTest(t, duplicateHandling, forceDuplicateOverwrite) {
-  let newPayload = buildPayload(t);
-  newPayload.config.duplicateHandling = duplicateHandling;
-  set(newPayload, 'cumulus_config.cumulus_context.forceDuplicateOverwrite', forceDuplicateOverwrite);
+function setupDuplicateHandlingConfig(t, duplicateHandling, forceDuplicateOverwrite) {
+  const payload = buildPayload(t);
+  payload.config.duplicateHandling = duplicateHandling;
+  set(payload, 'cumulus_config.cumulus_context.forceDuplicateOverwrite', forceDuplicateOverwrite);
+  return payload;
+}
 
+function setDuplicateHandlingCollection(t, duplicateHandling) {
+  const payload = buildPayload(t);
+  set(payload, 'config.collection.duplicateHandling', duplicateHandling);
+  return payload;
+}
+
+async function granuleFilesOverwrittenTest(t, newPayload) {
   // payload could be modified
   const newPayloadOrig = clonedeep(newPayload);
 
@@ -524,21 +534,31 @@ async function granuleFilesOverwrittenTest(t, duplicateHandling, forceDuplicateO
 }
 
 test.serial('when duplicateHandling is "replace", do overwrite files', async (t) => {
-  await granuleFilesOverwrittenTest(t, 'replace');
+  const payload = setupDuplicateHandlingConfig(t, 'replace');
+  await granuleFilesOverwrittenTest(t, payload);
 });
 
 test.serial('when duplicateHandling is "error" and forceDuplicateOverwrite is true, do overwrite files', async (t) => {
-  await granuleFilesOverwrittenTest(t, 'error', true);
+  const payload = setupDuplicateHandlingConfig(t, 'error', true);
+  await granuleFilesOverwrittenTest(t, payload);
 });
 
 test.serial('when duplicateHandling is "skip" and forceDuplicateOverwrite is true, do overwrite files', async (t) => {
-  await granuleFilesOverwrittenTest(t, 'skip', true);
+  const payload = setupDuplicateHandlingConfig(t, 'skip', true);
+  await granuleFilesOverwrittenTest(t, payload);
 });
 
 test.serial('when duplicateHandling is "version" and forceDuplicateOverwrite is true, do overwrite files', async (t) => {
-  await granuleFilesOverwrittenTest(t, 'version', true);
+  const payload = setupDuplicateHandlingConfig(t, 'version', true);
+  await granuleFilesOverwrittenTest(t, payload);
 });
 
 test.serial('when duplicateHandling is "replace" and forceDuplicateOverwrite is true, do overwrite files', async (t) => {
-  await granuleFilesOverwrittenTest(t, 'replace', true);
+  const payload = setupDuplicateHandlingConfig(t, 'replace', true);
+  await granuleFilesOverwrittenTest(t, payload);
+});
+
+test.serial('when duplicateHandling is specified as "replace" via collection, do overwrite files', async (t) => {
+  const payload = setDuplicateHandlingCollection(t, 'replace');
+  await granuleFilesOverwrittenTest(t, payload);
 });

--- a/tasks/sync-granule/index.js
+++ b/tasks/sync-granule/index.js
@@ -5,7 +5,10 @@ const cumulusMessageAdapter = require('@cumulus/cumulus-message-adapter-js');
 const errors = require('@cumulus/common/errors');
 const get = require('lodash.get');
 const lock = require('@cumulus/ingest/lock');
-const { selector: granuleSelector } = require('@cumulus/ingest/granule');
+const {
+  selector: granuleSelector,
+  duplicateHandlingType
+} = require('@cumulus/ingest/granule');
 const log = require('@cumulus/common/log');
 
 /**
@@ -68,13 +71,8 @@ exports.syncGranule = function syncGranule(event) {
   const collection = config.collection;
   const forceDownload = config.forceDownload || false;
   const downloadBucket = config.downloadBucket;
-  let duplicateHandling = get(
-    config, 'duplicateHandling', get(collection, 'duplicateHandling', 'error')
-  );
-  const forceDuplicateOverwrite = get(event, 'cumulus_config.cumulus_context.forceDuplicateOverwrite', false);
 
-  log.debug(`Configured duplicateHandling value: ${duplicateHandling}, forceDuplicateOverwrite ${forceDuplicateOverwrite}`);
-  if (forceDuplicateOverwrite === true) duplicateHandling = 'replace';
+  const duplicateHandling = duplicateHandlingType(event);
 
   // use stack and collection names to prefix fileStagingDir
   const fileStagingDir = path.join(

--- a/tasks/sync-granule/index.js
+++ b/tasks/sync-granule/index.js
@@ -3,7 +3,6 @@
 const path = require('path');
 const cumulusMessageAdapter = require('@cumulus/cumulus-message-adapter-js');
 const errors = require('@cumulus/common/errors');
-const get = require('lodash.get');
 const lock = require('@cumulus/ingest/lock');
 const {
   selector: granuleSelector,

--- a/tasks/sync-granule/package.json
+++ b/tasks/sync-granule/package.json
@@ -41,8 +41,7 @@
     "@cumulus/common": "1.11.2",
     "@cumulus/cumulus-message-adapter-js": "^1.0.7",
     "@cumulus/ingest": "1.11.2",
-    "@cumulus/test-data": "1.11.0",
-    "lodash.get": "^4.4.2"
+    "@cumulus/test-data": "1.11.0"
   },
   "devDependencies": {
     "ava": "^0.25.0",

--- a/tasks/sync-granule/tests/sync_granule_test.js
+++ b/tasks/sync-granule/tests/sync_granule_test.js
@@ -713,9 +713,16 @@ test.serial('when duplicateHandling is "skip", do not overwrite or create new', 
   }
 });
 
-async function granuleFilesOverwrittenTest(t, duplicateHandling, forceDuplicateOverwrite) {
+function setupDuplicateHandlingConfig(t, duplicateHandling, forceDuplicateOverwrite) {
   t.context.event.config.duplicateHandling = duplicateHandling;
   set(t.context.event, 'cumulus_config.cumulus_context.forceDuplicateOverwrite', forceDuplicateOverwrite);
+}
+
+function setupDuplicateHandlingCollection(t, duplicateHandling) {
+  set(t.context.event, 'config.collection.duplicateHandling', duplicateHandling);
+}
+
+async function granuleFilesOverwrittenTest(t) {
   await prepareS3DownloadEvent(t);
 
   const granuleFileName = t.context.event.input.granules[0].files[0].name;
@@ -763,22 +770,31 @@ async function granuleFilesOverwrittenTest(t, duplicateHandling, forceDuplicateO
 }
 
 test.serial('when duplicateHandling is "replace", do overwrite files', async (t) => {
-  // duplicateHandling is taken from task config or collection config
-  await granuleFilesOverwrittenTest(t, 'replace');
+  setupDuplicateHandlingConfig(t, 'replace');
+  await granuleFilesOverwrittenTest(t);
 });
 
 test.serial('when duplicateHandling is "error" and forceDuplicateOverwrite is true, do overwrite files', async (t) => {
-  await granuleFilesOverwrittenTest(t, 'error', true);
+  setupDuplicateHandlingConfig(t, 'error', true);
+  await granuleFilesOverwrittenTest(t);
 });
 
 test.serial('when duplicateHandling is "skip" and forceDuplicateOverwrite is true, do overwrite files', async (t) => {
-  await granuleFilesOverwrittenTest(t, 'skip', true);
+  setupDuplicateHandlingConfig(t, 'skip', true);
+  await granuleFilesOverwrittenTest(t);
 });
 
 test.serial('when duplicateHandling is "version" and forceDuplicateOverwrite is true, do overwrite files', async (t) => {
-  await granuleFilesOverwrittenTest(t, 'version', true);
+  setupDuplicateHandlingConfig(t, 'version', true);
+  await granuleFilesOverwrittenTest(t);
 });
 
 test.serial('when duplicateHandling is "replace" and forceDuplicateOverwrite is true, do overwrite files', async (t) => {
-  await granuleFilesOverwrittenTest(t, 'replace', true);
+  setupDuplicateHandlingConfig(t, 'replace', true);
+  await granuleFilesOverwrittenTest(t);
+});
+
+test.serial('when duplicateHandling is specified as "replace" via collection, do overwrite files', async (t) => {
+  setupDuplicateHandlingCollection(t, 'replace');
+  await granuleFilesOverwrittenTest(t);
 });


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-1187: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1187)

## Changes

* Fix duplicate handling logic to respect value from collection
* Move duplicate handling logic into re-usable helper function. Re-factor sync-granule and move-granules to use helper function
* Add unit tests to sync-granule and move-granules to test setting duplicate handling via collection

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests

