### PR TITLE
Cumulus 667 setup access logging docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,14 +15,12 @@ The documentation is accessible at https://nasa.github.io/cumulus
 
 ## Navigating the Cumulus Docs
 
-* Cumulus API Documentation - [here](nasa.github.io/nasa/cumulus-api)
-* Cumulus Developer Documentation - [here](github.com/nasa/cumulus) - Readme's throughout the main repository.
-* General Cumulus Documentation - [here](nasa.github.io/nasa/cumulus) <- you're here
-* Data Cookbooks - [here](nasa.github.io/cumulus/docs/data-cookbooks/about-cookbooks)
-* Operator Docs - [here](nasa.github.io/cumulus/docs/operator-docs/about-operator-docs)
-
+* Cumulus API Documentation - [here](https://nasa.github.io/cumulus-api)
+* Cumulus Developer Documentation - [here](https://github.com/nasa/cumulus) - Readme's throughout the main repository.
+* General Cumulus Documentation - [here](cumulus-docs-readme) <- you're here
+* Data Cookbooks - [here](data-cookbooks/about-cookbooks)
+* Operator Docs - [here](operator-docs/about-operator-docs)
 
 ## Contributing
 
 Please refer to: https://github.com/nasa/cumulus/blob/master/CONTRIBUTING.md for information
-

--- a/docs/deployment/create_bucket.md
+++ b/docs/deployment/create_bucket.md
@@ -8,9 +8,7 @@ hide_title: true
 
 Buckets can be created on the command line with [AWS CLI][cli] or via the web interface on the [AWS console][web].
 
-When creating a protected bucket (a bucket containing data which will be
-served through the distribution API), make sure to enable S3 Server Access
-Logging. See [EMS Reporting](ems_reporting.md) for more details.
+When creating a protected bucket (a bucket containing data which will be served through the distribution API), make sure to enable S3 Server Access Logging. See [EMS Reporting](ems_reporting.md) for more details.
 
 
 ## Command line
@@ -27,7 +25,6 @@ $ aws s3api create-bucket --bucket foobar-internal
 Please note security settings and other bucket options can be set via the options listed in the s3api documentation.
 
 Repeat the above step for each bucket to be created.
-
 
 ## Web interface
 

--- a/docs/deployment/create_bucket.md
+++ b/docs/deployment/create_bucket.md
@@ -8,7 +8,7 @@ hide_title: true
 
 Buckets can be created on the command line with [AWS CLI][cli] or via the web interface on the [AWS console][web].
 
-When creating a protected bucket (a bucket containing data which will be served through the distribution API), make sure to enable S3 Server Access Logging. See [EMS Reporting](ems_reporting.md) for more details.
+When creating a protected bucket (a bucket containing data which will be served through the distribution API), make sure to enable S3 server access logging. See [S3 Server Access Logging](server_access_logging.md) for more details.
 
 
 ## Command line

--- a/docs/deployment/server_access_logging.md
+++ b/docs/deployment/server_access_logging.md
@@ -6,7 +6,7 @@ hide_title: true
 
 # S3 Server Access Logging
 
-To enable [EMS Reporting](../ems_reporting.md), you need to enable [S3 Server access logging.][awslogging] on all protected buckets.
+To enable [EMS Reporting](../ems_reporting.md), you need to enable [S3 Server access logging][awslogging] on all protected buckets.
 
 
 ### Via AWS Console.

--- a/docs/deployment/server_access_logging.md
+++ b/docs/deployment/server_access_logging.md
@@ -6,14 +6,14 @@ hide_title: true
 
 # S3 Server Access Logging
 
-To enable [EMS Reporting](../ems_reporting.md), you need to enable [S3 Server access logging][awslogging] on all protected buckets.
+To enable [EMS Reporting](../ems_reporting.md), you need to enable [S3 server access logging][awslogging] on all protected buckets.
 
 
 ### Via AWS Console
 
-[Enable Server Access Logging for an S3 Bucket][howtologging]
+[Enable server access logging for an S3 bucket][howtologging]
 
-### Via [AWS CLI][cli]
+### Via [AWS Command Line Interface][cli]
 
 
 1. create a `logging.json` file with these contents, replacing `<stack-internal-bucket>` with your stack's internal bucket name, and `<stack>` with the name of your cumulus stack.

--- a/docs/deployment/server_access_logging.md
+++ b/docs/deployment/server_access_logging.md
@@ -13,7 +13,7 @@ To enable [EMS Reporting](../ems_reporting.md), you need to enable [S3 Server ac
 
 [Enable Server Access Logging for an S3 Bucket][howtologging]
 
-### Via [AWS CLI][cli].
+### Via [AWS CLI][cli]
 
 
 1. create a `logging.json` file with these contents, replacing `<stack-internal-bucket>` with your stack's internal bucket name, and `<stack>` with the name of your cumulus stack.

--- a/docs/deployment/server_access_logging.md
+++ b/docs/deployment/server_access_logging.md
@@ -9,7 +9,7 @@ hide_title: true
 To enable [EMS Reporting](../ems_reporting.md), you need to enable [S3 Server access logging][awslogging] on all protected buckets.
 
 
-### Via AWS Console.
+### Via AWS Console
 
 [Enable Server Access Logging for an S3 Bucket][howtologging]
 

--- a/docs/deployment/server_access_logging.md
+++ b/docs/deployment/server_access_logging.md
@@ -11,7 +11,7 @@ To enable [EMS Reporting](../ems_reporting.md), you need to enable [S3 Server ac
 
 ### Via AWS Console.
 
-[Enable Server Access Logging for an S3 Bucket?][howtologging]
+[Enable Server Access Logging for an S3 Bucket][howtologging]
 
 ### Via [AWS CLI][cli].
 

--- a/docs/deployment/server_access_logging.md
+++ b/docs/deployment/server_access_logging.md
@@ -1,0 +1,40 @@
+---
+id: server_access_logging
+title: S3 Server Access Logging
+hide_title: true
+---
+
+# S3 Server Access Logging
+
+To enable [EMS Reporting](../ems_reporting.md), you need to enable [S3 Server access logging.][awslogging] on all protected buckets.
+
+
+### Via AWS Console.
+
+[Enable Server Access Logging for an S3 Bucket?][howtologging]
+
+### Via [AWS CLI][cli].
+
+
+1. create a `logging.json` file with these contents, replacing `<stack-internal-bucket>` with your stack's internal bucket name, and `<stack>` with the name of your cumulus stack.
+	```json
+	{
+		"LoggingEnabled": {
+			"TargetBucket": "<stack-internal-bucket>",
+			"TargetPrefix": "<stack>/ems-distribution/s3-server-access-logs/"
+		}
+	}
+	```
+2. Add the logging policy to your protected buckets by calling this command on each protected bucket.
+
+	```sh
+	aws s3api put-bucket-logging --bucket <protected-bucket-name> --bucket-logging-status file://logging.json
+	```
+3. Verify the logging policy exists on your protected buckets..
+	```sh
+	aws s3api get-bucket-logging --bucket <protected-bucket-name>
+	```
+
+[cli]: https://aws.amazon.com/cli/ "Amazon command line interface"
+[howtologging]: https://docs.aws.amazon.com/AmazonS3/latest/user-guide/server-access-logging.html "Amazon Console Instructions"
+[awslogging]: https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerLogs.html "Amazon S3 Server Access Logging"

--- a/docs/ems_reporting.md
+++ b/docs/ems_reporting.md
@@ -22,19 +22,8 @@ A scheduled Lambda task will run nightly that generates Ingest, Archive and Arch
 
 ## Distribution
 
-Cumulus reports all data distribution requests that pass through the
-distribution API to EMS. In order to track these requests, S3 Server Access
-Logging must be enabled on all protected buckets.
+Cumulus reports all data distribution requests that pass through the distribution API to EMS. In order to track these requests, S3 Server access logging must be enabled on all protected buckets.
 
-You will need to enable logging for each bucket manually before distribution
-logging will work.
+You must manually enable logging for each bucket before distribution logging will work, see [S3 Server Access Logging.](./deployment/server_access_logging.md)
 
-[How Do I Enable Server Access Logging for an S3 Bucket?](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/server-access-logging.html)
-
-When enabling server access logging, the "Target bucket" should be set to your
-stack's internal bucket. The "Target prefix" should be set to
-"<STACK_NAME>/ems-distribution/s3-server-access-logs/" (include trailing slash),
-where "<STACK_NAME>" is replaced with the name of your Cumulus stack.
-
-A scheduled Lambda task will run nightly that collects distribution events and
-builds an EMS distribution report.
+A scheduled Lambda task will run nightly that collects distribution events and builds an EMS distribution report.

--- a/docs/ems_reporting.md
+++ b/docs/ems_reporting.md
@@ -22,7 +22,7 @@ A scheduled Lambda task will run nightly that generates Ingest, Archive and Arch
 
 ## Distribution
 
-Cumulus reports all data distribution requests that pass through the distribution API to EMS. In order to track these requests, S3 Server access logging must be enabled on all protected buckets.
+Cumulus reports all data distribution requests that pass through the distribution API to EMS. In order to track these requests, S3 server access logging must be enabled on all protected buckets.
 
 You must manually enable logging for each bucket before distribution logging will work, see [S3 Server Access Logging.](./deployment/server_access_logging.md)
 

--- a/docs/operator-docs/locating-access-logs.md
+++ b/docs/operator-docs/locating-access-logs.md
@@ -6,6 +6,6 @@ hide_title: true
 
 # Locating S3 Access Logs
 
-When [enabling S3 Access Logs](../deployment/server_access_logging) for EMS Reporting you configured a `TargetBucket` and `TargetPrefix`.  Those together, are where you will find the raw S3 access logs.
+When [enabling S3 Access Logs](../deployment/server_access_logging) for EMS Reporting you configured a `TargetBucket` and `TargetPrefix`.  Inside the `TargetBucket` at the `TargetPrefix` is where you will find the raw S3 access logs.
 
 In a standard deployment, this will be your stack's `<internal bucket name>` and a key prefix of `<stack>/ems-distribution/s3-server-access-logs/`

--- a/docs/operator-docs/locating-access-logs.md
+++ b/docs/operator-docs/locating-access-logs.md
@@ -1,0 +1,11 @@
+---
+id: locating-access-logs
+title: Locating S3 Access Logs
+hide_title: true
+---
+
+# Locating S3 Access Logs
+
+When [enabling S3 Access Logs](../deployment/server_access_logging) for EMS Reporting you configured a `TargetBucket` and `TargetPrefix`.  Those together, are where you will find the raw S3 access logs.
+
+In a standard deployment, this will be your stack's `<internal bucket name>` and a key prefix of `<stack>/ems-distribution/s3-server-access-logs/`

--- a/example/README.md
+++ b/example/README.md
@@ -32,15 +32,15 @@ NOTE: For this to work you need your default credentials to be credentials for t
 An S3 Access lambda is needed in the us-west-2 region to run the integration tests. To initially create the lambda, run:
 
 ```
-aws lambda create-function --region us-west-2  --function-name <STACK>-S3AccessTest --zip-file fileb://app/build/cloudformation/<ZIP>-S3AccessTest.zip  --role arn:aws:iam::<AWS_ACCOUNT_ID>:role/<PREFIX>-lambda-processing  --handler index.handler --runtime nodejs8.10 --profile ngap-sandbox
+aws lambda create-function --region us-west-2  --function-name <STACK>-S3AccessTest --zip-file fileb://app/build/cloudformation/<ZIP>-S3AccessTest.zip  --role arn:aws:iam::<AWS_ACCOUNT_ID>:role/<PREFIX>-lambda-processing  --handler index.handler --runtime nodejs8.10 --profile <NGAP Profile>
 ```
 
-Replace `<AWS_ACCOUNT_ID>` with your account Id, `<STACK>` with your stack name, `<PREFIX>` with your iam prefix name, and the zip file `<ZIP>` can be found in `app/build/cloudformation/` following a deployment. The zip file does not matter, but you need something there.
+Replace `<AWS_ACCOUNT_ID>` with your account Id, `<STACK>` with your stack name, `<PREFIX>` with your iam prefix name, and use your NGAP profile. An S3AccessTest zip file `<ZIP>` can be found under `app/build/` following a stack deployment (either in `cloudformation` or `workflow_lambda_versions` depending on your stack configuration). The version of zip file that you upload does not matter, but you need to deploy something to us-west-2 so that travis can update it with current lambdas.
 
-After the initial creation of this lambda, you can update it by running:
+If you need, after the initial creation of this lambda, you can update it by running:
 
 ```
-./node_modules/.bin/kes lambda S3AccessTest deploy --kes-folder app --template node_modules/@cumulus/deployment/app --deployment <deployment> --region us-west-2
+./node_modules/.bin/kes lambda S3AccessTest deploy --kes-folder app --template node_modules/@cumulus/deployment/app --deployment <deployment> --region us-west-2 --profile < NGAP Profile >
 ```
 
 This command will update the lambda with the latest lambda code.

--- a/example/README.md
+++ b/example/README.md
@@ -35,7 +35,7 @@ An S3 Access lambda is needed in the us-west-2 region to run the integration tes
 aws lambda create-function --region us-west-2  --function-name <STACK>-S3AccessTest --zip-file fileb://app/build/cloudformation/<ZIP>-S3AccessTest.zip  --role arn:aws:iam::<AWS_ACCOUNT_ID>:role/<PREFIX>-lambda-processing  --handler index.handler --runtime nodejs8.10 --profile <NGAP Profile>
 ```
 
-Replace `<AWS_ACCOUNT_ID>` with your account Id, `<STACK>` with your stack name, `<PREFIX>` with your iam prefix name, and use your NGAP profile. An S3AccessTest zip file `<ZIP>` can be found under `app/build/` following a stack deployment (either in `cloudformation` or `workflow_lambda_versions` depending on your stack configuration). The version of zip file that you upload does not matter, but you need to deploy something to us-west-2 so that travis can update it with current lambdas.
+Replace `<AWS_ACCOUNT_ID>` with your account Id, `<STACK>` with your stack name, `<PREFIX>` with your iam prefix name, and use your NGAP profile. An S3AccessTest zip file `<ZIP>` can be found under `app/build/` following a stack deployment (either in `cloudformation` or `workflow_lambda_versions` depending on your stack configuration). The version of the zip file that you upload does not matter, but you need to deploy something to us-west-2 so that travis can update it with current lambdas.
 
 If you need, after the initial creation of this lambda, you can update it by running:
 

--- a/packages/api/lib/testUtils.js
+++ b/packages/api/lib/testUtils.js
@@ -201,17 +201,13 @@ function fakeExecutionFactory(status = 'completed', type = 'fakeWorkflow') {
  * @returns {Object} - a fake user
  */
 function fakeUserFactory(params = {}) {
-  const {
-    userName = randomId('userName'),
-    password = randomId('password'),
-    expires = Date.now() + (60 * 60 * 1000) // Default to 1 hour
-  } = params;
-
-  return {
-    userName,
-    password,
-    expires
+  const user = {
+    userName: randomId('userName'),
+    password: randomId('password'),
+    expires: Date.now() + (60 * 60 * 1000) // Default to 1 hour
   };
+
+  return { ...user, ...params };
 }
 
 /**

--- a/packages/integration-tests/api/api.js
+++ b/packages/integration-tests/api/api.js
@@ -23,16 +23,17 @@ const {
  *   name.
  * @param {string} params.payload - the payload to send to the Lambda function.
  *   See https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
+ * @param {Object} params.userParams - parameter object passed to fakeUserFactory
  * @returns {Promise<Object>} - the parsed payload of the response.  See
  *   https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format
  */
-async function callCumulusApi({ prefix, payload: userPayload }) {
+async function callCumulusApi({ prefix, payload: userPayload, userParams = {} }) {
   const payload = cloneDeep(userPayload);
 
   process.env.UsersTable = `${prefix}-UsersTable`;
   const userModel = new User();
 
-  const { userName } = await userModel.create(fakeUserFactory());
+  const { userName } = await userModel.create(fakeUserFactory(userParams));
 
   process.env.AccessTokensTable = `${prefix}-AccessTokensTable`;
   const accessTokenModel = new AccessToken();

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -59,6 +59,9 @@
       "deployment/deployment-readme": {
         "title": "How to Deploy Cumulus"
       },
+      "deployment/server_access_logging": {
+        "title": "S3 Server Access Logging"
+      },
       "deployment/troubleshoot_deployment": {
         "title": "Troubleshooting Cumulus Deployment"
       },
@@ -100,6 +103,9 @@
       },
       "operator-docs/lifecycle-policies": {
         "title": "Lifecycle Policies"
+      },
+      "operator-docs/locating-access-logs": {
+        "title": "Locating S3 Access Logs"
       },
       "operator-docs/update-cumulus-dependencies": {
         "title": "Update Cumulus Dependencies"

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -21,6 +21,7 @@
     "Deployment": [
       "deployment/deployment-readme",
       "deployment/create_bucket",
+      "deployment/server_access_logging",
       "deployment/iam_roles",
       "deployment/obtain_cumulus_packages",
       "deployment/config_descriptions",
@@ -69,7 +70,8 @@
     ],
     "Configuration": [
       "operator-docs/update-cumulus-dependencies",
-      "operator-docs/lifecycle-policies"
+      "operator-docs/lifecycle-policies",
+      "operator-docs/locating-access-logs"
     ]
   }
 }


### PR DESCRIPTION

**Summary:** Updates Docs 

Addresses [CUMULUS-667: As a DAAC, I want to associate direct S3 data access with Earthdata Login ids so I may understand who is accessing my data](https://bugs.earthdata.nasa.gov/browse/CUMULUS-667)

## Changes

* Creates new sidebar and document for Server Access Logging
* Moves information from EMS Reporting to new document
* Points Operators to new document.
* Cleans up a number of broken links in the documentation.


* Clarifies how to deploy s3AccessTest lambda for developers.
* Small refactor to ensure the authenticated user's login appears in the token returned by s3credentials endpoint

