### PR TITLE
Use granule UR to remove a granule from CMR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Added helpers to `@packages/integration-tests/api/distribution`:
     - `getDistributionApiFileStream()` returns a stream to download files protected by the distribution API
     - `getDistributionFileUrl()` constructs URLs for requesting files from the distribution API
+- **CUMULUS-1185** `@cumulus/api/models/Granule.removeGranuleFromCmrByGranule` to replace `@cumulus/api/models/Granule.removeGranuleFromCmr` and use the Granule UR from the CMR metadata to remove the granule from CMR
 
 - **CUMULUS-1101**
   - Added new `@cumulus/checksum` package. This package provides functions to calculate and validate checksums.
@@ -85,6 +86,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     `provider.host`, and `provider.port`.
   - The default provider port was being set to 21, no matter what protocol was
     being used. Removed that default.
+
+### Deprecated
+
+- `@cumulus/api/models/Granule.removeGranuleFromCmr`, instead use `@cumulus/api/models/Granule.removeGranuleFromCmrByGranule`
 
 ## [v1.11.3] - 2019-3-5
 

--- a/packages/api/app/routes.js
+++ b/packages/api/app/routes.js
@@ -1,6 +1,9 @@
 'use strict';
 
 const router = require('express-promise-router')();
+
+const log = require('@cumulus/common/log');
+
 const collections = require('../endpoints/collections');
 const granules = require('../endpoints/granules');
 const providers = require('../endpoints/providers');
@@ -86,7 +89,9 @@ router.use('/dashboard', dashboard);
 // Catch and send the error message down (instead of just 500: internal server error)
 // Need all 4 params, because that's how express knows this is the error handler
 // eslint-disable-next-line no-unused-vars
-router.use((error, req, res, next) =>
-  res.boom.badImplementation(error.message));
+router.use((error, req, res, next) => {
+  log.error(error);
+  return res.status(500).send({ error: error.message });
+});
 
 module.exports = router;

--- a/packages/api/app/routes.js
+++ b/packages/api/app/routes.js
@@ -83,5 +83,10 @@ router.post('/refresh', token.refreshEndpoint);
 
 router.use('/dashboard', dashboard);
 
+// Catch and send the error message down (instead of just 500: internal server error)
+// Need all 4 params, because that's how express knows this is the error handler
+// eslint-disable-next-line no-unused-vars
+router.use((error, req, res, next) =>
+  res.boom.badImplementation(error.message));
 
 module.exports = router;

--- a/packages/api/endpoints/granules.js
+++ b/packages/api/endpoints/granules.js
@@ -73,7 +73,7 @@ async function put(req, res) {
   }
 
   if (action === 'removeFromCmr') {
-    await granuleModelClient.removeGranuleFromCmr(granule.granuleId, granule.collectionId);
+    await granuleModelClient.removeGranuleFromCmrByGranule(granule);
 
     return res.send({
       granuleId: granule.granuleId,

--- a/packages/api/lib/testUtils.js
+++ b/packages/api/lib/testUtils.js
@@ -81,6 +81,7 @@ function fakeGranuleFactory(status = 'completed') {
     status,
     execution: randomString(),
     createdAt: Date.now(),
+    updatedAt: Date.now(),
     published: true,
     cmrLink: 'example.com',
     productVolume: 100

--- a/packages/api/models/granules.js
+++ b/packages/api/models/granules.js
@@ -129,7 +129,8 @@ class Granule extends Manager {
 
     const metadata = await cmrjs.getMetadata(granule.cmrLink);
 
-    await cmr.deleteGranule(metadata.title, granule.collectionId); // Use granule UR to delete from CMR
+    // Use granule UR to delete from CMR
+    await cmr.deleteGranule(metadata.title, granule.collectionId);
     await this.update({ granuleId: granule.granuleId }, { published: false }, ['cmrLink']);
   }
 

--- a/packages/api/tests/serial/endpoints/test-granules.js
+++ b/packages/api/tests/serial/endpoints/test-granules.js
@@ -10,6 +10,7 @@ const {
   sfn
 } = require('@cumulus/common/aws');
 const aws = require('@cumulus/common/aws');
+const cmrjs = require('@cumulus/cmrjs');
 const { CMR } = require('@cumulus/cmrjs');
 const {
   metadataObjectFromCMRFile
@@ -432,13 +433,17 @@ test.serial('remove a granule from CMR', async (t) => {
     'deleteGranule'
   ).callsFake(() => Promise.resolve());
 
+  sinon.stub(
+    cmrjs,
+    'getMetadata'
+  ).callsFake(() => Promise.resolve({ title: t.context.fakeGranules[0].granuleId }));
+
   const response = await request(app)
     .put(`/granules/${t.context.fakeGranules[0].granuleId}`)
     .set('Accept', 'application/json')
     .set('Authorization', `Bearer ${accessToken}`)
     .send({ action: 'removeFromCmr' })
     .expect(200);
-
 
   const body = response.body;
   t.is(body.status, 'SUCCESS');
@@ -450,6 +455,7 @@ test.serial('remove a granule from CMR', async (t) => {
 
   CMR.prototype.deleteGranule.restore();
   DefaultProvider.decrypt.restore();
+  cmrjs.getMetadata.restore();
 });
 
 test.serial('DELETE deleting an existing granule that is published will fail', async (t) => {


### PR DESCRIPTION
**Summary:** Use granule UR instead of granule id when removing a granule from CMR

Addresses [CUMULUS-1185](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1185)

## Changes

* Update remove from CMR code to grab the metadata, use it to extract the granule UR, and use that to remove the granule

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

