### PR TITLE
CUMULUS-1194: improve S3KeyPairProvider error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - The default provider port was being set to 21, no matter what protocol was
     being used. Removed that default.
 
+- CUMULUS-1174
+  - Better error message and stacktrace for S3KeyPairProvider error reporting.
+
 ## [v1.11.3] - 2019-3-5
 
 ### Added

--- a/packages/common/key-pair-provider.js
+++ b/packages/common/key-pair-provider.js
@@ -70,7 +70,7 @@ class S3KeyPairProvider {
     try {
       const key = await getS3Object({
         Bucket: b, Key: `${s}/crypto/${keyId}`
-      }).promise();
+      });
       return key;
     }
     catch (err) {

--- a/packages/common/key-pair-provider.js
+++ b/packages/common/key-pair-provider.js
@@ -68,9 +68,7 @@ class S3KeyPairProvider {
     const b = bucket || process.env.system_bucket;
     const s = stack || process.env.stackName;
     try {
-      const key = await getS3Object({
-        Bucket: b, Key: `${s}/crypto/${keyId}`
-      });
+      const key = await getS3Object(b, `${s}/crypto/${keyId}`);
       return key;
     }
     catch (err) {

--- a/packages/common/key-pair-provider.js
+++ b/packages/common/key-pair-provider.js
@@ -53,13 +53,14 @@ class S3KeyPairProvider {
     return privateKey.decrypt(decoded);
   }
 
-  static retrieveKey(keyId = null, bucket = null, stack = null) {
+  static async retrieveKey(keyId = null, bucket = null, stack = null) {
     const b = bucket || process.env.system_bucket;
     const s = stack || process.env.stackName;
     try {
-      return getS3Object({
+      const key = await getS3Object({
         Bucket: b, Key: `${s}/crypto/${keyId}`
       }).promise();
+      return key;
     }
     catch (err) {
       log.error(`Failed to retrieve S3KeyPair key from bucket ${b} on stack ${s}`);

--- a/packages/common/key-pair-provider.js
+++ b/packages/common/key-pair-provider.js
@@ -53,6 +53,17 @@ class S3KeyPairProvider {
     return privateKey.decrypt(decoded);
   }
 
+  /**
+   * Retrieve encryption/decryption key from S3
+   *
+   * @param {string} keyId - The name of the key to retrieve
+   * @param {string} bucket - the optional bucket name. if not provided will
+   *                          use env variable "system_bucket"
+   * @param {stack} stack - the optional stack name. if not provided will
+   *                        use env variable "stackName"
+   * @throws {Error} - throws AWS SDK error if encountered. Logs error's variables before throwing.
+   * @returns {Promise} - AWS S3 Object
+   */
   static async retrieveKey(keyId = null, bucket = null, stack = null) {
     const b = bucket || process.env.system_bucket;
     const s = stack || process.env.stackName;


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-1194: Improve S3 KeyPairProvider error message](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1194)

## Changes

* Changed S3 call to use `getS3Object` which is wrapped by `improveStackTrace` for better stacktraces.
* Logs bucket/stack values if an error is caught.

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Adhoc testing
- [x] Integration tests

