### PR TITLE
CUMULUS-1176: refactor move-granules to take granules object as input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### BREAKING CHANGES
+- CUMULUS-1176:
+  - `@cumulus/move-granules` input expectations have changed. `@cumulus/files-to-granules` is a new intermediate task to perform input translation in the old style.
+    See the Added and Changed sections of this release changelog for more information.
+
 ### Added
 
 - **CUMULUS-670**
@@ -98,6 +103,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     `provider.host`, and `provider.port`.
   - The default provider port was being set to 21, no matter what protocol was
     being used. Removed that default.
+
+- **CUMULUS-1176**
+  - `@cumulus/move-granules` breaking change: Input to `move-granules` is now expected to be in the form of granules object (i.e. `{ granules: [ ... ] }`);
+    In order to continue to provide array-of-files type inputs following processing steps, use the new `@cumulus/files-to-granules` task as an intermediate step.
+    This task will perform the input translation. This change allows `move-granules` to be simpler and behave more predictably.
 
 - CUMULUS-1174
   - Better error message and stacktrace for S3KeyPairProvider error reporting.

--- a/tasks/move-granules/index.js
+++ b/tasks/move-granules/index.js
@@ -302,9 +302,9 @@ async function moveGranules(event) {
 
   const granulesInput = get(event, 'input.granules', []);
   const cmrFiles = granulesInput.reduce(
-    (cFiles, g) => g.files.filter(isCMRFile).map(
+    (cFiles, g) => cFiles.concat(g.files.filter(isCMRFile).map(
       (cf) => ({ filename: cf.filename, granuleId: g.granuleId })
-    ), []
+    )), []
   );
   const allGranules = keyBy(granulesInput, 'granuleId');
 

--- a/tasks/move-granules/index.js
+++ b/tasks/move-granules/index.js
@@ -289,7 +289,7 @@ async function updateEachCmrFileAccessURLs(cmrFiles, granulesObject, distEndpoin
  *                     https://nasa.github.io/cumulus/docs/data-cookbooks/setup#collections
  * @param {boolean} [event.config.moveStagedFiles=true] - set to false to skip moving files
  *                                 from staging to final bucket. Mostly useful for testing.
- * @param {Object} event.input - an array of s3 uris
+ * @param {Object} event.input - a granules object containing an array of granules
  * @returns {Promise} returns the promise of an updated event object
  */
 async function moveGranules(event) {

--- a/tasks/move-granules/index.js
+++ b/tasks/move-granules/index.js
@@ -19,6 +19,7 @@ const {
 const {
   isCMRFile,
   metadataObjectFromCMRFile,
+  reduceGranulesToCmrFileObjects,
   updateCMRMetadata
 } = require('@cumulus/cmrjs');
 
@@ -301,11 +302,7 @@ async function moveGranules(event) {
   const duplicateHandling = duplicateHandlingType(event);
 
   const granulesInput = get(event, 'input.granules', []);
-  const cmrFiles = granulesInput.reduce(
-    (cFiles, g) => cFiles.concat(g.files.filter(isCMRFile).map(
-      (cf) => ({ filename: cf.filename, granuleId: g.granuleId })
-    )), []
-  );
+  const cmrFiles = reduceGranulesToCmrFileObjects(granulesInput);
   const allGranules = keyBy(granulesInput, 'granuleId');
 
   let granulesToMove;

--- a/tasks/move-granules/index.js
+++ b/tasks/move-granules/index.js
@@ -5,6 +5,7 @@ const { DuplicateFile, InvalidArgument } = require('@cumulus/common/errors');
 const get = require('lodash.get');
 const clonedeep = require('lodash.clonedeep');
 const flatten = require('lodash.flatten');
+const keyBy = require('lodash.keyby');
 const path = require('path');
 
 const {
@@ -16,8 +17,6 @@ const {
 } = require('@cumulus/ingest/granule');
 
 const {
-  getCmrFiles,
-  getGranuleId,
   isCMRFile,
   metadataObjectFromCMRFile,
   updateCMRMetadata
@@ -35,59 +34,6 @@ const {
 } = require('@cumulus/common');
 const { urlPathTemplate } = require('@cumulus/ingest/url-path-template');
 const log = require('@cumulus/common/log');
-
-
-/**
- * Helper to turn an s3URI into a fileobject
- * @param {string} s3URI s3://mybucket/myprefix/myobject.
- * @returns {Object} file object
- */
-function fileObjectFromS3URI(s3URI) {
-  const uriParsed = parseS3Uri(s3URI);
-  return {
-    name: path.basename(s3URI),
-    bucket: uriParsed.Bucket,
-    filename: s3URI,
-    fileStagingDir: path.dirname(uriParsed.Key)
-  };
-}
-
-/**
- * Takes the files from input and granules and merges them into an object where
- * each file is associated with it's granuleId.
- *
- * @param {Array} inputFiles - list of s3 files to add to the inputgranules
- * @param {Array} inputGranules - an array of the granules
- * @param {string} regex - regex needed to extract granuleId from filenames
- * @returns {Object} an object that contains lists of each granules' files
- *                   attatched by their granuleId
- */
-function mergeInputFilesWithInputGranules(inputFiles, inputGranules, regex) {
-  const granulesHash = {};
-  const filesFromInputGranules = {};
-
-  // create hash list of the granules
-  // and a hash list of files
-  inputGranules.forEach((g) => {
-    granulesHash[g.granuleId] = g;
-    g.files.forEach((f) => {
-      filesFromInputGranules[f.filename] = g.granuleId;
-    });
-  });
-
-  // add input files to corresponding granules
-  // the process involve getting granuleId of each file
-  // match it against the granuleObj and adding the new files to the
-  // file list
-  inputFiles.forEach((f) => {
-    if (f && !filesFromInputGranules[f]) {
-      const granuleId = getGranuleId(f, regex);
-      granulesHash[granuleId].files.push(fileObjectFromS3URI(f));
-    }
-  });
-
-  return granulesHash;
-}
 
 /**
  * validates the file matched only one collection.file and has a valid bucket
@@ -109,6 +55,21 @@ function validateMatch(match, bucketsConfig, file) {
     throw new InvalidArgument(`Collection config specifies a bucket key of ${match[0].bucket}, `
                               + `but the configured bucket keys are: ${Object.keys(bucketsConfig).join(', ')}`);
   }
+}
+
+/**
+ * Helper to turn an s3URI into a fileobject
+ * @param {string} s3URI s3://mybucket/myprefix/myobject.
+ * @returns {Object} file object
+ */
+function fileObjectFromS3URI(s3URI) {
+  const uriParsed = parseS3Uri(s3URI);
+  return {
+    name: path.basename(s3URI),
+    bucket: uriParsed.Bucket,
+    filename: s3URI,
+    fileStagingDir: path.dirname(uriParsed.Key)
+  };
 }
 
 /**
@@ -321,54 +282,49 @@ async function updateEachCmrFileAccessURLs(cmrFiles, granulesObject, distEndpoin
  * @param {Object} event - Lambda function payload
  * @param {Object} event.config - the config object
  * @param {string} event.config.bucket - Bucket name where public/private keys are stored
- * @param {string} event.config.granuleIdExtraction - regex needed to extract granuleId
- *                                                    from filenames
- * @param {Array} event.config.input_granules - an array of granules
+ * @param {Object} event.config.buckets - Buckets config
  * @param {string} event.config.distribution_endpoint - distribution endpoint for the api
  * @param {Object} event.config.collection - collection configuration
  *                     https://nasa.github.io/cumulus/docs/data-cookbooks/setup#collections
  * @param {boolean} [event.config.moveStagedFiles=true] - set to false to skip moving files
  *                                 from staging to final bucket. Mostly useful for testing.
- * @param {Array} event.input - an array of s3 uris
+ * @param {Object} event.input - an array of s3 uris
  * @returns {Promise} returns the promise of an updated event object
  */
 async function moveGranules(event) {
   // we have to post the meta-xml file of all output granules
   // first we check if there is an output file
   const config = get(event, 'config');
-  const sourceBucket = get(config, 'bucket'); // the name of the bucket with staged data.
   const bucketsConfig = new BucketsConfig(get(config, 'buckets'));
-  const granuleIdExtractionRegex = get(config, 'granuleIdExtraction', '(.*)');
-  const inputGranules = get(config, 'input_granules', {});
-  const distEndpoint = get(config, 'distribution_endpoint');
   const moveStagedFiles = get(config, 'moveStagedFiles', true);
-  const collection = config.collection;
 
   const duplicateHandling = duplicateHandlingType(event);
 
-  const inputFileList = get(event, 'input', []);
-
-  // Get list of cmr file objects from the input Array of S3 filenames (in
-  // staging location after processing)
-  const cmrFiles = getCmrFiles(inputFileList, granuleIdExtractionRegex);
-
-  const allGranules = mergeInputFilesWithInputGranules(
-    inputFileList, inputGranules, granuleIdExtractionRegex
+  const granulesInput = get(event, 'input.granules', []);
+  const cmrFiles = granulesInput.reduce(
+    (cFiles, g) => g.files.filter(isCMRFile).map(
+      (cf) => ({ filename: cf.filename, granuleId: g.granuleId })
+    ), []
   );
+  const allGranules = keyBy(granulesInput, 'granuleId');
 
   let granulesToMove;
   let movedGranules;
   // allows us to disable moving the files
   if (moveStagedFiles) {
     // update allGranules with aspirational metadata (where the file should end up after moving.)
-    granulesToMove = await updateGranuleMetadata(allGranules, collection, cmrFiles, bucketsConfig);
+    granulesToMove = await updateGranuleMetadata(
+      allGranules, config.collection, cmrFiles, bucketsConfig
+    );
 
     // move files from staging location to final location
     movedGranules = await moveFilesForAllGranules(
-      granulesToMove, sourceBucket, duplicateHandling, bucketsConfig
+      granulesToMove, config.bucket, duplicateHandling, bucketsConfig
     );
     // update cmr metadata files with correct online access urls
-    await updateEachCmrFileAccessURLs(cmrFiles, movedGranules, distEndpoint, bucketsConfig);
+    await updateEachCmrFileAccessURLs(
+      cmrFiles, movedGranules, config.distribution_endpoint, bucketsConfig
+    );
   }
   else {
     movedGranules = allGranules;

--- a/tasks/move-granules/package.json
+++ b/tasks/move-granules/package.json
@@ -47,6 +47,7 @@
     "lodash.clonedeep": "^4.5.0",
     "lodash.flatten": "^4.4.0",
     "lodash.get": "^4.4.2",
+    "lodash.keyby": "^4.6.0",
     "url-join": "^1.0.0",
     "xml2js": "^0.4.19"
   },

--- a/tasks/move-granules/schemas/config.json
+++ b/tasks/move-granules/schemas/config.json
@@ -4,19 +4,11 @@
   "type": "object",
   "required": [
     "bucket",
-    "input_granules",
     "distribution_endpoint",
     "collection",
     "buckets"
   ],
   "properties": {
-    "input_granules": {
-      "type": "array",
-      "description": "granules object used to construct output for cumulus indexer",
-      "items": {
-        "type": "object"
-      }
-    },
     "bucket": {
       "type": "string",
       "description": "the bucket the has the private/public key needed for decrypting cmr password"
@@ -44,10 +36,6 @@
     "distribution_endpoint": {
       "type": "string",
       "description": "The api distribution endpoint"
-    },
-    "granuleIdExtraction": {
-      "type": "string",
-      "description": "The regex needed for extracting granuleId from filenames"
     },
     "collection": {
       "type": "object",

--- a/tasks/move-granules/schemas/input.json
+++ b/tasks/move-granules/schemas/input.json
@@ -1,13 +1,36 @@
 {
-  "title": "MoveGranulesInput",
+  "title": "PostToCmrInput",
   "description": "Describes the input expected by the move-granules task",
-  "type": "array",
-  "items": {
+  "type": "object",
+  "required": [
+    "granules"
+  ],
+  "properties": {
     "granules": {
       "type": "array",
+      "description": "Array of all granules",
       "items": {
-        "type": "string",
-        "description": "list of s3 uris"
+        "type": "object",
+        "required": ["granuleId", "files"],
+        "properties": {
+          "granuleId": {
+            "type": "string"
+          },
+          "files": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "filename": {
+                  "type": "string"
+                },
+                "bucket": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/tasks/move-granules/schemas/input.json
+++ b/tasks/move-granules/schemas/input.json
@@ -1,5 +1,5 @@
 {
-  "title": "PostToCmrInput",
+  "title": "MoveGranulesInput",
   "description": "Describes the input expected by the move-granules task",
   "type": "object",
   "required": [
@@ -20,8 +20,15 @@
             "type": "array",
             "items": {
               "type": "object",
+              "required": ["name"],
               "properties": {
+                "name": {
+                  "type": "string"
+                },
                 "filename": {
+                  "type": "string"
+                },
+                "fileType": {
                   "type": "string"
                 },
                 "bucket": {

--- a/tasks/move-granules/tests/data/payload.json
+++ b/tasks/move-granules/tests/data/payload.json
@@ -19,7 +19,6 @@
         "type": "public"
       }
     },
-    "granuleIdExtraction": "(MOD11A1\\..*)(\\.hdf|\\.cmr\\.xml|_[\\w]{1,}\\.jpg)",
     "distribution_endpoint": "https://something.api.us-east-1.amazonaws.com/",
     "collection": {
       "files": [
@@ -59,7 +58,6 @@
       "name": "MOD11A1",
       "granuleId": "^MOD11A1\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}$",
       "dataType": "MOD11A1",
-      "granuleIdExtraction": "(MOD11A1\\.(.*))\\.hdf",
       "process": "modis",
       "provider_path": "/TEST_B/Cumulus/MODIS/PDR/",
       "version": "006",

--- a/tasks/move-granules/tests/data/payload.json
+++ b/tasks/move-granules/tests/data/payload.json
@@ -20,20 +20,6 @@
       }
     },
     "granuleIdExtraction": "(MOD11A1\\..*)(\\.hdf|\\.cmr\\.xml|_[\\w]{1,}\\.jpg)",
-    "input_granules": [
-      {
-        "granuleId": "MOD11A1.A2017200.h19v04.006.2017201090724",
-        "files": [
-          {
-            "name": "MOD11A1.A2017200.h19v04.006.2017201090724.hdf",
-            "bucket": "cumulus-internal",
-            "fileType": "data",
-            "filename": "s3://cumulus-internal/file-staging/subdir/MOD11A1.A2017200.h19v04.006.2017201090724.hdf",
-            "fileStagingDir": "file-staging/subdir"
-          }
-        ]
-      }
-    ],
     "distribution_endpoint": "https://something.api.us-east-1.amazonaws.com/",
     "collection": {
       "files": [
@@ -81,10 +67,37 @@
       "id": "MOD11A1"
     }
   },
-  "input": [
-    "s3://cumulus-internal/file-staging/subdir/MOD11A1.A2017200.h19v04.006.2017201090724.hdf",
-    "s3://cumulus-internal/file-staging/subdir/MOD11A1.A2017200.h19v04.006.2017201090724_1.jpg",
-    "s3://cumulus-internal/file-staging/subdir/MOD11A1.A2017200.h19v04.006.2017201090724_2.jpg",
-    "s3://cumulus-internal/file-staging/subdir/MOD11A1.A2017200.h19v04.006.2017201090724.cmr.xml"
-  ]
+  "input": {
+    "granules": [
+      {
+        "granuleId": "MOD11A1.A2017200.h19v04.006.2017201090724",
+        "files": [
+          {
+            "name": "MOD11A1.A2017200.h19v04.006.2017201090724.hdf",
+            "bucket": "cumulus-internal",
+            "filename": "s3://cumulus-internal/file-staging/subdir/MOD11A1.A2017200.h19v04.006.2017201090724.hdf",
+            "fileStagingDir": "file-staging/subdir"
+          },
+          {
+            "name": "MOD11A1.A2017200.h19v04.006.2017201090724_1.jpg",
+            "bucket": "cumulus-internal",
+            "filename": "s3://cumulus-internal/file-staging/subdir/MOD11A1.A2017200.h19v04.006.2017201090724_1.jpg",
+            "fileStagingDir": "file-staging/subdir"
+          },
+          {
+            "name": "MOD11A1.A2017200.h19v04.006.2017201090724_2.jpg",
+            "bucket": "cumulus-internal",
+            "filename": "s3://cumulus-internal/file-staging/subdir/MOD11A1.A2017200.h19v04.006.2017201090724_2.jpg",
+            "fileStagingDir": "file-staging/subdir"
+          },
+          {
+            "name": "MOD11A1.A2017200.h19v04.006.2017201090724.cmr.xml",
+            "bucket": "cumulus-internal",
+            "filename": "s3://cumulus-internal/file-staging/subdir/MOD11A1.A2017200.h19v04.006.2017201090724.cmr.xml",
+            "fileStagingDir": "file-staging/subdir"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/tasks/move-granules/tests/test-index.js
+++ b/tasks/move-granules/tests/test-index.js
@@ -10,6 +10,7 @@ const {
   s3ObjectExists,
   s3,
   s3GetObjectTagging,
+  s3PutObjectTagging,
   promiseS3Upload,
   headObject,
   parseS3Uri
@@ -36,11 +37,16 @@ async function uploadFiles(files, bucket) {
 }
 
 async function updateFileTags(files, bucket, TagSet) {
-  await Promise.all(files.map((file) => s3().putObjectTagging({
-    Bucket: bucket,
-    Key: parseS3Uri(file).Key,
-    Tagging: { TagSet }
-  }).promise()));
+  await Promise.all(files.map((file) => s3PutObjectTagging(
+    bucket,
+    parseS3Uri(file).Key,
+    { TagSet }
+  )));
+}
+
+function granulesToFileURIs(granules) {
+  const m = granules.reduce((arr, g) => g.files.map((file) => file.filename), []);
+  return m;
 }
 
 function buildPayload(t) {
@@ -51,9 +57,7 @@ function buildPayload(t) {
   newPayload.config.buckets.public.name = t.context.publicBucket;
   newPayload.config.buckets.protected.name = t.context.protectedBucket;
 
-  newPayload.input = newPayload.input.map((file) =>
-    buildS3Uri(`${t.context.stagingBucket}`, parseS3Uri(file).Key));
-  newPayload.config.input_granules.forEach((gran) => {
+  newPayload.input.granules.forEach((gran) => {
     gran.files.forEach((file) => {
       file.bucket = t.context.stagingBucket;
       file.filename = buildS3Uri(t.context.stagingBucket, parseS3Uri(file.filename).Key);
@@ -61,16 +65,6 @@ function buildPayload(t) {
   });
 
   return newPayload;
-}
-
-function addCmrFileToPayload(t, payload) {
-  payload.config.input_granules[0].files.push({
-    name: 'MOD11A1.A2017200.h19v04.006.2017201090724.cmr.xml',
-    bucket: t.context.publicBucket,
-    fileType: 'userSetType',
-    filename: 's3://staging0ef4cf086c/file-staging/subdir/MOD11A1.A2017200.h19v04.006.2017201090724.cmr.xml',
-    fileStagingDir: 'file-staging/subdir'
-  });
 }
 
 function getExpectedOutputFileNames(t) {
@@ -118,6 +112,9 @@ test.beforeEach(async (t) => {
   const payloadPath = path.join(__dirname, 'data', 'payload.json');
   const rawPayload = await readFile(payloadPath, 'utf8');
   t.context.payload = JSON.parse(rawPayload);
+  const filesToUpload = granulesToFileURIs(t.context.payload.input.granules);
+  t.context.filesToUpload = filesToUpload.map((file) =>
+    buildS3Uri(`${t.context.stagingBucket}`, parseS3Uri(file).Key));
   process.env.REINGEST_GRANULE = false;
 });
 
@@ -129,7 +126,7 @@ test.afterEach.always(async (t) => {
 
 test.serial('Should move files to final location.', async (t) => {
   const newPayload = buildPayload(t);
-  await uploadFiles(newPayload.input, t.context.stagingBucket);
+  await uploadFiles(t.context.filesToUpload, t.context.stagingBucket);
 
   const output = await moveGranules(newPayload);
   await validateOutput(t, output);
@@ -146,7 +143,7 @@ test.serial('should not move files when event.moveStagedFiles is false', async (
   const newPayload = buildPayload(t);
   newPayload.config.moveStagedFiles = false;
 
-  await uploadFiles(newPayload.input, t.context.stagingBucket);
+  await uploadFiles(t.context.filesToUpload, t.context.stagingBucket);
 
   const output = await moveGranules(newPayload);
   await validateOutput(t, output);
@@ -161,10 +158,10 @@ test.serial('should not move files when event.moveStagedFiles is false', async (
 
 test.serial('should add input files to returned granule event.moveStagedFiles is false', async (t) => {
   const newPayload = buildPayload(t);
-  await uploadFiles(newPayload.input, t.context.stagingBucket);
+  await uploadFiles(t.context.filesToUpload, t.context.stagingBucket);
   newPayload.config.moveStagedFiles = false;
 
-  const inputFiles = [...newPayload.input];
+  const inputFiles = [...t.context.filesToUpload];
 
   const output = await moveGranules(newPayload);
   await validateOutput(t, output);
@@ -177,9 +174,15 @@ test.serial('should add input files to returned granule event.moveStagedFiles is
 
 test.serial('Should move renamed files in staging area to final location.', async (t) => {
   const newPayload = buildPayload(t);
-  const renamedFile = `s3://${t.context.stagingBucket}/file-staging/MOD11A1.A2017200.h19v04.006.2017201090724.hdf.v20180926T131408705`;
-  newPayload.input.push(renamedFile);
-  await uploadFiles(newPayload.input, t.context.stagingBucket);
+  const renamedFile = `s3://${t.context.stagingBucket}/file-staging/subdir/MOD11A1.A2017200.h19v04.006.2017201090724.hdf.v20180926T131408705`;
+  t.context.filesToUpload.push(renamedFile);
+  await uploadFiles(t.context.filesToUpload, t.context.stagingBucket);
+  newPayload.input.granules[0].files.push({
+    name: 'MOD11A1.A2017200.h19v04.006.2017201090724.hdf.v20180926T131408705',
+    bucket: t.context.stagingBucket,
+    filename: `s3://${t.context.stagingBucket}/file-staging/subdir/MOD11A1.A2017200.h19v04.006.2017201090724.hdf.v20180926T131408705`,
+    fileStagingDir: 'file-staging/subdir'
+  });
 
   const output = await moveGranules(newPayload);
   await validateOutput(t, output);
@@ -194,7 +197,7 @@ test.serial('Should move renamed files in staging area to final location.', asyn
 
 test.serial('Should add metadata type to CMR granule files.', async (t) => {
   const newPayload = buildPayload(t);
-  await uploadFiles(newPayload.input, t.context.stagingBucket);
+  await uploadFiles(t.context.filesToUpload, t.context.stagingBucket);
   const output = await moveGranules(newPayload);
 
   const outputFiles = output.granules[0].files;
@@ -210,7 +213,7 @@ test.serial('Should update filenames with updated S3 URLs.', async (t) => {
   const newPayload = buildPayload(t);
   const expectedFilenames = getExpectedOutputFileNames(t);
 
-  await uploadFiles(newPayload.input, t.context.stagingBucket);
+  await uploadFiles(t.context.filesToUpload, t.context.stagingBucket);
 
   const output = await moveGranules(newPayload);
   const outputFilenames = output.granules[0].files.map((f) => f.filename);
@@ -220,9 +223,10 @@ test.serial('Should update filenames with updated S3 URLs.', async (t) => {
 
 test.serial('Should not overwrite CMR fileType if already explicitly set', async (t) => {
   const newPayload = buildPayload(t);
-  addCmrFileToPayload(t, newPayload);
+  //addCmrFileToPayload(t, newPayload);
+  newPayload.input.granules[0].files[3].fileType = 'userSetType';
 
-  await uploadFiles(newPayload.input, t.context.stagingBucket);
+  await uploadFiles(t.context.filesToUpload, t.context.stagingBucket);
 
   const output = await moveGranules(newPayload);
   const cmrFile = output.granules[0].files.filter((file) => file.filename.includes('.cmr.xml'));
@@ -233,11 +237,11 @@ test.serial('Should preserve object tags.', async (t) => {
   const newPayload = buildPayload(t);
   const tagset = [
     { Key: 'fakeTag', Value: 'test-tag' },
-    { Key: 'granId', Value: newPayload.config.input_granules[0].granuleId }
+    { Key: 'granId', Value: newPayload.input.granules[0].granuleId }
   ];
 
-  await uploadFiles(newPayload.input, t.context.stagingBucket);
-  await updateFileTags(newPayload.input, t.context.stagingBucket, tagset);
+  await uploadFiles(t.context.filesToUpload, t.context.stagingBucket);
+  await updateFileTags(t.context.filesToUpload, t.context.stagingBucket, tagset);
 
   const output = await moveGranules(newPayload);
   await Promise.all(output.granules[0].files.map(async (file) => {
@@ -253,10 +257,10 @@ test.serial('Should overwrite files.', async (t) => {
 
   const newPayload = buildPayload(t);
   newPayload.config.duplicateHandling = 'replace';
-  newPayload.input = [
+  t.context.filesToUpload = [
     `s3://${t.context.stagingBucket}/${sourceKey}`
   ];
-  newPayload.config.input_granules[0].files = [{
+  newPayload.input.granules[0].files = [{
     filename: `s3://${t.context.stagingBucket}/${sourceKey}`,
     name: filename
   }];
@@ -337,7 +341,7 @@ async function duplicateHandlingErrorTest(t, duplicateHandling) {
   const newPayload = buildPayload(t);
   if (duplicateHandling) newPayload.config.duplicateHandling = duplicateHandling;
 
-  await uploadFiles(newPayload.input, t.context.stagingBucket);
+  await uploadFiles(t.context.filesToUpload, t.context.stagingBucket);
 
   let expectedErrorMessages;
   try {
@@ -355,7 +359,7 @@ async function duplicateHandlingErrorTest(t, duplicateHandling) {
       return `${parsed.Key} already exists in ${parsed.Bucket} bucket`;
     });
 
-    await uploadFiles(newPayload.input, t.context.stagingBucket);
+    await uploadFiles(t.context.filesToUpload, t.context.stagingBucket);
     await moveGranules(newPayloadOrig);
     t.fail('Expected a DuplicateFile error to be thrown');
   }
@@ -382,7 +386,7 @@ test.serial('when duplicateHandling is "version", keep both data if different', 
 
   const expectedFilenames = getExpectedOutputFileNames(t);
 
-  await uploadFiles(newPayload.input, t.context.stagingBucket);
+  await uploadFiles(t.context.filesToUpload, t.context.stagingBucket);
   let output = await moveGranules(newPayload);
   const existingFileNames = output.granules[0].files.map((f) => f.filename);
   t.deepEqual(expectedFilenames.sort(), existingFileNames.sort());
@@ -400,9 +404,9 @@ test.serial('when duplicateHandling is "version", keep both data if different', 
 
   // run 'moveGranules' again with one of the input files updated
   newPayload = clonedeep(newPayloadOrig);
-  await uploadFiles(newPayload.input, t.context.stagingBucket);
+  await uploadFiles(t.context.filesToUpload, t.context.stagingBucket);
 
-  const inputHdfFile = newPayload.input.filter((f) => f.endsWith('.hdf'))[0];
+  const inputHdfFile = t.context.filesToUpload.filter((f) => f.endsWith('.hdf'))[0];
   const updatedBody = randomString();
   const params = {
     Bucket: t.context.stagingBucket, Key: parseS3Uri(inputHdfFile).Key, Body: updatedBody
@@ -434,7 +438,7 @@ test.serial('when duplicateHandling is "version", keep both data if different', 
 
   // run 'moveGranules' the third time with the same input file updated
   newPayload = clonedeep(newPayloadOrig);
-  await uploadFiles(newPayload.input, t.context.stagingBucket);
+  await uploadFiles(t.context.filesToUpload, t.context.stagingBucket);
 
   params.Body = randomString();
   await s3().putObject(params).promise();
@@ -465,7 +469,7 @@ test.serial('When duplicateHandling is "skip", does not overwrite or create new.
 
   const expectedFilenames = getExpectedOutputFileNames(t);
 
-  await uploadFiles(newPayload.input, t.context.stagingBucket);
+  await uploadFiles(t.context.filesToUpload, t.context.stagingBucket);
   let output = await moveGranules(newPayload);
   const existingFileNames = output.granules[0].files.map((f) => f.filename);
   t.deepEqual(expectedFilenames.sort(), existingFileNames.sort());
@@ -477,9 +481,9 @@ test.serial('When duplicateHandling is "skip", does not overwrite or create new.
 
   // run 'moveGranules' again with one of the input files updated
   newPayload = clonedeep(newPayloadOrig);
-  await uploadFiles(newPayload.input, t.context.stagingBucket);
+  await uploadFiles(t.context.filesToUpload, t.context.stagingBucket);
 
-  const inputHdfFile = newPayload.input.filter((f) => f.endsWith('.hdf'))[0];
+  const inputHdfFile = t.context.filesToUpload.filter((f) => f.endsWith('.hdf'))[0];
   const updatedBody = randomString();
   const params = {
     Bucket: t.context.stagingBucket, Key: parseS3Uri(inputHdfFile).Key, Body: updatedBody
@@ -525,7 +529,7 @@ async function granuleFilesOverwrittenTest(t, newPayload) {
 
   const expectedFilenames = getExpectedOutputFileNames(t);
 
-  await uploadFiles(newPayload.input, t.context.stagingBucket);
+  await uploadFiles(t.context.filesToUpload, t.context.stagingBucket);
   let output = await moveGranules(newPayload);
   await validateOutput(t, output);
   const existingFileNames = output.granules[0].files.map((f) => f.filename);
@@ -537,9 +541,9 @@ async function granuleFilesOverwrittenTest(t, newPayload) {
 
   // run 'moveGranules' again with one of the input files updated
   newPayload = clonedeep(newPayloadOrig);
-  await uploadFiles(newPayload.input, t.context.stagingBucket);
+  await uploadFiles(t.context.filesToUpload, t.context.stagingBucket);
 
-  const inputHdfFile = newPayload.input.filter((f) => f.endsWith('.hdf'))[0];
+  const inputHdfFile = t.context.filesToUpload.filter((f) => f.endsWith('.hdf'))[0];
   const updatedBody = randomString();
   const params = {
     Bucket: t.context.stagingBucket, Key: parseS3Uri(inputHdfFile).Key, Body: updatedBody

--- a/tasks/move-granules/tests/test-index.js
+++ b/tasks/move-granules/tests/test-index.js
@@ -48,7 +48,9 @@ async function updateFileTags(files, bucket, TagSet) {
 function updateCmrFileType(payload) {
   payload.input.granules.forEach(
     (g) => {
-      g.files.filter(isCMRFile).forEach((cmrFile) => cmrFile.fileType = 'userSetType');
+      g.files.filter(isCMRFile).forEach((cmrFile) => {
+        cmrFile.fileType = 'userSetType'
+      });
     }
   );
 }

--- a/tasks/move-granules/tests/test-index.js
+++ b/tasks/move-granules/tests/test-index.js
@@ -56,8 +56,8 @@ function updateCmrFileType(payload) {
 }
 
 function granulesToFileURIs(granules) {
-  const m = granules.reduce((arr, g) => arr.concat(g.files.map((file) => file.filename)), []);
-  return m;
+  const s3URIs = granules.reduce((arr, g) => arr.concat(g.files.map((file) => file.filename)), []);
+  return s3URIs;
 }
 
 function buildPayload(t) {

--- a/tasks/move-granules/tests/test-index.js
+++ b/tasks/move-granules/tests/test-index.js
@@ -45,7 +45,7 @@ async function updateFileTags(files, bucket, TagSet) {
 }
 
 function granulesToFileURIs(granules) {
-  const m = granules.reduce((arr, g) => g.files.map((file) => file.filename), []);
+  const m = granules.reduce((arr, g) => arr.concat(g.files.map((file) => file.filename)), []);
   return m;
 }
 


### PR DESCRIPTION
Addresses [CUMULUS-1176](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1176)

## Changes

* Refactor move-granules to take granules object as input
* Update unit tests
* Integration tests will be updated in a separate PR when files-to-granules becomes available on the feature branch master.

## PR Checklist

- [x] Update CHANGELOG
- [X] Unit tests
- [X] Adhoc testing

