### PR TITLE
CUMULUS-1176: remove granuleIdExtraction from post-to-cmr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - The default provider port was being set to 21, no matter what protocol was
     being used. Removed that default.
 
+- **CUMULUS-1176**
+  - `@cumulus/post-to-cmr`: `config.granuleIdExtraction` is no longer needed/used by `post-to-cmr`.
+
 - CUMULUS-1174
   - Better error message and stacktrace for S3KeyPairProvider error reporting.
 

--- a/packages/cmrjs/cmr-utils.js
+++ b/packages/cmrjs/cmr-utils.js
@@ -54,6 +54,21 @@ function isCMRFile(fileobject) {
   return isCMRFilename(cmrfilename);
 }
 
+/**
+ * Reduce granule object array to CMR files array
+ *
+ * @param {Object} granules = granule objects array
+ *
+ * @returns {Array<Object>} - CMR file object array: { filename, granuleId }
+ */
+function reduceGranulesToCmrFileObjects(granules) {
+  const reducer = (cFiles, g) => cFiles.concat(
+    g.files.filter(isCMRFile).map(
+      (cf) => ({ filename: cf.filename, granuleId: g.granuleId })
+    ));
+  return granules.reduce(reducer, []);
+}
+
 
 /**
  * Instantiates a CMR instance for ingest of metadata
@@ -669,5 +684,6 @@ module.exports = {
   metadataObjectFromCMRFile,
   publish2CMR,
   reconcileCMRMetadata,
+  reduceGranulesToCmrFileObjects,
   updateCMRMetadata
 };

--- a/packages/cmrjs/index.js
+++ b/packages/cmrjs/index.js
@@ -24,6 +24,7 @@ const {
   isCMRFile,
   metadataObjectFromCMRFile,
   publish2CMR,
+  reduceGranulesToCmrFileObjects,
   reconcileCMRMetadata,
   updateCMRMetadata
 } = require('./cmr-utils');
@@ -93,6 +94,7 @@ module.exports = {
   metadataObjectFromCMRFile,
   publish2CMR,
   reconcileCMRMetadata,
+  reduceGranulesToCmrFileObjects,
   searchConcept,
   updateCMRMetadata,
   updateToken

--- a/tasks/post-to-cmr/package.json
+++ b/tasks/post-to-cmr/package.json
@@ -43,7 +43,6 @@
     "@cumulus/cumulus-message-adapter-js": "^1.0.7",
     "@cumulus/ingest": "1.11.3",
     "@cumulus/test-data": "1.11.0",
-    "lodash.flatten": "^4.4.0",
     "lodash.keyby": "^4.6.0",
     "xml2js": "^0.4.19"
   },

--- a/tasks/post-to-cmr/schemas/config.json
+++ b/tasks/post-to-cmr/schemas/config.json
@@ -21,10 +21,6 @@
       "type": "string",
       "description": "The name of the deployment stack"
     },
-    "granuleIdExtraction": {
-      "type": "string",
-      "description": "The regex needed for extracting granuleId from filenames"
-    },
     "cmr": {
       "type": "object",
       "description": "credentials needed to post metadata to CMR",

--- a/tasks/post-to-cmr/tests/data/payload.json
+++ b/tasks/post-to-cmr/tests/data/payload.json
@@ -6,7 +6,6 @@
       "username": "xxxxxx",
       "password": "xxxxx"
     },
-    "granuleIdExtraction": "(MOD11A1\\..*)(\\.hdf|\\.cmr\\.xml|_[\\w]{1,}\\..*)",
     "bucket": "cumulus-internal",
     "stack": "myStack"
   },


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-1176](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1176)

## Changes

* Remove post-to-cmr dependency on granuleIdExtraction

## PR Checklist

- [ ] Update CHANGELOG
- [X] Unit tests
- [X] Adhoc testing

