### PR TITLE
Report should only scan completed granules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - CUMULUS-1174
   - Better error message and stacktrace for S3KeyPairProvider error reporting.
 
+### Fixed
+
+- **CUMULUS-1218** Reconciliation report will now scan only completed granules.  
+
 ### Deprecated
 
 - `@cumulus/api/models/Granule.removeGranuleFromCmr`, instead use `@cumulus/api/models/Granule.removeGranuleFromCmrByGranule`

--- a/packages/api/lambdas/create-reconciliation-report.js
+++ b/packages/api/lambdas/create-reconciliation-report.js
@@ -250,7 +250,7 @@ async function reconciliationReportForGranules(collectionId, bucketsConfig) {
     { short_name: name, version: version, sort_key: ['granule_ur'] }, 'umm_json'
   );
 
-  const dbGranulesIterator = new Granule().getGranulesForCollection(collectionId, 'completed'); 
+  const dbGranulesIterator = new Granule().getGranulesForCollection(collectionId, 'completed');
 
   const granulesReport = {
     okCount: 0,

--- a/packages/api/lambdas/create-reconciliation-report.js
+++ b/packages/api/lambdas/create-reconciliation-report.js
@@ -250,7 +250,7 @@ async function reconciliationReportForGranules(collectionId, bucketsConfig) {
     { short_name: name, version: version, sort_key: ['granule_ur'] }, 'umm_json'
   );
 
-  const dbGranulesIterator = new Granule().getGranulesForCollection(collectionId);
+  const dbGranulesIterator = new Granule().getGranulesForCollection(collectionId, 'completed'); 
 
   const granulesReport = {
     okCount: 0,


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-1218  ](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1218)

Testing on a dev stack resulted in granules that were in an incomplete+bad state causing the completed granules integration tests to fail.  

Per @jennyhliu  the intent of this report was to only scan completed granules.    Adding a fix to an apparent inadvertent change.    Will follow up with a ticket to cover the failure case in a test. 

