### PR TITLE
CUMULUS-1208: Update queue-granules to not transform granule objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### PLEASE NOTE
+
+- As a result of **CUMULUS-1208**, the granule object input to `@cumulus/queue-granules` will be added to ingest workflow messages **as is**. In practice, this means that if you are using `@cumulus/queue-granules` to trigger ingest workflows and your granule objects input have invalid properties, then your ingest workflows will fail due to schema validation errors.
+
 ### Added
 
 - **CUMULUS-670**
@@ -47,6 +51,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- **CUMULUS-1208** - Updated `@cumulus/ingest/queue/enqueueGranuleIngestMessage()` to not transform granule object passed to it when building an ingest message
 - **CUMULUS-1170**
   - Update scripts and docs to use `npm` instead of `yarn`
   - Use `package-lock.json` files to ensure matching versions of npm packages

--- a/packages/ingest/queue.js
+++ b/packages/ingest/queue.js
@@ -83,7 +83,9 @@ async function enqueueGranuleIngestMessage(
   const message = await getMessageFromTemplate(granuleIngestMessageTemplateUri);
 
   message.payload = {
-    granules: [ granule ]
+    granules: [
+      granule
+    ]
   };
   if (pdr) message.meta.pdr = pdr;
 

--- a/packages/ingest/test/test-queue.js
+++ b/packages/ingest/test/test-queue.js
@@ -58,9 +58,9 @@ test.serial('the queue receives a correctly formatted workflow message without a
       QueueUrl: t.context.queueUrl,
       MaxNumberOfMessages: 10,
       WaitTimeSeconds: 1
-    }).promise()
+    }).promise();
   }
-  catch(err) {
+  catch (err) {
     t.fail(err);
   }
 
@@ -104,9 +104,9 @@ test.serial('the queue receives a correctly formatted workflow message with a PD
       QueueUrl: t.context.queueUrl,
       MaxNumberOfMessages: 10,
       WaitTimeSeconds: 1
-    }).promise()
+    }).promise();
   }
-  catch(err) {
+  catch (err) {
     t.fail(err);
   }
 

--- a/packages/ingest/test/test-queue.js
+++ b/packages/ingest/test/test-queue.js
@@ -1,16 +1,17 @@
 'use strict';
 
 const test = require('ava');
-const sinon = require('sinon');
-const aws = require('@cumulus/common/aws');
+const {
+  createQueue, sqs, s3, recursivelyDeleteS3Bucket
+} = require('@cumulus/common/aws');
 const { randomString, randomId } = require('@cumulus/common/test-utils');
 const queue = require('../queue');
 
 test.beforeEach(async (t) => {
   t.context.templateBucket = randomString();
-  await aws.s3().createBucket({ Bucket: t.context.templateBucket }).promise();
+  await s3().createBucket({ Bucket: t.context.templateBucket }).promise();
 
-  t.context.queueUrl = await aws.createQueue();
+  t.context.queueUrl = await createQueue();
 
   t.context.stateMachineArn = randomString();
 
@@ -23,7 +24,7 @@ test.beforeEach(async (t) => {
 
   const messageTemplateKey = `${randomString()}/template.json`;
   t.context.messageTemplateKey = messageTemplateKey;
-  await aws.s3().putObject({
+  await s3().putObject({
     Bucket: t.context.templateBucket,
     Key: messageTemplateKey,
     Body: JSON.stringify(t.context.messageTemplate)
@@ -34,48 +35,54 @@ test.beforeEach(async (t) => {
 
 test.afterEach(async (t) => {
   await Promise.all([
-    aws.recursivelyDeleteS3Bucket(t.context.templateBucket),
-    aws.sqs().deleteQueue({ QueueUrl: t.context.queueUrl }).promise()
+    recursivelyDeleteS3Bucket(t.context.templateBucket),
+    sqs().deleteQueue({ QueueUrl: t.context.queueUrl }).promise()
   ]);
 });
 
-test.serial(
-  'the queue receives a correctly formatted workflow message without a PDR', async (t) => {
-    const granule = { granuleId: '1', files: [] };
-    const { queueUrl } = t.context;
-    const templateUri = `s3://${t.context.templateBucket}/${t.context.messageTemplateKey}`;
-    const collection = { name: 'test-collection', version: '0.0.0' };
-    const provider = { id: 'test-provider' };
+test.serial('the queue receives a correctly formatted workflow message without a PDR', async (t) => {
+  const granule = { granuleId: '1', files: [] };
+  const { queueUrl } = t.context;
+  const templateUri = `s3://${t.context.templateBucket}/${t.context.messageTemplateKey}`;
+  const collection = { name: 'test-collection', version: '0.0.0' };
+  const provider = { id: 'test-provider' };
 
-    const output = await queue
-      .enqueueGranuleIngestMessage(granule, queueUrl, templateUri, provider, collection);
-    await aws.sqs().receiveMessage({
+  let output;
+  let receiveMessageResponse;
+
+  try {
+    output = await queue.enqueueGranuleIngestMessage(
+      granule, queueUrl, templateUri, provider, collection
+    );
+    receiveMessageResponse = await sqs().receiveMessage({
       QueueUrl: t.context.queueUrl,
       MaxNumberOfMessages: 10,
       WaitTimeSeconds: 1
     }).promise()
-      .then((receiveMessageResponse) => {
-        t.is(receiveMessageResponse.Messages.length, 1);
-
-        const actualMessage = JSON.parse(receiveMessageResponse.Messages[0].Body);
-        const expectedMessage = {
-          cumulus_meta: {
-            state_machine: t.context.stateMachineArn
-          },
-          meta: {
-            queues: { startSF: t.context.queueUrl },
-            provider: provider,
-            collection: collection
-          },
-          payload: { granules: [granule] }
-        };
-        t.truthy(actualMessage.cumulus_meta.execution_name);
-        t.true(output.endsWith(actualMessage.cumulus_meta.execution_name));
-        expectedMessage.cumulus_meta.execution_name = actualMessage.cumulus_meta.execution_name;
-        t.deepEqual(expectedMessage, actualMessage);
-      });
   }
-);
+  catch(err) {
+    t.fail(err);
+  }
+
+  t.is(receiveMessageResponse.Messages.length, 1);
+
+  const actualMessage = JSON.parse(receiveMessageResponse.Messages[0].Body);
+  const expectedMessage = {
+    cumulus_meta: {
+      state_machine: t.context.stateMachineArn
+    },
+    meta: {
+      queues: { startSF: t.context.queueUrl },
+      provider: provider,
+      collection: collection
+    },
+    payload: { granules: [granule] }
+  };
+  t.truthy(actualMessage.cumulus_meta.execution_name);
+  t.true(output.endsWith(actualMessage.cumulus_meta.execution_name));
+  expectedMessage.cumulus_meta.execution_name = actualMessage.cumulus_meta.execution_name;
+  t.deepEqual(expectedMessage, actualMessage);
+});
 
 test.serial('the queue receives a correctly formatted workflow message with a PDR', async (t) => {
   const granule = { granuleId: '1', files: [] };
@@ -86,40 +93,46 @@ test.serial('the queue receives a correctly formatted workflow message with a PD
   const pdr = { name: randomString(), path: randomString() };
   const arn = randomString();
 
-  const output = await queue
-    .enqueueGranuleIngestMessage(granule, queueUrl, templateUri, provider, collection, pdr, arn);
-  await aws.sqs().receiveMessage({
-    QueueUrl: t.context.queueUrl,
-    MaxNumberOfMessages: 10,
-    WaitTimeSeconds: 1
-  }).promise()
-    .then((receiveMessageResponse) => {
-      t.is(receiveMessageResponse.Messages.length, 1);
+  let output;
+  let receiveMessageResponse;
 
-      const actualMessage = JSON.parse(receiveMessageResponse.Messages[0].Body);
-      const expectedMessage = {
-        cumulus_meta: {
-          state_machine: t.context.stateMachineArn,
-          parentExecutionArn: arn
-        },
-        meta: {
-          queues: { startSF: t.context.queueUrl },
-          provider: provider,
-          collection: collection,
-          pdr: pdr
-        },
-        payload: { granules: [granule] }
-      };
-      t.truthy(actualMessage.cumulus_meta.execution_name);
-      t.true(output.endsWith(actualMessage.cumulus_meta.execution_name));
-      expectedMessage.cumulus_meta.execution_name = actualMessage.cumulus_meta.execution_name;
-      t.deepEqual(expectedMessage, actualMessage);
-    });
+  try {
+    output = await queue.enqueueGranuleIngestMessage(
+      granule, queueUrl, templateUri, provider, collection, pdr, arn
+    );
+    receiveMessageResponse = await sqs().receiveMessage({
+      QueueUrl: t.context.queueUrl,
+      MaxNumberOfMessages: 10,
+      WaitTimeSeconds: 1
+    }).promise()
+  }
+  catch(err) {
+    t.fail(err);
+  }
+
+  t.is(receiveMessageResponse.Messages.length, 1);
+
+  const actualMessage = JSON.parse(receiveMessageResponse.Messages[0].Body);
+  const expectedMessage = {
+    cumulus_meta: {
+      state_machine: t.context.stateMachineArn,
+      parentExecutionArn: arn
+    },
+    meta: {
+      queues: { startSF: t.context.queueUrl },
+      provider: provider,
+      collection: collection,
+      pdr: pdr
+    },
+    payload: { granules: [granule] }
+  };
+  t.truthy(actualMessage.cumulus_meta.execution_name);
+  t.true(output.endsWith(actualMessage.cumulus_meta.execution_name));
+  expectedMessage.cumulus_meta.execution_name = actualMessage.cumulus_meta.execution_name;
+  t.deepEqual(expectedMessage, actualMessage);
 });
 
 test.serial('enqueueGranuleIngestMessage does not transform granule objects ', async (t) => {
-  const sendSQSMessageStub = sinon.stub(aws, 'sendSQSMessage').resolves();
-
   const granule = {
     granuleId: randomId(),
     dataType: randomString(),
@@ -138,17 +151,22 @@ test.serial('enqueueGranuleIngestMessage does not transform granule objects ', a
     ]
   };
 
+  let response;
+
   try {
     await queue.enqueueGranuleIngestMessage(
       granule, queueUrl, templateUri, provider, collection
     );
+    response = await sqs().receiveMessage({
+      QueueUrl: queueUrl,
+      MaxNumberOfMessages: 10,
+      WaitTimeSeconds: 1
+    }).promise();
   }
   catch (err) {
     t.fail(err);
   }
-  finally {
-    t.true(sendSQSMessageStub.calledOnce);
-    t.deepEqual(sendSQSMessageStub.getCall(0).args[1].payload, expectedPayload);
-    sendSQSMessageStub.restore();
-  }
+
+  const actualMessage = JSON.parse(response.Messages[0].Body);
+  t.deepEqual(actualMessage.payload, expectedPayload);
 });

--- a/packages/ingest/test/test-queue.js
+++ b/packages/ingest/test/test-queue.js
@@ -125,15 +125,17 @@ test.serial('enqueueGranuleIngestMessage does not transform granule objects ', a
     dataType: randomString(),
     version: randomString(),
     files: [],
-    foo: "bar" // should not be removed or altered
-  }
+    foo: 'bar' // should not be removed or altered
+  };
   const { queueUrl } = t.context;
   const templateUri = `s3://${t.context.templateBucket}/${t.context.messageTemplateKey}`;
   const collection = { name: 'test-collection', version: '0.0.0' };
   const provider = { id: 'test-provider' };
 
   const expectedPayload = {
-    granules: [granule]
+    granules: [
+      granule
+    ]
   };
 
   try {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-1208: queue-granules strips arbitrary granule properties ](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1208)

## Changes

* Update enqueueGranuleIngestMessage to not transform granule objects
* Add unit test

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests

