### PR TITLE
Cumulus 1176 doc update

### DIFF
--- a/docs/data-cookbooks/browse-generation.md
+++ b/docs/data-cookbooks/browse-generation.md
@@ -526,7 +526,7 @@ Their expected values from the example above may be useful in constructing a pro
 
 #### payload
 
-The payload includes a full list of files to be 'moved' into the cumulus archive.   The ```FilesToGranules``` task will take this list, merge it with the information from ```InputGranules```, then pass that list to the ```MoveGranules``` task and move the files to their targets and update the cmr metadata file if it exists with the updated granule locations.
+The payload includes a full list of files to be 'moved' into the cumulus archive.   The ```FilesToGranules``` task will take this list, merge it with the information from ```InputGranules```, then pass that list to the ```MoveGranules``` task.  The ```MoveGranules``` task will then move the files to their targets and update the CMR metadata file if it exists with the updated granule locations.
 
 In the provided example, a payload being passed to the  ```FilesToGranules``` task should be expected to look like:
 
@@ -539,7 +539,7 @@ In the provided example, a payload being passed to the  ```FilesToGranules``` ta
   ]
 ```
 
-This list is the list of granules ```FilesToGranules``` will act upon to move from the staging directory to the configured buckets.
+This list is the list of granules ```FilesToGranules``` will act upon to add/merge with the input_granules object.
 
 The pathing is generated from sync-granules, but in principle the files can be staged wherever you like so long as the processing/```MoveGranules``` task's roles have access and the filename matches the collection configuration.
 

--- a/docs/data-cookbooks/browse-generation.md
+++ b/docs/data-cookbooks/browse-generation.md
@@ -88,7 +88,7 @@ For this example, you are going to be adding two workflows to your Cumulus deplo
 
   The output from this step will be passed into the 'ProcessingStep', which in this example will utilize a 'fake' processing lambda we provide for testing/as an example in Core, however to use your own data you will need to write a lambda that generates the appropriate CMR metadata file and accepts and returns appropriate task inputs and outputs.
 
-  From that step we will utilize a core task ```FilesToGranulesStep``` that will transform the processing output event.input list/config.InputGranules into an array of Cumulus [granules](https://github.com/nasa/cumulus/blob/master/packages/api/models/schemas.js) objects.
+  From that step we will utilize a core task ```FilesToGranules``` that will transform the processing output event.input list/config.InputGranules into an array of Cumulus [granules](https://github.com/nasa/cumulus/blob/master/packages/api/models/schemas.js) objects.
 
   Using the generated granules list, we will utilize the core task ```MoveGranules``` to move the granules to the target buckets as defined in the collection configuration.  That step will transfer the files to their final storage location and update the CMR metadata files and the granules list as output.
 

--- a/docs/data-cookbooks/browse-generation.md
+++ b/docs/data-cookbooks/browse-generation.md
@@ -88,9 +88,11 @@ For this example, you are going to be adding two workflows to your Cumulus deplo
 
   The output from this step will be passed into the 'ProcessingStep', which in this example will utilize a 'fake' processing lambda we provide for testing/as an example in Core, however to use your own data you will need to write a lambda that generates the appropriate CMR metadata file and accepts and returns appropriate task inputs and outputs.
 
-  From that step we will utilize the core task ```MoveGranules``` to move the granules to the target buckets as defined in the collection configuration.  That step will transfer the files to their final storage location and update the payload.
+  From that step we will utilize a core task ```FilesToGranulesStep``` that will transform the processing output event.input list/config.InputGranules into an array of Cumulus [granules](https://github.com/nasa/cumulus/blob/master/packages/api/models/schemas.js) objects.
 
-  That payload will be used in the ```CmrStep``` combined with the previously generated CMR file to export the granule metadata to CMR.
+  Using the generated granules list, we will utilize the core task ```MoveGranules``` to move the granules to the target buckets as defined in the collection configuration.  That step will transfer the files to their final storage location and update the CMR metadata files and the granules list as output.
+
+  That output will be used in the ```CmrStep``` combined with the previously generated CMR file to export the granule metadata to CMR.
 
 #### Workflow Configuration
 
@@ -143,7 +145,7 @@ Note that in the lambda, the event.config.cmr will contain the values you config
             - States.ALL
           IntervalSeconds: 2
           MaxAttempts: 3
-      Next: MoveGranuleStep
+      Next: FilesToGranulesStep
 ```
 
 **Please note**: ```FakeProcessing``` is the core provided browse/cmr generation we're using for the example in this entry.
@@ -186,6 +188,9 @@ SyncGranuleNoVpc:
   logToElasticSearch: true
   source: node_modules/@cumulus/sync-granule/dist/
   useMessageAdapter: true
+FilesToGranules:
+  handler: index.handler
+  source: node_modules/@cumulus/files-to-granules/dist/
 FakeProcessing:
   handler: index.handler
   source: node_modules/@cumulus/test-processing/dist/
@@ -493,20 +498,20 @@ The provided example script used in the example goes through all granules and ad
 
 The processing lambda you construct will need to do the following:
 
-* Create a browse image file based on the input data, and stage it to a location accessible to both this task and the ```MoveGrranules``` task in a S3 bucket.
+* Create a browse image file based on the input data, and stage it to a location accessible to both this task and the ```FilesToGranules``` and ```MoveGranules``` tasks in a S3 bucket.
 * Add the browse file to the input granule files, making sure to set the granule fileType to ```browse```.
-* Update meta.input_granules with the updated granules list, as well as provide the files to be moved in the payload for ```MoveGranules``` as output from the task.
+* Update meta.input_granules with the updated granules list, as well as provide the files to be integrated by ```FilesToGranules``` as output from the task.
 
 
 ### Generating/updating CMR metadata
 
-If you do not already have a CMR file in the granules list, you will need to generate one for valid export.   This example's processing script generates and adds it to the ```MoveGranules``` file list via the payload  but it can be present in the InputGranules from the DiscoverGranules step as well if you'd prefer to pre-generate it.
+If you do not already have a CMR file in the granules list, you will need to generate one for valid export.   This example's processing script generates and adds it to the ```FilesToGranules``` file list via the payload  but it can be present in the InputGranules from the DiscoverGranules step as well if you'd prefer to pre-generate it.
 
-Both ```MoveGranules``` and ```CmrStep``` expect a valid CMR file to be available if you want to export to CMR.
+Both downstream steps ```MoveGranules``` and ```CmrStep``` expect a valid CMR file to be available if you want to export to CMR.
 
 ### Expected Outputs for processing step/steps
 
-In the above example, the critical portion of the output to ```MoveGranules``` is the payload and meta.input_granules.
+In the above example, the critical portion of the output to ```FilesToGranules``` is the payload and meta.input_granules.
 
 In the example provided, the processing step is setup to return an object with the keys "files" and "granules".   In the cumulus_message configuration, the outputs are mapped in the configuration to the payload, granules to meta.input_granules:
 
@@ -523,7 +528,7 @@ Their expected values from the example above may be useful in constructing a pro
 
 The payload includes a full list of files to be 'moved' into the cumulus archive.   The ```MoveGranules``` step will take this list, merge it with the information from input_granules adn move the files to their targets, then update the cmr metadata file if it exists with the updated granule locations.
 
-In the provided example, a payload being passed to ```MoveGranules``` should be expected to look like:
+In the provided example, a payload being passed to ```FilesToGranules``` should be expected to look like:
 
 ```
   "payload": [
@@ -534,13 +539,13 @@ In the provided example, a payload being passed to ```MoveGranules``` should be 
   ]
 ```
 
-This list is the list of granules ```MoveGranules``` will act upon to move from the staging directory to the configured buckets.
+This list is the list of granules ```FilesToGranules``` will act upon to move from the staging directory to the configured buckets.
 
 The pathing is generated from sync-granules, but in principle the files can be staged wherever you like so long as the processing/```MoveGranules``` lambda's roles have access and the filename matches the collection configuration.
 
 #### input_granules
 
-The ```MoveGranules``` task utilizes the incoming payload to chose which files to move, but pulls all other metadata from meta.input_granules.  As such, the output payload in the example would look like:
+The ```FilesToGranules``` task utilizes the incoming payload to chose which files to move, but pulls all other metadata from meta.input_granules.  As such, the output payload in the example would look like:
 
 ```
 "input_granules": [

--- a/docs/workflow_tasks/files_to_granules.md
+++ b/docs/workflow_tasks/files_to_granules.md
@@ -1,0 +1,50 @@
+---
+id: files_to_granules
+title: Files To Granules
+hide_title: true
+---
+
+# Files To Granules
+
+This task utilizes the Cumulus Message Adapter to interpret and construct incoming and outgoing messages.
+
+Links to the npm package, task input, output and configuration schema definitions and more can be found on the auto-generated [Cumulus Tasks](../tasks) page.
+
+## Summary
+
+This task utilizes the incoming ```config.input_granules``` and the task input list of s3 URIs along with the rest of the configuration objects to take the list of incoming files and sort them into a list of granule objects.
+
+  **Please note** Files passed in without metadata defined previously for ```config.input_granules``` will be added with the following keys:
+
+* name
+* bucket
+* filename
+* fileStagingDir
+
+It is primarily intended to support compatibility with the standard output of a processing task, and convert that output into a granule object accepted as input by the majority of other Cumulus tasks.
+
+## Task Inputs
+
+### Input
+
+This task expects an incoming input that contains an array  of 'staged' S3 URIs to move to their final archive location.
+
+For the specifics, see the [Cumulus Tasks page](../tasks) entry for the schema.
+
+### Configuration
+
+This task does expect values to be set in the CumulusConfig for the workflows.  A schema exists that defines the requirements for the task.
+
+For the most recent config.json schema, please see the [Cumulus Tasks page](../tasks) entry for the schema.
+
+Below are expanded descriptions of selected config keys:
+
+#### inputGranules
+
+An array of Cumulus [granule](https://github.com/nasa/cumulus/blob/master/packages/api/models/schemas.js) objects.
+
+This object will be used to define metadata values for the move granules task, and is the basis for the updated object that will be added to the output.
+
+## Task Outputs
+
+This task outputs an assembled array of Cumulus [granule](https://github.com/nasa/cumulus/blob/master/packages/api/models/schemas.js) objects as the payload for the next task, and returns only the expected payload for the next task.

--- a/docs/workflow_tasks/files_to_granules.md
+++ b/docs/workflow_tasks/files_to_granules.md
@@ -12,9 +12,9 @@ Links to the npm package, task input, output and configuration schema definition
 
 ## Summary
 
-This task utilizes the incoming ```config.input_granules``` and the task input list of s3 URIs along with the rest of the configuration objects to take the list of incoming files and sort them into a list of granule objects.
+This task utilizes the incoming ```config.inputGranules``` and the task input list of s3 URIs along with the rest of the configuration objects to take the list of incoming files and sort them into a list of granule objects.
 
-  **Please note** Files passed in without metadata defined previously for ```config.input_granules``` will be added with the following keys:
+  **Please note** Files passed in without metadata defined previously for ```config.inputGranules``` will be added with the following keys:
 
 * name
 * bucket

--- a/docs/workflow_tasks/move_granules.md
+++ b/docs/workflow_tasks/move_granules.md
@@ -47,7 +47,7 @@ This task expects event.input to provide an array of Cumulus [granule](https://g
 
 ## Task Outputs
 
-This task outputs an assembled array of Cumulus [granule](https://github.com/nasa/cumulus/blob/master/packages/api/models/schemas.js) objects  with post-move file locations as the payload for the next task, and returns only the expected payload for the next task.    If a CMR file has been specified for a granule object, the CMR resources related to the granule files  will be updated according to the update granule file metadata.
+This task outputs an assembled array of Cumulus [granule](https://github.com/nasa/cumulus/blob/master/packages/api/models/schemas.js) objects  with post-move file locations as the payload for the next task, and returns only the expected payload for the next task.    If a CMR file has been specified for a granule object, the CMR resources related to the granule files  will be updated according to the updated granule file metadata.
 
 ## Examples
 

--- a/docs/workflow_tasks/move_granules.md
+++ b/docs/workflow_tasks/move_granules.md
@@ -12,13 +12,11 @@ Links to the npm package, task input, output and configuration schema definition
 
 ## Summary
 
-This task utilizes the incoming ```config.input_granules``` and the task input list of s3 URIs along with the rest of the configuration objects to do the following for a list of files assigned to a single collection:
-
-* Take the list of incoming files and sort them into a list of granule objects.  Assign files to existing granules where appropriate.
+This task utilizes the incoming ```event.input``` array of Cumulus [granule](https://github.com/nasa/cumulus/blob/master/packages/api/models/schemas.js) objects to do the following:
 
 * Move granules from their 'staging' location to the final location (as configured in the Sync Granules task)
 
-* Update the ```config.input_granules``` object with the new file locations.
+* Update the ```event.input``` object with the new file locations.
 
 * If the granule has a ECHO10/UMM CMR file(.cmr.xml or .cmr.json) file included in the ```config.input_granules```:
   *  Update that file's access locations
@@ -43,17 +41,13 @@ This task does expect values to be set in the CumulusConfig for the workflows.  
 
 For the most recent config.json schema, please see the [Cumulus Tasks page](../tasks) entry for the schema.
 
-Below are expanded descriptions of selected config keys:
+### Input
 
-#### Input_Granules
-
-An array of Cumulus [granule](https://github.com/nasa/cumulus/blob/master/packages/api/models/schemas.js) objects.
-
-This object will be used to define metadata values for the move granules task, and is the basis for the updated object that will be added to the output.
+This task expects event.input to provide an array of Cumulus [granule](https://github.com/nasa/cumulus/blob/master/packages/api/models/schemas.js) objects.   The files listed for each granule represent the files to be acted upon as described in [summary](#summary).
 
 ## Task Outputs
 
-This task outputs an assembled array of Cumulus [granule](https://github.com/nasa/cumulus/blob/master/packages/api/models/schemas.js) objects as the payload for the next task, and returns only the expected payload for the next task.
+This task outputs an assembled array of Cumulus [granule](https://github.com/nasa/cumulus/blob/master/packages/api/models/schemas.js) objects as the payload for the next task, and returns only the expected payload for the next task.    If a CMR file has been specified for a granule, it will be updated with the appropriate values for it's relevant metadata.
 
 ## Examples
 

--- a/docs/workflow_tasks/move_granules.md
+++ b/docs/workflow_tasks/move_granules.md
@@ -47,7 +47,7 @@ This task expects event.input to provide an array of Cumulus [granule](https://g
 
 ## Task Outputs
 
-This task outputs an assembled array of Cumulus [granule](https://github.com/nasa/cumulus/blob/master/packages/api/models/schemas.js) objects as the payload for the next task, and returns only the expected payload for the next task.    If a CMR file has been specified for a granule, it will be updated with the appropriate values for it's relevant metadata.
+This task outputs an assembled array of Cumulus [granule](https://github.com/nasa/cumulus/blob/master/packages/api/models/schemas.js) objects as the payload for the next task, and returns only the expected payload for the next task.    If a CMR file has been specified for a granule object, the CMR resources related to the granule files  will be updated according to the updatee granule file metadata.
 
 ## Examples
 

--- a/docs/workflow_tasks/move_granules.md
+++ b/docs/workflow_tasks/move_granules.md
@@ -43,7 +43,7 @@ For the most recent config.json schema, please see the [Cumulus Tasks page](../t
 
 ### Input
 
-This task expects event.input to provide an array of Cumulus [granule](https://github.com/nasa/cumulus/blob/master/packages/api/models/schemas.js) objects.   The files listed for each granule represent the files to be acted upon as described in [summary](#summary).
+This task expects event.input to provide an array of Cumulus [granule](https://github.com/nasa/cumulus/blob/master/packages/api/models/schemas.js) objects with post-move file locations.   The files listed for each granule represent the files to be acted upon as described in [summary](#summary).
 
 ## Task Outputs
 

--- a/docs/workflow_tasks/move_granules.md
+++ b/docs/workflow_tasks/move_granules.md
@@ -43,11 +43,11 @@ For the most recent config.json schema, please see the [Cumulus Tasks page](../t
 
 ### Input
 
-This task expects event.input to provide an array of Cumulus [granule](https://github.com/nasa/cumulus/blob/master/packages/api/models/schemas.js) objects with post-move file locations.   The files listed for each granule represent the files to be acted upon as described in [summary](#summary).
+This task expects event.input to provide an array of Cumulus [granule](https://github.com/nasa/cumulus/blob/master/packages/api/models/schemas.js) objects.   The files listed for each granule represent the files to be acted upon as described in [summary](#summary).
 
 ## Task Outputs
 
-This task outputs an assembled array of Cumulus [granule](https://github.com/nasa/cumulus/blob/master/packages/api/models/schemas.js) objects as the payload for the next task, and returns only the expected payload for the next task.    If a CMR file has been specified for a granule object, the CMR resources related to the granule files  will be updated according to the updatee granule file metadata.
+This task outputs an assembled array of Cumulus [granule](https://github.com/nasa/cumulus/blob/master/packages/api/models/schemas.js) objects  with post-move file locations as the payload for the next task, and returns only the expected payload for the next task.    If a CMR file has been specified for a granule object, the CMR resources related to the granule files  will be updated according to the updatee granule file metadata.
 
 ## Examples
 

--- a/docs/workflow_tasks/move_granules.md
+++ b/docs/workflow_tasks/move_granules.md
@@ -47,7 +47,7 @@ This task expects event.input to provide an array of Cumulus [granule](https://g
 
 ## Task Outputs
 
-This task outputs an assembled array of Cumulus [granule](https://github.com/nasa/cumulus/blob/master/packages/api/models/schemas.js) objects  with post-move file locations as the payload for the next task, and returns only the expected payload for the next task.    If a CMR file has been specified for a granule object, the CMR resources related to the granule files  will be updated according to the updatee granule file metadata.
+This task outputs an assembled array of Cumulus [granule](https://github.com/nasa/cumulus/blob/master/packages/api/models/schemas.js) objects  with post-move file locations as the payload for the next task, and returns only the expected payload for the next task.    If a CMR file has been specified for a granule object, the CMR resources related to the granule files  will be updated according to the update granule file metadata.
 
 ## Examples
 

--- a/example/workflows/browseExample.yml
+++ b/example/workflows/browseExample.yml
@@ -125,14 +125,24 @@ CookbookBrowseExample:
             - States.ALL
           IntervalSeconds: 2
           MaxAttempts: 3
+      Next: FilesToGranulesStep
+    FilesToGranulesStep:
+      CumulusConfig:
+        inputGranules: '{$.meta.input_granules}'
+        granuleIdExtraction: '{$.meta.collection.granuleIdExtraction}'
+      Type: Task
+      Resource: ${FilesToGranulesLambdaFunction.Arn}
+      Catch:
+        - ErrorEquals:
+          - States.ALL
+          ResultPath: '$.exception'
+          Next: StopStatus
       Next: MoveGranuleStep
     MoveGranuleStep:
       CumulusConfig:
         bucket: '{$.meta.buckets.internal.name}'
         buckets: '{$.meta.buckets}'
-        granuleIdExtraction: '{$.meta.collection.granuleIdExtraction}'
         distribution_endpoint: '{$.meta.distribution_endpoint}'
-        input_granules: '{$.meta.input_granules}'
         collection: '{$.meta.collection}'
         duplicateHandling: '{$.meta.collection.duplicateHandling}'
       Type: Task

--- a/tasks/files-to-granules/schemas/output.json
+++ b/tasks/files-to-granules/schemas/output.json
@@ -30,6 +30,9 @@
                 },
                 "bucket": {
                   "type": "string"
+                },
+                "fileStagingDir" : {
+                  "type": "string"
                 }
               }
             }

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -21,6 +21,7 @@
     "Tasks" : [
       "tasks",
       "workflow_tasks/discover_granules",
+      "workflow_tasks/files_to_granules",
       "workflow_tasks/move_granules",
       "workflow_tasks/parse_pdr"
     ],


### PR DESCRIPTION
This PR updates the docs introduced in 835 to match the current state of the work. 

We should consider re-writing the SIPS/fake processing/browse generation examples/ingest tests to map to the suggested path where processing pushes the correct objects direct to move granules instead of needing a compatibility assembly lambda, however as that's dependant on work in the main 1176 branch's approach , this PR is intended to map to the current state of those workflows.  