### PR TITLE
[CUMULUS-852] documentation for running tasks in lambda vs docker

### DIFF
--- a/docs/data-cookbooks/run-tasks-in-lambda-or-docker.md
+++ b/docs/data-cookbooks/run-tasks-in-lambda-or-docker.md
@@ -10,7 +10,7 @@ hide_title: true
 
 [AWS Step Function Tasks](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-tasks.html) can run tasks on [AWS Lambda](https://aws.amazon.com/lambda/) or on [AWS Elastic Container Service (ECS)](https://aws.amazon.com/ecs/) as a Docker container.
 
-Lambda provides serverless architecture, providing the best option for minimizing cost and server management. ECS provides the flexibility to execute arbitrary code on any AWS EC2 instance type. 
+Lambda provides serverless architecture, providing the best option for minimizing cost and server management. ECS provides the fullest extent of AWS EC2 resources via the flexibility to execute arbitrary code on any AWS EC2 instance type.
 
 ## When to use Lambda
 

--- a/docs/data-cookbooks/run-tasks-in-lambda-or-docker.md
+++ b/docs/data-cookbooks/run-tasks-in-lambda-or-docker.md
@@ -46,7 +46,7 @@ QueueGranules:
   useMessageAdapter: true
 ```
 
-Given the `QueueGranules` lambda package is already used Step Function State Machine definition, the following will exist in a workflows yml file:
+Given the `QueueGranules` lambda package is already used in a Step Function State Machine definition, the following will exist in a workflow YAML file:
 
 ```yaml
     QueueGranules:

--- a/docs/data-cookbooks/run-tasks-in-lambda-or-docker.md
+++ b/docs/data-cookbooks/run-tasks-in-lambda-or-docker.md
@@ -93,7 +93,7 @@ and then modifying the corresponding Step Function State Machine definition in a
       Next: StopStatus
 ```
 
-## How do I name my resources? A Short Primer on Cumulus Resource Naming Conventions
+## How do I name my resources? A short primer on Cumulus resource naming conventions
 
 Cumulus deployments currently depend on the [`kes`](https://github.com/developmentseed/kes) cli tool. `kes` references values in `app/config.yml`, `iam/config.yml`, lambda and workflow `.yml` files to populate the cloudformation templates that are a part of the `@cumulus/deployment` package. `kes` generates final cloudformation files and uploads them to AWS Cloudformation, creating or updating AWS Cloudformation Stacks.
 

--- a/docs/data-cookbooks/run-tasks-in-lambda-or-docker.md
+++ b/docs/data-cookbooks/run-tasks-in-lambda-or-docker.md
@@ -93,6 +93,17 @@ and then modifying the corresponding Step Function State Machine definition in a
       Next: StopStatus
 ```
 
+## How do I name my resources? A Short Primer on Cumulus Resource Naming Conventions
+
+Cumulus deployments currently depend on the [`kes`](https://github.com/developmentseed/kes) cli tool. `kes` references values in `app/config.yml`, `iam/config.yml`, lambda and workflow `.yml` files to populate the cloudformation templates that are a part of the `@cumulus/deployment` package. `kes` generates final cloudformation files and uploads them to AWS Cloudformation, creating or updating AWS Cloudformation Stacks.
+
+When deploying AWS Lambdas and AWS Activities as detailed above, note the following naming conventions:
+
+* `QueueGranules` in `lambdas.yml`: When kes generates the final cloudformation file, it will define a resource called `QueueGranulesLambdaFunction`. A valid lambda function resource name, such as `QueueGranulesLambdaFunction`, must be used in `app/config.yml` when passed as a command argument to `cumulus-ecs-task`.
+* `QueueGranules` in `app/config.yml`: The string `QueueGranules` exists twice in the `app/config.yml` above.
+    * The first occurence is as a key under `services`. This key provides a descriptive prefix when naming the corresponding ECS Service. It will be included in final cloudformation yaml as an `AWS::ECS::Service` resource with the name `QueueGranulesECSService`. This ECS Service name prefix (`QueueGranules` in this example) can be anything since the service is not referenced in any other part of the deployment at this time.
+    * The second occurence of `QueueGranules` is as a value under `activities: - name:`. The value of `activites: - name:` can be anything, but it should match the prefix of the `--activityArn` command argument passed to `cumulus-ecs-task`.
+
 ## Final Note
 
 Step Function Activities and AWS Lambda are not the only ways to run tasks in an AWS Step Function. Learn more about other service integrations, including direct ECS integration via the [AWS Service Integrations](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-connectors.html) page.

--- a/docs/data-cookbooks/run-tasks-in-lambda-or-docker.md
+++ b/docs/data-cookbooks/run-tasks-in-lambda-or-docker.md
@@ -8,30 +8,30 @@ hide_title: true
 
 ## Overview
 
-[AWS Step Function Tasks](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-tasks.html) can run tasks on [AWS Lambda](https://aws.amazon.com/lambda/) functions or [AWS Elastic Container Service (ECS)](https://aws.amazon.com/ecs/) as a Docker container.
+[AWS Step Function Tasks](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-tasks.html) can run tasks on [AWS Lambda](https://aws.amazon.com/lambda/) or on [AWS Elastic Container Service (ECS)](https://aws.amazon.com/ecs/) as a Docker container.
 
-Lambda provides serverless architecture, providing the best option for cost and server management. ECS provides the flexibility to execute any code on any AWS EC2 instance type your task might require. 
+Lambda provides serverless architecture, providing the best option for minimizing cost and server management. ECS provides the flexibility to execute arbitrary code on any AWS EC2 instance type. 
 
 ## When to use Lambda
 
 You should use AWS Lambda whenever all of the following are true:
 
-* The task runs on one of the supported [Lambda Runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html). At time of this writing, supported runtimes include select versions of python, Java, Ruby, node.js, Go and .NET.
+* The task runs on one of the supported [Lambda Runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html). At time of this writing, supported runtimes include versions of python, Java, Ruby, node.js, Go and .NET.
 * The lambda package is less than 50 MB in size, zipped.
-* The task consumes less the following resources:
+* The task consumes less than each of the following resources:
     * 3008 MB memory allocation
     * 512 MB disk storage (must be written to `/tmp`)
     * 15 minutes of execution time
 
 See [this page](https://docs.aws.amazon.com/lambda/latest/dg/limits.html) for a complete and up-to-date list of AWS Lambda limits.
 
-If your task requires more than any of these resource limitations or an unsupported runtime, creating a Docker image which can be run on ECS is the way to go. Cumulus supports running any lambda package as a Docker container using Step Function Activities and `cumulus-ecs-task`.
+If your task requires more than any of these resources or an unsupported runtime, creating a Docker image which can be run on ECS is the way to go. Cumulus supports running any lambda package as a Docker container with [`cumulus-ecs-task`](https://github.com/nasa/cumulus-ecs-task).
 
 ## Step Function Activities and `cumulus-ecs-task`
 
-[Step Function Activities](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-activities.html) enable a state machine task to "publish" an activity task which can be picked up by any activity worker. Activity workers can run pretty much anywhere, but Cumulus workflows support [`cumulus-ecs-task`](https://github.com/nasa/cumulus-ecs-task) activity workers. The `cumulus-ecs-task` worker runs as a Docker container on the Cumulus ECS cluster.
+[Step Function Activities](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-activities.html) enable a state machine task to "publish" an activity task which can be picked up by any activity worker. Activity workers can run pretty much anywhere, but Cumulus workflows support the [`cumulus-ecs-task`](https://github.com/nasa/cumulus-ecs-task) activity worker. The `cumulus-ecs-task` worker runs as a Docker container on the Cumulus ECS cluster.
 
-The `cumulus-ecs-task` container takes an AWS Lambda Amazon Resource Name (ARN) as an argument (see `--lambdaArn` in the example below). This ARN argument is defined at deployment time. The `cumulus-ecs-task` container polls for new Step Function Activity Tasks. When a Step Function executes, the worker (container) picks up the task and runs the code contained in the lambda package defined on deployment.
+The `cumulus-ecs-task` container takes an AWS Lambda Amazon Resource Name (ARN) as an argument (see `--lambdaArn` in the example below). This ARN argument is defined at deployment time. The `cumulus-ecs-task` worker polls for new Step Function Activity Tasks. When a Step Function executes, the worker (container) picks up the activity task and runs the code contained in the lambda package defined on deployment.
 
 ## Example: Replacing AWS Lambda with a Docker container run on ECS
 
@@ -46,7 +46,7 @@ QueueGranules:
   useMessageAdapter: true
 ```
 
-Given the `QueueGranules` lambda package is already used Step Function State Machine definition, the following will exist in a workflows yaml file:
+Given the `QueueGranules` lambda package is already used Step Function State Machine definition, the following will exist in a workflows yml file:
 
 ```yaml
     QueueGranules:
@@ -55,7 +55,7 @@ Given the `QueueGranules` lambda package is already used Step Function State Mac
       Next: StopStatus
 ```
 
-Given it has been discovered this task can no longer run in AWS Lambda because it uses more than 3008MB of memory, it can be run on the Cumulus ECS cluster by including the following in `app/config.yml`:
+Given it has been discovered this task can no longer run in AWS Lambda, it can be run on the Cumulus ECS cluster by including the following in `app/config.yml`:
 
 ```yaml
   ecs:

--- a/docs/data-cookbooks/run-tasks-in-lambda-or-docker.md
+++ b/docs/data-cookbooks/run-tasks-in-lambda-or-docker.md
@@ -102,7 +102,7 @@ When deploying AWS Lambdas and AWS Activities as detailed above, note the follow
 * `QueueGranules` in `lambdas.yml`: When kes generates the final cloudformation file, it will define a resource called `QueueGranulesLambdaFunction`. A valid lambda function resource name, such as `QueueGranulesLambdaFunction`, must be used in `app/config.yml` when passed as a command argument to `cumulus-ecs-task`.
 * `QueueGranules` in `app/config.yml`: The string `QueueGranules` exists twice in the `app/config.yml` above.
     * The first occurence is as a key under `services`. This key provides a descriptive prefix when naming the corresponding ECS Service. It will be included in final cloudformation yaml as an `AWS::ECS::Service` resource with the name `QueueGranulesECSService`. This ECS Service name prefix (`QueueGranules` in this example) can be anything since the service is not referenced in any other part of the deployment at this time.
-    * The second occurence of `QueueGranules` is as a value under `activities: - name:`. The value of `activites: - name:` can be anything, but it should match the prefix of the `--activityArn` command argument passed to `cumulus-ecs-task`.
+    * The second occurrence of `QueueGranules` is as a value under `activities: - name:`. The value of `activites: - name:` can be anything, but the `--activityArn` command argument passed to `cumulus-ecs-task` must use this value plus `Activity` as a suffix (`QueueGranulesActivity` in this example).
 
 ## Final Note
 

--- a/docs/data-cookbooks/run-tasks-in-lambda-or-docker.md
+++ b/docs/data-cookbooks/run-tasks-in-lambda-or-docker.md
@@ -84,7 +84,7 @@ Given it has been discovered this task can no longer run in AWS Lambda, it can b
     - name: QueueGranules
 ```
 
-and then modifying the corresponding Step Function State Machine definition:
+and then modifying the corresponding Step Function State Machine definition in a workflow YAML file:
 
 ```yaml
     QueueGranules:

--- a/docs/data-cookbooks/run-tasks-in-lambda-or-docker.md
+++ b/docs/data-cookbooks/run-tasks-in-lambda-or-docker.md
@@ -1,0 +1,99 @@
+---
+id: run-tasks-in-lambda-or-docker
+title: Run Step Function Tasks in Lambda or Docker
+hide_title: true
+---
+
+# Running Step Function Tasks in AWS Lambda or Docker
+
+## Overview
+
+[AWS Step Function Tasks](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-tasks.html) can run tasks on [AWS Lambda](https://aws.amazon.com/lambda/) functions or [AWS Elastic Container Service (ECS)](https://aws.amazon.com/ecs/) as a Docker container.
+
+Lambda provides serverless architecture, providing the best option for cost and server management. ECS provides the flexibility to execute any code on any AWS EC2 instance type your task might require. 
+
+## When to use Lambda
+
+You should use AWS Lambda whenever all of the following are true:
+
+* The task runs on one of the supported [Lambda Runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html). At time of this writing, supported runtimes include select versions of python, Java, Ruby, node.js, Go and .NET.
+* The lambda package is less than 50 MB in size, zipped.
+* The task consumes less the following resources:
+    * 3008 MB memory allocation
+    * 512 MB disk storage (must be written to `/tmp`)
+    * 15 minutes of execution time
+
+See [this page](https://docs.aws.amazon.com/lambda/latest/dg/limits.html) for a complete and up-to-date list of AWS Lambda limits.
+
+If your task requires more than any of these resource limitations or an unsupported runtime, creating a Docker image which can be run on ECS is the way to go. Cumulus supports running any lambda package as a Docker container using Step Function Activities and `cumulus-ecs-task`.
+
+## Step Function Activities and `cumulus-ecs-task`
+
+[Step Function Activities](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-activities.html) enable a state machine task to "publish" an activity task which can be picked up by any activity worker. Activity workers can run pretty much anywhere, but Cumulus workflows support [`cumulus-ecs-task`](https://github.com/nasa/cumulus-ecs-task) activity workers. The `cumulus-ecs-task` worker runs as a Docker container on the Cumulus ECS cluster.
+
+The `cumulus-ecs-task` container takes an AWS Lambda Amazon Resource Name (ARN) as an argument (see `--lambdaArn` in the example below). This ARN argument is defined at deployment time. The `cumulus-ecs-task` container polls for new Step Function Activity Tasks. When a Step Function executes, the worker (container) picks up the task and runs the code contained in the lambda package defined on deployment.
+
+## Example: Replacing AWS Lambda with a Docker container run on ECS
+
+Whether using AWS Lambda or Step Functions Activities, there will be a lambda package defined in `lambdas.yml`:
+
+```yaml
+QueueGranules:
+  handler: index.handler
+  timeout: 900
+  memory: 3008
+  source: node_modules/@cumulus/queue-granules/dist/
+  useMessageAdapter: true
+```
+
+Given the `QueueGranules` lambda package is already used Step Function State Machine definition, the following will exist in a workflows yaml file:
+
+```yaml
+    QueueGranules:
+      Type: Task
+      Resource: ${QueueGranulesLambdaFunction.Arn}
+      Next: StopStatus
+```
+
+Given it has been discovered this task can no longer run in AWS Lambda because it uses more than 3008MB of memory, it can be run on the Cumulus ECS cluster by including the following in `app/config.yml`:
+
+```yaml
+  ecs:
+    instanceType: t2.large
+    desiredInstances: 1
+    services:
+      QueueGranules:
+        docker: true
+        image: cumuluss/cumulus-ecs-task:1.2.5
+        memory: 4000
+        count: 1
+        envs:
+          AWS_DEFAULT_REGION:
+            function: Fn::Sub
+            value: '${AWS::Region}'
+        commands:
+          - cumulus-ecs-task
+          - '--activityArn'
+          - function: Ref
+            value: QueueGranulesActivity
+          - '--lambdaArn'
+          - function: Ref
+            value: QueueGranulesLambdaFunction
+
+  activities:
+    - name: QueueGranules
+```
+
+and then modifying the corresponding Step Function State Machine definition:
+
+```yaml
+    QueueGranules:
+      Type: Task
+      Resource: ${QueueGranulesActivity}
+      Next: StopStatus
+```
+
+## Final Note
+
+Step Function Activities and AWS Lambda are not the only ways to run tasks in an AWS Step Function. Learn more about other service integrations, including direct ECS integration via the [AWS Service Integrations](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-connectors.html) page.
+

--- a/docs/data-cookbooks/run-tasks-in-lambda-or-docker.md
+++ b/docs/data-cookbooks/run-tasks-in-lambda-or-docker.md
@@ -101,7 +101,7 @@ When deploying AWS Lambdas and AWS Activities as detailed above, note the follow
 
 * `QueueGranules` in `lambdas.yml`: When kes generates the final cloudformation file, it will define a resource called `QueueGranulesLambdaFunction`. A valid lambda function resource name, such as `QueueGranulesLambdaFunction`, must be used in `app/config.yml` when passed as a command argument to `cumulus-ecs-task`.
 * `QueueGranules` in `app/config.yml`: The string `QueueGranules` exists twice in the `app/config.yml` above.
-    * The first occurence is as a key under `services`. This key provides a descriptive prefix when naming the corresponding ECS Service. It will be included in final cloudformation yaml as an `AWS::ECS::Service` resource with the name `QueueGranulesECSService`. This ECS Service name prefix (`QueueGranules` in this example) can be anything since the service is not referenced in any other part of the deployment at this time.
+    * The first occurrence is as a key under `services`. This key provides a descriptive prefix when naming the corresponding ECS Service. It will be included in final cloudformation YAML as an `AWS::ECS::Service` resource with the name `QueueGranulesECSService`. This ECS Service name prefix (`QueueGranules` in this example) can be anything since the service is not referenced in any other part of the deployment at this time.
     * The second occurrence of `QueueGranules` is as a value under `activities: - name:`. The value of `activites: - name:` can be anything, but the `--activityArn` command argument passed to `cumulus-ecs-task` must use this value plus `Activity` as a suffix (`QueueGranulesActivity` in this example).
 
 ## Final Note

--- a/example/app/config.yml
+++ b/example/app/config.yml
@@ -232,9 +232,9 @@ aj:
   stackName: aj-integration
   stackNameNoDash: AjIntegration
 
-aimee-test:
-  stackName: aimee-test
-  stackNameNoDash: aimeeTest
+aimee:
+  stackName: aimee
+  stackNameNoDash: aimee
 
 lf:
   stackName: lf-cumulus

--- a/example/iam/config.yml
+++ b/example/iam/config.yml
@@ -108,9 +108,9 @@ mhs2:
 aj:
   prefix: aj-integration
 
-aimee-test:
-  prefix: aimee-test
-  stackName: aimee-test-iam
+aimee:
+  prefix: aimee
+  stackName: aimee-iam
 
 lf:
   prefix: lf-cumulus

--- a/packages/ingest/s3.js
+++ b/packages/ingest/s3.js
@@ -54,7 +54,8 @@ module.exports.s3Mixin = (superclass) => class extends superclass {
 
     const params = {
       Bucket: this.host,
-      FetchOwner: true
+      FetchOwner: true,
+      Prefix: this.path
     };
 
     const objects = await aws.listS3ObjectsV2(params);

--- a/travis-ci/select-stack.js
+++ b/travis-ci/select-stack.js
@@ -15,7 +15,7 @@ function determineIntegrationTestStackName(cb) {
   if (branch === 'master') return cb('cumulus-from-source');
 
   const stacks = {
-    'Aimee Barciauskas': 'aimee-test',
+    'Aimee Barciauskas': 'aimee',
     'Jenny Liu': 'jl',
     jennyhliu: 'jl',
     kkelly51: 'kk',


### PR DESCRIPTION
**Summary:**

Addresses [CUMULUS-852: As a DAAC operator, I want to promote my workflow tasks to be run in Docker instead of Lambda as necessary so I may avoid issues with timeouts and disk space restriction during execution](https://bugs.earthdata.nasa.gov/browse/CUMULUS-852)

## Changes

* Add data cookbook entry for running tasks in lambda or docker

## PR Checklist

n/a

