### PR TITLE
CUMULUS-803: add alarms to check the running tasks of ECS service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **CUMULUS-805**
   - Added a CloudWatch alarm to check running ElasticSearch instances, and a CloudWatch dashboard to view the health of ElasticSearch
   - Specify `AWS_REGION` in `.env` to be used by deployment script
+- **CUMULUS-803**
+  - Added CloudWatch alarms to check running tasks of each ECS service, and add the alarms to CloudWatch dashboard
 - **CUMULUS-670**
   - Added Ancillary Metadata Export feature (see https://nasa.github.io/cumulus/docs/features/ancillary_metadata for more information)
   - Added new Collection file parameter "fileType" that allows configuration of workflow granule file fileType

--- a/docs/deployment/config_descriptions.md
+++ b/docs/deployment/config_descriptions.md
@@ -53,6 +53,20 @@ note `instanceType` and `desiredInstances` have been selected for a sample insta
 
 Also note, if you dont specify the `amiid`, it will try to use a default, which may or may not exist.
 
+For each service, a TaskCountLowAlarm alarm is added to check the RUNNING Task Count against the service configuration.  You can update `ecs` properties and add additional ECS alarms to your service.  For example,
+
+    ecs:
+      services:
+        EcsTaskHelloWorld:
+          alarms:
+            TaskCountHigh:
+              alarm_description: 'There are more tasks running than the desired'
+              comparison_operator: GreaterThanThreshold
+              evaluation_periods: 1
+              metric: MemoryUtilization
+              statistic: SampleCount
+              threshold: '{{ecs.services.EcsTaskHelloWorld.count}}'
+
 ## es
 Configuration for the Amazon Elasticsearch Service (ES) instance.  You can update `es` properties and add additional ES alarms. For example:
 

--- a/example/app/config.yml
+++ b/example/app/config.yml
@@ -108,6 +108,14 @@ default:
           - '--lambdaArn'
           - function: Ref
             value: HelloWorldLambdaFunction
+        alarms:
+          TaskCountHigh:
+            alarm_description: 'There are more tasks running than the desired'
+            comparison_operator: GreaterThanThreshold
+            evaluation_periods: 1
+            metric: MemoryUtilization
+            statistic: SampleCount
+            threshold: '{{ecs.services.EcsTaskHelloWorld.count}}'
 
   activities:
     - name: EcsTaskHelloWorld

--- a/packages/deployment/app/cloudformation.template.yml
+++ b/packages/deployment/app/cloudformation.template.yml
@@ -1283,11 +1283,11 @@ Resources:
   #################################################
   # CloudWatch Dashboard BEGIN
   #################################################
-  # CumulusCloudWatchDashboard:
-  #   Type: AWS::CloudWatch::Dashboard
-  #   Properties:
-  #     DashboardName: {{stackName}}-CloudWatch-Dashboard
-  #     DashboardBody: '{{#buildCWDashboard dashboard ecs es stackName}}{{/buildCWDashboard}}'
+  CumulusCloudWatchDashboard:
+    Type: AWS::CloudWatch::Dashboard
+    Properties:
+      DashboardName: {{stackName}}-CloudWatch-Dashboard
+      DashboardBody: '{{#buildCWDashboard dashboard ecs es stackName}}{{/buildCWDashboard}}'
   #################################################
   # CloudWatch Dashboard END
   #################################################

--- a/packages/deployment/app/cloudformation.template.yml
+++ b/packages/deployment/app/cloudformation.template.yml
@@ -410,11 +410,9 @@ Resources:
       Namespace: AWS/ES
       Dimensions:
         - Name: ClientId
-          Value:
-            Fn::Sub: ${AWS::AccountId}
+          Value: !Sub ${AWS::AccountId}
         - Name: DomainName
-          Value:
-            Ref: {{../es.name}}Domain
+          Value: !Ref {{../es.name}}Domain
   {{/each}}
   {{/if}}
 
@@ -1136,6 +1134,49 @@ Resources:
         MaximumPercent: 100
         MinimumHealthyPercent: 0
 
+  {{@key}}ECSServiceTaskCountLowAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: There are less tasks running than the desired
+      AlarmName: {{../stackName}}-{{@key}}-TaskCountLowAlarm
+      ComparisonOperator: LessThanThreshold
+      EvaluationPeriods: 1
+      MetricName: MemoryUtilization
+      Statistic: SampleCount
+      Threshold: {{# if this.count}}{{this.count}}{{ else }} 0 {{/if}}
+      Period: 60
+      Namespace: AWS/ECS
+      Dimensions:
+        - Name: ClusterName
+          Value: !Ref CumulusECSCluster
+        - Name: ServiceName
+          Value: !GetAtt {{@key}}ECSService.Name
+
+  {{# if this.alarms}}
+  # the service has cumstom alarms
+  {{# each this.alarms}}
+  {{@../key}}{{@key}}Alarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+    {{#if alarm_description}}
+      AlarmDescription: {{ alarm_description }}
+    {{/if}}
+      AlarmName: {{../../stackName}}-{{@../key}}-{{@key}}Alarm
+      ComparisonOperator: {{ comparison_operator }}
+      EvaluationPeriods: {{#if evaluation_periods }}{{ evaluation_periods }}{{ else }}5{{/if}}
+      MetricName: {{ metric }}
+      Statistic: {{#if statistic }}{{ statistic }}{{ else }}Average{{/if}}
+      Threshold: {{ threshold }}
+      Period: {{#if period }}{{ period }}{{ else }}60{{/if}}
+      Namespace: AWS/ECS
+      Dimensions:
+        - Name: ClusterName
+          Value: !Ref CumulusECSCluster
+        - Name: ServiceName
+          Value: !GetAtt {{@../key}}ECSService.Name
+  {{/each}}
+  {{/if}}
+
 {{/each}}
 
 {{#each ecs.tasks}}
@@ -1242,13 +1283,11 @@ Resources:
   #################################################
   # CloudWatch Dashboard BEGIN
   #################################################
-{{# if es.name}}
-  CumulusCloudWatchDashboard:
-    Type: AWS::CloudWatch::Dashboard
-    Properties:
-      DashboardName: {{stackName}}-CloudWatch-Dashboard
-      DashboardBody: '{{#buildCWDashboard dashboard es stackName}}{{/buildCWDashboard}}'
-{{/if}}
+  # CumulusCloudWatchDashboard:
+  #   Type: AWS::CloudWatch::Dashboard
+  #   Properties:
+  #     DashboardName: {{stackName}}-CloudWatch-Dashboard
+  #     DashboardBody: '{{#buildCWDashboard dashboard ecs es stackName}}{{/buildCWDashboard}}'
   #################################################
   # CloudWatch Dashboard END
   #################################################

--- a/packages/deployment/app/cloudformation.template.yml
+++ b/packages/deployment/app/cloudformation.template.yml
@@ -410,9 +410,11 @@ Resources:
       Namespace: AWS/ES
       Dimensions:
         - Name: ClientId
-          Value: !Sub ${AWS::AccountId}
+          Value:
+            Fn::Sub: ${AWS::AccountId}
         - Name: DomainName
-          Value: !Ref {{../es.name}}Domain
+          Value:
+            Fn::Sub: {{../es.name}}Domain
   {{/each}}
   {{/if}}
 
@@ -1148,9 +1150,13 @@ Resources:
       Namespace: AWS/ECS
       Dimensions:
         - Name: ClusterName
-          Value: !Ref CumulusECSCluster
+          Value:
+            Ref: CumulusECSCluster
         - Name: ServiceName
-          Value: !GetAtt {{@key}}ECSService.Name
+          Value:
+            Fn::GetAtt:
+              - {{@key}}ECSService
+              - Name
 
   {{# if this.alarms}}
   # the service has cumstom alarms
@@ -1171,9 +1177,13 @@ Resources:
       Namespace: AWS/ECS
       Dimensions:
         - Name: ClusterName
-          Value: !Ref CumulusECSCluster
+          Value:
+            Ref: CumulusECSCluster
         - Name: ServiceName
-          Value: !GetAtt {{@../key}}ECSService.Name
+          Value:
+            Fn::GetAtt:
+              - {{@../key}}ECSService
+              - Name
   {{/each}}
   {{/if}}
 

--- a/packages/deployment/app/cloudformation.template.yml
+++ b/packages/deployment/app/cloudformation.template.yml
@@ -414,7 +414,7 @@ Resources:
             Fn::Sub: ${AWS::AccountId}
         - Name: DomainName
           Value:
-            Fn::Sub: {{../es.name}}Domain
+            Ref: {{../es.name}}Domain
   {{/each}}
   {{/if}}
 

--- a/packages/deployment/app/cloudwatchDashboard.yml
+++ b/packages/deployment/app/cloudwatchDashboard.yml
@@ -5,17 +5,33 @@
 # dashboard.
 ##############################################################
 
-## template for creating widgets for Elasticsearch Service alarms
-esTemplateAlarm:
+## template for creating widgets for alarms
+alarmTemplate:
   type: metric
   width: 6
   height: 3
   properties:
-    title: esTemplateAlarm
+    title: alarmTemplate
     annotations:
       alarms:
-      - arn:aws:cloudwatch:{{AWS_REGION}}:{{AWS_ACCOUNT_ID}}:alarm:esTemplateAlarm
+      - arn:aws:cloudwatch:{{AWS_REGION}}:{{AWS_ACCOUNT_ID}}:alarm:alarmTemplate
     view: singleValue
+
+## header widget for alarms
+alarmHeader:
+- type: text
+  width: 24
+  height: 1
+  properties:
+    markdown: "## Alarms"
+
+## header widget for ECS
+ecsHeader:
+- type: text
+  width: 24
+  height: 1
+  properties:
+    markdown: "# Elastic Container Service"
 
 ## header widget for ES
 esHeader:
@@ -24,14 +40,6 @@ esHeader:
   height: 1
   properties:
     markdown: "# Elasticsearch Service"
-
-# header widget for ES alarms
-esAlarmHeader:
-- type: text
-  width: 24
-  height: 1
-  properties:
-    markdown: "## Alarms"
 
 ## additional widgets for ES
 esWidgets:

--- a/packages/deployment/test/fixtures/config.json
+++ b/packages/deployment/test/fixtures/config.json
@@ -39,6 +39,119 @@
         "clientId": "CUMULUS",
         "password": "kD;LfvcNTBRJXTiUBmFd9Z3Fw%wkgQhWskYyxFJ9w.fXCuq?g7"
     },
+    "ecs": {
+        "restartTasksOnDeploy": true,
+        "amiid": "ami-a7a242da",
+        "instanceType": "t2.medium",
+        "volumeSize": 50,
+        "availabilityZone": "us-east-1b",
+        "maxInstances": 2,
+        "desiredInstances": 2,
+        "tasks": {
+            "AsyncOperation": {
+                "image": "cumuluss/async-operation:25",
+                "cpu": 400,
+                "memory": 700,
+                "count": 1,
+                "envs": {
+                    "AWS_REGION": {
+                        "function": "Fn::Sub",
+                        "value": "${AWS::Region}"
+                    }
+                }
+            }
+        },
+        "docker": {
+            "registry": "dockerhub",
+            "storageDriver": "overlay2",
+            "username": "cumulususer"
+        },
+        "publicIp": true,
+        "services": {
+            "EcsTaskHelloWorld": {
+                "image": "cumuluss/cumulus-ecs-task:1.2.3",
+                "cpu": 400,
+                "memory": 700,
+                "count": 1,
+                "envs": {
+                    "AWS_DEFAULT_REGION": {
+                        "function": "Fn::Sub",
+                        "value": "${AWS::Region}"
+                    }
+                },
+                "commands": [
+                    "cumulus-ecs-task",
+                    "--activityArn",
+                    {
+                        "function": "Ref",
+                        "value": "EcsTaskHelloWorldActivity"
+                    },
+                    "--lambdaArn",
+                    {
+                        "function": "Ref",
+                        "value": "HelloWorldLambdaFunction"
+                    }
+                ],
+                "alarms": {
+                    "TaskCountHigh": {
+                        "alarm_description": "There are more instances running than the desired",
+                        "comparison_operator": "GreaterThanThreshold",
+                        "evaluation_periods": 1,
+                        "metric": "MemoryUtilization",
+                        "statistic": "SampleCount",
+                        "threshold": "1"
+                    }
+                }
+            },
+            "EcsTaskHelloWorldSecond": {
+                "image": "cumuluss/cumulus-ecs-task:1.2.3",
+                "cpu": 400,
+                "memory": 700,
+                "count": 2,
+                "envs": {
+                    "AWS_DEFAULT_REGION": {
+                        "function": "Fn::Sub",
+                        "value": "${AWS::Region}"
+                    }
+                },
+                "commands": [
+                    "cumulus-ecs-task",
+                    "--activityArn",
+                    {
+                        "function": "Ref",
+                        "value": "EcsTaskHelloWorldActivity"
+                    },
+                    "--lambdaArn",
+                    {
+                        "function": "Ref",
+                        "value": "HelloWorldLambdaFunction"
+                    }
+                ]
+            }
+        }
+    },
+    "es": {
+        "name": "es5",
+        "elasticSearchMapping": 8,
+        "version": 5.3,
+        "instanceCount": 2,
+        "instanceType": "t2.small.elasticsearch",
+        "volumeSize": 35,
+        "alarms": {
+            "NodesLow": {
+                "alarm_description": "There are less instances running than the desired",
+                "comparison_operator": "LessThanThreshold",
+                "threshold": "2",
+                "metric": "Nodes"
+            },
+            "NodesHigh": {
+                "alarm_description": "There are more instances running than the desired",
+                "comparison_operator": "GreaterThanThreshold",
+                "threshold": "2",
+                "metric": "Nodes"
+            }
+        }
+    },
     "apiStage": "dev",
     "dynamos": {
         "CollectionsTable": {
@@ -773,5 +886,90 @@
             "WorkflowFailed": {}
         }
     },
-    "distribution_endpoint": "https://example.execute-api.us-east-1.amazonaws.com/dev/"
+    "distribution_endpoint": "https://example.execute-api.us-east-1.amazonaws.com/dev/",
+    "dashboard": 
+    {
+        "alarmTemplate": {
+            "type": "metric",
+            "width": 6,
+            "height": 3,
+            "properties": {
+                "title": "alarmTemplate",
+                "annotations": {
+                    "alarms": [
+                        "arn:aws:cloudwatch:us-east-1:596205514787:alarm:alarmTemplate"
+                    ]
+                },
+                "view": "singleValue"
+            }
+        },
+        "alarmHeader": [
+            {
+                "type": "text",
+                "width": 24,
+                "height": 1,
+                "properties": {
+                    "markdown": "## Alarms"
+                }
+            }
+        ],
+        "ecsHeader": [
+            {
+                "type": "text",
+                "width": 24,
+                "height": 1,
+                "properties": {
+                    "markdown": "# Elastic Container Service"
+                }
+            }
+        ],
+        "esHeader": [
+            {
+                "type": "text",
+                "width": 24,
+                "height": 1,
+                "properties": {
+                    "markdown": "# Elasticsearch Service"
+                }
+            }
+        ],
+        "esWidgets": [
+            {
+                "type": "text",
+                "width": 24,
+                "height": 1,
+                "properties": {
+                    "markdown": "## Overall health"
+                }
+            },
+            {
+                "type": "metric",
+                "width": 6,
+                "height": 6,
+                "properties": {
+                    "view": "timeSeries",
+                    "stacked": false,
+                    "metrics": [
+                        [
+                            "AWS/ES",
+                            "Nodes",
+                            "DomainName",
+                            "jl-test-integration-es5",
+                            "ClientId",
+                            "596205514787"
+                        ]
+                    ],
+                    "region": "us-east-1",
+                    "title": "Total nodes (Count)",
+                    "period": 60,
+                    "stat": "Minimum",
+                    "yAxis": {
+                        "left": {
+                            "showUnits": false
+                        }
+                    }
+                }
+            }
+        ]
+    }
 }


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-803: view the status and health of all Docker services in CloudWatch](https://bugs.earthdata.nasa.gov/browse/CUMULUS-803)

## Changes

* Added CloudWatch alarms to check running tasks of each ECS service, and add the alarms to CloudWatch dashboard
* The CloudWatch metrics for ECS cluster/service are limited, and don't include the status and other Cluster Metadata, so we can't add them in the CloudWatch dashboard like ElasticSearch service.

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

