### PR TITLE
CUMULUS-1198: remove leading slash from provider path expectations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - **CUMULUS-1208** - Updated `@cumulus/ingest/queue/enqueueGranuleIngestMessage()` to not transform granule object passed to it when building an ingest message
+- **CUMULUS-1198** - `@cumulus/ingest` no longer enforces any expectations about whether `provider_path` contains a leading slash or not.
 - **CUMULUS-1170**
   - Update scripts and docs to use `npm` instead of `yarn`
   - Use `package-lock.json` files to ensure matching versions of npm packages

--- a/packages/api/lib/testUtils.js
+++ b/packages/api/lib/testUtils.js
@@ -224,7 +224,7 @@ function fakeCollectionFactory(options = {}) {
       name: randomString(),
       dataType: randomString(),
       version: '0.0.0',
-      provider_path: '/',
+      provider_path: '',
       duplicateHandling: 'replace',
       granuleId: '^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$',
       granuleIdExtraction: '(MOD09GQ\\.(.*))\\.hdf',

--- a/packages/api/models/schemas.js
+++ b/packages/api/models/schemas.js
@@ -85,7 +85,7 @@ module.exports.collection = {
       description: 'The path to look for the collection Granules or '
                    + 'PDRs. Use regex for recursive search',
       type: 'string',
-      default: '/'
+      default: ''
     },
     url_path: {
       title: 'Url Path',

--- a/packages/api/tests/data/granule_failed.json
+++ b/packages/api/tests/data/granule_failed.json
@@ -45,7 +45,7 @@
       "process": "modis",
       "dataType": "MOD09GQ",
       "granuleIdExtraction": "(MOD09GQ\\..*)(\\.hdf|\\.cmr\\.xml|_[\\w]{1,}\\.jpg)",
-      "provider_path": "/",
+      "provider_path": "",
       "version": "006",
       "updatedAt": 1519154288958,
       "duplicateHandling": "replace",

--- a/packages/api/tests/data/granule_success.json
+++ b/packages/api/tests/data/granule_success.json
@@ -56,7 +56,7 @@
       "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "dataType": "MOD09GQ",
       "process": "modis",
-      "provider_path": "/",
+      "provider_path": "",
       "version": "006",
       "updatedAt": 1519154288958,
       "duplicateHandling": "replace",

--- a/packages/api/tests/data/pdr_failure.json
+++ b/packages/api/tests/data/pdr_failure.json
@@ -45,7 +45,7 @@
       "process": "modis",
       "dataType": "MOD09GQ",
       "granuleIdExtraction": "(MOD09GQ\\..*)(\\.hdf|\\.cmr\\.xml|_[\\w]{1,}\\.jpg)",
-      "provider_path": "/",
+      "provider_path": "",
       "version": "006",
       "updatedAt": 1519154288958,
       "duplicateHandling": "replace",

--- a/packages/api/tests/data/pdr_success.json
+++ b/packages/api/tests/data/pdr_success.json
@@ -45,7 +45,7 @@
       "process": "modis",
       "dataType": "MOD09GQ",
       "granuleIdExtraction": "(MOD09GQ\\..*)(\\.hdf|\\.cmr\\.xml|_[\\w]{1,}\\.jpg)",
-      "provider_path": "/",
+      "provider_path": "",
       "version": "006",
       "updatedAt": 1519154288958,
       "duplicateHandling": "replace",

--- a/packages/api/tests/endpoints/collections/update-collection.js
+++ b/packages/api/tests/endpoints/collections/update-collection.js
@@ -84,7 +84,7 @@ test('CUMULUS-912 PUT with pathParameters and with an invalid access token retur
 test.todo('CUMULUS-912 PUT with pathParameters and with an unauthorized user returns an unauthorized response');
 
 test('PUT updates an existing collection', async (t) => {
-  const newPath = '/new_path';
+  const newPath = 'new_path';
   const response = await request(app)
     .put(`/collections/${t.context.testCollection.name}/${t.context.testCollection.version}`)
     .set('Accept', 'application/json')

--- a/packages/ingest/ftp.js
+++ b/packages/ingest/ftp.js
@@ -51,7 +51,7 @@ module.exports.ftpMixin = (superclass) => class extends superclass {
    * @returns {Promise.<string>} - the path that the file was saved to
    */
   async download(remotePath, localPath) {
-    const remoteUrl = `ftp://${this.host}${remotePath}`;
+    const remoteUrl = `ftp://${this.host}/${remotePath}`;
     log.info(`Downloading ${remoteUrl} to ${localPath}`);
 
     if (!this.decrypted) await this.decrypt();
@@ -153,7 +153,7 @@ module.exports.ftpMixin = (superclass) => class extends superclass {
    * @returns {Promise} s3 uri of destination file
    */
   async sync(remotePath, bucket, key) {
-    const remoteUrl = `ftp://${this.host}${remotePath}`;
+    const remoteUrl = `ftp://${this.host}/${remotePath}`;
     const s3uri = buildS3Uri(bucket, key);
     log.info(`Sync ${remoteUrl} to ${s3uri}`);
 

--- a/packages/ingest/granule.js
+++ b/packages/ingest/granule.js
@@ -26,6 +26,7 @@ const { ftpMixin } = require('./ftp');
 const { httpMixin } = require('./http');
 const { s3Mixin } = require('./s3');
 const { baseProtocol } = require('./protocol');
+const { conformProviderPath } = require('./util');
 
 /**
 * The abstract Discover class
@@ -49,12 +50,12 @@ class Discover {
 
     this.port = this.provider.port;
     this.host = this.provider.host;
-    this.path = this.collection.provider_path || '/';
+    this.path = conformProviderPath(this.collection.provider_path);
 
     this.endpoint = buildURL({
       protocol: this.provider.protocol,
-      host: this.provider.host,
-      port: this.provider.port,
+      host: this.host,
+      port: this.port,
       path: this.path
     });
 

--- a/packages/ingest/granule.js
+++ b/packages/ingest/granule.js
@@ -26,7 +26,7 @@ const { ftpMixin } = require('./ftp');
 const { httpMixin } = require('./http');
 const { s3Mixin } = require('./s3');
 const { baseProtocol } = require('./protocol');
-const { conformProviderPath } = require('./util');
+const { normalizeProviderPath } = require('./util');
 
 /**
 * The abstract Discover class
@@ -50,7 +50,7 @@ class Discover {
 
     this.port = this.provider.port;
     this.host = this.provider.host;
-    this.path = conformProviderPath(this.collection.provider_path);
+    this.path = normalizeProviderPath(this.collection.provider_path);
 
     this.endpoint = buildURL({
       protocol: this.provider.protocol,

--- a/packages/ingest/pdr.js
+++ b/packages/ingest/pdr.js
@@ -13,6 +13,7 @@ const { httpMixin } = require('./http');
 const { parsePdr } = require('./parse-pdr');
 const { s3Mixin } = require('./s3');
 const { sftpMixin } = require('./sftp');
+const { conformProviderPath } = require('./util');
 
 
 /**
@@ -46,7 +47,7 @@ class Discover {
     // get authentication information
     this.port = get(this.provider, 'port');
     this.host = get(this.provider, 'host', null);
-    this.path = providerPath || '/';
+    this.path = conformProviderPath(providerPath);
     this.username = get(this.provider, 'username', null);
     this.password = get(this.provider, 'password', null);
   }

--- a/packages/ingest/pdr.js
+++ b/packages/ingest/pdr.js
@@ -13,7 +13,7 @@ const { httpMixin } = require('./http');
 const { parsePdr } = require('./parse-pdr');
 const { s3Mixin } = require('./s3');
 const { sftpMixin } = require('./sftp');
-const { conformProviderPath } = require('./util');
+const { normalizeProviderPath } = require('./util');
 
 
 /**
@@ -47,7 +47,7 @@ class Discover {
     // get authentication information
     this.port = get(this.provider, 'port');
     this.host = get(this.provider, 'host', null);
-    this.path = conformProviderPath(providerPath);
+    this.path = normalizeProviderPath(providerPath);
     this.username = get(this.provider, 'username', null);
     this.password = get(this.provider, 'password', null);
   }

--- a/packages/ingest/recursion.js
+++ b/packages/ingest/recursion.js
@@ -18,7 +18,7 @@ const log = require('@cumulus/common/log');
 async function recursion(fn, originalPath, currentPath = null, position = 0) {
   // build the recursion path object
   const regex = /(\(.*?\))/g;
-  const rules = originalPath.split(regex).map((i) => i.replace(/\\\\/g, '\\'));
+  const rules = (originalPath || '/').split(regex).map((i) => i.replace(/\\\\/g, '\\'));
   const map = rules.map((r) => (r.match(regex) !== null));
 
   let files = [];

--- a/packages/ingest/s3.js
+++ b/packages/ingest/s3.js
@@ -35,13 +35,7 @@ module.exports.s3Mixin = (superclass) => class extends superclass {
    * @private
    */
   async list() {
-    // There are two different "path" variables being set here, which gets
-    // confusing.  "this.path" originally comes from
-    // "event.config.collection.provider_path".  In the case of S3, it refers
-    // to the prefix used when searching for objects.  That should be the
-    // _only_ time that variable is used.
-    //
-    // The other use of "path" here is in reference to the file that was
+    // The use of "path" here is in reference to the file that was
     // discovered.  It's easiest to explain using an example.  Given this URL:
     //
     // s3://my-bucket/some/path/my-file.pdr

--- a/packages/ingest/s3.js
+++ b/packages/ingest/s3.js
@@ -63,21 +63,6 @@ module.exports.s3Mixin = (superclass) => class extends superclass {
       FetchOwner: true
     };
 
-    // The constructor defaults the path to '/' if one is not specified when
-    // this object is created.  That is a problem in the case of S3 because
-    // S3 keys do not start with a leading slash.  This module is mixed in to
-    // a number of different types of objects, not all of which have the same
-    // constructor arguments.  We can't override the constructor here because
-    // of that.  As a result, we need to test for a default path of '/'.
-    // also handle the edge case where leading / in key creates incorrect path
-    // by remove the first slash if it exists
-    if (this.path && this.path !== '/') {
-      if (this.path[0] === '/') {
-        this.path = this.path.substr(1);
-      }
-      params.Prefix = this.path;
-    }
-
     const objects = await aws.listS3ObjectsV2(params);
 
     return objects.map((object) => {

--- a/packages/ingest/sftp.js
+++ b/packages/ingest/sftp.js
@@ -90,7 +90,7 @@ module.exports.sftpMixin = (superclass) => class extends superclass {
   async download(remotePath, localPath) {
     if (!this.connected) await this.connect();
 
-    const remoteUrl = `sftp://${this.host}${remotePath}`;
+    const remoteUrl = `sftp://${this.host}/${remotePath}`;
     log.info(`Downloading ${remoteUrl} to ${localPath}`);
 
     return new Promise((resolve, reject) => {
@@ -186,7 +186,7 @@ module.exports.sftpMixin = (superclass) => class extends superclass {
    * @returns {Promise} s3 uri of destination file
    */
   async sync(remotePath, bucket, key) {
-    const remoteUrl = `sftp://${this.host}${remotePath}`;
+    const remoteUrl = `sftp://${this.host}/${remotePath}`;
     const s3uri = buildS3Uri(bucket, key);
     log.info(`Sync ${remoteUrl} to ${s3uri}`);
 

--- a/packages/ingest/test/test-ftp.js
+++ b/packages/ingest/test/test-ftp.js
@@ -15,7 +15,7 @@ class MyTestDiscoveryClass {
     this.decrypted = true;
     this.host = '127.0.0.1';
     this.password = 'testpass';
-    this.path = '/';
+    this.path = '';
     this.provider = { encrypted: false };
     this.useList = useList;
     this.username = 'testuser';

--- a/packages/ingest/test/test-http.js
+++ b/packages/ingest/test/test-http.js
@@ -21,7 +21,7 @@ http.__set__('Crawler', TestEmitter);
 class MyTestDiscoveryClass {
   constructor(useList) {
     this.decrypted = true;
-    this.path = '/';
+    this.path = '';
     this.provider = {
       protocol: 'http',
       host: 'localhost',

--- a/packages/ingest/test/test-sftp.js
+++ b/packages/ingest/test/test-sftp.js
@@ -26,7 +26,7 @@ class MyTestDiscoveryClass {
     this.host = '127.0.0.1';
     this.port = '2222';
     this.username = 'user';
-    this.path = '/pdrs';
+    this.path = 'pdrs';
     this.provider = {
       encrypted: false,
       privateKey: privateKey

--- a/packages/ingest/test/test-sftp.js
+++ b/packages/ingest/test/test-sftp.js
@@ -26,7 +26,7 @@ class MyTestDiscoveryClass {
     this.host = '127.0.0.1';
     this.port = '2222';
     this.username = 'user';
-    this.path = 'pdrs';
+    this.path = '';
     this.provider = {
       encrypted: false,
       privateKey: privateKey

--- a/packages/ingest/test/test-util.js
+++ b/packages/ingest/test/test-util.js
@@ -1,22 +1,20 @@
 'use strict';
 
 const test = require('ava');
-const { conformProviderPath } = require('../util');
+const { normalizeProviderPath } = require('../util');
 
-test('conformProviderPath removes only leading slashes', (t) => {
+test('normalizeProviderPath removes only leading slashes', (t) => {
   const testString = '/////fake/path/';
-  const conformed = conformProviderPath(testString);
+  const conformed = normalizeProviderPath(testString);
   t.is(conformed, 'fake/path/');
 });
 
-test('conformProviderPath does not act on paths without leading slashes', (t) => {
+test('normalizeProviderPath does not act on paths without leading slashes', (t) => {
   const testString = 'fake/path/';
-  const conformed = conformProviderPath(testString);
+  const conformed = normalizeProviderPath(testString);
   t.is(conformed, 'fake/path/');
 });
 
-test('conformProviderPath returns empty string by default', (t) => {
-  let notString;
-  const conformed = conformProviderPath(notString);
-  t.is(conformed, '');
+test('normalizeProviderPath returns empty string by default', (t) => {
+  t.is(normalizeProviderPath(null), '');
 });

--- a/packages/ingest/test/test-util.js
+++ b/packages/ingest/test/test-util.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const test = require('ava');
+const { conformProviderPath } = require('../util');
+
+test('conformProviderPath removes only leading slashes', (t) => {
+  const testString = '/////fake/path/';
+  const conformed = conformProviderPath(testString);
+  t.is(conformed, 'fake/path/');
+});
+
+test('conformProviderPath does not act on paths without leading slashes', (t) => {
+  const testString = 'fake/path/';
+  const conformed = conformProviderPath(testString);
+  t.is(conformed, 'fake/path/');
+});
+
+test('conformProviderPath returns empty string by default', (t) => {
+  let notString;
+  const conformed = conformProviderPath(notString);
+  t.is(conformed, '');
+});

--- a/packages/ingest/util.js
+++ b/packages/ingest/util.js
@@ -11,6 +11,7 @@ function conformProviderPath(provPath) {
     if (provPath[0] === '/') {
       return provPath.substr(1);
     }
+    return provPath;
   }
   return '';
 }

--- a/packages/ingest/util.js
+++ b/packages/ingest/util.js
@@ -2,16 +2,15 @@
 
 /**
  * Ensure provider path conforms to expectations.
+ * Removes any/all leading forward slashes.
  *
  * @param {string} provPath - provider path
  * @returns {string} path, updated to conform if necessary.
  */
 function conformProviderPath(provPath) {
   if (provPath) {
-    if (provPath[0] === '/') {
-      return provPath.substr(1);
-    }
-    return provPath;
+    const leadingSlashRegex = /^\/*/g;
+    return provPath.replace(leadingSlashRegex, '');
   }
   return '';
 }

--- a/packages/ingest/util.js
+++ b/packages/ingest/util.js
@@ -7,7 +7,7 @@
  * @param {string} provPath - provider path
  * @returns {string} path, updated to conform if necessary.
  */
-function conformProviderPath(provPath) {
+function normalizeProviderPath(provPath) {
   if (provPath) {
     const leadingSlashRegex = /^\/*/g;
     return provPath.replace(leadingSlashRegex, '');
@@ -16,5 +16,5 @@ function conformProviderPath(provPath) {
 }
 
 module.exports = {
-  conformProviderPath
+  normalizeProviderPath
 };

--- a/packages/ingest/util.js
+++ b/packages/ingest/util.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/**
+ * Ensure provider path conforms to expectations.
+ *
+ * @param {string} provPath - provider path
+ * @returns {string} path, updated to conform if necessary.
+ */
+function conformProviderPath(provPath) {
+  if (provPath) {
+    if (provPath[0] === '/') {
+      return provPath.substr(1);
+    }
+  }
+  return '';
+}
+
+module.exports = {
+  conformProviderPath
+};

--- a/packages/test-data/cumulus_messages/discover-pdrs.json
+++ b/packages/test-data/cumulus_messages/discover-pdrs.json
@@ -39,7 +39,7 @@
     "collection": {
       "process": "modis",
       "duplicateHandling": "replace",
-      "provider_path": "/",
+      "provider_path": "",
       "granuleIdExtraction": "(MOD09GQ\\..*)(\\.hdf|\\.cmr\\.xml|_[\\w]{1,}\\.jpg)",
       "version": "006",
       "dataType": "MOD09GQ",

--- a/packages/test-data/cumulus_messages/discover-s3-granules.json
+++ b/packages/test-data/cumulus_messages/discover-s3-granules.json
@@ -39,7 +39,7 @@
     "collection": {
       "process": "modis",
       "duplicateHandling": "replace",
-      "provider_path": "/",
+      "provider_path": "",
       "granuleIdExtraction": "(MOD09GQ\\..*)(\\.hdf|\\.cmr\\.xml|_[\\w]{1,}\\.jpg)",
       "version": "006",
       "dataType": "MOD09GQ",

--- a/packages/test-data/cumulus_messages/parse-pdr.json
+++ b/packages/test-data/cumulus_messages/parse-pdr.json
@@ -64,7 +64,7 @@
       "process": "modis",
       "dataType": "MOD09GQ",
       "granuleIdExtraction": "(MOD09GQ\\..*)(\\.hdf|\\.cmr\\.xml|_[\\w]{1,}\\.jpg)",
-      "provider_path": "/",
+      "provider_path": "",
       "version": "006",
       "updatedAt": 1519154288958,
       "duplicateHandling": "replace",

--- a/packages/test-data/cumulus_messages/pdr-status-check.json
+++ b/packages/test-data/cumulus_messages/pdr-status-check.json
@@ -46,7 +46,7 @@
       "process": "modis",
       "dataType": "MOD09GQ",
       "granuleIdExtraction": "(MOD09GQ\\..*)(\\.hdf|\\.cmr\\.xml|_[\\w]{1,}\\.jpg)",
-      "provider_path": "/",
+      "provider_path": "",
       "version": "006",
       "updatedAt": 1519154288958,
       "duplicateHandling": "replace",

--- a/packages/test-data/cumulus_messages/post-to-cmr.json
+++ b/packages/test-data/cumulus_messages/post-to-cmr.json
@@ -49,7 +49,7 @@
       "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "dataType": "MOD09GQ",
       "process": "modis",
-      "provider_path": "/",
+      "provider_path": "",
       "version": "006",
       "updatedAt": 1519154288958,
       "duplicateHandling": "replace",

--- a/packages/test-data/cumulus_messages/sync-granule.json
+++ b/packages/test-data/cumulus_messages/sync-granule.json
@@ -70,7 +70,7 @@
       "process": "aster",
       "dataType": "AST_L1A",
       "granuleIdExtraction": "^pg-[P|B]R(1A.*)$",
-      "provider_path": "/TEST_B/Cumulus/PDR/",
+      "provider_path": "TEST_B/Cumulus/PDR/",
       "version": "003",
       "url_path": "/",
       "updatedAt": 1517326637137,

--- a/packages/test-data/payloads/amsr2/discover.json
+++ b/packages/test-data/payloads/amsr2/discover.json
@@ -50,7 +50,7 @@
     "meta": {
       "name": "AMSR2",
       "version": "1",
-      "provider_path": "/prd/NRT/([\\d]{4}\\.[\\d]{2}\\.[\\d]{2})/L1/L1R/global",
+      "provider_path": "prd/NRT/([\\d]{4}\\.[\\d]{2}\\.[\\d]{2})/L1/L1R/global",
       "granuleId": "^GW1AM2_[\\d]{12}_[\\d]{3}B_L1S[N|G]RTBR_[\\d]{7}$",
       "sampleFileName": "GW1AM2_201708071110_057B_L1SNRTBR_2220220.h5.gz",
       "granuleIdExtraction": "^(GW1AM2_(.*))\\.h5\\.gz$",

--- a/packages/test-data/payloads/modis/cmr.json
+++ b/packages/test-data/payloads/modis/cmr.json
@@ -44,7 +44,7 @@
     "dataType": "MOD11A1",
     "granuleIdExtraction": "(MOD11A1\\.(.*))\\.hdf",
     "process": "modis",
-    "provider_path": "/TEST_B/Cumulus/MODIS/PDR/",
+    "provider_path": "TEST_B/Cumulus/MODIS/PDR/",
     "version": "006",
     "sampleFileName": "MOD11A1.A2017025.h21v00.006.2017034065104.hdf",
     "id": "MOD11A1"

--- a/packages/test-data/payloads/modis/discover.json
+++ b/packages/test-data/payloads/modis/discover.json
@@ -49,7 +49,7 @@
       "name": "MOD09GQ",
       "version": "006",
       "process": "modis",
-      "provider_path": "/TEST_B/Cumulus/PDR/TEST_CASES",
+      "provider_path": "TEST_B/Cumulus/PDR/TEST_CASES",
       "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
       "granuleIdExtraction": "(MOD09GQ\\.(.*))\\.hdf",

--- a/packages/test-data/payloads/modis/ingest-checksumfile.json
+++ b/packages/test-data/payloads/modis/ingest-checksumfile.json
@@ -48,7 +48,7 @@
       "name": "MOD09GQ",
       "version": "006",
       "process": "modis",
-      "provider_path": "/MODOPS/MODAPS/EDC/CUMULUS/FPROC/PDR/",
+      "provider_path": "MODOPS/MODAPS/EDC/CUMULUS/FPROC/PDR/",
       "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
       "granuleIdExtraction": "(MOD09GQ\\.(.*))\\.hdf",

--- a/packages/test-data/payloads/modis/ingest.json
+++ b/packages/test-data/payloads/modis/ingest.json
@@ -51,7 +51,7 @@
       "name": "MOD09GQ",
       "version": "006",
       "process": "modis",
-      "provider_path": "/MODOPS/MODAPS/EDC/CUMULUS/FPROC/PDR/",
+      "provider_path": "MODOPS/MODAPS/EDC/CUMULUS/FPROC/PDR/",
       "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
       "granuleIdExtraction": "(MOD09GQ\\.(.*))\\.hdf",

--- a/packages/test-data/payloads/modis/parse.json
+++ b/packages/test-data/payloads/modis/parse.json
@@ -49,7 +49,7 @@
       "name": "MOD09GQ",
       "version": "006",
       "process": "modis",
-      "provider_path": "/TEST_B/Cumulus/PDR/TEST_CASES",
+      "provider_path": "TEST_B/Cumulus/PDR/TEST_CASES",
       "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
       "granuleIdExtraction": "(MOD09GQ\\.(.*))\\.hdf",

--- a/packages/test-data/payloads/mur/discover.json
+++ b/packages/test-data/payloads/mur/discover.json
@@ -48,7 +48,7 @@
       "name": "MUR-JPL-L4-GLOB-v4.1",
       "dataType": "MUR-JPL-L4-GLOB",
       "version": "4.1",
-      "provider_path": "/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2017/(20[\\d])",
+      "provider_path": "allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2017/(20[\\d])",
       "granuleId": "^.*$",
       "sampleFileName": "20170603090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc",
       "granuleIdExtraction": "^(.*)\\.(nc|nc\\.md5)$",

--- a/packages/test-data/payloads/new-message-schema/cmr.json
+++ b/packages/test-data/payloads/new-message-schema/cmr.json
@@ -52,7 +52,7 @@
       "dataType": "MYD09A1",
       "granuleIdExtraction": "(MYD09A1\\..*)(\\.hdf|\\.cmr\\.xml|_[\\w]{1,}\\.jpg)",
       "process": "modis",
-      "provider_path": "/MODOPS/MODAPS/EDC/CUMULUS/FPROC/PDR/",
+      "provider_path": "MODOPS/MODAPS/EDC/CUMULUS/FPROC/PDR/",
       "version": "006",
       "duplicateHandling": "replace",
       "sampleFileName": "MYD09A1.A2017025.h21v00.006.2017034065104.hdf"

--- a/packages/test-data/payloads/new-message-schema/discover.json
+++ b/packages/test-data/payloads/new-message-schema/discover.json
@@ -44,7 +44,7 @@
       "name": "MOD09GQ",
       "version": "006",
       "process": "modis",
-      "provider_path": "/TEST_B/Cumulus/PDR/TEST_CASES",
+      "provider_path": "TEST_B/Cumulus/PDR/TEST_CASES",
       "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
       "granuleIdExtraction": "(MOD09GQ\\.(.*))\\.hdf",

--- a/packages/test-data/payloads/new-message-schema/ingest-checksumfile.json
+++ b/packages/test-data/payloads/new-message-schema/ingest-checksumfile.json
@@ -44,7 +44,7 @@
       "name": "MOD09GQ",
       "version": "6",
       "process": "modis",
-      "provider_path": "/MODOPS/MODAPS/EDC/CUMULUS/FPROC/PDR/",
+      "provider_path": "MODOPS/MODAPS/EDC/CUMULUS/FPROC/PDR/",
       "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
       "granuleIdExtraction": "(MOD09GQ\\.(.*))\\.hdf",

--- a/packages/test-data/payloads/new-message-schema/ingest.json
+++ b/packages/test-data/payloads/new-message-schema/ingest.json
@@ -46,7 +46,7 @@
       "dataType": "MOD09GQ",
       "version": "6",
       "process": "modis",
-      "provider_path": "/MODOPS/MODAPS/EDC/CUMULUS/FPROC/PDR/",
+      "provider_path": "MODOPS/MODAPS/EDC/CUMULUS/FPROC/PDR/",
       "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
       "granuleIdExtraction": "(MOD09GQ\\.(.*))\\.hdf",

--- a/packages/test-data/payloads/new-message-schema/parse.json
+++ b/packages/test-data/payloads/new-message-schema/parse.json
@@ -13,7 +13,7 @@
       "name": "MOD09GQ",
       "version": "006",
       "process": "modis",
-      "provider_path": "/TEST_B/Cumulus/PDR/TEST_CASES",
+      "provider_path": "TEST_B/Cumulus/PDR/TEST_CASES",
       "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
       "granuleIdExtraction": "(MOD09GQ\\.(.*))\\.hdf",

--- a/tasks/discover-granules/tests/fixtures/mur.json
+++ b/tasks/discover-granules/tests/fixtures/mur.json
@@ -28,7 +28,7 @@
       "name": "MUR-JPL-L4-GLOB-v4.1",
       "dataType": "MUR-JPL-L4-GLOB",
       "version": "4.1",
-      "provider_path": "/allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2017/(20[1-3])",
+      "provider_path": "allData/ghrsst/data/GDS2/L4/GLOB/JPL/MUR/v4.1/2017/(20[1-3])",
       "granuleId": "^.*$",
       "sampleFileName": "20170603090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc",
       "granuleIdExtraction": "^(.*)\\.(nc|nc\\.md5)$",

--- a/tasks/discover-granules/tests/index.js
+++ b/tasks/discover-granules/tests/index.js
@@ -59,8 +59,7 @@ test('discover granules sets the correct dataType for granules', async (t) => {
   }
 });
 
-// This test is broken and will be fixed by CUMULUS-427
-test.skip('discover granules using FTP', async (t) => {
+test('discover granules using FTP', async (t) => {
   const { event } = t.context;
   event.config.bucket = randomString();
   event.config.collection.provider_path = '/granules/fake_granules';

--- a/tasks/discover-pdrs/tests/fixtures/input.json
+++ b/tasks/discover-pdrs/tests/fixtures/input.json
@@ -13,7 +13,7 @@
       "name": "MOD09GQ",
       "version": "006",
       "process": "modis",
-      "provider_path": "/TEST_B/Cumulus/PDR/TEST_CASES",
+      "provider_path": "TEST_B/Cumulus/PDR/TEST_CASES",
       "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
       "granuleIdExtraction": "(MOD09GQ\\.(.*))\\.hdf",

--- a/tasks/move-granules/tests/data/payload.json
+++ b/tasks/move-granules/tests/data/payload.json
@@ -59,7 +59,7 @@
       "granuleId": "^MOD11A1\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}$",
       "dataType": "MOD11A1",
       "process": "modis",
-      "provider_path": "/TEST_B/Cumulus/MODIS/PDR/",
+      "provider_path": "TEST_B/Cumulus/MODIS/PDR/",
       "version": "006",
       "sampleFileName": "MOD11A1.A2017200.h19v04.006.2017201090724.hdf",
       "id": "MOD11A1"

--- a/tasks/queue-pdrs/tests/fixtures/input.json
+++ b/tasks/queue-pdrs/tests/fixtures/input.json
@@ -8,7 +8,7 @@
       "name": "MOD09GQ",
       "version": "006",
       "process": "modis",
-      "provider_path": "/TEST_B/Cumulus/PDR/TEST_CASES",
+      "provider_path": "TEST_B/Cumulus/PDR/TEST_CASES",
       "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
       "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
       "granuleIdExtraction": "(MOD09GQ\\.(.*))\\.hdf",


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-1198: Inconsistent Provider Path expectations](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1198)

## Changes

* Fix `packages/ingest` to remove leading slash from expectations.
* Continue to _allow_ both forms, but expect no leading slash.

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Adhoc testing
- [x] Integration tests

