### PR TITLE
Re-factor users config for deployment

### DIFF
--- a/docs/deployment/config_descriptions.md
+++ b/docs/deployment/config_descriptions.md
@@ -80,7 +80,7 @@ For information on how to locate them in the Console see [Locating Cumulus IAM R
 
 ## users
 
-List of EarthData users you wish to have access to your dashboard application.   These users will be populated in your `<stackname>-UsersTable` [DynamoDb](https://console.aws.amazon.com/dynamodb/) (in addition to the default_users defined in the Cumulus default template).
+List of EarthData users you wish to have access to your dashboard application. These users will be populated in your `<stackname>-UsersTable` [DynamoDb](https://console.aws.amazon.com/dynamodb/) table.
 
 # Footnotes
 

--- a/example/app/config.yml
+++ b/example/app/config.yml
@@ -182,7 +182,18 @@ default:
 
   # URS users who should have access to the dashboard application.
   users:
-    - username: testuser
+    - username: aimeeb
+    - username: jennyhliu
+    - username: jnorton1
+    - username: kbaynes
+    - username: kkelly
+    - username: kovarik
+    - username: lfrederick
+    - username: mhuffnagle2
+    - username: pquinn1
+    - username: menno.vandiermen
+    - username: matthewsavoie
+    - username: mboyd
 
 
 # ------------------------

--- a/packages/deployment/README.md
+++ b/packages/deployment/README.md
@@ -45,7 +45,6 @@ For example:
 | ems.provider | CUMULUS | the provider used for sending reports to EMS
 | vpc.vpcId | (required if ecs is used) | the vpcId used with the deployment
 | vpc.subnets | (required) | the subnets used
-| defaults_users | cumulus core | list of default users included in all deployments
 | ecs.amiid | ami-9eb4b1e5 | amiid of an optimized ecs instance (differnet for each region)
 | ecs.instanceType | (required) | the instance type of the ec2 machine used for running ecs tasks
 | ecs.volumeSize | 50 | the storage on ec2 instance running the ecs tasks

--- a/packages/deployment/app/cloudformation.template.yml
+++ b/packages/deployment/app/cloudformation.template.yml
@@ -151,12 +151,6 @@ Resources:
         table:
           Ref: UsersTableDynamoDB
         records:
-        {{# each default_users}}
-          {{# if this }}
-          - username: {{@key}}
-            password: OAuth
-          {{/if}}
-        {{/each}}
         {{# each users}}
           - username: {{username}}
             password: OAuth

--- a/packages/deployment/app/config.yml
+++ b/packages/deployment/app/config.yml
@@ -81,21 +81,6 @@ default:
     subnets:
       - subnet-xxxxx #change me
 
-  default_users:
-    aimeeb: true
-    jennyhliu: true
-    jnorton1: true
-    kbaynes: true
-    kkelly: true
-    kovarik: true
-    lfrederick: true
-    mhuffnagle2: true
-    pquinn1: true
-    sethvincent: true
-    menno.vandiermen: true
-    matthewsavoie: true
-    mboyd: true
-
   ecs:
     restartTasksOnDeploy: false
     amiid: ami-6944c513


### PR DESCRIPTION
While pairing with Brian B on dashboard login issues, we noticed that even though he had specified `users` in his app's config.yml, the default list of Cumulus core developers still had access to his API/dashboard. Initially, I thought this was because Kes was merging the `users` config with the default list of users from the deployment package. 

In fact, the default list of users in the deployment package is stored on a `default_users` key, which is always added to the list of users in cloudformation.template.yml. So this is not a Kes merging issue.

Since all Cumulus users rely on the deployment package, it seems like it shouldn't be including hidden configuration that they cannot modify, especially as it pertains to user with access to their deployments. Also, for the Cumulus core team deployments, setting our deployment config in `example/` to use the same `users` config as everyone else makes our configuration less idiosyncratic  which is beneficial for making our test deployments match how users actually deploy Cumulus.

I was going to file a ticket for this, but it seemed just as quick to actually fix it and issue a PR.