### PR TITLE
CUMULUS-777: Ancillary File in Granule & CMR Record Feature Validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- **CUMULUS-777**
+  - Added new cookbook entry on configuring Cumulus to track ancillary files.
 - **CUMULUS-853**
   - Updated FakeProcessing example lambda to include option to generate fake browse
   - Added feature documentation for ancillary metadata export, a new cookbook entry describing a workflow with ancillary metadata generation(browse), and related task definition documentation

--- a/docs/data-cookbooks/browse-generation.md
+++ b/docs/data-cookbooks/browse-generation.md
@@ -477,7 +477,7 @@ In our example, the payload would look like the following.  **Note**: The fileTy
           },
           {
             "name": "MOD09GQ.A2016358.h13v04.006.2016360104606.hdf.met",
-            "fileType": "meatadata",
+            "fileType": "metadata",
             "bucket": "cumulus-test-sandbox-internal",
             "filename": "s3://cumulus-test-sandbox-internal/file-staging/jk2/MOD09GQ___006/MOD09GQ.A2016358.h13v04.006.2016360104606.hdf.met",
             "fileStagingDir": "file-staging/jk2/MOD09GQ___006",
@@ -568,7 +568,7 @@ The ```FilesToGranules``` task utilizes the incoming payload to chose which file
           },
           {
             "name": "MOD09GQ.A2016358.h13v04.006.2016360104606.hdf.met",
-            "fileType": "meatadata",
+            "fileType": "metadata",
             "bucket": "cumulus-test-sandbox-internal",
             "filename": "s3://cumulus-test-sandbox-internal/file-staging/jk2/MOD09GQ___006/MOD09GQ.A2016358.h13v04.006.2016360104606.hdf.met",
             "fileStagingDir": "file-staging/jk2/MOD09GQ___006",

--- a/docs/data-cookbooks/tracking-files.md
+++ b/docs/data-cookbooks/tracking-files.md
@@ -1,6 +1,6 @@
 ---
 id: tracking-files
-title: Tracking Files
+title: Tracking Ancillary Files
 hide_title: true
 ---
 

--- a/docs/data-cookbooks/tracking-files.md
+++ b/docs/data-cookbooks/tracking-files.md
@@ -1,0 +1,83 @@
+---
+id: tracking-files
+title: Tracking Files
+hide_title: true
+---
+
+# Tracking Files
+
+## Contents
+
+* [Introduction](#introduction)
+* [File Types](#file-types)
+* [Collection Configuration](#collection-configuration)
+* [Publish to CMR](#publish-to-cmr)
+
+### Introduction
+
+This document covers setting up ingest to track primary and ancillary files under various file types, which will carry through to the CMR and granule record.
+Cumulus has a number of options for tracking files and publishing files to CMR under certain metadata elements or with specified file types.
+We will cover Cumulus file types, collection configuration, and effects on publishing to CMR.
+
+### File types
+
+Cumulus follows the Cloud Notification Mechanism (CNM) file type conventions. Under this schema, there are four data types:
+
+* `data`
+* `browse`
+* `metadata`
+* `qa`
+
+In Cumulus, these data types are mapped to the `Type` attribute on `RelatedURL`s for UMM-G metadata, or used to map
+resources to one of `OnlineAccessURL`, `OnlineResource` or `AssociatedBrowseImages` for ECHO10 XML metadata.
+
+### Collection Configuration
+
+File types for each file in a granule can be configured at the collection level as below:
+
+```json
+{
+  "name": "MOD09GQ",
+  "version": "006",
+  "dataType": "MOD09GQ",
+  "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
+  "granuleIdExtraction": "(MOD09GQ\\..*)(\\.hdf|\\.cmr|_ndvi\\.jpg)",
+  "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
+  "files": [
+    {
+      "bucket": "protected",
+      "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$",
+      "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
+      "fileType": "data"
+    },
+    {
+      "bucket": "protected-2",
+      "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.cmr\\.xml$",
+      "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.cmr.xml",
+      "fileType": "metadata"
+    },
+    {
+      "bucket": "public",
+      "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}_ndvi\\.jpg$",
+      "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104_ndvi.jpg",
+      "fileType": "browse"
+    }
+  ]
+}
+```
+
+Files on a particular granule which match a given file specification will be receive the provided `fileType` in the granule record,
+which will then be used to inform CMR metadata updates in the publish step.
+
+### Publish to CMR
+
+When publishing granule metadata to CMR, the `PostToCmr` task will perform a few metadata updates in the area of URLs for its respective metadata schema.
+The table below shows how the CNM data types map to CMR Metadata updates.
+The UMM-G column reflects the `RelatedURL`'s `Type` derived from the CNM type, whereas the ECHO10 column shows how the CNM type affects the destination element.
+
+|CNM Type |UMM-G Location |ECHO10 Location |
+| ------  | ------ | ------ |
+| `data` | `RelatedURL.Type = 'GET DATA'` | `OnlineAccessURL` |
+| `browse` | `RelatedURL.Type = 'GET RELATED VISUALIZATION'` | `AssociatedBrowseImage` |
+| `metadata` | `RelatedURL.Type = 'EXTENDED METADATA` | `OnlineResource` |
+| `qa` | `RelatedURL.Type = 'EXTENDED METADATA'` | `OnlineResource` |

--- a/docs/data-cookbooks/tracking-files.md
+++ b/docs/data-cookbooks/tracking-files.md
@@ -12,6 +12,7 @@ hide_title: true
 * [File Types](#file-types)
 * [Collection Configuration](#collection-configuration)
 * [Publish to CMR](#publish-to-cmr)
+* [Common Use Cases](#common-use-cases)
 
 ### Introduction
 
@@ -81,3 +82,40 @@ The UMM-G column reflects the `RelatedURL`'s `Type` derived from the CNM type, w
 | `browse` | `RelatedURL.Type = 'GET RELATED VISUALIZATION'` | `AssociatedBrowseImage` |
 | `metadata` | `RelatedURL.Type = 'EXTENDED METADATA` | `OnlineResource` |
 | `qa` | `RelatedURL.Type = 'EXTENDED METADATA'` | `OnlineResource` |
+
+### Common Use Cases
+
+This section briefly documents some common use cases and the recommended collection configuration for the file.
+
+Configuring browse imagery:
+
+```json
+{
+  "bucket": "public",
+  "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\_[\\d]{1}.jpg$",
+  "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104_1.jpg",
+  "fileType": "browse"
+}  
+```
+
+Configuring a documentation entry:
+
+```json
+{
+  "bucket": "protected",
+  "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\_README.pdf$",
+  "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104_README.pdf",
+  "fileType": "metadata"
+}
+```
+
+Configuring other associated files (use fileTypes `metadata` or `qa` as appropriate):
+
+```json
+{
+  "bucket": "protected",
+  "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\_QA.txt$",
+  "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104_QA.txt",
+  "fileType": "qa"
+}
+```

--- a/docs/data-cookbooks/tracking-files.md
+++ b/docs/data-cookbooks/tracking-files.md
@@ -10,7 +10,7 @@ hide_title: true
 
 * [Introduction](#introduction)
 * [File Types](#file-types)
-* [Collection Configuration](#collection-configuration)
+* [File Type Configuration](#file-type-configuration)
 * [Publish to CMR](#publish-to-cmr)
 * [Common Use Cases](#common-use-cases)
 
@@ -18,7 +18,7 @@ hide_title: true
 
 This document covers setting up ingest to track primary and ancillary files under various file types, which will carry through to the CMR and granule record.
 Cumulus has a number of options for tracking files and publishing files to CMR under certain metadata elements or with specified file types.
-We will cover Cumulus file types, collection configuration, and effects on publishing to CMR.
+We will cover Cumulus file types, file type configuration, effects on publishing to CMR, and some common use case examples.
 
 ### File types
 
@@ -32,48 +32,15 @@ Cumulus follows the Cloud Notification Mechanism (CNM) file type conventions. Un
 In Cumulus, these data types are mapped to the `Type` attribute on `RelatedURL`s for UMM-G metadata, or used to map
 resources to one of `OnlineAccessURL`, `OnlineResource` or `AssociatedBrowseImages` for ECHO10 XML metadata.
 
-### Collection Configuration
+### File Type Configuration
 
-File types for each file in a granule can be configured at the collection level as below:
-
-```json
-{
-  "name": "MOD09GQ",
-  "version": "006",
-  "dataType": "MOD09GQ",
-  "granuleId": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}$",
-  "granuleIdExtraction": "(MOD09GQ\\..*)(\\.hdf|\\.cmr|_ndvi\\.jpg)",
-  "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
-  "files": [
-    {
-      "bucket": "protected",
-      "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$",
-      "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.hdf",
-      "fileType": "data"
-    },
-    {
-      "bucket": "protected-2",
-      "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.cmr\\.xml$",
-      "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104.cmr.xml",
-      "fileType": "metadata"
-    },
-    {
-      "bucket": "public",
-      "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}_ndvi\\.jpg$",
-      "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104_ndvi.jpg",
-      "fileType": "browse"
-    }
-  ]
-}
-```
-
-Files on a particular granule which match a given file specification will be receive the provided `fileType` in the granule record,
-which will then be used to inform CMR metadata updates in the publish step.
+File types for each file in a granule can be configured in a number of different ways, depending on the ingest type and workflow.
+For more information, see the [ancillary metadata](../features/ancillary_metadata) documentation.
 
 ### Publish to CMR
 
 When publishing granule metadata to CMR, the `PostToCmr` task will perform a few metadata updates in the area of URLs for its respective metadata schema.
-The table below shows how the CNM data types map to CMR Metadata updates.
+The table below shows how the CNM data types map to CMR Metadata updates. Non-CNM file types are handled as 'data' file types.
 The UMM-G column reflects the `RelatedURL`'s `Type` derived from the CNM type, whereas the ECHO10 column shows how the CNM type affects the destination element.
 
 |CNM Type |UMM-G Location |ECHO10 Location |
@@ -85,7 +52,9 @@ The UMM-G column reflects the `RelatedURL`'s `Type` derived from the CNM type, w
 
 ### Common Use Cases
 
-This section briefly documents some common use cases and the recommended collection configuration for the file.
+This section briefly documents some common use cases and the recommended configuration for the file.
+The examples shown here are for the DiscoverGranules use case, which allows configuration at the Cumulus dashboard level.
+The other two cases covered in the [ancillary metadata](../features/ancillary_metadata) documentation require configuration at the provider notification level (either CNM message or PDR) and are not covered here.
 
 Configuring browse imagery:
 

--- a/docs/data-cookbooks/tracking-files.md
+++ b/docs/data-cookbooks/tracking-files.md
@@ -43,12 +43,12 @@ When publishing granule metadata to CMR, the `PostToCmr` task will perform a few
 The table below shows how the CNM data types map to CMR Metadata updates. Non-CNM file types are handled as 'data' file types.
 The UMM-G column reflects the `RelatedURL`'s `Type` derived from the CNM type, whereas the ECHO10 column shows how the CNM type affects the destination element.
 
-|CNM Type |UMM-G Location |ECHO10 Location |
+|CNM Type |UMM-G `RelatedUrl.Type` |ECHO10 Location |
 | ------  | ------ | ------ |
-| `data` | `RelatedURL.Type = 'GET DATA'` | `OnlineAccessURL` |
-| `browse` | `RelatedURL.Type = 'GET RELATED VISUALIZATION'` | `AssociatedBrowseImage` |
-| `metadata` | `RelatedURL.Type = 'EXTENDED METADATA` | `OnlineResource` |
-| `qa` | `RelatedURL.Type = 'EXTENDED METADATA'` | `OnlineResource` |
+| `data` | `'GET DATA'` | `OnlineAccessURL` |
+| `browse` | `'GET RELATED VISUALIZATION'` | `AssociatedBrowseImage` |
+| `metadata` | `'EXTENDED METADATA'` | `OnlineResource` |
+| `qa` | `'EXTENDED METADATA'` | `OnlineResource` |
 
 ### Common Use Cases
 

--- a/docs/data-cookbooks/tracking-files.md
+++ b/docs/data-cookbooks/tracking-files.md
@@ -11,14 +11,14 @@ hide_title: true
 * [Introduction](#introduction)
 * [File Types](#file-types)
 * [File Type Configuration](#file-type-configuration)
-* [Publish to CMR](#publish-to-cmr)
+* [CMR Metadata](#cmr-metadata)
 * [Common Use Cases](#common-use-cases)
 
 ### Introduction
 
 This document covers setting up ingest to track primary and ancillary files under various file types, which will carry through to the CMR and granule record.
-Cumulus has a number of options for tracking files and publishing files to CMR under certain metadata elements or with specified file types.
-We will cover Cumulus file types, file type configuration, effects on publishing to CMR, and some common use case examples.
+Cumulus has a number of options for tracking files in granule records, and in CMR metadata under certain metadata elements or with specified file types.
+We will cover Cumulus file types, file type configuration, effects on CMR metadata, and some common use case examples.
 
 ### File types
 
@@ -37,10 +37,10 @@ resources to one of `OnlineAccessURL`, `OnlineResource` or `AssociatedBrowseImag
 File types for each file in a granule can be configured in a number of different ways, depending on the ingest type and workflow.
 For more information, see the [ancillary metadata](../features/ancillary_metadata) documentation.
 
-### Publish to CMR
+### CMR Metadata
 
-When publishing granule metadata to CMR, the `PostToCmr` task will perform a few metadata updates in the area of URLs for its respective metadata schema.
-The table below shows how the CNM data types map to CMR Metadata updates. Non-CNM file types are handled as 'data' file types.
+When updating granule CMR metadata, the `MoveGranules` task will add the external facing URLs to the CMR metadata file based on the fileType.
+The table below shows how the CNM data types map to CMR metadata updates. Non-CNM file types are handled as 'data' file types.
 The UMM-G column reflects the `RelatedURL`'s `Type` derived from the CNM type, whereas the ECHO10 column shows how the CNM type affects the destination element.
 
 |CNM Type |UMM-G `RelatedUrl.Type` |ECHO10 Location |

--- a/docs/features/ancillary_metadata.md
+++ b/docs/features/ancillary_metadata.md
@@ -25,3 +25,8 @@ This feature utilizes the fileType key on a files object in a Cumulus [granule](
   Uses the granule file fileType key to update UMM/ECHO 10 CMR files passed in as candidates to the task.   This task adds the external facing URLs to the CMR metadata file based on the fileType.
 
   If a non CNM fileType is specified, the task assumes it is a 'data' file.
+
+### Post to CMR
+  When publishing granule metadata to CMR, the `PostToCmr` task will perform a few metadata updates in the area of URLs for its respective metadata schema.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  If a non CNM fileType is specified, the task assumes it is a 'data' file and will use the 'data' mapping for URLs.

--- a/docs/features/ancillary_metadata.md
+++ b/docs/features/ancillary_metadata.md
@@ -22,11 +22,6 @@ This feature utilizes the fileType key on a files object in a Cumulus [granule](
 ## Tasks using fileType
 
 ### [Move Granules](../workflow_tasks/move_granules)
-  Uses the granule file fileType key to update UMM/ECHO 10 CMR files passed in as candidates to the task.   This task adds the external facing URLs to the CMR metadata file based on the fileType.
-
-  If a non CNM fileType is specified, the task assumes it is a 'data' file.
-
-### Post to CMR
-  When publishing granule metadata to CMR, the `PostToCmr` task will perform a few metadata updates in the area of URLs for its respective metadata schema.
+  Uses the granule file fileType key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the fileType.
   See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
-  If a non CNM fileType is specified, the task assumes it is a 'data' file and will use the 'data' mapping for URLs.
+  If a non CNM fileType is specified, the task assumes it is a 'data' file.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -26,6 +26,14 @@ Discover PDRs in FTP and HTTP endpoints
 
 ---
 
+### [@cumulus/files-to-granules](https://github.com/nasa/cumulus/tree/master/tasks/post-to-cmr)
+Converts array-of-files input into a granules object by extracting granuleId from filename
+
+- Schemas: See this module's [schema definitions](https://github.com/nasa/cumulus/tree/master/tasks/post-to-cmr/schemas).
+- Resources: [npm](https://npmjs.com/package/@cumulus/files-to-granules) | [source](https://github.com/nasa/cumulus) | [web](https://github.com/nasa/cumulus/tree/master/tasks/post-to-cmr)
+
+---
+
 ### [@cumulus/hello-world](https://github.com/nasa/cumulus/tree/master/tasks/hello-world)
 Example task
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -26,11 +26,11 @@ Discover PDRs in FTP and HTTP endpoints
 
 ---
 
-### [@cumulus/files-to-granules](https://github.com/nasa/cumulus/tree/master/tasks/post-to-cmr)
+### [@cumulus/files-to-granules](https://github.com/nasa/cumulus/tree/master/tasks/files-to-granules)
 Converts array-of-files input into a granules object by extracting granuleId from filename
 
-- Schemas: See this module's [schema definitions](https://github.com/nasa/cumulus/tree/master/tasks/post-to-cmr/schemas).
-- Resources: [npm](https://npmjs.com/package/@cumulus/files-to-granules) | [source](https://github.com/nasa/cumulus) | [web](https://github.com/nasa/cumulus/tree/master/tasks/post-to-cmr)
+- Schemas: See this module's [schema definitions](https://github.com/nasa/cumulus/tree/master/tasks/files-to-granules/schemas).
+- Resources: [npm](https://npmjs.com/package/@cumulus/files-to-granules) | [source](https://github.com/nasa/cumulus) | [web](https://github.com/nasa/cumulus/tree/master/tasks/files-to-granules)
 
 ---
 

--- a/packages/cmrjs/cmr-utils.js
+++ b/packages/cmrjs/cmr-utils.js
@@ -509,6 +509,7 @@ function mergeURLs(original, updated = [], removed = []) {
  *
  * @param {Object} metadataObject - JSON Object to stringify
  * @param {Object} cmrFile - cmr file object to write body to
+ * @returns {Promise} returns promised aws.promiseS3Upload response
  */
 async function uploadUMMGJSONCMRFile(metadataObject, cmrFile) {
   const tags = await aws.s3GetObjectTagging(cmrFile.bucket, getS3KeyOfFile(cmrFile));
@@ -517,7 +518,8 @@ async function uploadUMMGJSONCMRFile(metadataObject, cmrFile) {
     Bucket: cmrFile.bucket,
     Key: getS3KeyOfFile(cmrFile),
     Body: JSON.stringify(metadataObject),
-    Tagging: tagsQueryString
+    Tagging: tagsQueryString,
+    ContentType: 'application/json'
   });
 }
 
@@ -592,7 +594,11 @@ async function uploadEcho10CMRFile(xml, cmrFile) {
   const tags = await aws.s3GetObjectTagging(cmrFile.bucket, getS3KeyOfFile(cmrFile));
   const tagsQueryString = aws.s3TagSetToQueryString(tags.TagSet);
   return aws.promiseS3Upload({
-    Bucket: cmrFile.bucket, Key: getS3KeyOfFile(cmrFile), Body: xml, Tagging: tagsQueryString
+    Bucket: cmrFile.bucket,
+    Key: getS3KeyOfFile(cmrFile),
+    Body: xml,
+    Tagging: tagsQueryString,
+    ContentType: 'application/xml'
   });
 }
 /**

--- a/packages/cmrjs/tests/fixtures/UMMGFilesObjectFixture.json
+++ b/packages/cmrjs/tests/fixtures/UMMGFilesObjectFixture.json
@@ -1,0 +1,40 @@
+[
+    {
+        "name": "MOD09GQ.A3411593.1itJ_e.006.9747594822314.hdf",
+        "filepath": "MOD09GQ___006/2016/MOD/MOD09GQ.A3411593.1itJ_e.006.9747594822314.hdf",
+        "fileType": "data",
+        "bucket": "cumulus-test-sandbox-protected",
+        "filename": "s3://cumulus-test-sandbox-protected/MOD09GQ___006/2016/MOD/MOD09GQ.A3411593.1itJ_e.006.9747594822314.hdf",
+        "fileSize": 17865615,
+        "path": "fixture-IngestUMMGSuccess-1551945983640-test-data/files",
+        "url_path": "{cmrMetadata.CollectionReference.ShortName}___{cmrMetadata.CollectionReference.Version}/{extractYear(cmrMetadata.TemporalExtent.RangeDateTime.BeginningDateTime)}/{substring(file.name, 0, 3)}"
+      },
+      {
+        "name": "MOD09GQ.A3411593.1itJ_e.006.9747594822314.hdf.met",
+        "filepath": "MOD09GQ___006/MOD/MOD09GQ.A3411593.1itJ_e.006.9747594822314.hdf.met",
+        "fileType": "metadata",
+        "bucket": "cumulus-test-sandbox-private",
+        "filename": "s3://cumulus-test-sandbox-private/MOD09GQ___006/MOD/MOD09GQ.A3411593.1itJ_e.006.9747594822314.hdf.met",
+        "fileSize": 44118,
+        "path": "fixture-IngestUMMGSuccess-1551945983640-test-data/files",
+        "url_path": "{cmrMetadata.CollectionReference.ShortName}___{cmrMetadata.CollectionReference.Version}/{substring(file.name, 0, 3)}"
+      },
+      {
+        "name": "MOD09GQ.A3411593.1itJ_e.006.9747594822314_ndvi.jpg",
+        "filepath": "MOD09GQ___006/MOD/MOD09GQ.A3411593.1itJ_e.006.9747594822314_ndvi.jpg",
+        "fileType": "browse",
+        "bucket": "cumulus-test-sandbox-public",
+        "filename": "s3://cumulus-test-sandbox-public/MOD09GQ___006/MOD/MOD09GQ.A3411593.1itJ_e.006.9747594822314_ndvi.jpg",
+        "fileSize": 44118,
+        "path": "fixture-IngestUMMGSuccess-1551945983640-test-data/files",
+        "url_path": "{cmrMetadata.CollectionReference.ShortName}___{cmrMetadata.CollectionReference.Version}/{substring(file.name, 0, 3)}"
+      },
+      {
+        "name": "MOD09GQ.A3411593.1itJ_e.006.9747594822314.cmr.json",
+        "filepath": "MOD09GQ___006/MOD/MOD09GQ.A3411593.1itJ_e.006.9747594822314.cmr.json",
+        "fileType": "metadata",
+        "bucket": "cumulus-test-sandbox-protected-2",
+        "filename": "s3://cumulus-test-sandbox-protected-2/MOD09GQ___006/MOD/MOD09GQ.A3411593.1itJ_e.006.9747594822314.cmr.json",
+        "url_path": "{cmrMetadata.CollectionReference.ShortName}___{cmrMetadata.CollectionReference.Version}/{substring(file.name, 0, 3)}"
+      }
+]

--- a/tasks/files-to-granules/package.json
+++ b/tasks/files-to-granules/package.json
@@ -6,7 +6,7 @@
   "directories": {
     "test": "tests"
   },
-  "homepage": "https://github.com/nasa/cumulus/tree/master/tasks/post-to-cmr",
+  "homepage": "https://github.com/nasa/cumulus/tree/master/tasks/files-to-granules",
   "repository": {
     "type": "git",
     "url": "https://github.com/nasa/cumulus"

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -20,6 +20,9 @@
       "data-cookbooks/about-cookbooks": {
         "title": "About Cookbooks"
       },
+      "data-cookbooks/browse-generation": {
+        "title": "Ingest Browse Generation"
+      },
       "data-cookbooks/choice-states": {
         "title": "Choice States"
       },
@@ -43,6 +46,9 @@
       },
       "data-cookbooks/sns": {
         "title": "SNS Notification in Workflows"
+      },
+      "data-cookbooks/tracking-files": {
+        "title": "Tracking Ancillary Files"
       },
       "deployment/config_descriptions": {
         "title": "Configuration Descriptions"
@@ -82,6 +88,9 @@
       },
       "ems_reporting": {
         "title": "EMS Reporting"
+      },
+      "features/ancillary_metadata": {
+        "title": "Ancillary Metadata Export"
       },
       "features/execution_payload_retention": {
         "title": "Execution Payload Retention"
@@ -137,6 +146,18 @@
       "upgrade/upgrade-readme": {
         "title": "Upgrading Cumulus"
       },
+      "workflow_tasks/discover_granules": {
+        "title": "Discover Granules"
+      },
+      "workflow_tasks/files_to_granules": {
+        "title": "Files To Granules"
+      },
+      "workflow_tasks/move_granules": {
+        "title": "Move Granules"
+      },
+      "workflow_tasks/parse_pdr": {
+        "title": "Parse PDR"
+      },
       "workflows/cumulus-task-message-flow": {
         "title": "Cumulus Tasks: Message Flow"
       },
@@ -164,262 +185,262 @@
       "workflows/workflow-triggers": {
         "title": "Workflow Triggers"
       },
-      "version-1.11.0-cloudwatch-retention": {
+      "version-1.11.0/data-cookbooks/version-1.11.0-cloudwatch-retention": {
         "title": "Cloudwatch Retention"
       },
-      "version-1.11.0-cnm-workflow": {
+      "version-1.11.0/data-cookbooks/version-1.11.0-cnm-workflow": {
         "title": "CNM Workflow"
       },
-      "version-1.11.0-error-handling": {
+      "version-1.11.0/data-cookbooks/version-1.11.0-error-handling": {
         "title": "Error Handling in Workflows"
       },
-      "version-1.11.0-setup": {
+      "version-1.11.0/data-cookbooks/version-1.11.0-setup": {
         "title": "Data Cookbooks Setup"
       },
-      "version-1.11.0-iam_roles": {
+      "version-1.11.0/deployment/version-1.11.0-iam_roles": {
         "title": "Cumulus IAM Roles"
       },
-      "version-1.11.0-deployment-readme": {
+      "version-1.11.0/deployment/version-1.11.0-deployment-readme": {
         "title": "How to Deploy Cumulus"
       },
-      "version-1.11.0-docs-how-to": {
+      "version-1.11.0/version-1.11.0-docs-how-to": {
         "title": "Cumulus Documentation: How To's"
       },
-      "version-1.11.0-execution_payload_retention": {
+      "version-1.11.0/features/version-1.11.0-execution_payload_retention": {
         "title": "Execution Payload Retention"
       },
-      "version-1.11.0-dead_letter_queues": {
+      "version-1.11.0/features/version-1.11.0-dead_letter_queues": {
         "title": "Dead Letter Queues"
       },
-      "version-1.11.0-about-operator-docs": {
+      "version-1.11.0/operator-docs/version-1.11.0-about-operator-docs": {
         "title": "About Operator Docs"
       },
-      "version-1.11.0-system-documentation": {
+      "version-1.11.0/system-documentation/version-1.11.0-system-documentation": {
         "title": "Troubleshooting Cumulus"
       },
-      "version-1.11.0-1.11.0": {
+      "version-1.11.0/upgrade/version-1.11.0-1.11.0": {
         "title": "Upgrading to Cumulus 1.11.0"
       },
-      "version-1.11.0-1.6.0": {
+      "version-1.11.0/upgrade/version-1.11.0-1.6.0": {
         "title": "Upgrading to Cumulus 1.6.0"
       },
-      "version-1.11.0-1.7.0": {
+      "version-1.11.0/upgrade/version-1.11.0-1.7.0": {
         "title": "Upgrading to Cumulus 1.7.0"
       },
-      "version-1.11.0-1.9.0": {
+      "version-1.11.0/upgrade/version-1.11.0-1.9.0": {
         "title": "Upgrading to Cumulus 1.9.0"
       },
-      "version-1.11.0-upgrade-readme": {
+      "version-1.11.0/upgrade/version-1.11.0-upgrade-readme": {
         "title": "Upgrading Cumulus"
       },
-      "version-1.11.0-developing-workflow-tasks": {
+      "version-1.11.0/workflows/version-1.11.0-developing-workflow-tasks": {
         "title": "Developing Workflow Tasks"
       },
-      "version-1.11.0-workflow-triggers": {
+      "version-1.11.0/workflows/version-1.11.0-workflow-triggers": {
         "title": "Workflow Triggers"
       },
-      "version-v1.10.1-adding-a-task": {
+      "version-v1.10.1/version-v1.10.1-adding-a-task": {
         "title": "Contributing a Task"
       },
-      "version-v1.10.1-api": {
+      "version-v1.10.1/version-v1.10.1-api": {
         "title": "Cumulus API"
       },
-      "version-v1.10.1-architecture": {
+      "version-v1.10.1/version-v1.10.1-architecture": {
         "title": "Cumulus Architecture"
       },
-      "version-v1.10.1-data_in_dynamodb": {
+      "version-v1.10.1/version-v1.10.1-data_in_dynamodb": {
         "title": "Cumulus Metadata in DynamoDB"
       },
-      "version-v1.10.1-about-cookbooks": {
+      "version-v1.10.1/data-cookbooks/version-v1.10.1-about-cookbooks": {
         "title": "About Cookbooks"
       },
-      "version-v1.10.1-choice-states": {
+      "version-v1.10.1/data-cookbooks/version-v1.10.1-choice-states": {
         "title": "Choice States"
       },
-      "version-v1.10.1-cnm-workflow": {
+      "version-v1.10.1/data-cookbooks/version-v1.10.1-cnm-workflow": {
         "title": "CNM Workflow"
       },
-      "version-v1.10.1-error-handling": {
+      "version-v1.10.1/data-cookbooks/version-v1.10.1-error-handling": {
         "title": "Error Handling in Workflows"
       },
-      "version-v1.10.1-hello-world": {
+      "version-v1.10.1/data-cookbooks/version-v1.10.1-hello-world": {
         "title": "HelloWorld Workflow"
       },
-      "version-v1.10.1-setup": {
+      "version-v1.10.1/data-cookbooks/version-v1.10.1-setup": {
         "title": "Data Cookbooks Setup"
       },
-      "version-v1.10.1-sips-workflow": {
+      "version-v1.10.1/data-cookbooks/version-v1.10.1-sips-workflow": {
         "title": "Science Investigator-led Processing Systems (SIPS)"
       },
-      "version-v1.10.1-sns": {
+      "version-v1.10.1/data-cookbooks/version-v1.10.1-sns": {
         "title": "SNS Notification in Workflows"
       },
-      "version-v1.10.1-create_bucket": {
+      "version-v1.10.1/deployment/version-v1.10.1-create_bucket": {
         "title": "Creating an S3 Bucket"
       },
-      "version-v1.10.1-iam_roles": {
+      "version-v1.10.1/deployment/version-v1.10.1-iam_roles": {
         "title": "Cumulus IAM Roles"
       },
-      "version-v1.10.1-deployment-readme": {
+      "version-v1.10.1/deployment/version-v1.10.1-deployment-readme": {
         "title": "How to Deploy Cumulus"
       },
-      "version-v1.10.1-troubleshoot_deployment": {
+      "version-v1.10.1/deployment/version-v1.10.1-troubleshoot_deployment": {
         "title": "Troubleshooting Cumulus Deployment"
       },
-      "version-v1.10.1-doc_installation": {
+      "version-v1.10.1/version-v1.10.1-doc_installation": {
         "title": "Cumulus Docs Installation"
       },
-      "version-v1.10.1-ems_reporting": {
+      "version-v1.10.1/version-v1.10.1-ems_reporting": {
         "title": "EMS Reporting"
       },
-      "version-v1.10.1-lambda_versioning": {
+      "version-v1.10.1/version-v1.10.1-lambda_versioning": {
         "title": "Lambda Versioning"
       },
-      "version-v1.10.1-about-operator-docs": {
+      "version-v1.10.1/operator-docs/version-v1.10.1-about-operator-docs": {
         "title": "About Operator Docs"
       },
-      "version-v1.10.1-cumulus-docs-readme": {
+      "version-v1.10.1/version-v1.10.1-cumulus-docs-readme": {
         "title": "Cumulus Description"
       },
-      "version-v1.10.1-system-documentation": {
+      "version-v1.10.1/system-documentation/version-v1.10.1-system-documentation": {
         "title": "System Documentation"
       },
-      "version-v1.10.1-tasks": {
+      "version-v1.10.1/version-v1.10.1-tasks": {
         "title": "Cumulus Tasks"
       },
-      "version-v1.10.1-team": {
+      "version-v1.10.1/version-v1.10.1-team": {
         "title": "Team"
       },
-      "version-v1.10.1-1.6.0": {
+      "version-v1.10.1/upgrade/version-v1.10.1-1.6.0": {
         "title": "Upgrading to Cumulus 1.6.0"
       },
-      "version-v1.10.1-1.7.0": {
+      "version-v1.10.1/upgrade/version-v1.10.1-1.7.0": {
         "title": "Upgrading to Cumulus 1.7.0"
       },
-      "version-v1.10.1-1.9.0": {
+      "version-v1.10.1/upgrade/version-v1.10.1-1.9.0": {
         "title": "Upgrading to Cumulus 1.9.0"
       },
-      "version-v1.10.1-upgrade-readme": {
+      "version-v1.10.1/upgrade/version-v1.10.1-upgrade-readme": {
         "title": "Upgrading Cumulus"
       },
-      "version-v1.10.1-cumulus-task-message-flow": {
+      "version-v1.10.1/workflows/version-v1.10.1-cumulus-task-message-flow": {
         "title": "Cumulus Tasks: Message Flow"
       },
-      "version-v1.10.1-developing-workflow-tasks": {
+      "version-v1.10.1/workflows/version-v1.10.1-developing-workflow-tasks": {
         "title": "Developing Workflow Tasks"
       },
-      "version-v1.10.1-docker": {
+      "version-v1.10.1/workflows/version-v1.10.1-docker": {
         "title": "Dockerizing Data Processing"
       },
-      "version-v1.10.1-input_output": {
+      "version-v1.10.1/workflows/version-v1.10.1-input_output": {
         "title": "Workflows Input & Output"
       },
-      "version-v1.10.1-lambda": {
+      "version-v1.10.1/workflows/version-v1.10.1-lambda": {
         "title": "Develop Lambda Functions"
       },
-      "version-v1.10.1-protocol": {
+      "version-v1.10.1/workflows/version-v1.10.1-protocol": {
         "title": "Workflow Protocol"
       },
-      "version-v1.10.1-workflows-readme": {
+      "version-v1.10.1/workflows/version-v1.10.1-workflows-readme": {
         "title": "Workflows"
       },
-      "version-v1.10.1-workflow-configuration-how-to": {
+      "version-v1.10.1/workflows/version-v1.10.1-workflow-configuration-how-to": {
         "title": "Workflow Configuration How To's"
       },
-      "version-v1.10.1-workflow-triggers": {
+      "version-v1.10.1/workflows/version-v1.10.1-workflow-triggers": {
         "title": "Workflow Triggers"
       },
-      "version-v1.10.3-adding-a-task": {
+      "version-v1.10.3/version-v1.10.3-adding-a-task": {
         "title": "Contributing a Task"
       },
-      "version-v1.10.3-architecture": {
+      "version-v1.10.3/version-v1.10.3-architecture": {
         "title": "Cumulus Architecture"
       },
-      "version-v1.10.3-about-cookbooks": {
+      "version-v1.10.3/data-cookbooks/version-v1.10.3-about-cookbooks": {
         "title": "About Cookbooks"
       },
-      "version-v1.10.3-choice-states": {
+      "version-v1.10.3/data-cookbooks/version-v1.10.3-choice-states": {
         "title": "Choice States"
       },
-      "version-v1.10.3-cnm-workflow": {
+      "version-v1.10.3/data-cookbooks/version-v1.10.3-cnm-workflow": {
         "title": "CNM Workflow"
       },
-      "version-v1.10.3-error-handling": {
+      "version-v1.10.3/data-cookbooks/version-v1.10.3-error-handling": {
         "title": "Error Handling in Workflows"
       },
-      "version-v1.10.3-hello-world": {
+      "version-v1.10.3/data-cookbooks/version-v1.10.3-hello-world": {
         "title": "HelloWorld Workflow"
       },
-      "version-v1.10.3-sips-workflow": {
+      "version-v1.10.3/data-cookbooks/version-v1.10.3-sips-workflow": {
         "title": "Science Investigator-led Processing Systems (SIPS)"
       },
-      "version-v1.10.3-iam_roles": {
+      "version-v1.10.3/deployment/version-v1.10.3-iam_roles": {
         "title": "Cumulus IAM Roles"
       },
-      "version-v1.10.3-docs-how-to": {
+      "version-v1.10.3/version-v1.10.3-docs-how-to": {
         "title": "Cumulus Documentation: How To's"
       },
-      "version-v1.10.3-about-operator-docs": {
+      "version-v1.10.3/operator-docs/version-v1.10.3-about-operator-docs": {
         "title": "About Operator Docs"
       },
-      "version-v1.10.3-cumulus-docs-readme": {
+      "version-v1.10.3/version-v1.10.3-cumulus-docs-readme": {
         "title": "Cumulus Description"
       },
-      "version-v1.10.3-system-documentation": {
+      "version-v1.10.3/system-documentation/version-v1.10.3-system-documentation": {
         "title": "Troubleshooting Cumulus"
       },
-      "version-v1.10.3-tasks": {
+      "version-v1.10.3/version-v1.10.3-tasks": {
         "title": "Cumulus Tasks"
       },
-      "version-v1.10.3-cumulus-task-message-flow": {
+      "version-v1.10.3/workflows/version-v1.10.3-cumulus-task-message-flow": {
         "title": "Cumulus Tasks: Message Flow"
       },
-      "version-v1.10.3-docker": {
+      "version-v1.10.3/workflows/version-v1.10.3-docker": {
         "title": "Dockerizing Data Processing"
       },
-      "version-v1.10.3-protocol": {
+      "version-v1.10.3/workflows/version-v1.10.3-protocol": {
         "title": "Workflow Protocol"
       },
-      "version-v1.10.3-workflows-readme": {
+      "version-v1.10.3/workflows/version-v1.10.3-workflows-readme": {
         "title": "Workflows"
       },
-      "version-v1.10.3-workflow-triggers": {
+      "version-v1.10.3/workflows/version-v1.10.3-workflow-triggers": {
         "title": "Workflow Triggers"
       },
-      "version-v1.11.1-about-operator-docs": {
+      "version-v1.11.1/operator-docs/version-v1.11.1-about-operator-docs": {
         "title": "About Operator Docs"
       },
-      "version-v1.11.2-config_descriptions": {
+      "version-v1.11.2/deployment/version-v1.11.2-config_descriptions": {
         "title": "Configuration Descriptions"
       },
-      "version-v1.11.2-obtain_cumulus_packages": {
+      "version-v1.11.2/deployment/version-v1.11.2-obtain_cumulus_packages": {
         "title": "Obtaining Cumulus Packages"
       },
-      "version-v1.11.2-deployment-readme": {
+      "version-v1.11.2/deployment/version-v1.11.2-deployment-readme": {
         "title": "How to Deploy Cumulus"
       },
-      "version-v1.11.2-glossary": {
+      "version-v1.11.2/version-v1.11.2-glossary": {
         "title": "Cumulus Glossary"
       },
-      "version-v1.11.2-lifecycle-policies": {
+      "version-v1.11.2/operator-docs/version-v1.11.2-lifecycle-policies": {
         "title": "Lifecycle Policies"
       },
-      "version-v1.11.2-update-cumulus-dependencies": {
+      "version-v1.11.2/operator-docs/version-v1.11.2-update-cumulus-dependencies": {
         "title": "Update Cumulus Dependencies"
       },
-      "version-v1.11.2-cumulus-docs-readme": {
+      "version-v1.11.2/version-v1.11.2-cumulus-docs-readme": {
         "title": "Cumulus Description"
       },
-      "version-v1.11.2-team": {
+      "version-v1.11.2/version-v1.11.2-team": {
         "title": "Team"
       },
-      "version-v1.11.2-developing-workflow-tasks": {
+      "version-v1.11.2/workflows/version-v1.11.2-developing-workflow-tasks": {
         "title": "Developing Workflow Tasks"
       },
-      "version-v1.11.2-lambda": {
+      "version-v1.11.2/workflows/version-v1.11.2-lambda": {
         "title": "Develop Lambda Functions"
       },
-      "version-v1.11.2-workflows-readme": {
+      "version-v1.11.2/workflows/version-v1.11.2-workflows-readme": {
         "title": "Workflows"
       }
     },
@@ -433,6 +454,7 @@
     "categories": {
       "About Cumulus": "About Cumulus",
       "What are Cumulus Workflows?": "What are Cumulus Workflows?",
+      "Tasks": "Tasks",
       "Deployment": "Deployment",
       "Additional Features": "Additional Features",
       "Cumulus Versions": "Cumulus Versions",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -70,7 +70,8 @@
       "data-cookbooks/error-handling",
       "data-cookbooks/choice-states",
       "data-cookbooks/cloudwatch-retention",
-      "data-cookbooks/browse-generation"
+      "data-cookbooks/browse-generation",
+      "data-cookbooks/tracking-files"
     ]
   },
   "Operator Docs": {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-777: As a DAAC operator, I want to configure workflows to generate additional files such as browse or QA information to be tracked and stored with a granule so I may provide users with useful ancillary data](https://bugs.earthdata.nasa.gov/browse/CUMULUS-777)

## Acceptance Criteria:
* When configuring ingest, it allows operators to configure arbitrary associated files to be tracked by CMR and stored as part of the granule record
* When ingest is configured for tracking associated files, it provides UMM-compliant metadata to CMR for the files as configured
* The integration test suite demonstrates the above acceptance criteria
* The data cookbook contains an entry that describes configuring browse imagery for a granule
* The data cookbook contains an entry that describes configuring a documentation entry for a granule
* The data cookbook contains an entry that describes configuring generic associated files for a granule

## Changes

* Add data cookbook about configuring files to be tracked & configuring file types.
* Write unit test for UMM-G JSON RelatedUrls (ECHO10 test already existed)

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Adhoc testing
- [x] Integration tests

