### PR TITLE
small refactor of bucket configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- **CUMULUS-1223**
+  - Adds convenience function `@cumulus/common/bucketsConfigJsonObject` for fetching stack's bucket configuration as an object .
 - **CUMULUS-853**
   - Updated FakeProcessing example lambda to include option to generate fake browse
   - Added feature documentation for ancillary metadata export, a new cookbook entry describing a workflow with ancillary metadata generation(browse), and related task definition documentation

--- a/example/app/config.yml
+++ b/example/app/config.yml
@@ -527,8 +527,7 @@ mhs3:
     shared:
       name: cumulus-data-shared
       type: shared
-  system_bucket: mhs3-internal
-
+  api_distribution_url: '{{API_DISTRIBUTION_URL}}'
 
 jk:
   stackName: jk

--- a/example/spec/createReconciliationReport/CreateReconciliationReportSpec.js
+++ b/example/spec/createReconciliationReport/CreateReconciliationReportSpec.js
@@ -10,6 +10,8 @@ const {
     lambda,
     s3
   },
+  BucketsConfig,
+  bucketsConfigJsonObject,
   constructCollectionId,
   testUtils: {
     randomString,
@@ -61,18 +63,10 @@ const granuleModel = new Granule();
 const cmr = new CMR(config.cmr.provider, config.cmr.clientId, config.cmr.username, config.cmr.password);
 
 async function findProtectedBucket(systemBucket, stackName) {
-  const bucketConfigs = await s3().getObject({
-    Bucket: systemBucket,
-    Key: `${stackName}/workflows/buckets.json`
-  }).promise()
-    .then((response) => response.Body.toString())
-    .then((bucketsConfigString) => JSON.parse(bucketsConfigString))
-    .then(Object.values);
-
-  const protectedBucketConfig = bucketConfigs.find((bc) => bc.type === 'protected');
-  if (!protectedBucketConfig) throw new Error(`Unable to find protected bucket in ${JSON.stringify(bucketConfigs)}`);
-
-  return protectedBucketConfig.name;
+  const bucketsConfig = new BucketsConfig(await bucketsConfigJsonObject(systemBucket, stackName));
+  const protectedBucketConfig = bucketsConfig.protectedBuckets();
+  if (!protectedBucketConfig) throw new Error(`Unable to find protected bucket in ${JSON.stringify(bucketsConfig)}`);
+  return protectedBucketConfig[0].name;
 }
 
 function getReportsKeys(systemBucket, stackName) {

--- a/packages/cmrjs/cmr-utils.js
+++ b/packages/cmrjs/cmr-utils.js
@@ -12,6 +12,7 @@ const js2xmlParser = require('js2xmlparser');
 const {
   aws,
   BucketsConfig,
+  bucketsConfigJsonObject,
   errors,
   log
 } = require('@cumulus/common');
@@ -298,26 +299,6 @@ function getCmrFiles(input, granuleIdExtraction) {
   });
 
   return files;
-}
-
-/**
- * Retrieve the stack's bucket configuration from s3 and return the bucket configuration object.
- *
- * @param {string} bucket - system bucket name.
- * @param {string} stackName - stack name.
- * @returns {Object} - stack's bucket configuration.
- */
-async function bucketConfig(bucket, stackName) {
-  const bucketsString = await aws.s3().getObject({
-    Bucket: bucket,
-    Key: `${stackName}/workflows/buckets.json`
-  }).promise();
-  return JSON.parse(bucketsString.Body);
-}
-
-/** Return the stack's buckets object read from from S3 */
-async function bucketsConfigDefaults() {
-  return bucketConfig(process.env.system_bucket, process.env.stackName);
 }
 
 /**
@@ -680,7 +661,10 @@ async function updateCMRMetadata({
   const filename = getS3UrlOfFile(cmrFile);
 
   log.debug(`cmrjs.updateCMRMetadata granuleId ${granuleId}, cmrMetadata file ${filename}`);
-  const buckets = inBuckets || new BucketsConfig(await bucketsConfigDefaults());
+  const buckets = inBuckets
+        || new BucketsConfig(
+          await bucketsConfigJsonObject(process.env.system_bucket, process.env.stackName)
+        );
   const cmrCredentials = (published) ? getCreds() : {};
   let theMetadata;
 

--- a/packages/cmrjs/tests/cmr-utils/test-reconcilecmrmetadata.js
+++ b/packages/cmrjs/tests/cmr-utils/test-reconcilecmrmetadata.js
@@ -125,8 +125,8 @@ test('reconcileCMRMetadata calls updateEcho10XMLMetadata but not publishECHO10XM
   const { granId, distEndpoint } = t.context;
   const published = false;
   const fakeBuckets = { private: { type: 'private', name: 'private' } };
-  const fakeBucketsConfigDefaults = sinon.fake.returns(fakeBuckets);
-  const restoreBucketsConfigDefaults = cmrUtils.__set__('bucketsConfigDefaults', fakeBucketsConfigDefaults);
+  const fakeBucketsConfigJsonObject = sinon.fake.returns(fakeBuckets);
+  const restoreBucketsConfigDefaults = cmrUtils.__set__('bucketsConfigJsonObject', fakeBucketsConfigJsonObject);
 
   const fakeUpdateCMRMetadata = sinon.fake.resolves(true);
   const restoreUpdateEcho10XMLMetadata = cmrUtils.__set__('updateEcho10XMLMetadata', fakeUpdateCMRMetadata);
@@ -178,8 +178,8 @@ test('reconcileCMRMetadata calls updateEcho10XMLMetadata and publishECHO10XML2CM
   const restorePublishECHO10XML2CMR = cmrUtils.__set__('publishECHO10XML2CMR', fakePublishECHO10XML2CMR);
 
   const fakeBuckets = { private: { type: 'private', name: 'private' } };
-  const fakeBucketsConfigDefaults = sinon.fake.returns(fakeBuckets);
-  const restoreBucketsConfigDefaults = cmrUtils.__set__('bucketsConfigDefaults', fakeBucketsConfigDefaults);
+  const fakeBucketsConfigJsonObject = sinon.fake.returns(fakeBuckets);
+  const restoreBucketsConfigDefaults = cmrUtils.__set__('bucketsConfigJsonObject', fakeBucketsConfigJsonObject);
 
 
   const bucket = randomId('bucket');
@@ -228,8 +228,8 @@ test('reconcileCMRMetadata calls updateUMMGMetadata and publishUMMGJSON2CMR if i
   } = t.context;
 
   const defaultBucketsConfig = { private: { type: 'private', name: 'private' } };
-  const fakeBucketsConfigDefaults = sinon.fake.returns(defaultBucketsConfig);
-  const restoreBucketsConfigDefaults = cmrUtils.__set__('bucketsConfigDefaults', fakeBucketsConfigDefaults);
+  const fakeBucketsConfigJsonObject = sinon.fake.returns(defaultBucketsConfig);
+  const restoreBucketsConfigDefaults = cmrUtils.__set__('bucketsConfigJsonObject', fakeBucketsConfigJsonObject);
 
   const fakeUpdateUMMGMetadata = sinon.fake.resolves({ fake: 'metadata' });
   const restoreUpdateUMMGMetadata = cmrUtils.__set__('updateUMMGMetadata', fakeUpdateUMMGMetadata);

--- a/packages/common/BucketsConfig.js
+++ b/packages/common/BucketsConfig.js
@@ -76,6 +76,47 @@ class BucketsConfig {
   nameByKey(configKey) {
     return this.buckets[configKey].name;
   }
+
+  /**
+   * return a list of configured buckets of desired type.
+   *
+   * @param {string/Array} types - types of buckets to return
+   * @returns {Array<Object>} - array of buckets that are of desired types
+   */
+  bucketsOfType(types) {
+    const checkTypes = [].concat(types);
+    return Object.keys(this.buckets).map((key) => {
+      if (checkTypes.includes(this.buckets[key].type)) {
+        return this.buckets[key];
+      }
+      return undefined;
+    }).filter((valid) => valid);
+  }
+
+  /** @returns {Array} list of private buckets */
+  privateBuckets() {
+    return this.bucketsOfType('private');
+  }
+
+  /** @returns {Array} list of protected buckets */
+  protectedBuckets() {
+    return this.bucketsOfType('protected');
+  }
+
+  /** @returns {Array} list of public buckets */
+  publicBuckets() {
+    return this.bucketsOfType('public');
+  }
+
+  /** @returns {Array} list of shared buckets */
+  sharedBuckets() {
+    return this.bucketsOfType('shared');
+  }
+
+  /** @returns {Array} list of internal buckets */
+  internalBuckets() {
+    return this.bucketsOfType('internal');
+  }
 }
 
 

--- a/packages/common/bucketsConfigJsonObject.js
+++ b/packages/common/bucketsConfigJsonObject.js
@@ -13,15 +13,16 @@ async function bucketsConfigJsonObject(
   bucket = process.env.system_bucket,
   stackName = process.env.stackName
 ) {
+  const Key = `${stackName}/workflows/buckets.json`;
   try {
     const bucketsString = await aws.s3().getObject({
       Bucket: bucket,
-      Key: `${stackName}/workflows/buckets.json`
+      Key
     }).promise();
     return JSON.parse(bucketsString.Body);
   }
   catch (error) {
-    error.message = `Unable to read bucketsConfiguration from s3: ${error.message}`;
+    error.message = `Unable to read bucketsConfiguration from ${bucket}/${Key}: ${error.message}`;
     throw error;
   }
 }

--- a/packages/common/bucketsConfigJsonObject.js
+++ b/packages/common/bucketsConfigJsonObject.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const aws = require('./aws');
+
 /**
  * Retrieve the stack's bucket configuration from s3 and return the bucket configuration object.
  *
@@ -12,12 +13,16 @@ async function bucketsConfigJsonObject(
   bucket = process.env.system_bucket,
   stackName = process.env.stackName
 ) {
-  const bucketsString = await aws.s3().getObject({
-    Bucket: bucket,
-    Key: `${stackName}/workflows/buckets.json`
-  }).promise();
-  return JSON.parse(bucketsString.Body);
+  try {
+    const bucketsString = await aws.s3().getObject({
+      Bucket: bucket,
+      Key: `${stackName}/workflows/buckets.json`
+    }).promise();
+    return JSON.parse(bucketsString.Body);}
+  catch (error){
+    error.message = 'Unable to read bucketsConfiguration from s3: ' + error.message;
+    throw error;
+  }
 }
-
 
 module.exports = bucketsConfigJsonObject;

--- a/packages/common/bucketsConfigJsonObject.js
+++ b/packages/common/bucketsConfigJsonObject.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const aws = require('./aws');
+/**
+ * Retrieve the stack's bucket configuration from s3 and return the bucket configuration object.
+ *
+ * @param {string} bucket - system bucket name.
+ * @param {string} stackName - stack name.
+ * @returns {Object} - stack's bucket configuration.
+ */
+async function bucketsConfigJsonObject(
+  bucket = process.env.system_bucket,
+  stackName = process.env.stackName
+) {
+  const bucketsString = await aws.s3().getObject({
+    Bucket: bucket,
+    Key: `${stackName}/workflows/buckets.json`
+  }).promise();
+  return JSON.parse(bucketsString.Body);
+}
+
+
+module.exports = bucketsConfigJsonObject;

--- a/packages/common/bucketsConfigJsonObject.js
+++ b/packages/common/bucketsConfigJsonObject.js
@@ -18,9 +18,10 @@ async function bucketsConfigJsonObject(
       Bucket: bucket,
       Key: `${stackName}/workflows/buckets.json`
     }).promise();
-    return JSON.parse(bucketsString.Body);}
-  catch (error){
-    error.message = 'Unable to read bucketsConfiguration from s3: ' + error.message;
+    return JSON.parse(bucketsString.Body);
+  }
+  catch (error) {
+    error.message = `Unable to read bucketsConfiguration from s3: ${error.message}`;
     throw error;
   }
 }

--- a/packages/common/index.js
+++ b/packages/common/index.js
@@ -2,6 +2,7 @@
 
 exports.aws = require('./aws');
 exports.BucketsConfig = require('./BucketsConfig');
+exports.bucketsConfigJsonObject = require('./bucketsConfigJsonObject');
 exports.cliUtils = require('./cli-utils');
 exports.CloudFormationGateway = require('./CloudFormationGateway');
 exports.CollectionConfigStore = require('./collection-config-store').CollectionConfigStore;

--- a/packages/common/tests/test-BucketsConfig.js
+++ b/packages/common/tests/test-BucketsConfig.js
@@ -9,8 +9,11 @@ const bucketConfig = {
   public: { type: 'public', name: 'a-public-bucket' },
   protected: { type: 'protected', name: 'a-protected-bucket' },
   shared: { type: 'shared', name: 'a-shared-bucket' },
-  internal: { type: 'internal', name: 'an-internal-bucket' }
+  internal: { type: 'internal', name: 'an-internal-bucket' },
+  public2: { type: 'public', name: 'a-second-public-bucket' }
 };
+
+const sortByName = (a, b) => a.name < b.name;
 
 test('bucket keys are found by bucketName', (t) => {
   const bucketName = 'a-protected-bucket';
@@ -76,4 +79,47 @@ test('checks a bucket key\'s existence in config', (t) => {
 
   t.truthy(Bucket.keyExists(existsKey));
   t.falsy(Bucket.keyExists(doesNotExistKey));
+});
+
+test('bucketsOfType returns a list of buckets of desired type with string input', (t) => {
+  const testType = 'public';
+
+  const Bucket = new BucketsConfig(bucketConfig);
+  const expected = [
+    { type: 'public', name: 'a-public-bucket' },
+    { type: 'public', name: 'a-second-public-bucket' }
+  ];
+
+  const actual = Bucket.bucketsOfType(testType);
+
+  t.deepEqual(actual.sort(sortByName), expected.sort(sortByName));
+});
+
+test('bucketsOfType returns protected and private buckets with array input', (t) => {
+  const testTypes = ['public', 'protected'];
+
+  const Bucket = new BucketsConfig(bucketConfig);
+  const expected = [
+    { type: 'public', name: 'a-public-bucket' },
+    { type: 'public', name: 'a-second-public-bucket' },
+    { type: 'protected', name: 'a-protected-bucket' }
+  ];
+
+  const actual = Bucket.bucketsOfType(testTypes);
+
+  t.deepEqual(actual.sort(sortByName), expected.sort(sortByName));
+});
+
+test('returns private buckets', (t) => {
+  const Bucket = new BucketsConfig(bucketConfig);
+  const expected = [{ type: 'private', name: 'a-private-bucket' }];
+  const actual = Bucket.privateBuckets();
+  t.deepEqual(actual.sort(sortByName), expected.sort(sortByName));
+});
+
+test('returns internal buckets', (t) => {
+  const Bucket = new BucketsConfig(bucketConfig);
+  const expected = [{ type: 'internal', name: 'an-internal-bucket' }];
+  const actual = Bucket.internalBuckets();
+  t.deepEqual(actual.sort(sortByName), expected.sort(sortByName));
 });

--- a/packages/common/tests/test-bucketsConfigJsonObject.js
+++ b/packages/common/tests/test-bucketsConfigJsonObject.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const test = require('ava');
+
+const bucketConfig = {
+  private: { type: 'private', name: 'a-private-bucket' },
+  public: { type: 'public', name: 'a-public-bucket' },
+  protected: { type: 'protected', name: 'a-protected-bucket' },
+  shared: { type: 'shared', name: 'a-shared-bucket' },
+  internal: { type: 'internal', name: 'an-internal-bucket' },
+  public2: { type: 'public', name: 'a-second-public-bucket' }
+};
+
+const {
+  recursivelyDeleteS3Bucket,
+  s3
+} = require('../aws');
+const { randomId } = require('../test-utils');
+const bucketsConfigJsonObject = require('../bucketsConfigJsonObject');
+
+const context = {};
+
+test.before(async () => {
+  context.systemBucket = randomId('systemBucket');
+  context.stackName = randomId('stackName');
+  await s3().createBucket({ Bucket: context.systemBucket }).promise();
+  await s3().putObject({
+    Bucket: context.systemBucket,
+    Key: `${context.stackName}/workflows/buckets.json`,
+    Body: JSON.stringify(bucketConfig)
+  }).promise();
+});
+
+test.after.always(() => {
+  recursivelyDeleteS3Bucket(context.systemBucket);
+});
+
+test('reads default bucket.json values', async (t) => {
+  process.env.system_bucket = context.systemBucket;
+  process.env.stackName = context.stackName;
+
+  const actualBucketObject = await bucketsConfigJsonObject();
+  t.deepEqual(bucketConfig, actualBucketObject);
+});
+
+test('has understandable error messages for bad bucket name', async (t) => {
+  process.env.system_bucket = 'badbucket';
+  process.env.stackName = context.stackName;
+
+  await t.throws(
+    bucketsConfigJsonObject(),
+    'Unable to read bucketsConfiguration from s3: The specified bucket does not exist'
+  );
+});
+
+test('has understandable error messages for bad key', async (t) => {
+  process.env.system_bucket = context.systemBucket;
+  process.env.stackName = 'wrong-stackname';
+
+  await t.throws(
+    bucketsConfigJsonObject(),
+    'Unable to read bucketsConfiguration from s3: The specified key does not exist.'
+  );
+});

--- a/packages/common/tests/test-bucketsConfigJsonObject.js
+++ b/packages/common/tests/test-bucketsConfigJsonObject.js
@@ -44,12 +44,13 @@ test('reads default bucket.json values', async (t) => {
 });
 
 test('has understandable error messages for bad bucket name', async (t) => {
-  process.env.system_bucket = 'badbucket';
+  process.env.system_bucket = 'bad-bucket';
   process.env.stackName = context.stackName;
+  const location = `bad-bucket/${context.stackName}/workflows/buckets.json`;
 
   await t.throws(
     bucketsConfigJsonObject(),
-    'Unable to read bucketsConfiguration from s3: The specified bucket does not exist'
+    `Unable to read bucketsConfiguration from ${location}: The specified bucket does not exist`
   );
 });
 
@@ -57,8 +58,10 @@ test('has understandable error messages for bad key', async (t) => {
   process.env.system_bucket = context.systemBucket;
   process.env.stackName = 'wrong-stackname';
 
+  const location = `${context.systemBucket}/wrong-stackname/workflows/buckets.json`;
+
   await t.throws(
     bucketsConfigJsonObject(),
-    'Unable to read bucketsConfiguration from s3: The specified key does not exist.'
+    `Unable to read bucketsConfiguration from ${location}: The specified key does not exist.`
   );
 });

--- a/packages/common/tests/test-bucketsConfigJsonObject.js
+++ b/packages/common/tests/test-bucketsConfigJsonObject.js
@@ -31,8 +31,8 @@ test.before(async () => {
   }).promise();
 });
 
-test.after.always(() => {
-  recursivelyDeleteS3Bucket(context.systemBucket);
+test.after.always(async () => {
+  await recursivelyDeleteS3Bucket(context.systemBucket);
 });
 
 test('reads default bucket.json values', async (t) => {

--- a/packages/ingest/s3.js
+++ b/packages/ingest/s3.js
@@ -35,7 +35,13 @@ module.exports.s3Mixin = (superclass) => class extends superclass {
    * @private
    */
   async list() {
-    // The use of "path" here is in reference to the file that was
+    // There are two different "path" variables being set here, which gets
+    // confusing.  "this.path" originally comes from
+    // "event.config.collection.provider_path".  In the case of S3, it refers
+    // to the prefix used when searching for objects.  That should be the
+    // _only_ time that variable is used.
+    //
+    // The other use of "path" here is in reference to the file that was
     // discovered.  It's easiest to explain using an example.  Given this URL:
     //
     // s3://my-bucket/some/path/my-file.pdr
@@ -54,7 +60,8 @@ module.exports.s3Mixin = (superclass) => class extends superclass {
 
     const params = {
       Bucket: this.host,
-      FetchOwner: true
+      FetchOwner: true,
+      Prefix: this.path
     };
 
     const objects = await aws.listS3ObjectsV2(params);

--- a/travis-ci/docker-compose.yml
+++ b/travis-ci/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     volumes:
       - ../packages/test-data:/usr/local/apache2/htdocs:ro
   sftp:
-    image: panubo/sshd
+    image: nsidc/panubo_sshd:latest
     command: /bootstrap-sftp.sh
     ports:
       - "127.0.0.1:2222:22"


### PR DESCRIPTION
**Summary:** refactor to add convenience function.

Originally I wrote this to be used in the distribution API (but will probably use a different method).  This refactor cleans up some repeated code.

Addresses [CUMULUS-1223: public s3 urls](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1223)

## Changes

* Adds new function `@cumulus/common/bucketsConfigJsonObject` which reads the buckets.json file from the stack configuration's system_bucket and returns an object suitable for input to `BucketsConfig`.
* Adds helpers to BucketsConfig to get lists of buckets by types.

## PR Checklist

- [ X ] Update CHANGELOG
- [ X ] Unit tests
- [ X ] Integration tests