### PR TITLE
Cumulus 1183: Add lambda configuration check to kes 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -111,6 +111,7 @@
     "implicit-arrow-linebreak": "off",
 
     "eslint-comments/no-unused-disable": "warn",
+    "eslint-comments/disable-enable-pair": ["error", {"allowWholeFile": true}],
 
     "lodash/import-scope": ["error", "method-package"],
     "lodash/prefer-constant": "off",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - **CUMULUS-1183**
-  - Kes overrides will now abort with a warning if a workflow is configured without a corresponding
+  - Kes overrides will now abort with a warning if a workflow step is configured without a corresponding
     lambda configuration
 - **CUMULUS-853**
   - Updated FakeProcessing example lambda to include option to generate fake browse

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- **CUMULUS-1183**
+  - Kes overrides will now abort with a warning if a workflow is configured without a corresponding
+    lambda configuration
 - **CUMULUS-853**
   - Updated FakeProcessing example lambda to include option to generate fake browse
   - Added feature documentation for ancillary metadata export, a new cookbook entry describing a workflow with ancillary metadata generation(browse), and related task definition documentation

--- a/packages/deployment/lib/configValidators.js
+++ b/packages/deployment/lib/configValidators.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const get = require('lodash.get');
+
 /**
  * @param  {Object} config kes configuration object
  *
@@ -14,13 +15,12 @@ function validateWorkflowDefinedLambdas(config) {
   let resources = [].concat(...stepFunctionStates).reduce((result, cfg) => {
     if (cfg.Type === 'Task') {
       const lambdaArnMatch = cfg.Resource.match(lambdaResourceMatch);
-      if (lambdaArnMatch) {
+      if (lambdaArnMatch && !result.includes(lambdaArnMatch[1])) {
         result.push(lambdaArnMatch[1]);
       }
     }
     return result;
   }, []);
-  resources = [...new Set(resources)];
   resources.forEach((resource) => {
     if (!lambdas.includes(resource)) {
       console.log(`At failure for ${resource} lambdas was ${lambdas}`);

--- a/packages/deployment/lib/configValidators.js
+++ b/packages/deployment/lib/configValidators.js
@@ -1,7 +1,10 @@
 'use strict';
 
 const get = require('lodash.get');
-
+/**
+ * @param  {Object} config kes configuration object
+ *
+ */
 function validateWorkflowDefinedLambdas(config) {
   const lambdaResourceMatch = /\$\{(.*)LambdaFunction\.Arn\}/;
   const stepFunctions = get(config, 'stepFunctions', {});

--- a/packages/deployment/lib/configValidators.js
+++ b/packages/deployment/lib/configValidators.js
@@ -12,7 +12,7 @@ function validateWorkflowDefinedLambdas(config) {
   const stepFunctionStates = Object.values(stepFunctions).map((sf) => Object.values(sf.States));
   const lambdas = Object.keys(config.lambdas);
 
-  let resources = [].concat(...stepFunctionStates).reduce((result, cfg) => {
+  const resources = [].concat(...stepFunctionStates).reduce((result, cfg) => {
     if (cfg.Type === 'Task') {
       const lambdaArnMatch = cfg.Resource.match(lambdaResourceMatch);
       if (lambdaArnMatch && !result.includes(lambdaArnMatch[1])) {

--- a/packages/deployment/lib/configValidators.js
+++ b/packages/deployment/lib/configValidators.js
@@ -8,10 +8,10 @@ const get = require('lodash.get');
 function validateWorkflowDefinedLambdas(config) {
   const lambdaResourceMatch = /\$\{(.*)LambdaFunction\.Arn\}/;
   const stepFunctions = get(config, 'stepFunctions', {});
-  const stepFunctionValues = Object.values(stepFunctions).map((sf) => Object.values(sf.States));
+  const stepFunctionStates = Object.values(stepFunctions).map((sf) => Object.values(sf.States));
   const lambdas = Object.keys(config.lambdas);
 
-  let resources = [].concat(...stepFunctionValues).reduce((result, cfg) => {
+  let resources = [].concat(...stepFunctionStates).reduce((result, cfg) => {
     if (cfg.Type === 'Task') {
       const lambdaArnMatch = cfg.Resource.match(lambdaResourceMatch);
       if (lambdaArnMatch) {

--- a/packages/deployment/lib/configValidators.js
+++ b/packages/deployment/lib/configValidators.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const get = require('lodash.get');
+
+function validateWorkflowDefinedLambdas(config) {
+  const lambdaResourceMatch = /\$\{(.*)LambdaFunction\.Arn\}/;
+  const stepFunctions = get(config, 'stepFunctions', {});
+  const stepFunctionValues = Object.values(stepFunctions).map((sf) => Object.values(sf.States));
+  const lambdas = Object.keys(config.lambdas);
+
+  let resources = [].concat(...stepFunctionValues).reduce((result, cfg) => {
+    if (cfg.Type === 'Task') {
+      const lambdaArnMatch = cfg.Resource.match(lambdaResourceMatch);
+      if (lambdaArnMatch) {
+        result.push(lambdaArnMatch[1]);
+      }
+    }
+    return result;
+  }, []);
+  resources = [...new Set(resources)];
+  resources.forEach((resource) => {
+    if (!lambdas.includes(resource)) {
+      console.log(`At failure for ${resource} lambdas was ${lambdas}`);
+      throw new Error(`*** Error: Workflow lambda resource ${resource} not defined in lambda configuration`);
+    }
+  });
+}
+
+module.exports = validateWorkflowDefinedLambdas;

--- a/packages/deployment/lib/kes.js
+++ b/packages/deployment/lib/kes.js
@@ -21,7 +21,7 @@
  *
  */
 
- 'use strict';
+'use strict';
 
 const cloneDeep = require('lodash.clonedeep');
 const zipObject = require('lodash.zipobject');

--- a/packages/deployment/lib/kes.js
+++ b/packages/deployment/lib/kes.js
@@ -21,7 +21,7 @@
  *
  */
 
-'use strict';
+ 'use strict';
 
 const cloneDeep = require('lodash.clonedeep');
 const zipObject = require('lodash.zipobject');
@@ -33,6 +33,7 @@ const util = require('util');
 const { sleep } = require('@cumulus/common/util');
 
 const Lambda = require('./lambda');
+const validateWorkflowDefinedLambdas = require('./configValidators');
 const { crypto } = require('./crypto');
 const { fetchMessageAdapter } = require('./adapter');
 const { extractCumulusConfigFromSF, generateTemplates } = require('./message');
@@ -62,6 +63,7 @@ class UpdatedKes extends Kes {
   constructor(config) {
     super(config);
     this.Lambda = Lambda;
+    validateWorkflowDefinedLambdas(config);
     this.messageAdapterGitPath = `${config.repo_owner}/${config.message_adapter_repo}`;
   }
 
@@ -581,7 +583,7 @@ class UpdatedKes extends Kes {
    *
    * @param {string} stateObjectResource - CF template resource reference for a state function
    * @returns {string} The correct reference to the lambda function, either a hashed alias
-   * reference or the passed in resource if hasing/versioning isn't possible for this resource
+   * reference or the passed in resource if hashing/versioning isn't possible for this resource
    * @throws {Error} Throws an error if the passed in stateObjectResource isn't a LambdaFunctionArn
    * reference
    */

--- a/packages/deployment/test/test_configValidations.js
+++ b/packages/deployment/test/test_configValidations.js
@@ -1,11 +1,13 @@
 /* eslint-disable no-template-curly-in-string */
+/*eslint-comments/disable-enable-pair": ["error", {"allowWholeFile": true}]*/
+
 'use strict';
 
 const test = require('ava');
 const validateWorkflowDefinedLambdas = require('../lib/configValidators');
 
 test.beforeEach((t) => {
-  t.context.config = {}
+  t.context.config = {};
   t.context.config.lambdas = { TestLambda1: {}, TestLambda2: {} };
   t.context.config.stepFunctions = {
     SomeStepFunction: {
@@ -23,7 +25,7 @@ test.beforeEach((t) => {
         }
       }
     }
-  }
+  };
 });
 
 test('validateWorkflowDefinedLambdas throws an exception when lambda is undefined', async (t) => {

--- a/packages/deployment/test/test_configValidations.js
+++ b/packages/deployment/test/test_configValidations.js
@@ -1,0 +1,37 @@
+/* eslint-disable no-template-curly-in-string */
+'use strict';
+
+const test = require('ava');
+const validateWorkflowDefinedLambdas = require('../lib/configValidators');
+
+test.beforeEach((t) => {
+  t.context.config = {}
+  t.context.config.lambdas = { TestLambda1: {}, TestLambda2: {} };
+  t.context.config.stepFunctions = {
+    SomeStepFunction: {
+      States: {
+        TestState: {
+          Type: 'Task',
+          Resource: '${TestLambda1LambdaFunction.Arn}'
+        },
+        TestNonLambdaTaskState: {
+          Type: 'Task',
+          Resource: '${NonLambdaResource}'
+        },
+        NonTaskState: {
+          Type: 'Choice'
+        }
+      }
+    }
+  }
+});
+
+test('validateWorkflowDefinedLambdas throws an exception when lambda is undefined', async (t) => {
+  const config = t.context.config;
+  config.stepFunctions.SomeStepFunction.States.TestState.Resource = '${UndefinedLambdaFunction.Arn}';
+  await t.throws(() => validateWorkflowDefinedLambdas(config));
+});
+
+test('validateWorkflowDefinedLambdas does not throw an exception when configuration is correct', async (t) => {
+  await t.notThrows(() => validateWorkflowDefinedLambdas(t.context.config));
+});

--- a/packages/deployment/test/test_configValidations.js
+++ b/packages/deployment/test/test_configValidations.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-template-curly-in-string */
-/*eslint-comments/disable-enable-pair": ["error", {"allowWholeFile": true}]*/
 
 'use strict';
 

--- a/packages/deployment/test/test_kes.js
+++ b/packages/deployment/test/test_kes.js
@@ -17,7 +17,9 @@ test.beforeEach((t) => {
 });
 
 function setupKesForLookupLambdaReference(kes, functionName, hashValue) {
-  kes.config.lambdas = Object.assign(kes.config.lambdas, { [functionName]: { hash: hashValue } });
+  kes.config.lambdas = Object.assign({}, kes.config.lambdas, {
+    [functionName]: { hash: hashValue }
+  });
   return kes;
 }
 

--- a/packages/deployment/test/test_kes.js
+++ b/packages/deployment/test/test_kes.js
@@ -5,17 +5,19 @@
 const sinon = require('sinon');
 const test = require('ava');
 const get = require('lodash.get');
+const clonedeep = require('lodash.clonedeep');
 
 const configFixture = require('./fixtures/config.json');
 const aliasFixture = require('./fixtures/aliases.json');
 const UpdatedKes = require('../lib/kes');
 
 test.beforeEach((t) => {
-  t.context.kes = new UpdatedKes(configFixture);
+  const config = clonedeep(configFixture);
+  t.context.kes = new UpdatedKes(config);
 });
 
 function setupKesForLookupLambdaReference(kes, functionName, hashValue) {
-  kes.config.lambdas = { [functionName]: { hash: hashValue } };
+  kes.config.lambdas = Object.assign(kes.config.lambdas, { [functionName]: { hash: hashValue } });
   return kes;
 }
 
@@ -147,7 +149,6 @@ test('parseAliasName returns null hash if hash missing', (t) => {
   t.deepEqual(expected, actual);
 });
 
-
 test.serial('getAllLambdaAliases returns an unpaginated list of aliases', async (t) => {
   const kes = t.context.kes;
 
@@ -187,7 +188,7 @@ test.serial('getAllLambdaAliases returns an unpaginated list of aliases', async 
 test.serial('getRetainedLambdaAliasMetadata returns filtered aliasNames', async (t) => {
   const kes = t.context.kes;
 
-  kes.config.workflowLambdas = aliasFixture.workflowLambdas;
+  kes.config.workflowLambdas = clonedeep(aliasFixture.workflowLambdas);
   kes.config.maxNumberOfRetainedLambdas = 2;
   const getAllLambdaAliasesStub = sinon.stub(kes, 'getAllLambdaAliases');
   for (let i = 0; i < aliasFixture.aliases.length; i += 1) {
@@ -217,7 +218,8 @@ test.serial('getRetainedLambdaAliasNames returns filtered aliasNames '
             + 'on previous version redeployment', async (t) => {
   const kes = t.context.kes;
 
-  kes.config.workflowLambdas = aliasFixture.workflowLambdas;
+  kes.config.workflowLambdas = clonedeep(aliasFixture.workflowLambdas);
+  kes.config.maxNumberOfRetainedLambdas = 2;
   kes.config.workflowLambdas.VersionUpTest.hash = 'PreviousVersionHash';
   const getAllLambdaAliasesStub = sinon.stub(kes, 'getAllLambdaAliases');
   for (let i = 0; i < aliasFixture.aliases.length; i += 1) {
@@ -242,14 +244,14 @@ test.serial('getRetainedLambdaAliasNames returns filtered aliasNames '
   t.deepEqual(expected, actual);
 });
 
-test.serial('getHumanReadableIdentifier returns a packed ID from the descriptiohn string', (t) => {
+test('getHumanReadableIdentifier returns a packed ID from the descriptiohn string', (t) => {
   const testString = 'Some Description Here|version';
   const expected = 'version';
   const actual = t.context.kes.getHumanReadableIdentifier(testString);
   t.is(expected, actual);
 });
 
-test.serial("getHumanReadableIdentifier returns '' for a version string with no packed ID", (t) => {
+test("getHumanReadableIdentifier returns '' for a version string with no packed ID", (t) => {
   const testString = 'Some Bogus Version String';
   const expected = '';
   const actual = t.context.kes.getHumanReadableIdentifier(testString);
@@ -257,7 +259,7 @@ test.serial("getHumanReadableIdentifier returns '' for a version string with no 
 });
 
 
-test.serial('setParentOverrideConfigValues merges defined parent configuration', (t) => {
+test('setParentOverrideConfigValues merges defined parent configuration', (t) => {
   const parentConfig = { overrideKey: true };
   const kes = t.context.kes;
   kes.config.overrideKey = false;
@@ -271,7 +273,7 @@ test.serial('setParentOverrideConfigValues merges defined parent configuration',
   t.is(expected, actual);
 });
 
-test.serial('setParentOverrideConfigValues ignores missing parent configuration', (t) => {
+test('setParentOverrideConfigValues ignores missing parent configuration', (t) => {
   const parentConfig = {};
   const kes = t.context.kes;
   kes.config.overrideKey = false;
@@ -286,7 +288,7 @@ test.serial('setParentOverrideConfigValues ignores missing parent configuration'
 });
 
 
-test.serial('addLambdaDeadLetterQueues adds dead letter queue to the sqs configuration', (t) => {
+test('addLambdaDeadLetterQueues adds dead letter queue to the sqs configuration', (t) => {
   const kes = t.context.kes;
   kes.config.lambdas.jobs.namedLambdaDeadLetterQueue = true;
   kes.config.DLQDefaultTimeout = 60;
@@ -297,12 +299,11 @@ test.serial('addLambdaDeadLetterQueues adds dead letter queue to the sqs configu
     MessageRetentionPeriod: 5,
     visibilityTimeout: 60
   };
-
   const actual = kes.config.sqs.jobsDeadLetterQueue;
   t.deepEqual(expected, actual);
 });
 
-test.serial('addLambdaDeadLetterQueues adds dead letter queue to the sqs configuration', (t) => {
+test('addLambdaDeadLetterQueues adds dead letter queue to the sqs configuration', (t) => {
   const kes = t.context.kes;
   kes.config.lambdas.jobs.namedLambdaDeadLetterQueue = true;
   kes.addLambdaDeadLetterQueues();
@@ -311,7 +312,7 @@ test.serial('addLambdaDeadLetterQueues adds dead letter queue to the sqs configu
   t.is(expected, actual);
 });
 
-test.serial('buildCWDashboard creates alarm widgets', (t) => {
+test('buildCWDashboard creates alarm widgets', (t) => {
   const kes = t.context.kes;
   // each ECS service has a default alarm
   const ecsDefaultAlarmCount = Object.keys(kes.config.ecs.services).length;

--- a/travis-ci/docker-compose.yml
+++ b/travis-ci/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     volumes:
       - ../packages/test-data:/usr/local/apache2/htdocs:ro
   sftp:
-    image: panubo/sshd
+    image: nsidc/panubo_sshd:latest
     command: /bootstrap-sftp.sh
     ports:
       - "127.0.0.1:2222:22"


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-1183](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1183)

- **CUMULUS-1183**
  - Kes overrides will now abort with a warning if a workflow step is configured without a corresponding
    lambda configuration

PR also addresses a bug in the test_kes.js unit test setup. 
