### PR TITLE
Replace sftp image with temporary fix image

### DIFF
--- a/travis-ci/docker-compose.yml
+++ b/travis-ci/docker-compose.yml
@@ -18,7 +18,8 @@ services:
     volumes:
       - ../packages/test-data:/usr/local/apache2/htdocs:ro
   sftp:
-    image: panubo/sshd
+    # image: panubo/sshd
+    image: nsidc:image: nsidc/panubo_sshd:latest
     command: /bootstrap-sftp.sh
     ports:
       - "127.0.0.1:2222:22"

--- a/travis-ci/docker-compose.yml
+++ b/travis-ci/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - ../packages/test-data:/usr/local/apache2/htdocs:ro
   sftp:
     # image: panubo/sshd
-    image: nsidc:image: nsidc/panubo_sshd:latest
+    image: nsidc/panubo_sshd:latest
     command: /bootstrap-sftp.sh
     ports:
       - "127.0.0.1:2222:22"


### PR DESCRIPTION
**Summary:** Replace sftp image with temporary fix image

Addresses [CUMULUS-1229: Fix unit test sshd docker container](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1229)