### PR TITLE
Move public files behind distribution endpoint.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,7 +242,7 @@ Note: There was an issue publishing 1.12.0. Upgrade to 1.12.1.
   - Schema validation is now strongly enforced when writing to the database.
     Additional properties are not allowed and will result in a validation error.
 - CUMULUS-678
-  `tasks/move-granules` simplified and refactored to use  functionality from cmrjs.
+  `tasks/move-granules` simplified and refactored to use functionality from cmrjs.
   `ingest/granules.moveGranuleFiles` now just moves granule files and returns a list of the updated files. Updating metadata now handled by `@cumulus/cmrjs/reconcileCMRMetadata`.
   `move-granules.updateGranuleMetadata` refactored and bugs fixed in the case of a file matching multiple collection.files.regexps.
   `getCmrXmlFiles` simplified and now only returns an object with the cmrfilename and the granuleId.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Changed
 
+- **CUMULUS-1236**
+  - Moves access to public files behind the distribution endpoint.  Authentication is not required, but direct http access has been disallowed.
+
 - **CUMULUS-1223**
   - Adds unauthenticated access for public bucket files to the Distribution API.  Public files should be requested the same way as protected files, but for public files a redirect to a self-signed S3 URL will happen without requiring authentication with Earthdata login.
 

--- a/example/spec/helpers/testUtils.js
+++ b/example/spec/helpers/testUtils.js
@@ -165,19 +165,6 @@ function getExecutionUrl(executionArn) {
 }
 
 /**
- * Get URL to a public file in S3
- *
- * @param {Object} params
- * @param {string} params.bucket - S3 bucket
- * @param {string} params.key - S3 object key
- *
- * @returns {string} - Public S3 file URL
- */
-function getPublicS3FileUrl({ bucket, key }) {
-  return `https://${bucket}.s3.amazonaws.com/${key}`;
-}
-
-/**
  * Redeploy the current Cumulus deployment.
  *
  * @param {Object} config - configuration object from loadConfig()
@@ -293,7 +280,6 @@ module.exports = {
   uploadTestDataToBucket,
   deleteFolder,
   getExecutionUrl,
-  getPublicS3FileUrl,
   redeploy,
   getFilesMetadata,
   protectFile,

--- a/example/spec/ingestGranule/IngestUMMGSuccessSpec.js
+++ b/example/spec/ingestGranule/IngestUMMGSuccessSpec.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const fs = require('fs-extra');
-const got = require('got');
 const path = require('path');
 const {
   URL,
@@ -24,7 +23,6 @@ const {
     parseS3Uri,
     headObject
   },
-  BucketsConfig,
   constructCollectionId
 } = require('@cumulus/common');
 const { getUrl } = require('@cumulus/cmrjs');
@@ -254,15 +252,12 @@ describe('The S3 Ingest Granules workflow configured to ingest UMM-G', () => {
   });
 
   describe('the PostToCmr task', () => {
-    let bucketsConfig;
     let onlineResources;
     let files;
     let resourceURLs;
     let accessToken;
 
     beforeAll(async () => {
-      bucketsConfig = new BucketsConfig(config.buckets);
-
       postToCmrOutput = await lambdaStep.getStepOutput(workflowExecution.executionArn, 'PostToCmr');
       if (postToCmrOutput === null) throw new Error(`Failed to get the PostToCmr step's output for ${workflowExecution.executionArn}`);
 

--- a/example/spec/ingestGranule/IngestUMMGSuccessSpec.js
+++ b/example/spec/ingestGranule/IngestUMMGSuccessSpec.js
@@ -419,27 +419,27 @@ describe('The S3 Ingest Granules workflow configured to ingest UMM-G', () => {
     it('updates the UMM-G JSON file in S3 with new paths', async () => {
       const updatedUmm = await getUmmObject(newS3UMMJsonFileLocation);
 
-      const expectedToChange = updatedUmm.RelatedUrls
+      const changedUrls = updatedUmm.RelatedUrls
         .filter((urlObject) => urlObject.URL.match(/.*.hdf$/))
         .map((urlObject) => urlObject.URL);
-      const expectedSame = updatedUmm.RelatedUrls
+      const unchangedUrls = updatedUmm.RelatedUrls
         .filter((urlObject) => !urlObject.URL.match(/.*.hdf$/))
         .map((urlObject) => urlObject.URL);
 
       // Only the file that was moved was updated
-      expect(expectedToChange.length).toEqual(1);
-      expect(expectedToChange[0]).toContain(destinationKey);
+      expect(changedUrls.length).toEqual(1);
+      expect(changedUrls[0]).toContain(destinationKey);
 
-      const unchangedOriginals = originalUmmUrls.filter((original) => !original.match(/.*.hdf$/));
-      expect(unchangedOriginals.length).toEqual(expectedSame.length);
+      const unchangedOriginalUrls = originalUmmUrls.filter((original) => !original.match(/.*.hdf$/));
+      expect(unchangedOriginalUrls.length).toEqual(unchangedUrls.length);
 
       // Each originalUmmUrl (removing the DISTRIBUTION_ENDPOINT) should be found
       // in one of the updated URLs. We have to do this comparison because the
       // setup tests uses a fake endpoint, but it's possible that the api has
       // the actual endpoint.
-      unchangedOriginals.forEach((original) => {
+      unchangedOriginalUrls.forEach((original) => {
         const base = original.replace(process.env.DISTRIBUTION_ENDPOINT, '');
-        expect(expectedSame.filter((expected) => expected.match(base)).length).toBe(1);
+        expect(unchangedUrls.filter((expected) => expected.match(base)).length).toBe(1);
       });
     });
   });

--- a/example/spec/ingestGranule/IngestUMMGSuccessSpec.js
+++ b/example/spec/ingestGranule/IngestUMMGSuccessSpec.js
@@ -50,8 +50,7 @@ const {
   createTimestampedTestId,
   createTestDataPath,
   createTestSuffix,
-  templateFile,
-  getPublicS3FileUrl
+  templateFile
 } = require('../helpers/testUtils');
 const {
   setDistributionApiEnvVars,
@@ -311,11 +310,16 @@ describe('The S3 Ingest Granules workflow configured to ingest UMM-G', () => {
     });
 
     it('updates the CMR metadata online resources with the final metadata location', () => {
+      const scienceFile = files.find((f) => f.filepath.endsWith('hdf'));
+      const browseFile = files.find((f) => f.filepath.endsWith('jpg'));
+
       const distributionUrl = getDistributionFileUrl({
-        bucket: files[0].bucket,
-        key: files[0].filepath
+        bucket: scienceFile.bucket, key: scienceFile.filepath
       });
-      const s3BrowseImageUrl = getPublicS3FileUrl({ bucket: files[2].bucket, key: files[2].filepath });
+
+      const s3BrowseImageUrl = getDistributionFileUrl({
+        bucket: browseFile.bucket, key: browseFile.filepath
+      });
 
       expect(resourceURLs.includes(distributionUrl)).toBe(true);
       expect(resourceURLs.includes(s3BrowseImageUrl)).toBe(true);
@@ -365,18 +369,11 @@ describe('The S3 Ingest Granules workflow configured to ingest UMM-G', () => {
             );
             const file = files.find((f) => f.name.endsWith(extension));
 
-            let fileStream;
-
-            if (bucketsConfig.type(file.bucket) === 'protected') {
-              const fileUrl = getDistributionFileUrl({
-                bucket: file.bucket,
-                key: file.filepath
-              });
-              fileStream = await getDistributionApiFileStream(fileUrl, accessToken);
-            }
-            else if (bucketsConfig.type(file.bucket) === 'public') {
-              fileStream = got.stream(url);
-            }
+            const fileUrl = getDistributionFileUrl({
+              bucket: file.bucket,
+              key: file.filepath
+            });
+            const fileStream = await getDistributionApiFileStream(fileUrl, accessToken);
 
             // Compare checksum of downloaded file with expected checksum.
             const downloadChecksum = await generateChecksumFromStream('cksum', fileStream);
@@ -427,21 +424,28 @@ describe('The S3 Ingest Granules workflow configured to ingest UMM-G', () => {
     it('updates the UMM-G JSON file in S3 with new paths', async () => {
       const updatedUmm = await getUmmObject(newS3UMMJsonFileLocation);
 
-      const relatedUrlDifferences = updatedUmm.RelatedUrls.filter((urlObject) => {
-        // Skip non-science URLs and public S3 URLs
-        if (!isUMMGScienceUrl(urlObject.URL) ||
-            urlObject.URL.match(/s3\.amazonaws\.com/)) {
-          return false;
-        }
-        const relatedUrl = new URL(urlObject.URL);
-        relatedUrl.host = process.env.DISTRIBUTION_ENDPOINT;
-        return !originalUmmUrls.includes(relatedUrl.toString());
-      });
+      const expectedToChange = updatedUmm.RelatedUrls
+        .filter((urlObject) => urlObject.URL.match(/.*.hdf$/))
+        .map((urlObject) => urlObject.URL);
+      const expectedSame = updatedUmm.RelatedUrls
+        .filter((urlObject) => !urlObject.URL.match(/.*.hdf$/))
+        .map((urlObject) => urlObject.URL);
 
       // Only the file that was moved was updated
-      expect(relatedUrlDifferences.length).toEqual(1);
+      expect(expectedToChange.length).toEqual(1);
+      expect(expectedToChange[0]).toContain(destinationKey);
 
-      expect(relatedUrlDifferences[0].URL).toContain(destinationKey);
+      const unchangedOriginals = originalUmmUrls.filter((original) => !original.match(/.*.hdf$/));
+      expect(unchangedOriginals.length).toEqual(expectedSame.length);
+
+      // Each originalUmmUrl (removing the DISTRIBUTION_ENDPOINT) should be found
+      // in one of the updated URLs. We have to do this comparison because the
+      // setup tests uses a fake endpoint, but it's possible that the api has
+      // the actual endpoint.
+      unchangedOriginals.forEach((original) => {
+        const base = original.replace(process.env.DISTRIBUTION_ENDPOINT, '');
+        expect(expectedSame.filter((expected) => expected.match(base)).length).toBe(1);
+      });
     });
   });
 });

--- a/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const fs = require('fs-extra');
-const got = require('got');
 const path = require('path');
 const { URL, resolve } = require('url');
 const cloneDeep = require('lodash.clonedeep');
@@ -25,7 +24,6 @@ const {
     s3GetObjectTagging,
     s3ObjectExists
   },
-  BucketsConfig,
   constructCollectionId
 } = require('@cumulus/common');
 const { getUrl } = require('@cumulus/cmrjs');
@@ -327,7 +325,6 @@ describe('The S3 Ingest Granules workflow', () => {
   });
 
   describe('the PostToCmr task', () => {
-    let bucketsConfig;
     let cmrResource;
     let ummCmrResource;
     let files;
@@ -336,7 +333,6 @@ describe('The S3 Ingest Granules workflow', () => {
     let accessToken;
 
     beforeAll(async () => {
-      bucketsConfig = new BucketsConfig(config.buckets);
       postToCmrOutput = await lambdaStep.getStepOutput(workflowExecution.executionArn, 'PostToCmr');
       if (postToCmrOutput === null) throw new Error(`Failed to get the PostToCmr step's output for ${workflowExecution.executionArn}`);
       granule = postToCmrOutput.payload.granules[0];

--- a/packages/api/tests/lambdas/create-reconciliation-report.js
+++ b/packages/api/tests/lambdas/create-reconciliation-report.js
@@ -625,7 +625,7 @@ test.serial('reconciliationReportForGranuleFiles reports discrepancy of granule 
     Description: 'File to download'
   },
   {
-    URL: 'https://testbucket-public.s3.amazonaws.com/MOD09GQ___006/MOD/MOD09GQ.A4675287.SWPE5_.006.7310007729190_ndvi.jpg',
+    URL: `${process.env.DISTRIBUTION_ENDPOINT}testbucket-public/MOD09GQ___006/MOD/MOD09GQ.A4675287.SWPE5_.006.7310007729190_ndvi.jpg`,
     Type: 'GET DATA',
     Description: 'File to download'
   },

--- a/packages/cmrjs/cmr-utils.js
+++ b/packages/cmrjs/cmr-utils.js
@@ -352,8 +352,8 @@ function constructOnlineAccessUrl({
   buckets
 }) {
   const bucketType = buckets.type(file.bucket);
-  const urlBuckets = ['protected', 'public'];
-  if (urlBuckets.includes(bucketType)) {
+  const distributionApiBuckets = ['protected', 'public'];
+  if (distributionApiBuckets.includes(bucketType)) {
     const extension = urljoin(file.bucket, getS3KeyOfFile(file));
     return {
       URL: urljoin(distEndpoint, extension),

--- a/packages/cmrjs/cmr-utils.js
+++ b/packages/cmrjs/cmr-utils.js
@@ -352,21 +352,14 @@ function constructOnlineAccessUrl({
   buckets
 }) {
   const bucketType = buckets.type(file.bucket);
-  if (bucketType === 'protected') {
+  const urlBuckets = ['protected', 'public'];
+  if (urlBuckets.includes(bucketType)) {
     const extension = urljoin(file.bucket, getS3KeyOfFile(file));
     return {
       URL: urljoin(distEndpoint, extension),
       URLDescription: 'File to download', // used by ECHO10
       Description: 'File to download', // used by UMMG
       Type: mapCNMTypeToCMRType(file.fileType) // used by UMMG
-    };
-  }
-  if (bucketType === 'public') {
-    return {
-      URL: `https://${file.bucket}.s3.amazonaws.com/${getS3KeyOfFile(file)}`,
-      URLDescription: 'File to download',
-      Description: 'File to download',
-      Type: mapCNMTypeToCMRType(file.fileType)
     };
   }
   return null;

--- a/packages/cmrjs/tests/cmr-utils/test-cmr-utils.js
+++ b/packages/cmrjs/tests/cmr-utils/test-cmr-utils.js
@@ -187,7 +187,7 @@ test.serial('updateEcho10XMLMetadata adds granule files correctly to OnlineAcces
   ];
   const AssociatedBrowseExpected = [
     {
-      URL: 'https://cumulus-test-sandbox-public.s3.amazonaws.com/MOD09GQ___006/TESTFIXTUREDIR/MOD09GQ.A6391489.a3Odk1.006.3900731509248_ndvi.jpg',
+      URL: `${distEndpoint}/cumulus-test-sandbox-public/MOD09GQ___006/TESTFIXTUREDIR/MOD09GQ.A6391489.a3Odk1.006.3900731509248_ndvi.jpg`,
       Description: 'File to download'
     }
   ];
@@ -237,7 +237,7 @@ test.serial('updateUMMGMetadata adds Type correctly to RelatedURLs for granule f
       Type: 'GET DATA'
     },
     {
-      URL: 'https://cumulus-test-sandbox-public.s3.amazonaws.com/MOD09GQ___006/MOD/MOD09GQ.A3411593.1itJ_e.006.9747594822314_ndvi.jpg',
+      URL: `${distEndpoint}/cumulus-test-sandbox-public/MOD09GQ___006/MOD/MOD09GQ.A3411593.1itJ_e.006.9747594822314_ndvi.jpg`,
       Description: 'File to download',
       Type: 'GET RELATED VISUALIZATION'
     },

--- a/packages/cmrjs/tests/cmr-utils/test-constructurls.js
+++ b/packages/cmrjs/tests/cmr-utils/test-constructurls.js
@@ -14,8 +14,8 @@ const mapCNMTypeToCMRType = cmrUtils.__get__('mapCNMTypeToCMRType');
 
 const sortByURL = (a, b) => a.URL < b.URL;
 
-const endpoint = 'https://endpoint';
-const s3CredentialsEndpointObject = getS3CredentialsObject(`${endpoint}/s3credentials`);
+const distEndpoint = 'https://endpoint';
+const s3CredentialsEndpointObject = getS3CredentialsObject(`${distEndpoint}/s3credentials`);
 
 
 test.beforeEach((t) => {
@@ -48,7 +48,7 @@ test('returns correct url for protected data', (t) => {
   ];
   const expected = [
     {
-      URL: `${endpoint}/${t.context.bucketConfig.protected.name}/some/path/protected-file.hdf`,
+      URL: `${distEndpoint}/${t.context.bucketConfig.protected.name}/some/path/protected-file.hdf`,
       Description: 'File to download',
       URLDescription: 'File to download',
       Type: 'GET DATA'
@@ -57,7 +57,7 @@ test('returns correct url for protected data', (t) => {
 
   const actual = constructOnlineAccessUrls({
     files: movedFiles,
-    distEndpoint: endpoint,
+    distEndpoint,
     buckets: t.context.buckets
   });
 
@@ -74,7 +74,7 @@ test('Returns correct url object for public data.', (t) => {
   ];
   const expected = [
     {
-      URL: `https://${publicBucketName}.s3.amazonaws.com/some/path/browse_image.jpg`,
+      URL: `${distEndpoint}/${publicBucketName}/some/path/browse_image.jpg`,
       Description: 'File to download',
       URLDescription: 'File to download',
       Type: 'GET DATA'
@@ -83,7 +83,7 @@ test('Returns correct url object for public data.', (t) => {
 
   const actual = constructOnlineAccessUrls({
     files: movedFiles,
-    distEndpoint: endpoint,
+    distEndpoint,
     buckets: t.context.buckets
   });
 
@@ -101,7 +101,7 @@ test('Returns empty list for private data.', (t) => {
   ];
   const actual = constructOnlineAccessUrls({
     files: movedFiles,
-    distEndpoint: endpoint,
+    distEndpoint,
     buckets: t.context.buckets
   });
 
@@ -129,13 +129,13 @@ test('returns an array of correct url objects given a list of moved files.', (t)
 
   const expected = [
     {
-      URL: `${endpoint}/${t.context.bucketConfig.protected.name}/another/path/protected.hdf`,
+      URL: `${distEndpoint}/${t.context.bucketConfig.protected.name}/another/path/protected.hdf`,
       Description: 'File to download',
       URLDescription: 'File to download',
       Type: 'GET DATA'
     },
     {
-      URL: `https://${t.context.bucketConfig.public.name}.s3.amazonaws.com/path/publicfile.jpg`,
+      URL: `${distEndpoint}/${t.context.bucketConfig.public.name}/path/publicfile.jpg`,
       Description: 'File to download',
       URLDescription: 'File to download',
       Type: 'GET RELATED VISUALIZATION'
@@ -144,7 +144,7 @@ test('returns an array of correct url objects given a list of moved files.', (t)
 
   const actual = constructOnlineAccessUrls({
     files: movedFiles,
-    distEndpoint: endpoint,
+    distEndpoint,
     buckets: t.context.buckets
   });
 
@@ -169,12 +169,12 @@ test('constructRelatedUrls returns expected array when called with file list', (
 
   const expected = [
     {
-      URL: `${endpoint}/${t.context.bucketConfig.protected.name}/another/path/protected.hdf`,
+      URL: `${distEndpoint}/${t.context.bucketConfig.protected.name}/another/path/protected.hdf`,
       Description: 'File to download',
       Type: 'GET DATA'
     },
     {
-      URL: `https://${t.context.bucketConfig.public.name}.s3.amazonaws.com/path/publicfile.jpg`,
+      URL: `${distEndpoint}/${t.context.bucketConfig.public.name}/path/publicfile.jpg`,
       Description: 'File to download',
       Type: 'GET DATA'
     },
@@ -183,7 +183,7 @@ test('constructRelatedUrls returns expected array when called with file list', (
 
   const actual = constructRelatedUrls({
     files: movedFiles,
-    distEndpoint: endpoint,
+    distEndpoint,
     buckets: t.context.buckets
   });
 
@@ -196,7 +196,7 @@ test('constructRelatedUrls returns expected array when called with an empty file
 
   const actual = constructRelatedUrls({
     files: movedFiles,
-    distEndpoint: endpoint,
+    distEndpoint,
     buckets: t.context.buckets
   });
 

--- a/packages/ingest/test/test-ftp.js
+++ b/packages/ingest/test/test-ftp.js
@@ -60,7 +60,7 @@ test('Download remote file to s3 with correct content-type', async (t) => {
   class MyTestFtpDiscoveryClass extends TestFtpMixin(MyTestDiscoveryClass) {}
   const myTestFtpDiscoveryClass = new MyTestFtpDiscoveryClass();
   const bucket = randomString();
-  const key = randomString() + '.hdf';
+  const key = `${randomString()}.hdf`;
   const expectedContentType = 'application/x-hdf';
   try {
     await s3().createBucket({ Bucket: bucket }).promise();

--- a/packages/ingest/test/test-sftp.js
+++ b/packages/ingest/test/test-sftp.js
@@ -75,7 +75,7 @@ test('Download remote file to s3 with correct content-type', async (t) => {
   const myTestSftpDiscoveryClass = new MyTestSftpDiscoveryClass(true);
   const expectedContentType = 'application/x-hdf';
 
-  const key = randomString() + '.hdf';
+  const key = `${randomString()}.hdf`;
   await myTestSftpDiscoveryClass.sync(
     '/granules/MOD09GQ.A2017224.h27v08.006.2017227165029.hdf', bucket, key
   );

--- a/packages/integration-tests/api/distribution.js
+++ b/packages/integration-tests/api/distribution.js
@@ -108,7 +108,8 @@ function getDistributionFileUrl({
   bucket,
   key
 }) {
-  return `${distributionEndpoint}/${bucket}/${key}`;
+  const theUrl = new URL(`${bucket}/${key}`, distributionEndpoint);
+  return theUrl.href;
 }
 
 module.exports = {

--- a/packages/integration-tests/api/distribution.js
+++ b/packages/integration-tests/api/distribution.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { URL } = require('url');
 const { Lambda } = require('aws-sdk');
 const got = require('got');
 


### PR DESCRIPTION
**Summary:** Changes how public file URLs are created, and now places them behind the distribution API (still without requiring authentication)

Addresses [CUMULUS-1236: As a same region cloud user / service, I want to access ancillary files such as documentation and browse directly from S3 so I may better understand the data](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1236)

## Changes

* removes testUtil helper getPublicS3FileUrl and replaces those calls with calls to getDistributionFileUrl
* Updates tests to expect updated data in correct locations.

## PR Checklist

- [ X ] Update CHANGELOG
- [ X ] Unit tests
- [ X ] Adhoc testing
- [ X ] Integration tests