### PR TITLE
CUMULUS-1264: Rename nested stacks

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -9,8 +9,8 @@ app/dist
 node_modules
 *.env
 /deployer/cloudformation.yml
-CumulusApiDefault.yml
-CumulusApiV1.yml
+CumulusApiBackend.yml
+CumulusApiDistribution.yml
 yarn.lock
 spec/config.override.yml
 spec/**/*.input.json

--- a/packages/api/config/api.yml
+++ b/packages/api/config/api.yml
@@ -1,4 +1,3 @@
-
 ApiEndpoints:
   handler: index.appHandler
   timeout: 20
@@ -38,9 +37,6 @@ ApiEndpoints:
     UsersTable:
       function: Ref
       value: UsersTableDynamoDB
-    BulkDeleteLambda:
-      function: Ref
-      value: BulkDeleteLambdaFunction
     AsyncOperationTaskDefinition:
       function: Ref
       value: AsyncOperationTaskDefinition
@@ -48,6 +44,9 @@ ApiEndpoints:
       function: Ref
       value: EcsCluster
     system_bucket: '{{parent.system_bucket}}'
+    BulkDeleteLambda:
+      function: Ref
+      value: BulkDeleteLambdaFunction
     invoke:
       function: "Ref"
       value: ScheduleSFLambdaFunction
@@ -63,6 +62,7 @@ ApiEndpoints:
     KinesisInboundEventLogger:
       function: "Ref"
       value: KinesisInboundEventLoggerLambdaFunction
+    STSCredentialsLambda: '{{parent.sts_credentials_lambda}}'
     cmr_provider: '{{parent.cmr.provider}}'
     cmr_client_id: '{{parent.cmr.clientId}}'
     cmr_username: '{{parent.cmr.username}}'
@@ -72,7 +72,6 @@ ApiEndpoints:
     ES_HOST:
       function: Ref
       value: ElasticSearchDomain
-    STSCredentialsLambda: '{{parent.sts_credentials_lambda}}'
     TOKEN_SECRET: '{{TOKEN_SECRET}}'
   apiGateway:
     - api: backend

--- a/packages/api/config/distribution.yml
+++ b/packages/api/config/distribution.yml
@@ -14,9 +14,9 @@ ApiDistribution:
       function: Ref
       value: AccessTokensTableDynamoDB
   apiGateway:
-    - api: download
+    - api: distribution
       path: 'redirect'
       method: get
-    - api: download
+    - api: distribution
       path: '{proxy+}'
       method: any

--- a/packages/api/config/lambdas.yml
+++ b/packages/api/config/lambdas.yml
@@ -4,7 +4,6 @@ sqs2sf:
   memory: 512
   source: 'node_modules/@cumulus/api/dist/'
 
-
 executeMigrations:
   handler: index.executeMigrations
   timeout: 300
@@ -31,7 +30,6 @@ executeMigrations:
       function: Ref
       value: KinesisInboundEventLoggerLambdaFunction
     system_bucket: '{{system_bucket}}'
-
 
 sns2elasticsearch:
   handler: index.indexer
@@ -167,7 +165,6 @@ EmsReport:
     system_bucket: '{{system_bucket}}'
     ems_provider: '{{ems.provider}}'
   namedLambdaDeadLetterQueue: true
-
 
 EmsDistributionReport:
   handler: index.emsDistributionReport

--- a/packages/deployment/app/cloudformation.template.yml
+++ b/packages/deployment/app/cloudformation.template.yml
@@ -54,21 +54,9 @@ Resources:
           Fn::GetAtt:
             - KinesisInboundEventLoggerLambdaFunction
             - Arn
-        KinesisOutboundEventLoggerLambdaFunction:
-          Fn::GetAtt:
-            - KinesisOutboundEventLoggerLambdaFunction
-            - Arn
-        log2elasticsearchLambdaFunction:
-          Fn::GetAtt:
-            - log2elasticsearchLambdaFunction
-            - Arn
         ScheduleSFLambdaFunction:
           Fn::GetAtt:
             - ScheduleSFLambdaFunction
-            - Arn
-        dbIndexerLambdaFunction:
-          Fn::GetAtt:
-            - dbIndexerLambdaFunction
             - Arn
         messageConsumerLambdaFunction:
           Fn::GetAtt:
@@ -81,6 +69,14 @@ Resources:
         BulkDeleteLambdaFunction:
           Fn::GetAtt:
             - BulkDeleteLambdaFunction
+            - Arn
+        log2elasticsearchLambdaFunction:
+          Fn::GetAtt:
+            - log2elasticsearchLambdaFunction
+            - Arn
+        dbIndexerLambdaFunction:
+          Fn::GetAtt:
+            - dbIndexerLambdaFunction
             - Arn
         EcsCluster:
           Ref: CumulusECSCluster
@@ -518,18 +514,6 @@ Resources:
   {{/each}}
 {{/each}}
 
-## Generic lambda permission for custom rules
-## created in the dashboard
-  GenericLambdaPermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName:
-        Fn::GetAtt:
-        - ScheduleSFLambdaFunction
-        - Arn
-      Action: lambda:InvokeFunction
-      Principal: events.amazonaws.com
-
   #################################################
   # CloudWatch RULE config END
   #################################################
@@ -594,90 +578,12 @@ Resources:
   #################################################
   # APIGateway config BEGIN
   #################################################
-{{# if apiMethods}}
-
-{{#each apiMethods}}
-  {{name}}:
-    Type: AWS::ApiGateway::Method
-    Properties:
-      ResourceId:
-        Ref: {{resource}}
-      RestApiId:
-        Ref: {{api}}RestApi
-      HttpMethod: {{method}}
-      AuthorizationType: NONE
-      Integration:
-        Type: AWS_PROXY
-        IntegrationHttpMethod: POST
-        Uri:
-          Fn::Join:
-          - ''
-          - - 'arn:aws:apigateway:'
-            - Ref: AWS::Region
-            - :lambda:path/2015-03-31/functions/
-            - Fn::GetAtt:
-              - {{lambda}}LambdaFunction
-              - Arn
-            - /invocations
-
-{{/each}}
-
-{{#each apiMethodsOptions}}
-  {{name}}:
-    Type: AWS::ApiGateway::Method
-    Properties:
-      AuthorizationType: NONE
-      HttpMethod: OPTIONS
-      Integration:
-        IntegrationResponses:
-        - ResponseParameters:
-            method.response.header.Access-Control-Allow-Headers: '''Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'''
-            method.response.header.Access-Control-Allow-Methods: '''OPTIONS,PUT,POST,GET,DELETE'''
-            method.response.header.Access-Control-Allow-Origin: '''*'''
-          ResponseTemplates:
-            application/json: ''
-          StatusCode: '200'
-        RequestTemplates:
-          application/json: '{statusCode:200}'
-        Type: MOCK
-      MethodResponses:
-      - ResponseModels: {}
-        ResponseParameters:
-          method.response.header.Access-Control-Allow-Headers: true
-          method.response.header.Access-Control-Allow-Methods: true
-          method.response.header.Access-Control-Allow-Origin: true
-        StatusCode: '200'
-      RequestParameters:
-        method.request.header.Authorization: true
-      ResourceId:
-        Ref: {{resource}}
-      RestApiId:
-        Ref: {{api}}RestApi
-
-{{/each}}
-
-{{#each apiResources}}
-  {{name}}:
-    Type: AWS::ApiGateway::Resource
-    Properties:
-      ParentId:
-      {{#each parents}}
-        {{this}}
-      {{/each}}
-      PathPart: '{{pathPart}}'
-      RestApiId:
-        Ref: {{api}}RestApi
-
-{{/each}}
-{{/if}}
-
 {{#each apis}}
   {{name}}RestApi:
     Type: AWS::ApiGateway::RestApi
     Properties:
       Name: {{../stackName}}-{{name}}
 {{/each}}
-
   #################################################
   # APIGateway config END
   #################################################
@@ -719,29 +625,6 @@ Resources:
           {{@key}}: {{{this}}}
       {{/if}}
     {{/each}}
-      {{# if ../api_backend_url}}
-          BACKEND_API_URL: {{../api_backend_url}}
-      {{else}}
-          BACKEND_API_URL:
-            Fn::Join: ["", [ "https://", {"Ref": "backendRestApi"}, ".execute-api.", {"Fn::Sub": "${AWS::Region}"}, ".amazonaws.com/{{../apiStage}}/"]]
-      {{/if}}
-      {{# if this.urs}}
-        {{# if ../api_backend_url}}
-          TOKEN_REDIRECT_ENDPOINT: {{../api_backend_url}}token
-        {{else}}
-          TOKEN_REDIRECT_ENDPOINT:
-            Fn::Join: ["", [ "https://", {"Ref": "backendRestApi"}, ".execute-api.", {"Fn::Sub": "${AWS::Region}"}, ".amazonaws.com/{{../apiStage}}/token"]]
-        {{/if}}
-        {{# if ../api_distribution_url}}
-          DISTRIBUTION_ENDPOINT: {{../api_distribution_url}}
-          DISTRIBUTION_REDIRECT_ENDPOINT: {{../api_distribution_url}}redirect
-        {{else}}
-          DISTRIBUTION_ENDPOINT:
-            Fn::Join: ["", [ "https://", {"Ref": "downloadRestApi"}, ".execute-api.", {"Fn::Sub": "${AWS::Region}"}, ".amazonaws.com/{{../apiStage}}"]]
-          DISTRIBUTION_REDIRECT_ENDPOINT:
-            Fn::Join: ["", [ "https://", {"Ref": "downloadRestApi"}, ".execute-api.", {"Fn::Sub": "${AWS::Region}"}, ".amazonaws.com/{{../apiStage}}/redirect"]]
-        {{/if}}
-      {{/if}}
       Handler: {{this.handler}}
       MemorySize: {{this.memory}}
 {{# if this.apiRole }}
@@ -815,6 +698,20 @@ Resources:
       LogGroupName: '/aws/lambda/{{../stackName}}-{{@key}}'
       RetentionInDays: 30
 {{/if}}
+
+  {{#ifEquals @key "ScheduleSF"}}
+  ## Generic lambda permission for custom rules
+  ## created in the dashboard
+  GenericLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName:
+        Fn::GetAtt:
+        - ScheduleSFLambdaFunction
+        - Arn
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+  {{/ifEquals}}
 {{/each}}
 
   log2elasticsearchLambdaPermissionLog:
@@ -1259,14 +1156,14 @@ Outputs:
   {{else}}
     Value:
       Fn::Join: ["", [ "https://", {"Ref": "backendRestApi"}, ".execute-api.", {"Fn::Sub": "${AWS::Region}"}, ".amazonaws.com/{{apiStage}}/"]]
-      {{/if}}
+  {{/if}}
 
   Distribution:
   {{# if api_distribution_url}}
     Value: {{api_distribution_url}}
   {{else}}
     Value:
-      Fn::Join: ["", [ "https://", {"Ref": "downloadRestApi"}, ".execute-api.", {"Fn::Sub": "${AWS::Region}"}, ".amazonaws.com/{{apiStage}}/"]]
+      Fn::Join: ["", [ "https://", {"Ref": "distributionRestApi"}, ".execute-api.", {"Fn::Sub": "${AWS::Region}"}, ".amazonaws.com/{{apiStage}}/"]]
   {{/if}}
 
   ApiId:
@@ -1275,7 +1172,7 @@ Outputs:
 
   DistributionId:
     Value:
-      Ref: downloadRestApi
+      Ref: distributionRestApi
 
   ApiStage:
     Value: {{apiStage}}

--- a/packages/deployment/app/config.yml
+++ b/packages/deployment/app/config.yml
@@ -28,12 +28,12 @@ default:
   processDefaultDeadLetterQueues: true
 
   nested_templates:
-    CumulusApiDefault:
+    CumulusApiDistribution:
       cfFile: node_modules/@cumulus/deployment/app/cumulus_api.template.yml
-      configFile: node_modules/@cumulus/deployment/app/cumulus_api_default.config.yml
-    CumulusApiV1:
+      configFile: node_modules/@cumulus/deployment/app/cumulus_api_distribution.config.yml
+    CumulusApiBackend:
       cfFile: node_modules/@cumulus/deployment/app/cumulus_api.template.yml
-      configFile: node_modules/@cumulus/deployment/app/cumulus_api_v1.config.yml
+      configFile: node_modules/@cumulus/deployment/app/cumulus_api_backend.config.yml
     WorkflowLambdaVersions:
       cfFile: node_modules/@cumulus/deployment/app/workflow_lambda_versions.template.yml
       configFile: node_modules/@cumulus/deployment/app/workflow_lambda_versions.config.yml
@@ -157,7 +157,7 @@ default:
           protocol: lambda
 
   apis:
-    - name: download
+    - name: distribution
     - name: backend
 
   sqs_consumer_rate: 500

--- a/packages/deployment/app/cumulus_api.template.yml
+++ b/packages/deployment/app/cumulus_api.template.yml
@@ -64,7 +64,7 @@ Resources:
   #################################################
 {{# if apiMethods}}
 {{# each apiDependencies}}
-  {{# if apiDeploy }}
+  {{# if ../apiDeploy }}
   ApiGatewayDeployment{{../parent.apiStage}}{{name}}:
     DependsOn:
   {{#each methods}}
@@ -178,14 +178,12 @@ Resources:
           public_buckets: {{{collectBuckets ../parent.buckets "public"}}}
           protected_buckets: {{{collectBuckets ../parent.buckets "protected"}}}
       {{# if this.urs}}
-        {{# ifEquals ../apiName "backend" }}
         {{# if ../parent.api_backend_url}}
           TOKEN_REDIRECT_ENDPOINT: {{../parent.api_backend_url}}token
         {{else}}
           TOKEN_REDIRECT_ENDPOINT:
             Fn::Join: ["", [ "https://", {"Ref": "backendRestApi"}, ".execute-api.", {"Fn::Sub": "${AWS::Region}"}, ".amazonaws.com/{{../parent.apiStage}}/token"]]
         {{/if}}
-        {{/ifEquals}}
         {{# if ../parent.api_distribution_url}}
           DISTRIBUTION_ENDPOINT: {{../parent.api_distribution_url}}
           DISTRIBUTION_REDIRECT_ENDPOINT: {{../parent.api_distribution_url}}redirect

--- a/packages/deployment/app/cumulus_api.template.yml
+++ b/packages/deployment/app/cumulus_api.template.yml
@@ -1,12 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: 'stack: {{stackName}} | deployed by Kes'
 Parameters:
-  KinesisInboundEventLoggerLambdaFunction:
-    Type: String
-    Description: 'Arn for KinesisInboundEventLogger Lambda Function'
-  KinesisOutboundEventLoggerLambdaFunction:
-    Type: String
-    Description: 'Arn for KinesisOutboundEventLogger Lambda Function'
   CmrPassword:
     Type: String
     Description: 'Password used to publish CMR records. This is encrypted by Custom::Cumulus'
@@ -20,15 +14,12 @@ Parameters:
     Type: String
     Description: 'Security Group ID'
     Default: 'noValue'
-  log2elasticsearchLambdaFunction:
+  KinesisInboundEventLoggerLambdaFunction:
     Type: String
-    Description: 'logToElasticsearch Lambda function arn'
+    Description: 'Arn for KinesisInboundEventLogger Lambda Function'
   ScheduleSFLambdaFunction:
     Type: String
     Description: 'ScheduleSF lambda function arn'
-  dbIndexerLambdaFunction:
-    Type: String
-    Description: 'Arn for dbIndexer lambda function'
   messageConsumerLambdaFunction:
     Type: String
     Description: 'messageConsumer lambda function arn'
@@ -37,6 +28,12 @@ Parameters:
     Description: 'CreateReconciliationReport lambda function arn'
   BulkDeleteLambdaFunction:
     Type: String
+  log2elasticsearchLambdaFunction:
+    Type: String
+    Description: 'logToElasticsearch Lambda function arn'
+  dbIndexerLambdaFunction:
+    Type: String
+    Description: 'Arn for dbIndexer lambda function'
   AsyncOperationTaskDefinition:
     Type: String
   EcsCluster:
@@ -181,20 +178,22 @@ Resources:
           public_buckets: {{{collectBuckets ../parent.buckets "public"}}}
           protected_buckets: {{{collectBuckets ../parent.buckets "protected"}}}
       {{# if this.urs}}
+        {{# ifEquals ../apiName "backend" }}
         {{# if ../parent.api_backend_url}}
           TOKEN_REDIRECT_ENDPOINT: {{../parent.api_backend_url}}token
         {{else}}
           TOKEN_REDIRECT_ENDPOINT:
             Fn::Join: ["", [ "https://", {"Ref": "backendRestApi"}, ".execute-api.", {"Fn::Sub": "${AWS::Region}"}, ".amazonaws.com/{{../parent.apiStage}}/token"]]
         {{/if}}
+        {{/ifEquals}}
         {{# if ../parent.api_distribution_url}}
           DISTRIBUTION_ENDPOINT: {{../parent.api_distribution_url}}
           DISTRIBUTION_REDIRECT_ENDPOINT: {{../parent.api_distribution_url}}redirect
         {{else}}
           DISTRIBUTION_ENDPOINT:
-            Fn::Join: ["", [ "https://", {"Ref": "downloadRestApi"}, ".execute-api.", {"Fn::Sub": "${AWS::Region}"}, ".amazonaws.com/{{../parent.apiStage}}"]]
+            Fn::Join: ["", [ "https://", {"Ref": "distributionRestApi"}, ".execute-api.", {"Fn::Sub": "${AWS::Region}"}, ".amazonaws.com/{{../parent.apiStage}}"]]
           DISTRIBUTION_REDIRECT_ENDPOINT:
-            Fn::Join: ["", [ "https://", {"Ref": "downloadRestApi"}, ".execute-api.", {"Fn::Sub": "${AWS::Region}"}, ".amazonaws.com/{{../parent.apiStage}}/redirect"]]
+            Fn::Join: ["", [ "https://", {"Ref": "distributionRestApi"}, ".execute-api.", {"Fn::Sub": "${AWS::Region}"}, ".amazonaws.com/{{../parent.apiStage}}/redirect"]]
         {{/if}}
       {{/if}}
     {{#each this.envs}}

--- a/packages/deployment/app/cumulus_api_backend.config.yml
+++ b/packages/deployment/app/cumulus_api_backend.config.yml
@@ -1,5 +1,6 @@
 default:
 
+  apiDeploy: true
   apis:
     - name: backend
 

--- a/packages/deployment/app/cumulus_api_backend.config.yml
+++ b/packages/deployment/app/cumulus_api_backend.config.yml
@@ -3,4 +3,6 @@ default:
   apis:
     - name: backend
 
+  apiName: backend
+
   lambdas: !!files [ 'node_modules/@cumulus/api/config/api.yml' ]

--- a/packages/deployment/app/cumulus_api_backend.config.yml
+++ b/packages/deployment/app/cumulus_api_backend.config.yml
@@ -3,6 +3,4 @@ default:
   apis:
     - name: backend
 
-  apiName: backend
-
   lambdas: !!files [ 'node_modules/@cumulus/api/config/api.yml' ]

--- a/packages/deployment/app/cumulus_api_distribution.config.yml
+++ b/packages/deployment/app/cumulus_api_distribution.config.yml
@@ -14,8 +14,9 @@ default:
       - ExecutionsTable
 
   apis:
-    - name: download 
-    - name: backend
+    - name: distribution
+
+  apiName: distribution
 
   lambdas: !!files [
     'node_modules/@cumulus/api/config/distribution.yml'

--- a/packages/deployment/app/cumulus_api_distribution.config.yml
+++ b/packages/deployment/app/cumulus_api_distribution.config.yml
@@ -16,8 +16,6 @@ default:
   apis:
     - name: distribution
 
-  apiName: distribution
-
   lambdas: !!files [
     'node_modules/@cumulus/api/config/distribution.yml'
   ]


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-1264: Re-factor/simplify API deployment configuration](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1264)

## Changes

- Rename `download` to `distribution` for distribution API configuration
- Rename nested stacks so they correspond to the API they are deploying. `CumulusApiDefault` was just the nested stack for the distribution API, so it is now named `CumulusApiDistribution`. And `CumulusApiV1` -> `CumulusApiBackend`. 
  - The original naming convention was based on the original approach where separate versions of the API would be managing as nested stacks. However, after the switch to using a single API lambda that runs Express, API versioning will now be in code via Express routing. So these name changes are really just more clearly communicating what these stacks are actually deploying.
  - Only downside to these changes is that right now they seem to require removing your API nested stacks before you can deploy. The reason why is that the name of the underlying resources used by the nested stacks, such as `ApiEndpointsLambdaFunction`, have not changed. So when Cloudformation tries to deploy the newly named API nested stacks, it finds resources that are used by the existing API nested stacks and fails. This would not be a problem if Cloudformation deleted the existing API nested stacks before trying to create the newly named API nested stacks, but it seems like it waits to do that until the last step in the Cloudformation deployment.
- Remove unnecessary config for distribution API

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Manual testing
- [ ] Integration tests

