### PR TITLE
CUMULUS-1203 Add missing refactor changes redeploy->runKes

### DIFF
--- a/example/spec/helpers/configUtils.js
+++ b/example/spec/helpers/configUtils.js
@@ -58,6 +58,7 @@ function updateConfigObject(configFilePath, nodeName, configJson) {
 module.exports = {
   getConfigObject,
   loadYmlFile,
+  loadYmlConfigFile,
   saveYmlConfigFile,
   updateConfigObject
 };

--- a/example/spec/helpers/testUtils.js
+++ b/example/spec/helpers/testUtils.js
@@ -197,7 +197,7 @@ function getPublicS3FileUrl({ bucket, key }) {
  *
  * @param {Object} config - configuration object from loadConfig()
  * @param {Object} [options] - configuration options with the following keys>
- * @param {string} [options.template=template=node_modules/@cumulus/deployment/app] - optional template command line kes option
+ * @param {string} [options.template=node_modules/@cumulus/deployment/app] - optional template command line kes option
  * @param {string} [options.kesClass] - optional kes-class command line kes option
  * @param {string} [options.kesCommand] - optional kes command to run, defaults to deploy
  * @param {integer} [options.timeout=30] - Timeout value in minutes
@@ -207,7 +207,6 @@ async function runKes(config, options = {}) {
   const timeoutInMinutes = options.timeout || 30;
 
   const kesCommand = './node_modules/.bin/kes';
-
   const kesOptions = [
     'cf', options.kesCommand || 'deploy',
     '--kes-folder', options.kesFolder || 'app',

--- a/example/spec/standalone/redeployment/LambdaRedeploySpec.js
+++ b/example/spec/standalone/redeployment/LambdaRedeploySpec.js
@@ -12,7 +12,7 @@ const fs = require('fs-extra');
 const {
   loadConfig,
   protectFile,
-  redeploy
+  runKes
 } = require('../../helpers/testUtils');
 
 const config = loadConfig();
@@ -40,7 +40,7 @@ describe('When a workflow is running and a new version of a workflow lambda is d
   beforeAll(async () => {
     await protectFile(lambdaFile, async () => {
       await fs.appendFile(lambdaFile, `// ${new Date()}`);
-      await redeploy(config);
+      await runKes(config);
     });
 
     startVersions = await getLambdaVersions(lambdaName);
@@ -54,7 +54,7 @@ describe('When a workflow is running and a new version of a workflow lambda is d
 
     await protectFile(lambdaFile, async () => {
       await fs.appendFile(lambdaFile, `// ${new Date()}`);
-      await redeploy(config);
+      await runKes(config);
     });
 
     workflowStatus = await waitForCompletedExecution(workflowExecutionArn);

--- a/example/spec/standalone/redeployment/LambdaVersionOption.js
+++ b/example/spec/standalone/redeployment/LambdaVersionOption.js
@@ -9,7 +9,7 @@ const StepFunctions = require('@cumulus/common/StepFunctions');
 const { getWorkflowArn } = require('@cumulus/integration-tests');
 const {
   loadConfig,
-  redeploy
+  runKes
 } = require('../../helpers/testUtils');
 
 const config = loadConfig();
@@ -23,7 +23,7 @@ describe('When the useWorkflowLambdaVersions option is set to false the deployme
   const startDate = new Date();
 
   beforeAll(async () => {
-    await redeploy(config);
+    await runKes(config);
 
     // Redeploy with custom configuration
     try {
@@ -32,7 +32,7 @@ describe('When the useWorkflowLambdaVersions option is set to false the deployme
       const updatedConfig = configString.replace(/useWorkflowLambdaVersions: true/, 'useWorkflowLambdaVersions: false/');
       await fs.writeFile('./test_app/config.yml', updatedConfig, 'utf-8');
 
-      await redeploy(config, {
+      await runKes(config, {
         template: 'test_app/',
         kesClass: 'node_modules/@cumulus/deployment/app/kes.js'
       });
@@ -54,7 +54,7 @@ describe('When the useWorkflowLambdaVersions option is set to false the deployme
     stackList = await cf().listStacks({ StackStatusFilter: deletedStatuses }).promise();
   });
 
-  afterAll(() => redeploy(config));
+  afterAll(() => runKes(config));
 
   it('has no alias references in any workflow', () => {
     const allStates = workflowDefinitions.map((def) => jsyaml.load(def).States);

--- a/example/spec/standalone/redeployment/WorkflowRedeploySpec.js
+++ b/example/spec/standalone/redeployment/WorkflowRedeploySpec.js
@@ -11,7 +11,7 @@ const {
 const {
   loadConfig,
   protectFile,
-  redeploy
+  runKes
 } = require('../../helpers/testUtils');
 
 const {
@@ -28,7 +28,7 @@ const deployTimeout = 15; // deployment timeout in minutes
 
 function redeployWithRetries() {
   return pRetry(
-    () => redeploy(config, { timeout: deployTimeout }),
+    () => runKes(config, { timeout: deployTimeout }),
     {
       retries: 2,
       minTimeout: 0
@@ -54,7 +54,7 @@ describe('When a workflow', () => {
 
         await protectFile(workflowsYmlFile, async () => {
           removeTaskFromWorkflow('WaitForDeployWorkflow', 'HelloWorld', workflowsYmlFile);
-          await redeploy(config, { timeout: deployTimeout });
+          await runKes(config, { timeout: deployTimeout });
         });
 
         workflowStatus = await waitForCompletedExecution(workflowExecutionArn);
@@ -108,7 +108,7 @@ describe('When a workflow', () => {
 
         await protectFile(workflowsYmlFile, async () => {
           removeWorkflow('WaitForDeployWorkflow', workflowsYmlFile);
-          await redeploy(config, { timeout: deployTimeout });
+          await runKes(config, { timeout: deployTimeout });
         });
 
         workflowStatus = await waitForCompletedExecution(workflowExecutionArn);

--- a/packages/deployment/app/cloudformation.template.yml
+++ b/packages/deployment/app/cloudformation.template.yml
@@ -982,7 +982,8 @@ Resources:
       {{/each}}
     {{/if}}
       LaunchConfigurationName:
-        Ref: CumulusContainerInstanceLaunch
+        Ref:
+          CumulusContainerInstanceLaunch
       MinSize: '{{ ecs.minInstances }}'
       DesiredCapacity: '{{ ecs.desiredInstances }}'
       MaxSize: '{{ ecs.maxInstances }}'
@@ -995,7 +996,9 @@ Resources:
     Type: AWS::AutoScaling::LifecycleHook
     Properties:
       LifecycleHookName: {{stackName}}-ecs-termination-hook
-      AutoScalingGroupName: !Ref CumulusECSAutoScalingGroup
+      AutoScalingGroupName:
+        Ref:
+          CumulusECSAutoScalingGroup
       DefaultResult: CONTINUE
       HeartbeatTimeout: 150
       LifecycleTransition: "autoscaling:EC2_INSTANCE_TERMINATING"
@@ -1004,7 +1007,9 @@ Resources:
     Type: AWS::AutoScaling::ScalingPolicy
     Properties:
       AdjustmentType: PercentChangeInCapacity
-      AutoScalingGroupName: !Ref CumulusECSAutoScalingGroup
+      AutoScalingGroupName:
+        Ref:
+          CumulusECSAutoScalingGroup
       EstimatedInstanceWarmup: 180
       MetricAggregationType: Average
       PolicyType: StepScaling
@@ -1017,12 +1022,14 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Ref CumulusECSScaleOutPolicy
+        - Ref: CumulusECSScaleOutPolicy
       ComparisonOperator: GreaterThanThreshold
       DatapointsToAlarm: 1
       Dimensions:
         - Name: ClusterName
-          Value: !Ref CumulusECSCluster
+          Value:
+           Ref:
+             CumulusECSCluster
       EvaluationPeriods: 1
       MetricName: MemoryReservation
       Namespace: AWS/ECS
@@ -1036,12 +1043,14 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Ref CumulusECSScaleOutPolicy
+        - Ref: CumulusECSScaleOutPolicy
       ComparisonOperator: GreaterThanThreshold
       DatapointsToAlarm: 1
       Dimensions:
         - Name: ClusterName
-          Value: !Ref CumulusECSCluster
+          Value:
+            Ref:
+              CumulusECSCluster
       EvaluationPeriods: 1
       MetricName: CPUReservation
       Namespace: AWS/ECS
@@ -1054,7 +1063,9 @@ Resources:
     Type: AWS::AutoScaling::ScalingPolicy
     Properties:
       AdjustmentType: PercentChangeInCapacity
-      AutoScalingGroupName: !Ref CumulusECSAutoScalingGroup
+      AutoScalingGroupName:
+        Ref:
+          CumulusECSAutoScalingGroup
       MetricAggregationType: Average
       PolicyType: StepScaling
       StepAdjustments:
@@ -1066,12 +1077,14 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Ref CumulusECSScaleInPolicy
+        - Ref: CumulusECSScaleInPolicy
       ComparisonOperator: LessThanThreshold
       DatapointsToAlarm: 1
       Dimensions:
         - Name: ClusterName
-          Value: !Ref CumulusECSCluster
+          Value:
+            Ref:
+              CumulusECSCluster
       EvaluationPeriods: 1
       MetricName: MemoryReservation
       Namespace: AWS/ECS
@@ -1085,12 +1098,14 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Ref CumulusECSScaleInPolicy
+        - Ref: CumulusECSScaleInPolicy
       ComparisonOperator: LessThanThreshold
       DatapointsToAlarm: 1
       Dimensions:
         - Name: ClusterName
-          Value: !Ref CumulusECSCluster
+          Value:
+            Ref:
+              CumulusECSCluster
       EvaluationPeriods: 1
       MetricName: CPUReservation
       Namespace: AWS/ECS
@@ -1236,7 +1251,9 @@ Resources:
     Properties:
       PolicyName: {{../stackName}}{{@key}}ECSServiceScalingInPolicy
       PolicyType: StepScaling
-      ScalingTargetId: !Ref {{@key}}ECSServiceScalableTarget
+      ScalingTargetId:
+        Ref:
+         {{@key}}ECSServiceScalableTarget
       StepScalingPolicyConfiguration:
         Cooldown: 60
         AdjustmentType: PercentChangeInCapacity
@@ -1252,7 +1269,9 @@ Resources:
     Properties:
       PolicyName: {{../stackName}}{{@key}}ECSServiceScalingOutPolicy
       PolicyType: StepScaling
-      ScalingTargetId: !Ref {{@key}}ECSServiceScalableTarget
+      ScalingTargetId:
+        Ref:
+         {{@key}}ECSServiceScalableTarget
       StepScalingPolicyConfiguration:
         Cooldown: 60
         AdjustmentType: PercentChangeInCapacity
@@ -1268,7 +1287,7 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Ref {{@key}}ECSServiceScalingInPolicy
+        - Ref: {{@key}}ECSServiceScalingInPolicy
       DatapointsToAlarm: 1
       EvaluationPeriods: 1
       Metrics:
@@ -1282,7 +1301,9 @@ Resources:
               MetricName: ActivityScheduleTime
               Dimensions:
                 - Name: ActivityArn
-                  Value: !Ref {{this.activityName}}Activity
+                  Value:
+                    Ref:
+                      {{this.activityName}}Activity
             Period: 60
             Stat: Average
           ReturnData: false
@@ -1297,7 +1318,7 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !Ref {{@key}}ECSServiceScalingOutPolicy
+        - Ref: {{@key}}ECSServiceScalingOutPolicy
       DatapointsToAlarm: 1
       EvaluationPeriods: 1
       Metrics:
@@ -1311,7 +1332,9 @@ Resources:
               MetricName: ActivityScheduleTime
               Dimensions:
                 - Name: ActivityArn
-                  Value: !Ref {{this.activityName}}Activity
+                  Value:
+                    Ref:
+                      {{this.activityName}}Activity
             Period: 60
             Stat: Average
           ReturnData: false


### PR DESCRIPTION
Addresses redeploy test failure introduced in CUMULUS-1203, as well as template use of "!" intrinsic functions in the CF scaling work. 

testUtils 'redeploy' was made more general and renamed to runKes - the redeployment tests were missed somehow in the refactor.      Additionally as redeploy/kes template tests do not run prior to master merge, use of the !Ref functions was not caught.    This PR remedies those issues. 