### PR TITLE
Cumulus 1156 fix UUID

### DIFF
--- a/bamboo/bootstrap-build.sh
+++ b/bamboo/bootstrap-build.sh
@@ -2,5 +2,6 @@
 if [[ ! -z $CI_UID ]]; then
   groupadd -g $CI_UID bamboo
   useradd --gid bamboo --create-home --uid $CI_UID bamboo
+  chown -R bamboo:bamboo /usr/local/lib/node_modules
 fi
 tail -f /dev/null

--- a/bamboo/bootstrap-build.sh
+++ b/bamboo/bootstrap-build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 if [[ ! -z $CI_UID ]]; then
   groupadd -g $CI_UID bamboo
   useradd --gid bamboo --create-home --uid $CI_UID bamboo

--- a/bamboo/bootstrap-build.sh
+++ b/bamboo/bootstrap-build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+if [[ ! -z $CI_UID ]]; then
+  groupadd -g $CI_UID bamboo
+  useradd --gid bamboo --create-home --uid $CI_UID bamboo
+fi
+tail -f /dev/null

--- a/bamboo/bootstrap-build.sh
+++ b/bamboo/bootstrap-build.sh
@@ -2,6 +2,7 @@
 if [[ ! -z $CI_UID ]]; then
   groupadd -g $CI_UID bamboo
   useradd --gid bamboo --create-home --uid $CI_UID bamboo
-  chown -R bamboo:bamboo /usr/local/lib/node_modules
 fi
+
+npm install -g nyc
 tail -f /dev/null

--- a/bamboo/bootstrap-unit-tests.sh
+++ b/bamboo/bootstrap-unit-tests.sh
@@ -24,7 +24,7 @@ while ! docker container inspect ${container_id}\_build_env_1; do
 done
 
 ## Setup the build env container once it's started
-docker exec -t ${container_id}\_build_env_1 /bin/bash -c 'npm install --error --no-progress -g nyc; cd /source/cumulus; npm install --error  --no-progress; npm run bootstrap-quiet'
+docker exec --user bamboo -t ${container_id}\_build_env_1 /bin/bash -c 'npm install --error --no-progress -g nyc; cd /source/cumulus; npm install --error  --no-progress; npm run bootstrap-quiet'
 
 # Wait for the FTP server to be available
 while ! curl --connect-timeout 5 -sS -o /dev/null ftp://testuser:testpass@127.0.0.1/README.md; do

--- a/bamboo/bootstrap-unit-tests.sh
+++ b/bamboo/bootstrap-unit-tests.sh
@@ -2,6 +2,7 @@
 set -e
 # Export user information for sshd container
 export SSH_USERS=user:$(id -u):$(id -u)
+export CU_UID=$(id -u)
 
 ## Set container_id for docker-compose to use to identify the compose stack per planKey
 container_id=${bamboo_planKey,,}

--- a/bamboo/bootstrap-unit-tests.sh
+++ b/bamboo/bootstrap-unit-tests.sh
@@ -24,7 +24,7 @@ while ! docker container inspect ${container_id}\_build_env_1; do
 done
 
 ## Setup the build env container once it's started
-docker exec --user bamboo -t ${container_id}\_build_env_1 /bin/bash -c 'npm install --error --no-progress -g nyc; cd /source/cumulus; npm install --error  --no-progress; npm run bootstrap-quiet'
+docker exec --user bamboo -t ${container_id}\_build_env_1 /bin/bash -c 'cd /source/cumulus; npm install --error  --no-progress; npm run bootstrap-quiet'
 
 # Wait for the FTP server to be available
 while ! curl --connect-timeout 5 -sS -o /dev/null ftp://testuser:testpass@127.0.0.1/README.md; do

--- a/bamboo/bootstrap-unit-tests.sh
+++ b/bamboo/bootstrap-unit-tests.sh
@@ -2,7 +2,7 @@
 set -e
 # Export user information for sshd container
 export SSH_USERS=user:$(id -u):$(id -u)
-export CU_UID=$(id -u)
+export CI_UID=$(id -u)
 
 ## Set container_id for docker-compose to use to identify the compose stack per planKey
 container_id=${bamboo_planKey,,}

--- a/bamboo/docker-compose.yml
+++ b/bamboo/docker-compose.yml
@@ -40,6 +40,7 @@ services:
     image: node:8.10
     volumes:
       - ../:/source/cumulus
+      - ./bootstrap-build.sh:/bootstrap-build.sh
     environment:
       - LOCALSTACK_HOST=127.0.0.1
       - LOCAL_ES_HOST=127.0.0.1
@@ -52,4 +53,4 @@ services:
       - "127.0.0.1:9200:9200"
       - "127.0.0.1:4574:4574"
       - "127.0.0.1:4550-4570:4550-4570"
-    command: tail -f /dev/null
+    command: /bootstrap-build.sh

--- a/bamboo/unit-tests.sh
+++ b/bamboo/unit-tests.sh
@@ -5,6 +5,6 @@ container_id=${container_id/-/}
 docker ps -a ## Show running containers for output logs
 
 # Run unit tests, excluding integration/api tests
-docker exec -i ${container_id}\_build_env_1 /bin/bash -c 'cd /source/cumulus; nyc ./node_modules/.bin/lerna run test --ignore @cumulus/api --ignore cumulus-integration-tests'
+docker exec --user bamboo -i ${container_id}\_build_env_1 /bin/bash -c 'cd /source/cumulus; nyc ./node_modules/.bin/lerna run test --ignore @cumulus/api --ignore cumulus-integration-tests'
 # Run api tests
-docker exec -i ${container_id}\_build_env_1 /bin/bash -c 'cd /source/cumulus/packages/api; npm run test-coverage'
+docker exec --user bamboo -i ${container_id}\_build_env_1 /bin/bash -c 'cd /source/cumulus/packages/api; npm run test-coverage'


### PR DESCRIPTION
Optional fix to container UUID/filesystem issue.    Adds bamboo:bamboo user matching CI server (this may vary, per admins), runs root commands as bootstrap in lieu of creating custom image.  

