### PR TITLE
Cumulus 1156 seperate container

### DIFF
--- a/bamboo/bootstrap-sftp.sh
+++ b/bamboo/bootstrap-sftp.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 echo 'user:password' | chpasswd
 

--- a/bamboo/bootstrap-unit-tests.sh
+++ b/bamboo/bootstrap-unit-tests.sh
@@ -7,7 +7,6 @@ export SSH_USERS=user:$(id -u):$(id -u)
 container_id=${bamboo_planKey,,}
 container_id=${container_id/-/}
 
-container_id=bamboo
 docker ps -a
 
 ## Setup the compose stack

--- a/bamboo/bootstrap-unit-tests.sh
+++ b/bamboo/bootstrap-unit-tests.sh
@@ -6,6 +6,8 @@ export SSH_USERS=user:$(id -u):$(id -u)
 ## Set container_id for docker-compose to use to identify the compose stack per planKey
 container_id=${bamboo_planKey,,}
 container_id=${container_id/-/}
+container_id=bamboo
+docker_command='docker exec -t ${container_id}\_build_env_1 /bin/bash -c'
 
 docker ps -a
 
@@ -23,10 +25,10 @@ while ! docker container inspect ${container_id}\_build_env_1; do
 done
 
 ## Setup the build env container once it's started
-docker exec -t ${container_id}\_build_env_1 /bin/bash -c 'npm install --error --no-progress -g nyc; cd /source/cumulus; npm install --error  --no-progress; npm run bootstrap-quiet'
+$docker_command 'npm install --error --no-progress -g nyc; cd /source/cumulus; npm install --error  --no-progress; npm run bootstrap-quiet'
 
 # Wait for the FTP server to be available
-while ! docker exec -t ${container_id}\_build_env_1 /bin/bash -c 'curl --connect-timeout 5 -sS -o /dev/null ftp://testuser:testpass@127.0.0.1/README.md'; do
+while ! $docker_command  'curl --connect-timeout 5 -sS -o /dev/null ftp://testuser:testpass@127.0.0.1/README.md'; do
   echo 'Waiting for FTP to start'
   docker ps -a
   sleep 2
@@ -34,7 +36,7 @@ done
 echo 'FTP service is available'
 
 # Wait for the HTTP server to be available
-while ! docker exec -t ${container_id}\_build_env_1 /bin/bash -c 'curl --connect-timeout 5 -sS -o /dev/null http://127.0.0.1:3030/README.md'; do
+while ! $docker_command  'curl --connect-timeout 5 -sS -o /dev/null http://127.0.0.1:3030/README.md'; do
   echo 'Waiting for HTTP to start'
   docker ps -a
   sleep 2
@@ -45,7 +47,7 @@ echo 'HTTP service is available'
 chmod 0400 ../packages/test-data/keys/ssh_client_rsa_key
 
 # Wait for the SFTP server to be available
-while ! docker exec -t ${container_id}\_build_env_1 /bin/bash -c 'sftp\
+while ! $docker_command 'sftp\
   -P 2222\
   -i /source/cumulus/packages/test-data/keys/ssh_client_rsa_key\
   -o "ConnectTimeout=5"\
@@ -60,25 +62,25 @@ done
 echo 'SFTP service is available'
 
 # Wait for the Elasticsearch service to be available
-while ! docker exec -t ${container_id}\_build_env_1 /bin/bash -c 'nc -z 127.0.0.1 9200'; do
+while ! $docker_command  'nc -z 127.0.0.1 9200'; do
   echo 'Waiting for Elasticsearch to start'
   docker ps -a
   sleep 2
 done
 echo 'Elasticsearch service is started'
 
-while ! docker exec -t ${container_id}\_build_env_1 /bin/bash -c 'curl --connect-timeout 5 -sS http://127.0.0.1:9200/_cluster/health | grep green > /dev/null 2>&1'; do
+while ! $docker_command 'curl --connect-timeout 5 -sS http://127.0.0.1:9200/_cluster/health | grep green > /dev/null 2>&1'; do
   echo 'Waiting for Elasticsearch status to be green'
   sleep 2
 done
 echo 'Elasticsearch status is green'
 
 # Update Elasticsearch config to stop complaining about running out of disk space
-docker exec -t ${container_id}\_build_env_1 /bin/bash -c 'curl -XPUT "http://127.0.0.1:9200/_cluster/settings" -d @/source/cumulus/bamboo/elasticsearch.config'
+$docker_command 'curl -XPUT "http://127.0.0.1:9200/_cluster/settings" -d @/source/cumulus/bamboo/elasticsearch.config'
 
 
 # Lambda seems to be the last service that's started up by Localstack
-while ! docker exec -t ${container_id}\_build_env_1 /bin/bash -c 'nc -z 127.0.0.1 4574'; do
+while ! $docker_command 'nc -z 127.0.0.1 4574'; do
   echo 'Waiting for Localstack Lambda service to start'
   docker ps -a
   sleep 2

--- a/bamboo/bootstrap-unit-tests.sh
+++ b/bamboo/bootstrap-unit-tests.sh
@@ -6,7 +6,6 @@ export SSH_USERS=user:$(id -u):$(id -u)
 ## Set container_id for docker-compose to use to identify the compose stack per planKey
 container_id=${bamboo_planKey,,}
 container_id=${container_id/-/}
-container_id=bamboo
 docker_command='docker exec -t ${container_id}\_build_env_1 /bin/bash -c'
 
 docker ps -a
@@ -77,7 +76,6 @@ echo 'Elasticsearch status is green'
 
 # Update Elasticsearch config to stop complaining about running out of disk space
 $docker_command 'curl -XPUT "http://127.0.0.1:9200/_cluster/settings" -d @/source/cumulus/bamboo/elasticsearch.config'
-
 
 # Lambda seems to be the last service that's started up by Localstack
 while ! $docker_command 'nc -z 127.0.0.1 4574'; do

--- a/bamboo/bootstrap-unit-tests.sh
+++ b/bamboo/bootstrap-unit-tests.sh
@@ -6,7 +6,7 @@ export SSH_USERS=user:$(id -u):$(id -u)
 ## Set container_id for docker-compose to use to identify the compose stack per planKey
 container_id=${bamboo_planKey,,}
 container_id=${container_id/-/}
-docker_command='docker exec -t ${container_id}\_build_env_1 /bin/bash -c'
+docker_command="docker exec -t ${container_id}_build_env_1 /bin/bash -c"
 
 docker ps -a
 

--- a/bamboo/docker-compose.yml
+++ b/bamboo/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     environment:
       SERVICES: 'kinesis,lambda,s3,sns,sqs,dynamodb,dynamodbstreams'
   build_env:
-    image: node:8.10
+    image: jlkovarik/cumulus_build_env:1
     volumes:
       - ../:/source/cumulus
     environment:
@@ -45,11 +45,4 @@ services:
       - LOCAL_ES_HOST=127.0.0.1
       - CI_UID
       - bamboo_planKey
-    ports:
-      - "127.0.0.1:2222:2222"
-      - "127.0.0.1:3030:3030"
-      - "127.0.0.1:21:21"
-      - "127.0.0.1:9200:9200"
-      - "127.0.0.1:4574:4574"
-      - "127.0.0.1:4550-4570:4550-4570"
     command: tail -f /dev/null

--- a/bamboo/elasticsearch.config
+++ b/bamboo/elasticsearch.config
@@ -1,0 +1,8 @@
+{
+  "persistent": {
+    "cluster.routing.allocation.disk.threshold_enabled": true,
+    "cluster.routing.allocation.disk.watermark.low": "1g",
+    "cluster.routing.allocation.disk.watermark.high": "500m",
+    "cluster.info.update.interval": "5m"
+  }
+}


### PR DESCRIPTION
Amendment to 1156 PR.   THis PR removes the need for external container ports, and probably makes things cleaner on the whole relative to the rest of the build environment. 

Container in the 'jlkovarik' account is node:8.10 + netcat

Downsides:  

- Can't use this compose file for local development work

