### PR TITLE
Update NPM publish script to use lerna to pin dependencies to exact versions

### DIFF
--- a/travis-ci/deploy-to-npm.sh
+++ b/travis-ci/deploy-to-npm.sh
@@ -13,4 +13,5 @@ lerna publish \
   --no-push \
   --yes \
   --force-publish=* \
-  --dist-tag=${NPM_TAG}
+  --dist-tag=${NPM_TAG} \
+  --exact


### PR DESCRIPTION
A week or so ago, one of our users discovered that versions of Cumulus packages do not actually pin their dependencies on other Cumulus packages. You can see this by downloading the latest release of our [`@cumulus/post-to-cmr`](https://registry.npmjs.org/@cumulus/post-to-cmr/-/post-to-cmr-1.12.1.tgz) package and inspecting `package.json`. Or you can use this shell command:

`curl https://registry.npmjs.org/@cumulus/post-to-cmr/ | jq '.versions["1.12.1"].dependencies'`

This is problematic because new releases (e.g. 1.11 to 1.12) of Cumulus packages sometimes contain breaking changes, so `npm install` may give you a deployment with incompatible packages.

This PR updates our NPM publish script to ensure that Lerna pins the Cumulus dependencies of our published packages to exact versions, thus ensuring compatibility. 

https://github.com/lerna/lerna/issues/51 includes some options for testing this locally, which I can try out.