### PR TITLE
Trim granule names upon discovery

### DIFF
--- a/packages/ingest/http.js
+++ b/packages/ingest/http.js
@@ -54,7 +54,7 @@ module.exports.httpMixin = (superclass) => class extends superclass {
           if (split.length === 3) {
           // Some providers provide files with one number after the dot (".") ex (tmtdayacz8110_5.6)
             if (split[1].match(/^(.*\.[\w\d]{1,4})\s*$/) !== null) {
-              const name = split[1];
+              const name = split[1].trimRight();
               files.push({
                 name,
                 path: this.path

--- a/packages/ingest/test/test-http.js
+++ b/packages/ingest/test/test-http.js
@@ -62,7 +62,7 @@ test('Download remote file to s3 with correct content-type', async (t) => {
 
 test('returns files with provider path', async (t) => {
   const stubLink = 'file.txt ';
-  setupCrawler(stubLink)
+  setupCrawler(stubLink);
 
   const actualFiles = await myTestHttpDiscoveryClass.list();
   const expectedFiles = [{ name: stubLink, path: myTestHttpDiscoveryClass.path }];
@@ -72,7 +72,7 @@ test('returns files with provider path', async (t) => {
 
 test('strips trailing spaces from name', async (t) => {
   const stubLink = ' fileWithSpaces.txt ';
-  setupCrawler(stubLink)
+  setupCrawler(stubLink);
 
   const actualFiles = await myTestHttpDiscoveryClass.list();
   const expectedFiles = [{ name: stubLink.trimRight(), path: myTestHttpDiscoveryClass.path }];

--- a/packages/ingest/test/test-http.js
+++ b/packages/ingest/test/test-http.js
@@ -21,7 +21,7 @@ const setupCrawler = (stubLink) => {
     }
   }
   http.__set__('Crawler', TestEmitter);
-}
+};
 
 class MyTestDiscoveryClass {
   constructor(useList) {

--- a/packages/ingest/test/test-http.js
+++ b/packages/ingest/test/test-http.js
@@ -14,13 +14,14 @@ const {
 } = require('@cumulus/common/aws');
 const { randomString } = require('@cumulus/common/test-utils');
 
-const stubLink = 'file.txt';
-class TestEmitter extends EventEmitter {
-  start() {
-    this.emit('fetchcomplete', null, `<a href="${stubLink}">link</a>`);
+const setupCrawler = (stubLink) => {
+  class TestEmitter extends EventEmitter {
+    start() {
+      this.emit('fetchcomplete', null, `<a href="${stubLink}">link</a>`);
+    }
   }
+  http.__set__('Crawler', TestEmitter);
 }
-http.__set__('Crawler', TestEmitter);
 
 class MyTestDiscoveryClass {
   constructor(useList) {
@@ -60,7 +61,20 @@ test('Download remote file to s3 with correct content-type', async (t) => {
 });
 
 test('returns files with provider path', async (t) => {
+  const stubLink = 'file.txt ';
+  setupCrawler(stubLink)
+
   const actualFiles = await myTestHttpDiscoveryClass.list();
   const expectedFiles = [{ name: stubLink, path: myTestHttpDiscoveryClass.path }];
+  t.deepEqual(actualFiles, expectedFiles);
+});
+
+
+test('strips trailing spaces from name', async (t) => {
+  const stubLink = ' fileWithSpaces.txt ';
+  setupCrawler(stubLink)
+
+  const actualFiles = await myTestHttpDiscoveryClass.list();
+  const expectedFiles = [{ name: stubLink.trimRight(), path: myTestHttpDiscoveryClass.path }];
   t.deepEqual(actualFiles, expectedFiles);
 });

--- a/packages/ingest/test/test-http.js
+++ b/packages/ingest/test/test-http.js
@@ -61,7 +61,7 @@ test('Download remote file to s3 with correct content-type', async (t) => {
 });
 
 test('returns files with provider path', async (t) => {
-  const stubLink = 'file.txt ';
+  const stubLink = 'file.txt';
   setupCrawler(stubLink);
 
   const actualFiles = await myTestHttpDiscoveryClass.list();
@@ -69,12 +69,20 @@ test('returns files with provider path', async (t) => {
   t.deepEqual(actualFiles, expectedFiles);
 });
 
-
 test('strips trailing spaces from name', async (t) => {
-  const stubLink = ' fileWithSpaces.txt ';
+  const stubLink = 'fileWithTrailingSpaces.txt  ';
   setupCrawler(stubLink);
 
   const actualFiles = await myTestHttpDiscoveryClass.list();
-  const expectedFiles = [{ name: stubLink.trimRight(), path: myTestHttpDiscoveryClass.path }];
+  const expectedFiles = [{ name: 'fileWithTrailingSpaces.txt', path: myTestHttpDiscoveryClass.path }];
+  t.deepEqual(actualFiles, expectedFiles);
+});
+
+test('does not strip leading spaces from name', async (t) => {
+  const stubLink = ' fileWithSpaces.txt';
+  setupCrawler(stubLink);
+
+  const actualFiles = await myTestHttpDiscoveryClass.list();
+  const expectedFiles = [{ name: stubLink, path: myTestHttpDiscoveryClass.path }];
   t.deepEqual(actualFiles, expectedFiles);
 });


### PR DESCRIPTION
**Summary:** Trim granule names upon discovery

Currently, we are looking at the anchor tags returned by the crawler and scrutinizing them against a regex pattern looking for filenames:

https://github.com/nasa/cumulus/blob/00c734bb68384e15f8a83039cc0bbcd0e060a370/packages/ingest/http.js#L56

The regex supports the notion that a filename can end in a space character.  This is indeed needed for the [LVIS Gabon AfriSAR dataset](https://lvis.gsfc.nasa.gov/Data/Maps/Gabon2016Map.html), as some anchor tags have a trailing space on their `href` values. However, I believe this is just a typo on the part of the data provider. These files can be downloaded from their source with or without their trailing spaces. 

Later down the line, our [Cumulus workflow](https://github.com/maap-project/maap-cumulus) uploads these files to S3 (with the trailing slash intact) and the granules are registered with a (private) CMR instance.  When the CMR is queried for these granules, the file links have had the trailing spaces removed (I have not yet researched if the CMR is stripping the trailing spaces or if it the Cumulus code that is doing so). The problem is that S3 requires the trailing space to recover the needed file and returns a 404 if the trailing space is omitted.

I am currently considering it a bug that the files are uploaded with the trailing space.  Trimming the file extensions at time of discovery would resolve this bug.

### Concerns

It is somewhat possible that an existing Cumulus workflow expects that a file end with a space (perhaps the data provider would only correctly serve the file if that trailing space is present).  I can't really think of a reason why anyone would design a file extension in such a way, but it is possible. To error on the side of caution, I'm only using `trimRight()` rather than `trim()` to permit filenames that begin with the space character.

Additionally, I am not familiar with writing tests with Ava (I basically read through [this doc](https://github.com/avajs/ava/blob/master/docs/recipes/test-setup.md)), feel free to instruct me if a different method should be used when preparing test cases.

## Changes

* Add a `.trimRight()` call on the Granule name at time of discover
* Add a test case

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

