### PR TITLE
Rely on logger to describe error

### DIFF
--- a/packages/ingest/granule.js
+++ b/packages/ingest/granule.js
@@ -125,7 +125,7 @@ class Discover {
         // Add additional granule-related properties to the file
         .map((file) => this.setGranuleInfo(file));
     } catch (error) {
-      log.error(`discover exception ${JSON.stringify(error)}`);
+      log.error('discover exception', error);
     }
 
     // Group the files by granuleId


### PR DESCRIPTION
Current implementation of using JSON.stringify on caught error swallows all useful details. We should instead utilize existing logger logic to properly log error details.

A quick example of why `JSON.stringify(err)` is problematic:

```js
▶ node
> const test = () => {
... try { 
...   throw new TypeError('Uh oh! Bad thing!'); 
... } catch (err) { 
...   console.log(`Caught: ${JSON.stringify(err)}`); 
... }};
undefined
> test()
Caught: {}
undefined
> const test2 = () => {
... try { 
...   throw new TypeError('Uh oh! Bad thing!'); 
... } catch (err) { 
...   console.log(`Caught: ${err}`); 
... }};
undefined
> test2()
Caught: TypeError: Uh oh! Bad thing!
undefined
```

I did not review other packages within this codebase to see if they suffer from the same shortcoming as the `ingest/granule.js` file.

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

