### PR TITLE
CUMULUS-1309 Build per-lambda deployment files in the API package

### DIFF
--- a/packages/api/config/backend_api_lambdas.yml
+++ b/packages/api/config/backend_api_lambdas.yml
@@ -1,8 +1,8 @@
 ApiEndpoints:
-  handler: index.appHandler
+  handler: index.handler
   timeout: 20
   memory: '{{parent.api_lambda_memory}}'
-  source: 'node_modules/@cumulus/api/dist/'
+  source: 'node_modules/@cumulus/api/dist/app/'
   apiRole: true
   urs_redirect: 'token'
   useDistributionApi: true

--- a/packages/api/config/distribution_api_lambdas.yml
+++ b/packages/api/config/distribution_api_lambdas.yml
@@ -1,9 +1,9 @@
 
 ApiDistribution:
-  handler: index.distributionAppHandler
+  handler: index.handler
   timeout: 20
   memory: '{{parent.api_lambda_memory}}'
-  source: 'node_modules/@cumulus/api/dist/'
+  source: 'node_modules/@cumulus/api/dist/distribution/'
   distributionRole: true
   urs_redirect: 'distribution'
   useDistributionApi: true

--- a/packages/api/config/lambdas.yml
+++ b/packages/api/config/lambdas.yml
@@ -1,16 +1,16 @@
 sqs2sf:
-  handler: index.starter
+  handler: index.handler
   timeout: 200
-  memory: 512
-  source: 'node_modules/@cumulus/api/dist/'
+  memory: 128
+  source: 'node_modules/@cumulus/api/dist/sfStarter/'
 
 sns2elasticsearch:
-  handler: index.indexer
+  handler: index.handler
   timeout: 100
   useElasticSearch: '{{es.name}}'
   launchInVpc: true
-  memory: 512
-  source: 'node_modules/@cumulus/api/dist/'
+  memory: 320
+  source: 'node_modules/@cumulus/api/dist/indexer/'
   tables:
     - GranulesTable
     - ExecutionsTable
@@ -20,17 +20,17 @@ sns2elasticsearch:
 log2elasticsearch:
   handler: index.logHandler
   timeout: 100
-  memory: 512
+  memory: 320
   useElasticSearch: '{{es.name}}'
   launchInVpc: true
-  source: 'node_modules/@cumulus/api/dist/'
+  source: 'node_modules/@cumulus/api/dist/indexer/'
   namedLambdaDeadLetterQueue: true
 
 dbIndexer:
-  handler: index.dbIndexer
+  handler: index.handler
   timeout: 300
-  memory: 512
-  source: 'node_modules/@cumulus/api/dist/'
+  memory: 320
+  source: 'node_modules/@cumulus/api/dist/dbIndexer/'
   useElasticSearch: '{{es.name}}'
   tables:
     - FilesTable
@@ -40,10 +40,10 @@ dbIndexer:
   namedLambdaDeadLetterQueue: true
 
 fallbackConsumer:
-  handler: index.messageConsumer
+  handler: index.handler
   timeout: 100
-  memory: 512
-  source: 'node_modules/@cumulus/api/dist/'
+  memory: 256
+  source: 'node_modules/@cumulus/api/dist/messageConsumer/'
   deadletterqueue: kinesisFailure
   tables:
     - RulesTable
@@ -53,19 +53,19 @@ fallbackConsumer:
     system_bucket: '{{system_bucket}}'
 
 jobs:
-  handler: index.jobs
+  handler: index.handler
   timeout: 300
-  memory: 512
+  memory: 320
   useElasticSearch: '{{es.name}}'
   launchInVpc: true
-  source: 'node_modules/@cumulus/api/dist/'
+  source: 'node_modules/@cumulus/api/dist/jobs/'
   namedLambdaDeadLetterQueue: true
 
 cleanExecutions:
-  handler: index.cleanExecutions
+  handler: index.handler
   timeout: 900
-  memory: 1024
-  source: 'node_modules/@cumulus/api/dist/'
+  memory: 192
+  source: 'node_modules/@cumulus/api/dist/cleanExecutions/'
   namedLambdaDeadLetterQueue: true
   tables:
     - ExecutionsTable
@@ -77,19 +77,19 @@ cleanExecutions:
 
 # used as custom resource for cloudformation manipulation
 CustomBootstrap:
-  handler: index.bootstrap
+  handler: index.handler
   timeout: 300
-  memory: 512
-  source: 'node_modules/@cumulus/api/dist/'
+  memory: 320
+  source: 'node_modules/@cumulus/api/dist/bootstrap/'
   launchInVpc: true
   envs:
     system_bucket: '{{system_bucket}}'
 
 EmsReport:
-  handler: index.emsReport
+  handler: index.handler
   timeout: 300
-  memory: 512
-  source: 'node_modules/@cumulus/api/dist/'
+  memory: 320
+  source: 'node_modules/@cumulus/api/dist/emsReport/'
   useElasticSearch: '{{es.name}}'
   launchInVpc: true
   envs:
@@ -98,21 +98,21 @@ EmsReport:
   namedLambdaDeadLetterQueue: true
 
 EmsDistributionReport:
-  handler: index.emsDistributionReport
+  handler: index.handler
   timeout: 300
-  memory: 512
-  source: 'node_modules/@cumulus/api/dist/'
+  memory: 128
+  source: 'node_modules/@cumulus/api/dist/emsDistributionReport/'
   envs:
     LOGS_BUCKET: '{{system_bucket}}'
     REPORTS_BUCKET: '{{system_bucket}}'
     STACK_NAME: '{{stackName}}'
 
 executeMigrations:
-  handler: index.executeMigrations
+  handler: index.handler
   timeout: 300
   useElasticSearch: '{{es.name}}'
   memory: 1024
-  source: 'node_modules/@cumulus/api/dist/'
+  source: 'node_modules/@cumulus/api/dist/executeMigrations/'
   launchInVpc: true
   tables:
     - GranulesTable
@@ -127,10 +127,10 @@ executeMigrations:
     system_bucket: '{{system_bucket}}'
 
 messageConsumer:
-  handler: index.messageConsumer
+  handler: index.handler
   timeout: 100
-  memory: 512
-  source: 'node_modules/@cumulus/api/dist/'
+  memory: 256
+  source: 'node_modules/@cumulus/api/dist/messageConsumer/'
   tables:
     - RulesTable
     - CollectionsTable
@@ -142,8 +142,9 @@ messageConsumer:
       value: '${kinesisFallbackSns}'
 
 CreateReconciliationReport:
-  handler: index.createReconciliationReport
-  source: 'node_modules/@cumulus/api/dist/'
+  handler: index.handler
+  source: 'node_modules/@cumulus/api/dist/createReconciliationReport/'
+  memory: 256
   useDistributionApi: true
   tables:
     - CollectionsTable
@@ -156,27 +157,27 @@ CreateReconciliationReport:
 
 ScheduleSF:
   description: 'This lambda function is invoked by scheduled rules created via cumulus API'
-  handler: index.scheduler
+  handler: index.schedule
   timeout: 100
-  memory: 512
-  source: 'node_modules/@cumulus/api/dist/'
+  memory: 192
+  source: 'node_modules/@cumulus/api/dist/sfScheduler/'
   tables:
     - CollectionsTable
     - ProvidersTable
   namedLambdaDeadLetterQueue: true
 
 BulkDelete:
-  handler: index.bulkDeleteLambda
-  source: 'node_modules/@cumulus/api/dist/'
+  handler: index.handler
+  source: 'node_modules/@cumulus/api/dist/bulkDelete/'
 
 KinesisInboundEventLogger:
-  handler: index.logger
+  handler: index.handler
   timeout: 300
-  memory: 512
-  source: 'node_modules/@cumulus/api/dist/'
+  memory: 128
+  source: 'node_modules/@cumulus/api/dist/payloadLogger/'
 
 KinesisOutboundEventLogger:
-  handler: index.logger
+  handler: index.handler
   timeout: 300
   memory: 512
-  source: 'node_modules/@cumulus/api/dist'
+  source: 'node_modules/@cumulus/api/dist/payloadLogger/'

--- a/packages/api/config/workflowLambdas.yml
+++ b/packages/api/config/workflowLambdas.yml
@@ -1,11 +1,11 @@
 sf2snsStart:
-  handler: index.sfStart
+  handler: index.start
   timeout: 100
-  memory: 512
-  source: 'node_modules/@cumulus/api/dist/'
+  memory: 128
+  source: 'node_modules/@cumulus/api/dist/sfSnsBroadcast/'
 
 sf2snsEnd:
-  handler: index.sfEnd
+  handler: index.end
   timeout: 100
-  memory: 512
-  source: 'node_modules/@cumulus/api/dist/'
+  memory: 128
+  source: 'node_modules/@cumulus/api/dist/sfSnsBroadcast/'

--- a/packages/api/index.js
+++ b/packages/api/index.js
@@ -1,35 +1,5 @@
 'use strict';
 
-exports.appHandler = require('./app').handler;
-exports.app = require('./app').app;
-exports.distributionAppHandler = require('./app/distribution').handler;
-exports.distributionApp = require('./app/distribution').distributionApp;
-exports.dbIndexer = require('./lambdas/db-indexer');
-
-exports.bootstrap = require('./lambdas/bootstrap').handler;
-exports.executeMigrations = require('./lambdas/executeMigrations').handler;
-exports.cleanExecutions = require('./lambdas/cleanExecutions').handler;
-exports.jobs = require('./lambdas/jobs');
-exports.logger = require('./lambdas/payload-logger').handler;
-exports.messageConsumer = require('./lambdas/message-consumer').handler;
-exports.scheduler = require('./lambdas/sf-scheduler');
-exports.starter = require('./lambdas/sf-starter');
-
-exports.bulkDeleteLambda = require('./lambdas/bulk-delete').handler;
-
-exports.emsReport = require('./lambdas/ems-report').handler;
-exports.emsDistributionReport = require('./lambdas/ems-distribution-report').handler;
-
-exports.createReconciliationReport = require('./lambdas/create-reconciliation-report').handler;
-
-const indexer = require('./es/indexer');
-const broadcast = require('./lambdas/sf-sns-broadcast');
-
-exports.sfStart = broadcast.start;
-exports.sfEnd = broadcast.end;
-exports.indexer = indexer.handler;
-exports.logHandler = indexer.logHandler;
-
 exports.models = require('./models');
 exports.testUtils = require('./lib/testUtils');
 exports.tokenUtils = require('./lib/token');

--- a/packages/api/lambdas/db-indexer.js
+++ b/packages/api/lambdas/db-indexer.js
@@ -207,4 +207,4 @@ function handler(event, context, cb) {
   return indexRecords(records).then((r) => cb(null, r)).catch(cb);
 }
 
-module.exports = handler;
+module.exports = { handler };

--- a/packages/api/lambdas/jobs.js
+++ b/packages/api/lambdas/jobs.js
@@ -149,4 +149,4 @@ function handler(event, context, cb) {
   });
 }
 
-module.exports = handler;
+module.exports = { handler };

--- a/packages/api/lambdas/sf-scheduler.js
+++ b/packages/api/lambdas/sf-scheduler.js
@@ -63,4 +63,4 @@ function schedule(event, context, cb) {
     .catch((e) => cb(e));
 }
 
-module.exports = schedule;
+module.exports = { schedule };

--- a/packages/api/lambdas/sf-sns-broadcast.js
+++ b/packages/api/lambdas/sf-sns-broadcast.js
@@ -130,5 +130,4 @@ function end(event, context, cb) {
   return publish(event, true).then((r) => cb(null, r)).catch((e) => cb(e));
 }
 
-module.exports.start = start;
-module.exports.end = end;
+module.exports = { start, end };

--- a/packages/api/lambdas/sf-starter.js
+++ b/packages/api/lambdas/sf-starter.js
@@ -56,4 +56,4 @@ function handler(event, _context, cb) {
       .catch(cb);
   } else cb(new Error('queueUrl is missing'));
 }
-module.exports = handler;
+module.exports = { handler };

--- a/packages/api/lib/rulesHelpers.js
+++ b/packages/api/lib/rulesHelpers.js
@@ -1,4 +1,4 @@
-const sfSchedule = require('../lambdas/sf-scheduler');
+const { schedule } = require('../lambdas/sf-scheduler');
 const Rule = require('../models/rules');
 
 /**
@@ -20,7 +20,7 @@ async function queueMessageForRule(rule, eventObject) {
 
   const payload = await Rule.buildPayload(item);
 
-  return new Promise((resolve, reject) => sfSchedule(payload, {}, (err, result) => {
+  return new Promise((resolve, reject) => schedule(payload, {}, (err, result) => {
     if (err) reject(err);
     resolve(result);
   }));

--- a/packages/api/tests/lambdas/test-sf-starter.js
+++ b/packages/api/tests/lambdas/test-sf-starter.js
@@ -3,7 +3,7 @@
 const rewire = require('rewire');
 const test = require('ava');
 
-const handler = rewire('../../lambdas/sf-starter');
+const sfStarter = rewire('../../lambdas/sf-starter');
 class stubConsumer {
   async consume() {
     return 9;
@@ -18,12 +18,12 @@ const ruleInput = {
 
 test.serial('throws error when queueUrl is undefined', (t) => {
   const errCb = (err, _data) => t.is(err.message, 'queueUrl is missing');
-  handler(ruleInput, {}, errCb);
+  sfStarter.handler(ruleInput, {}, errCb);
 });
 
 test.serial('calls cb with number of messages received', async (t) => {
   ruleInput.queueUrl = 'queue';
-  handler.__set__('Consumer', stubConsumer);
+  sfStarter.__set__('Consumer', stubConsumer);
   const cb = (_err, data) => t.is(data, 9);
-  handler(ruleInput, {}, cb);
+  sfStarter.handler(ruleInput, {}, cb);
 });

--- a/packages/api/tests/serial/es/test-db-indexer.js
+++ b/packages/api/tests/serial/es/test-db-indexer.js
@@ -12,7 +12,7 @@ const {
 const models = require('../../../models');
 const { Search } = require('../../../es/search');
 const bootstrap = require('../../../lambdas/bootstrap');
-const dbIndexer = require('../../../lambdas/db-indexer');
+const { handler } = require('../../../lambdas/db-indexer');
 const {
   fakeCollectionFactory,
   fakeGranuleFactory,
@@ -151,7 +151,7 @@ test.serial('create, update and delete a collection in dynamodb and es', async (
   let records = await getDyanmoDBStreamRecords(process.env.CollectionsTable);
 
   // fake the lambda trigger
-  await dbIndexer(records, {}, noop);
+  await handler(records, {}, noop);
 
   const collectionIndex = new Search({}, 'collection');
   let indexedRecord = await collectionIndex.get(constructCollectionId(c.name, c.version));
@@ -166,7 +166,7 @@ test.serial('create, update and delete a collection in dynamodb and es', async (
   records = await getDyanmoDBStreamRecords(process.env.CollectionsTable);
 
   // fake the lambda trigger
-  await dbIndexer(records, {}, noop);
+  await handler(records, {}, noop);
 
   indexedRecord = await collectionIndex.get(constructCollectionId(c.name, c.version));
   t.is(indexedRecord.dataType, 'testing');
@@ -178,7 +178,7 @@ test.serial('create, update and delete a collection in dynamodb and es', async (
   records = await getDyanmoDBStreamRecords(process.env.CollectionsTable);
 
   // fake the lambda trigger
-  await dbIndexer(records, {}, noop);
+  await handler(records, {}, noop);
 
   const response = await collectionIndex.get(constructCollectionId(c.name, c.version));
   t.is(response.detail, 'Record not found');
@@ -198,7 +198,7 @@ test.serial('create, update and delete a granule in dynamodb and es', async (t) 
   let records = await getDyanmoDBStreamRecords(process.env.GranulesTable);
 
   // fake the lambda trigger
-  await dbIndexer(records, {}, noop);
+  await handler(records, {}, noop);
 
   const granuleIndex = new Search({}, 'granule');
   let indexedRecord = await granuleIndex.get(fakeGranule.granuleId);
@@ -222,7 +222,7 @@ test.serial('create, update and delete a granule in dynamodb and es', async (t) 
   records = await getDyanmoDBStreamRecords(process.env.GranulesTable);
 
   // fake the lambda trigger
-  await dbIndexer(records, {}, noop);
+  await handler(records, {}, noop);
 
   indexedRecord = await granuleIndex.get(fakeGranule.granuleId);
   t.is(indexedRecord.status, 'failed');
@@ -234,7 +234,7 @@ test.serial('create, update and delete a granule in dynamodb and es', async (t) 
   records = await getDyanmoDBStreamRecords(process.env.GranulesTable);
 
   // fake the lambda trigger
-  await dbIndexer(records, {}, noop);
+  await handler(records, {}, noop);
 
   indexedRecord = await granuleIndex.get(fakeGranule.granuleId);
   t.is(indexedRecord.detail, 'Record not found');
@@ -260,7 +260,7 @@ test.serial('create, update and delete an execution in dynamodb and es', async (
   let records = await getDyanmoDBStreamRecords(process.env.ExecutionsTable);
 
   // fake the lambda trigger
-  await dbIndexer(records, {}, noop);
+  await handler(records, {}, noop);
 
   const recordIndex = new Search({}, 'execution');
   let indexedRecord = await recordIndex.get(fakeRecord.arn);
@@ -275,7 +275,7 @@ test.serial('create, update and delete an execution in dynamodb and es', async (
   records = await getDyanmoDBStreamRecords(process.env.ExecutionsTable);
 
   // fake the lambda trigger
-  await dbIndexer(records, {}, noop);
+  await handler(records, {}, noop);
 
   indexedRecord = await recordIndex.get(fakeRecord.arn);
   t.is(indexedRecord.status, 'failed');
@@ -287,7 +287,7 @@ test.serial('create, update and delete an execution in dynamodb and es', async (
   records = await getDyanmoDBStreamRecords(process.env.ExecutionsTable);
 
   // fake the lambda trigger
-  await dbIndexer(records, {}, noop);
+  await handler(records, {}, noop);
 
   indexedRecord = await recordIndex.get(fakeRecord.arn);
   t.is(indexedRecord.detail, 'Record not found');

--- a/packages/api/webpack.config.js
+++ b/packages/api/webpack.config.js
@@ -1,26 +1,35 @@
-const path = require('path');
-
-let mode = 'development';
-let devtool = 'inline-source-map';
-
-if(process.env.PRODUCTION) {
-  mode = 'production',
-  devtool = false  
-}
+'use strict';
 
 module.exports = {
-  mode,
-  entry: './index.js',
+  mode: process.env.PRODUCTION ? 'production' : 'development',
+  entry: {
+    app: './app/index.js',
+    bootstrap: './lambdas/bootstrap.js',
+    bulkDelete: './lambdas/bulk-delete.js',
+    cleanExecutions: './lambdas/cleanExecutions.js',
+    createReconciliationReport: './lambdas/create-reconciliation-report.js',
+    dbIndexer: './lambdas/db-indexer.js',
+    distribution: './app/distribution.js',
+    emsDistributionReport: './lambdas/ems-distribution-report.js',
+    emsReport: './lambdas/ems-report.js',
+    executeMigrations: './lambdas/executeMigrations.js',
+    indexer: './es/indexer.js',
+    jobs: './lambdas/jobs.js',
+    messageConsumer: './lambdas/message-consumer.js',
+    payloadLogger: './lambdas/payload-logger.js',
+    sfScheduler: './lambdas/sf-scheduler.js',
+    sfSnsBroadcast: './lambdas/sf-sns-broadcast.js',
+    sfStarter: './lambdas/sf-starter.js'
+  },
   output: {
     libraryTarget: 'commonjs2',
-    filename: 'index.js',
-    path: path.resolve(__dirname, 'dist')
+    filename: '[name]/index.js'
   },
   externals: [
     'aws-sdk',
     'electron',
-    {'formidable': 'url'}
+    { formidable: 'url' }
   ],
-  devtool,
+  devtool: process.env.PRODUCTION ? false : 'inline-source-map',
   target: 'node'
 };

--- a/packages/api/webpack.config.js
+++ b/packages/api/webpack.config.js
@@ -19,6 +19,7 @@ module.exports = {
     payloadLogger: './lambdas/payload-logger.js',
     sfScheduler: './lambdas/sf-scheduler.js',
     sfSnsBroadcast: './lambdas/sf-sns-broadcast.js',
+    sfSemaphoreDown: './lambdas/sf-semaphore-down',
     sfStarter: './lambdas/sf-starter.js'
   },
   output: {


### PR DESCRIPTION
Fixes [CUMULUS-1309: Deploying lambdas in API package deploys entire API code in the lambda](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1309)

Before this PR, the entirety of the API package was being packaged into a single `index.js` file, and every lambda function was pointing at a different function inside that one 50 MB file.  This PR causes separate, Lambda function-specific, files to be generated and deployed.  These files now range anywhere from 350K to 8.1M.

The first step was to add separate entries for each function in the webpack config.  That caused webpack to generate an index.js for each lambda function in its own `packages/api/dist/[name]/`.  Once those separate, smaller files were generated, the `packages/api/config/*.yml` files were updated to point to those individual lambda function files.

Note: In some cases, the lambda function's was the default export from a module file.  That didn't work with the way that you need to specify the handler function in Lambda, so I had to change those cases from `module.exports = handler` to `module.exports = { handler }`.  These changes required updating some unit tests that invoked those handlers directly.

Lastly, after I verified that all of the tests were passing, I was able to check in CloudWatch logs to see how much memory was actually being used by the smaller Lambda functions, and adjusted the memory settings accordingly.  In a lot of cases, the memory allocation went from 768MB down to as low as 128MB.