### PR TITLE
CUMULUS-1310: Pass outputs as parameters instead of using import/export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,8 @@ As a result of the changes for **CUMULUS-1193** and **CUMULUS-1264**, **you must
   - `stackName` and `stackNameNoDash` have been retired as user-facing config parameters. Use `prefix` and `prefixNoDash` instead.
     This will be used to create stack names for all stacks in a single-config use case.
     `stackName` may still be used as an override in multi-config usage, although this is discouraged.
+    Warning: overriding the `db` stack's `stackName` will require you to set `dbStackName` in your `app/config.yml`.
+    This parameter is required to fetch outputs from the `db` stack to reference in the `app` stack.
   - The `iams` section in `app/config.yml` IAM roles has been retired as a user-facing parameter,
     *unless* your IAM role ARNs do not match the convention shown in `@cumulus/deployment/app/config.yml`
     In that case, overriding `iams` in your own config is recommended.

--- a/packages/deployment/app/cloudformation.template.yml
+++ b/packages/deployment/app/cloudformation.template.yml
@@ -8,13 +8,31 @@ Parameters:
   DockerPassword:
     Type: String
     Description: 'Password used to access a private docker repository (not required)'
-    Default: NoValue
+    Default: ""
     NoEcho: true
   DockerEmail:
     Type: String
     Description: 'Email used to login to a private docker repository (not required)'
-    Default: NoValue
+    Default: ""
     NoEcho: true
+{{#if vpc}}
+  EcsSecurityGroup:
+    Type: String
+    Description: 'Security Group deployed by the db stack'
+    NoEcho: true
+{{/if}}
+{{#if es.name}}
+  {{es.name}}DomainEndpoint:
+    Type: String
+    Description: 'ElasticSearch domain endpoint'
+    NoEcho: true
+{{/if}}
+{{#each dynamos}}
+  {{@key}}DynamoDBStreamArn:
+    Type: String
+    Description: 'DynamoDBStreamArn for {{@key}}'
+    NoEcho: true
+{{/each}}
 
 Resources:
 
@@ -48,8 +66,7 @@ Resources:
             - CmrPassword
       {{#if ../es.name}}
         ElasticSearchDomain:
-          Fn::ImportValue:
-            {{../prefix}}-ESDomainEndpoint
+          Ref: {{../es.name}}DomainEndpoint
       {{/if}}
         log2elasticsearchLambdaFunctionArn:
           Fn::GetAtt:
@@ -90,14 +107,11 @@ Resources:
             - Outputs.distributionRestApiResource
         {{/ifEquals}}
       {{# each ../dynamos}}
-        {{@key}}DynamoDB:
-          Fn::ImportValue:
-            {{../../prefix}}-{{@key}}DynamoDB
+        {{@key}}DynamoDB: {{../../prefix}}-{{@key}}
       {{/each}}
       {{# if ../vpc }}
         SecurityGroupId:
-          Fn::ImportValue:
-            {{../prefix}}-EcsSecurityGroup
+          Ref: EcsSecurityGroup
       {{/if}}
       TemplateURL: {{this.url}}
 {{/ifNotEquals}}
@@ -123,23 +137,18 @@ Resources:
     {{# if es.name}}
       ElasticSearch:
         host:
-          Fn::ImportValue:
-            {{prefix}}-ESDomainEndpoint
+          Ref: {{es.name}}DomainEndpoint
         version: {{es.elasticSearchMapping}}
     {{/if}}
     {{# if dynamos}}
       DynamoDBTables:
       {{#each dynamos}}
-        - name:
-            Fn::ImportValue:
-              {{../prefix}}-{{@key}}DynamoDB
+        - name: {{../prefix}}-{{@key}}
           pointInTime: {{this.pointInTime}}
       {{/each}}
     {{/if}}
       Users:
-        table:
-          Fn::ImportValue:
-            {{prefix}}-UsersTableDynamoDB
+        table: {{prefix}}-UsersTable
         records:
         {{# each users}}
           - username: {{username}}
@@ -375,8 +384,8 @@ Resources:
     Type: AWS::Lambda::EventSourceMapping
     Properties:
       EventSourceArn:
-        Fn::ImportValue:
-          {{../prefix}}-{{this}}DynamoDBStreamArn
+        Ref:
+          {{this}}DynamoDBStreamArn
       FunctionName:
         Ref: {{../dynamo2ElasticSearch.lambda}}LambdaFunction
       BatchSize: {{../dynamo2ElasticSearch.batchSize}}
@@ -405,14 +414,11 @@ Resources:
         {{#if this.useElasticSearch }}
         {{#if ../es.name}}
           ES_HOST:
-            Fn::ImportValue:
-              {{../prefix}}-ESDomainEndpoint
+            Ref: {{../es.name}}DomainEndpoint
         {{/if}}
         {{/if}}
         {{#each this.tables}}
-          {{this}}:
-            Fn::ImportValue:
-              {{../../prefix}}-{{this}}DynamoDB
+          {{this}}: {{../../prefix}}-{{this}}
         {{/each}}
       {{# if this.useDistributionApi}}
         {{# if ../api_distribution_url}}
@@ -472,8 +478,7 @@ Resources:
     {{# if ../vpc }}
       VpcConfig:
         SecurityGroupIds:
-          - Fn::ImportValue:
-              {{../prefix}}-EcsSecurityGroup
+          - Ref: EcsSecurityGroup
         SubnetIds:
         {{#each ../vpc.subnets}}
           - {{this}}
@@ -554,8 +559,7 @@ Resources:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
       GroupId:
-        Fn::ImportValue:
-          {{prefix}}-EcsSecurityGroup
+        Ref: EcsSecurityGroup
       IpProtocol: tcp
       FromPort: '22'
       ToPort: '22'
@@ -574,8 +578,7 @@ Resources:
       AssociatePublicIpAddress: {{#if ecs.publicIp}}{{ecs.publicIp}}{{else}}false{{/if}}
     {{/if}}
       SecurityGroups:
-        - Fn::ImportValue:
-            {{prefix}}-EcsSecurityGroup
+        - Ref: EcsSecurityGroup
        {{# if ecs.efs.mount}}
         - Fn::ImportValue:
             "{{prefix}}-EFSSecurityGroup"

--- a/packages/deployment/app/config.yml
+++ b/packages/deployment/app/config.yml
@@ -2,6 +2,7 @@ default:
   prefix: change-me-cumulus
   stackName: '{{prefix}}'
   prefixNoDash: ChangeMeCumulus
+  dbStackName: '{{prefix}}-db'
 
   urs_url: https://uat.urs.earthdata.nasa.gov/
 

--- a/packages/deployment/db/cloudformation.template.yml
+++ b/packages/deployment/db/cloudformation.template.yml
@@ -241,30 +241,20 @@ Resources:
 
 
 Outputs:
-  {{#each dynamos}}
-  {{@key}}DynamoDB:
-    Value:
-      Ref: {{@key}}DynamoDB
-    Export:
-      Name: {{../prefix}}-{{@key}}DynamoDB
-
+{{#each dynamos}}
   {{@key}}DynamoDBStreamArn:
     Value:
       Fn::GetAtt:
         - {{@key}}DynamoDB
         - StreamArn
-    Export:
-      Name: {{../prefix}}-{{@key}}DynamoDBStreamArn
-  {{/each}}
+{{/each}}
 
-{{# if es.name}}
+{{#if es.name}}
   {{es.name}}DomainEndpoint:
     Value:
       Fn::GetAtt:
         - {{es.name}}Domain
         - DomainEndpoint
-    Export:
-      Name: {{prefix}}-ESDomainEndpoint
 {{/if}}
 
 {{#if vpc}}
@@ -272,6 +262,4 @@ Outputs:
     Description: ECS security group
     Value:
       Ref: SecurityGroup
-    Export:
-      Name: {{prefix}}-EcsSecurityGroup
 {{/if}}

--- a/packages/deployment/lib/kes.js
+++ b/packages/deployment/lib/kes.js
@@ -405,7 +405,17 @@ class UpdatedKes extends Kes {
    */
   cloudFormation() {
     if (this.config.app && this.config.app.params) this.config.params = this.config.app.params;
-    return super.cloudFormation();
+    // Fetch db stack outputs to retrieve DynamoDBStreamARNs and ESDomainEndpoint
+    return this.describeStack(this.config.dbStackName).then((r) => {
+      if (r && r.Stacks[0] && r.Stacks[0].Outputs) {
+        r.Stacks[0].Outputs.forEach((o) => this.config.params.push({
+          name: o.OutputKey,
+          value: o.OutputValue
+        }));
+      } else {
+        throw new Error(`Failed to fetch outputs for db stack ${this.config.dbStackName}`);
+      }
+    }).then(() => super.cloudFormation());
   }
 
 


### PR DESCRIPTION
**Summary:** Summary of changes

Fetch outputs from DB stack and pass as parameters in kes override, rather than using CF import/exports. This change was made to avoid import/export namespace restrictions and restrictions placed on updating exported resources.

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

