### PR TITLE
Update audit-ci to 1.7.0, remove tar whitelist

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,4 +1,3 @@
 {
-    "high": true,
-    "whitelist": ["tar"]
+    "high": true
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "devDependencies": {
-    "audit-ci": "^1.6.0",
+    "audit-ci": "^1.7.0",
     "ava": "^0.25.0",
     "babel-eslint": "^8.2.2",
     "coveralls": "^3.0.0",


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-1317](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1317)

## Changes

* Updates audit-ci to 1.7.0 to take advantage of new retry capability 

https://github.com/IBM/audit-ci/releases
* Removes tar whitelist as npm-lifecycle has fixed the vulnerable dependency 

## PR Checklist

- [ NA ] Update CHANGELOG
- [ NA ] Unit tests
- [x] Adhoc testing
- [ NA ] Integration tests

