### PR TITLE
CUMULUS-1269 followup: use updated cnmToGranule in integration tests

### DIFF
--- a/example/lambdas.yml
+++ b/example/lambdas.yml
@@ -5,7 +5,7 @@ CNMToCMA:
   memory: 128
   s3Source:
     bucket: '{{buckets.shared.name}}'
-    key: daacs/podaac/cnmToGranule-1.0.2j.zip
+    key: daacs/podaac/cnmToGranule-1.0.2k.zip
   useMessageAdapter: false
   launchInVpc: true
 CnmResponse:

--- a/example/spec/parallel/kinesisTests/KinesisTestTriggerSpec.js
+++ b/example/spec/parallel/kinesisTests/KinesisTestTriggerSpec.js
@@ -78,11 +78,11 @@ const expectedTranslatePayload = {
       files: [
         {
           name: recordFile.name,
-          fileType: recordFile.type, // change when CnmToGranule outputs 'type' instead
+          type: recordFile.type,
           bucket: record.bucket,
           path: testDataFolder,
           url_path: recordFile.uri,
-          fileSize: recordFile.size // change when CnmToGranule outputs 'size' instead
+          size: recordFile.size
         }
       ]
     }
@@ -98,9 +98,8 @@ const fileDataWithFilename = {
   bucket: testConfig.buckets.private.name,
   url_path: '',
   fileStagingDir: filePrefix,
-  size: fileData.fileSize
+  size: fileData.size
 };
-delete fileDataWithFilename.fileSize;
 
 const expectedSyncGranulesPayload = {
   granules: [


### PR DESCRIPTION
**Summary:** Summary of changes

Follow-up for [CUMULUS-1269: Resolve Cumulus CNM implementation discrepancy](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1269)

## Changes

* Use updated copy of cnmToGranule
* Update test expectations accordingly

## PR Checklist

- [x] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

