### PR TITLE
Update integration cleanup to work with updated config/stack structure

### DIFF
--- a/travis-ci/cleanup-integration-tests.sh
+++ b/travis-ci/cleanup-integration-tests.sh
@@ -19,15 +19,23 @@ set +e
     ./node_modules/.bin/kes cf delete \
       --kes-folder app \
       --region us-east-1 \
-      --deployment "$DEPLOYMENT" \
+      --stack nightly
+      --yes
+
+    echo Delete db deployment
+
+    ./node_modules/.bin/kes cf delete \
+      --kes-folder app \
+      --region us-east-1 \
+      --stack nightly-db
       --yes
 
     echo Delete iam deployment
 
     ./node_modules/.bin/kes cf delete \
-      --kes-folder iam \
+      --kes-folder app \
       --region us-east-1 \
-      --deployment "$DEPLOYMENT" \
+      --stack nightly-iam
       --yes
 
     echo Delete app deployment


### PR DESCRIPTION

Addresses [CUMULUS-1328: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1328)

Minor fix to integration test cleanup - due to consolidating stack configuration, the deletion commands don't work for nightly, in addition to the db stack needing cleaned up.  


