### PR TITLE
Adds /distributionMetrics to the backendApi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### PLEASE NOTE
+**CUMULUS-799** added some additional IAM permissions to support reading cloudwatch and apigateway, so **you will have to redeploy your IAM stack.**
+
+## Added
+**CUMULUS-799**
+  - Adds new BackendApi endpoint `distributionMetrics` that returns a summary of successful s3 accesses as well as a summary of distribution errors -- including s3 access errors, 4XX and 5XX errors.
+
 ## [v1.13.0] - 2019-5-20
 
 ### PLEASE NOTE
 
-**CUMULUS-802** added some additional IAM permissions to support ECS autoscaling and changes were needed to run all lambdas in the VPC, so **you will have to redeploy your IAM stack.**
-
+**CUMULUS-802** added some additional IAM permissions to support ECS autoscaling, so **you will have to redeploy your IAM stack.**
 As a result of the changes for **CUMULUS-1193**, **CUMULUS-1264**, and **CUMULUS-1310**, **you must delete your existing stacks (except IAM) before deploying this version of Cumulus.**
 If running Cumulus within a VPC and extended downtime is acceptable, we recommend doing this at the end of the day to allow AWS backend resources and network interfaces to be cleaned up overnight.
 
@@ -92,6 +98,7 @@ If running Cumulus within a VPC and extended downtime is acceptable, we recommen
 - **CUMULUS-802**
   - Adds autoscaling of ECS clusters
   - Adds autoscaling of ECS services that are handling StepFunction activities
+
 
 ## Changed
 

--- a/example/app/config.yml
+++ b/example/app/config.yml
@@ -551,6 +551,10 @@ jc:
 mhs:
   prefix: mhs
   prefixNoDash: mhs
+  ecs:
+    ssh: true
+    keyPairName: mhs
+  api_distribution_url:
 
 mhs3:
   prefix: mhs3
@@ -575,7 +579,10 @@ mhs3:
       name: cumulus-data-shared
       type: shared
   system_bucket: mhs3-internal
-  api_distribution_url: '{{API_DISTRIBUTION_URL}}'
+  api_distribution_url:
+  ecs:
+    ssh: true
+    keyPairName: mhs
 
 jk:
   prefix: jk

--- a/packages/api/app/routes.js
+++ b/packages/api/app/routes.js
@@ -5,6 +5,7 @@ const router = require('express-promise-router')();
 const log = require('@cumulus/common/log');
 
 const collections = require('../endpoints/collections');
+const distributionMetrics = require('../endpoints/distribution-metrics');
 const granules = require('../endpoints/granules');
 const providers = require('../endpoints/providers');
 const pdrs = require('../endpoints/pdrs');
@@ -32,6 +33,8 @@ if (process.env.FAKE_AUTH === 'true') {
 
 // collections endpoints
 router.use('/collections', ensureAuthorized, collections);
+
+router.use('/distributionMetrics', ensureAuthorized, distributionMetrics);
 
 // granules endpoints
 router.use('/granules', ensureAuthorized, granules);

--- a/packages/api/config/backend_api_lambdas.yml
+++ b/packages/api/config/backend_api_lambdas.yml
@@ -74,6 +74,9 @@ ApiEndpoints:
       function: "Ref"
       value: "CmrPassword"
     TOKEN_SECRET: '{{TOKEN_SECRET}}'
+    distributionApiId:
+      function: Ref
+      value: distributionRestApi
   apiGateway:
     - api: backend
       path: '{proxy+}'

--- a/packages/api/endpoints/distribution-metrics.js
+++ b/packages/api/endpoints/distribution-metrics.js
@@ -1,0 +1,252 @@
+'use strict';
+
+const AWS = require('aws-sdk');
+const flatten = require('lodash.flatten');
+const router = require('express-promise-router')();
+
+const {
+  aws: { cloudwatch },
+  testUtils: { randomId }
+} = require('@cumulus/common');
+const Logger = require('@cumulus/logger');
+
+const log = new Logger({ sender: 'distributionMetrics' });
+
+/**
+ * @param {Array<numbers>} array
+ * @returns {number} sum of values in array
+ */
+const sumArray = (array) => array.reduce((accum, cur) => accum + cur, 0);
+
+const callGetStages = (restApiId) => {
+  const apiGateway = new AWS.APIGateway();
+  return apiGateway.getStages({ restApiId }).promise();
+};
+
+/**
+ *
+ * @param {Object} getStagesResult - return value of aws.apigateway.getStages on a given apiId
+ * @returns {Array<string>} - list of stage names associated with the apiId
+ */
+const parseStagesResult = (getStagesResult) =>
+  getStagesResult.item.map((i) => i.stageName);
+
+/**
+ * Get a list of the all stages associated with the url's api Gateway.
+ *
+ * @param {string} restApiId - api endpoint where the first part of the host is the restApiId.
+ * @returns {Promise<Array>} - array of names of stages found on api gateway.
+ */
+const getApiStages = (restApiId) =>
+  callGetStages(restApiId).then(parseStagesResult);
+
+/**
+ * Lists all stages associated with the backend and distribution api urls.
+ */
+const listAllStages = async () => {
+  const apiId = process.env.distributionApiId;
+  return getApiStages(apiId);
+};
+
+/**
+ * Returns the name of the stage used in the cumulus deployment.
+ */
+const getStageName = async () => {
+  const stages = Array.from(new Set(await listAllStages()));
+  if (stages.length !== 1) {
+    throw new Error(
+      `cumulus configured with wrong number of stages: ${stages.length}`
+    );
+  }
+  return stages[0];
+};
+
+/**
+ * create MetricData Queries for calling to getMetricData
+ *
+ * @param {Date} StartTime - Starting Date for Metric Query
+ * @param {Date} EndTime - Endting Date for Metric Query
+ * param {Object} Metric - Single item from the Metric array of a successful
+ *                          CloudWatch.listMetrics call
+ * @returns {<Object>} - metricDataQuery object
+ */
+const buildGetMetricParams = (StartTime, EndTime) => (Metric) => ({
+  MetricDataQueries: [
+    {
+      Id: randomId('id'),
+      MetricStat: {
+        Metric,
+        Period: 60 * 60 * 24, // seconds in day
+        Stat: 'Sum',
+        Unit: 'Count'
+      }
+    }
+  ],
+  ScanBy: 'TimestampDescending',
+  StartTime,
+  EndTime
+});
+
+/**
+ * builds the metric data parameters for a list of input metrics.
+ *
+ * @param {Array<Metrics>} listMetricsResult
+ * @returns {Promise<Array>} - Promise of results array.
+ */
+const buildGetMetricParamsFromListMetricsResult = (listMetricsResult) => {
+  const oneDayInMs = 8.64e7;
+  const EndTime = new Date(new Date(Date.now()).setSeconds(0, 0));
+  const StartTime = new Date(EndTime - oneDayInMs);
+
+  try {
+    return listMetricsResult.Metrics.map(
+      buildGetMetricParams(StartTime, EndTime)
+    );
+  } catch (error) {
+    log.error('getMetricsParams', error);
+    log.error('input listMetricsResult', listMetricsResult);
+    return [];
+  }
+};
+
+/**
+ * calls cloudwatch.getMetricData for a single parameters object.
+ * @param {Object} params - input params
+ * @returns {Promise<Object>} - Promise for a getMetricData result.
+ */
+const getMetricDatum = (params) =>
+  cloudwatch()
+    .getMetricData(params)
+    .promise();
+
+const getMetricData = (listOfParams) =>
+  Promise.all(listOfParams.map(getMetricDatum));
+
+const callListMetrics = (params) =>
+  cloudwatch()
+    .listMetrics(params)
+    .promise();
+
+/**
+ * Return the array Values from the metric, or [0] if no Values are found
+ *
+ * @param {Object} metric - array for a single metric from getMetric (which
+ *         collects calls to cloudwatch.getMetricData)
+ * @returns {Array<numbers>} - results in metric's Values, or [0]
+ */
+const valuesFromMetric = (metric) => {
+  try {
+    return metric.MetricDataResults[0].Values;
+  } catch (error) {
+    return [0];
+  }
+};
+
+const valuesFromMetrics = (metrics) => flatten(metrics.map(valuesFromMetric));
+
+const getSumOfMetric = (listMetricParams) =>
+  callListMetrics(listMetricParams)
+    .then(buildGetMetricParamsFromListMetricsResult)
+    .then(getMetricData)
+    .then(valuesFromMetrics)
+    .then(sumArray);
+
+/**
+ * Get the CloudWatch metricList for Cumulus' private namespace and desired MetricName.
+ *
+ * @param {string} stackName
+ * @param {string} MetricName - desired metric.
+ * @returns {Promise<Array>} - Promise for Array of CloudWatch metrics.
+ */
+const customListMetricsParam = (stackName, MetricName) => ({
+  MetricName,
+  Namespace: 'CumulusDistribution',
+  Dimensions: [{ Name: 'Stack', Value: stackName }]
+});
+
+const customErrorListMetricsParam = (stackName) =>
+  customListMetricsParam(stackName, 'FailureCount');
+
+const customSuccessListMetricsParam = (stackName) =>
+  customListMetricsParam(stackName, 'SuccessCount');
+
+/**
+ *  Return an object suitable for querying cloudwatch.listMetrics
+ *
+ * @param {string} stackName - Stack name
+ * @param {string} stageName - apiStage name
+ * @param {string} MetricName - desired metric
+ * @returns {<Object>} listMetric input parameter object
+ */
+const buildListMetricsParams = (stackName, stageName, MetricName) => ({
+  MetricName,
+  Dimensions: [
+    { Name: 'ApiName', Value: `${stackName}-distribution` },
+    { Name: 'Stage', Value: `${stageName}` }
+  ],
+  Namespace: 'AWS/ApiGateway'
+});
+
+/**
+ * get total errors for the stackName and errorType
+ * @param {string} stackName
+ * @param {string} errorType metric name for Error
+ * @returns {number} total errors on distribution APIs for the last 24 hours
+ */
+const apiErrorsCount = async (stackName, errorType) => {
+  const stageName = await getStageName(stackName);
+  return getSumOfMetric(
+    buildListMetricsParams(stackName, stageName, errorType)
+  );
+};
+
+const apiUserErrorsCount = (stackName) => apiErrorsCount(stackName, '4XXError');
+
+const apiServerErrorsCount = (stackName) =>
+  apiErrorsCount(stackName, '5XXError');
+
+const s3AccessErrorsCount = (stackname) =>
+  getSumOfMetric(customErrorListMetricsParam(stackname));
+
+const s3AccessSuccessCount = (stackName) =>
+  getSumOfMetric(customSuccessListMetricsParam(stackName));
+
+const combinedResults = (
+  userErrors,
+  serverErrors,
+  accessErrors,
+  accessSuccesses
+) => ({
+  errors: String(userErrors + serverErrors + accessErrors),
+  successes: String(accessSuccesses)
+});
+
+const getDistributionMetrics = async (stackName) => {
+  const [
+    apiUserErrors,
+    apiServerErrors,
+    s3AccessErrors,
+    s3AccessSuccess
+  ] = await Promise.all([
+    apiUserErrorsCount(stackName),
+    apiServerErrorsCount(stackName),
+    s3AccessErrorsCount(stackName),
+    s3AccessSuccessCount(stackName)
+  ]);
+
+  return combinedResults(
+    apiUserErrors,
+    apiServerErrors,
+    s3AccessErrors,
+    s3AccessSuccess
+  );
+};
+
+async function get(req, res) {
+  const stackName = req.query.stackName || process.env.stackName;
+  const metrics = await getDistributionMetrics(stackName);
+  return res.send(metrics);
+}
+
+router.get('/', get);
+module.exports = router;

--- a/packages/api/tests/endpoints/fixtures/distribution-metrics-fixture.js
+++ b/packages/api/tests/endpoints/fixtures/distribution-metrics-fixture.js
@@ -1,0 +1,110 @@
+const {
+  testUtils: { randomId }
+} = require('@cumulus/common');
+
+/** Typical resonse from cloudwatch.getMetrics()  */
+const getMetricDatasResult = {
+  ResponseMetadata: {
+    RequestId: '535bb868-7cb7-11e9-91f1-771c6077cbeb'
+  },
+  MetricDataResults: [
+    {
+      Id: 'id590a38dc92',
+      Label: 'SuccessCount',
+      Timestamps: ['2019-05-21T17:30:00.000Z', '2019-05-19T17:30:00.000Z'],
+      Values: [3, 11],
+      StatusCode: 'Complete',
+      Messages: []
+    }
+  ],
+  Messages: []
+};
+
+/** Typical Response from AWS.APIGateway.getStages */
+const getStagesResult = {
+  item: [
+    {
+      deploymentId: randomId('deploymentId'),
+      stageName: 'dev',
+      cacheClusterEnabled: false,
+      cacheClusterStatus: 'NOT_AVAILABLE',
+      methodSettings: {},
+      tracingEnabled: false,
+      createdDate: '2019-05-17T23:35:00.000Z',
+      lastUpdatedDate: '2019-05-20T23:17:00.000Z'
+    },
+    {
+      deploymentId: randomId('deploymentId'),
+      stageName: 'prod',
+      cacheClusterEnabled: false,
+      cacheClusterStatus: 'NOT_AVAILABLE',
+      methodSettings: {},
+      tracingEnabled: false,
+      createdDate: '2019-05-17T23:25:18.000Z',
+      lastUpdatedDate: '2019-05-20T23:07:52.000Z'
+    }
+  ]
+};
+
+/** Typical array of objects used as input to cloudwatch.getMetricData */
+const getMetricDatasInput = [
+  {
+    MetricDataQueries: [
+      {
+        Id: 'fakeIdValue',
+        MetricStat: {
+          Metric: {
+            Namespace: 'AWS/ApiGateway',
+            MetricName: '4XXError',
+            Dimensions: [
+              {
+                Name: 'ApiName',
+                Value: 'stackname-distribution'
+              },
+              {
+                Name: 'Stage',
+                Value: 'dev'
+              }
+            ]
+          },
+          Period: 86400,
+          Stat: 'Sum',
+          Unit: 'Count'
+        }
+      }
+    ],
+    ScanBy: 'TimestampDescending',
+    StartTime: new Date('2019-05-09T21:54:00.000Z'),
+    EndTime: new Date('2019-05-10T21:54:00.000Z')
+  }
+];
+
+/**Typical output from cloudwatch.listMetrics */
+const listMetricsResult = {
+  ResponseMetadata: {
+    RequestId: 'aaf7435b-7cca-11e9-ac94-e370d994b57c'
+  },
+  Metrics: [
+    {
+      Namespace: 'AWS/ApiGateway',
+      MetricName: '4XXError',
+      Dimensions: [
+        {
+          Name: 'ApiName',
+          Value: 'stackname-distribution'
+        },
+        {
+          Name: 'Stage',
+          Value: 'dev'
+        }
+      ]
+    }
+  ]
+};
+
+module.exports = {
+  getMetricDatasInput,
+  getMetricDatasResult,
+  getStagesResult,
+  listMetricsResult
+};

--- a/packages/api/tests/endpoints/test-distribution-metrics.js
+++ b/packages/api/tests/endpoints/test-distribution-metrics.js
@@ -1,0 +1,140 @@
+'use strict';
+
+const test = require('ava');
+const sinon = require('sinon');
+const rewire = require('rewire');
+
+const {
+  testUtils: { randomId }
+} = require('@cumulus/common');
+
+const distributionMetrics = rewire('../../endpoints/distribution-metrics');
+
+const fixture = require('./fixtures/distribution-metrics-fixture');
+
+const valuesFromMetrics = distributionMetrics.__get__('valuesFromMetrics');
+const listAllStages = distributionMetrics.__get__('listAllStages');
+const sumArray = distributionMetrics.__get__('sumArray');
+const getStageName = distributionMetrics.__get__('getStageName');
+const combinedResults = distributionMetrics.__get__('combinedResults');
+const buildGetMetricParamsFromListMetricsResult = distributionMetrics.__get__(
+  'buildGetMetricParamsFromListMetricsResult'
+);
+
+const sandbox = sinon.createSandbox();
+
+test.beforeEach((t) => {
+  t.context.originalDateNow = Date.now;
+  Date.now = () => 1557525280918; //'2019-05-10T21:54:00.000Z'
+});
+
+test.afterEach((t) => {
+  Date.now = t.context.originalDateNow;
+  sandbox.restore();
+});
+
+test('sumArray returns sum of an array', (t) => {
+  const inputValues = [1, 3, 5, 7];
+  const expected = 16;
+  const actual = sumArray(inputValues);
+
+  t.is(actual, expected);
+});
+
+test('sumArray returns zero for an empty array []', (t) => {
+  const inputValues = [];
+  const expected = 0;
+  const actual = sumArray(inputValues);
+
+  t.is(actual, expected);
+});
+
+test('valuesFromMetrics returns the Values arrays of an awsListMetrics result ', (t) => {
+  const expected = [3, 11, 3, 11];
+  const actual = valuesFromMetrics([
+    fixture.getMetricDatasResult,
+    fixture.getMetricDatasResult
+  ]);
+  t.deepEqual(expected, actual);
+});
+
+test('valuesFromMetrics returns [0] if no Value fields are available', (t) => {
+  const expected = [0];
+  const modified = [{ ...fixture.getMetricDatasResult[0] }];
+  delete modified[0].MetricDataResults;
+
+  const actual = valuesFromMetrics(modified);
+  t.deepEqual(expected, actual);
+});
+
+test('listAllStages returns list of api stages present', async (t) => {
+  const expected = ['dev', 'prod'];
+  const callGetStagesFake = sinon.fake.resolves(fixture.getStagesResult);
+
+  const resetDouble = distributionMetrics.__set__(
+    'callGetStages',
+    callGetStagesFake
+  );
+  process.env.distributionApiId = randomId('apiId');
+
+  const actual = await listAllStages();
+
+  t.deepEqual(expected, actual);
+  t.true(callGetStagesFake.calledOnceWith(process.env.distributionApiId));
+
+  resetDouble();
+});
+
+test('getStageName throws if cumulus has multiple stages defined', async (t) => {
+  const original = distributionMetrics.__get__('listAllStages');
+  const listAllStagesFake = () => Promise.resolve(['dev', 'prod']);
+  distributionMetrics.__set__('listAllStages', listAllStagesFake);
+
+  const error = await t.throws(getStageName());
+  console.log(error.message);
+  t.true(
+    error.message.includes('cumulus configured with wrong number of stages: 2')
+  );
+  distributionMetrics.__set__('listAllStages', original);
+});
+
+test('getStageName returns stage name for a single stage', async (t) => {
+  const original = distributionMetrics.__get__('listAllStages');
+  const listAllStagesFake = () => Promise.resolve(['only stage']);
+  distributionMetrics.__set__('listAllStages', listAllStagesFake);
+  const expected = 'only stage';
+
+  const actual = await getStageName();
+  t.is(expected, actual);
+  distributionMetrics.__set__('listAllStages', original);
+});
+
+test('buildGetMetricParamsFromListMetricsResult returns correct parameters for getMetricDatas', (t) => {
+  const randomIdFake = () => 'fakeIdValue';
+  const resetDouble = distributionMetrics.__set__('randomId', randomIdFake);
+  const expected = fixture.getMetricDatasInput;
+  const actual = buildGetMetricParamsFromListMetricsResult(
+    fixture.listMetricsResult
+  );
+  t.deepEqual(expected, actual);
+  resetDouble();
+});
+
+test('combineResults sums errors and returns them', (t) => {
+  const userErrors = 1;
+  const serverErrors = 2;
+  const accessErrors = 3;
+  const accessSuccesses = 4;
+
+  const actual = combinedResults(
+    userErrors,
+    serverErrors,
+    accessErrors,
+    accessSuccesses
+  );
+  const expected = {
+    errors: '6',
+    successes: '4'
+  };
+  t.deepEqual(expected, actual);
+});

--- a/packages/common/aws.js
+++ b/packages/common/aws.js
@@ -123,6 +123,7 @@ exports.lambda = awsClient(AWS.Lambda, '2015-03-31');
 exports.sqs = awsClient(AWS.SQS, '2012-11-05');
 exports.cloudwatchevents = awsClient(AWS.CloudWatchEvents, '2014-02-03');
 exports.cloudwatchlogs = awsClient(AWS.CloudWatchLogs, '2014-03-28');
+exports.cloudwatch = awsClient(AWS.CloudWatch, '2010-08-01');
 exports.dynamodb = awsClient(AWS.DynamoDB, '2012-08-10');
 exports.dynamodbstreams = awsClient(AWS.DynamoDBStreams, '2012-08-10');
 exports.dynamodbDocClient = awsClient(AWS.DynamoDB.DocumentClient, '2012-08-10');

--- a/packages/deployment/iam/cloudformation.template.yml
+++ b/packages/deployment/iam/cloudformation.template.yml
@@ -140,6 +140,19 @@ Resources:
                 Resource:
                   Fn::Sub: "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${ResourcePrefix}-*"
 
+              - Effect: Allow
+                Action:
+                  - cloudwatch:List*
+                  - cloudwatch:Get*
+                  - cloudwatch:Describe*
+                Resource: '*'
+
+              - Effect: Allow
+                Action:
+                  - apigateway:GET
+                Resource:
+                  Fn::Sub: "arn:aws:apigateway:${AWS::Region}::/restapis/*/stages"
+
               # allow adding/editing/deleting of rules associated with this deployment
               - Effect: Allow
                 Action:


### PR DESCRIPTION
**Summary:** 
New endpoint that returns errors and success counts for the last 24 hours.
To be used as a helper for the dashboard to expose this information to
operators.


Addresses [CUMULUS-799: summary of recent distribution errors](https://bugs.earthdata.nasa.gov/browse/CUMULUS-799)

## Changes
* 

## PR Checklist

- [ X ] Update CHANGELOG
- [ X ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

