### PR TITLE
Cumulus 1155 parallel junit

### DIFF
--- a/bamboo/integration-tests.sh
+++ b/bamboo/integration-tests.sh
@@ -3,4 +3,5 @@ set -e
 . ./bamboo/abort-if-not-pr-or-redeployment.sh
 . ./bamboo/abort-if-skip-integration-tests.sh
 . ./bamboo/set-bamboo-env-variables.sh
-(cd example && npm test)
+
+(cd example && npm install && npm test)

--- a/example/package.json
+++ b/example/package.json
@@ -68,6 +68,7 @@
     "got": "^9.6.0",
     "jasmine": "^3.1.0",
     "jasmine-console-reporter": "^2.0.1",
+    "jasmine-reporters": "^2.3.2",
     "js-yaml": "^3.12.0",
     "kes": "^2.2.5",
     "lodash.assignin": "^4.2.0",

--- a/example/spec/helpers/reporters/junitReporter.js
+++ b/example/spec/helpers/reporters/junitReporter.js
@@ -1,0 +1,7 @@
+
+var reporters = require('jasmine-reporters');
+var junitReporter = new reporters.JUnitXmlReporter({
+    savePath: process.env.JUNIT_DIR || '/tmp',
+    consolidateAll: false
+});
+jasmine.getEnv().addReporter(junitReporter)

--- a/example/spec/helpers/reporters/junitReporter.js
+++ b/example/spec/helpers/reporters/junitReporter.js
@@ -1,7 +1,7 @@
 
-var reporters = require('jasmine-reporters');
-var junitReporter = new reporters.JUnitXmlReporter({
-    savePath: process.env.JUNIT_DIR || '/tmp',
-    consolidateAll: false
+const reporters = require('jasmine-reporters');
+const junitReporter = new reporters.JUnitXmlReporter({
+  savePath: process.env.JUNIT_DIR || '/tmp',
+  consolidateAll: false
 });
-jasmine.getEnv().addReporter(junitReporter)
+jasmine.getEnv().addReporter(junitReporter);


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-1155: ](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1155)

## Changes

* Adds parallel build change to integration tests, this allows the deployment/integration test portion of the CI test to be seperated in bamboo
* Adds jasmine-reporters package and a junit reporter to the jasmine reporters.  

