### PR TITLE
feat(audit): Update audit-ci to v2.0.1 and re-enable audit-ci in the pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,16 +19,15 @@ stages:
 
 jobs:
   include:
-    # Temporarily disabling the audit step while we wait for npm audit to be fixed
-    # - name: "npm audit"
-    #   stage: audit and lint
-    #   if: tag !~ ^v\d+.* AND commit_message !~ \[skip-audit\]
-    #   install:
-    #     - nvm install-latest-npm
-    #     - ln -s /dev/stdout ./lerna-debug.log
-    #     - npm install --no-audit
-    #     - npm run install-locks
-    #   script: npm run audit
+    - name: "npm audit"
+      stage: audit and lint
+      if: tag !~ ^v\d+.* AND commit_message !~ \[skip-audit\]
+      install:
+        - nvm install-latest-npm
+        - ln -s /dev/stdout ./lerna-debug.log
+        - npm install --no-audit
+        - npm run install-locks
+      script: npm run audit
 
     - name: "eslint"
       stage: audit and lint

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "devDependencies": {
-    "audit-ci": "^1.7.0",
+    "audit-ci": "^2.0.1",
     "ava": "^0.25.0",
     "babel-eslint": "^8.2.2",
     "coveralls": "^3.0.0",


### PR DESCRIPTION
**Summary:**

Addresses [audit-ci not working in Travis](https://github.com/nasa/cumulus/issues/1040)

Feel free to modify this PR with the appropriate `CUMULUS-XXX` tags and suggest CHANGELOG updates.

## Changes

* Update `audit-ci` to `v2.0.1`
* Re-enable `audit-ci` in Travis

## PR Checklist

- [ ] Update CHANGELOG
- [x] Unit tests
- [x] Adhoc testing
- [x] Integration tests