### PR TITLE
IT failure: Files from move-granules not found in IngestGranuleDuplicateHandlingSpec LOGGING

### DIFF
--- a/example/spec/helpers/testUtils.js
+++ b/example/spec/helpers/testUtils.js
@@ -310,6 +310,7 @@ module.exports = {
   createTimestampedTestId,
   deleteFolder,
   getExecutionUrl,
+  getFileMetadata,
   getFilesMetadata,
   getPublicS3FileUrl,
   isCumulusLogEntry,

--- a/example/spec/helpers/testUtils.js
+++ b/example/spec/helpers/testUtils.js
@@ -315,7 +315,6 @@ module.exports = {
   createTimestampedTestId,
   deleteFolder,
   getExecutionUrl,
-  getFileMetadata,
   getFilesMetadata,
   getPublicS3FileUrl,
   isCumulusLogEntry,

--- a/example/spec/helpers/testUtils.js
+++ b/example/spec/helpers/testUtils.js
@@ -14,7 +14,8 @@ const yaml = require('js-yaml');
 
 const {
   aws: { s3, headObject, parseS3Uri },
-  stringUtils: { globalReplace }
+  stringUtils: { globalReplace },
+  log
 } = require('@cumulus/common');
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000000;
@@ -246,13 +247,17 @@ async function getFileMetadata(file) {
     throw new Error(`Unable to determine file location: ${JSON.stringify(file)}`);
   }
 
-  const headObjectResponse = await headObject(Bucket, Key);
-
-  return {
-    filename: file.filename,
-    size: headObjectResponse.ContentLength,
-    LastModified: headObjectResponse.LastModified
-  };
+  try {
+    const headObjectResponse = await headObject(Bucket, Key);
+    return {
+      filename: file.filename,
+      size: headObjectResponse.ContentLength,
+      LastModified: headObjectResponse.LastModified
+    };
+  } catch (err) {
+    log.error(`Failed to headObject the object at ${Bucket}/${Key} in s3.`);
+    throw (err);
+  }
 }
 
 /**

--- a/example/spec/parallel/ingestGranule/IngestGranuleDuplicateHandlingSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleDuplicateHandlingSpec.js
@@ -5,8 +5,7 @@ const path = require('path');
 const { Collection } = require('@cumulus/api/models');
 const {
   aws: { parseS3Uri, s3 },
-  testUtils: { randomString },
-  log
+  testUtils: { randomString }
 } = require('@cumulus/common');
 const {
   addCollections,
@@ -24,7 +23,6 @@ const {
   createTimestampedTestId,
   createTestDataPath,
   createTestSuffix,
-  getFileMetadata, // temporarily added for logging
   getFilesMetadata
 } = require('../../helpers/testUtils');
 const { setupTestGranuleForIngest } = require('../../helpers/granuleUtils');
@@ -136,18 +134,7 @@ describe('When the Ingest Granules workflow is configured\n', () => {
 
       it('MoveGranules outputs', async () => {
         lambdaOutput = await lambdaStep.getStepOutput(workflowExecution.executionArn, 'MoveGranules');
-        // Logging to catch intermittent failures
-        const outputGranule = lambdaOutput.payload.granules[0];
-        currentFiles = await Promise.all(outputGranule.files.map((file) => {
-          log.info(`Getting metadata of ${file.bucket}/${file.filename} in s3`);
-          try {
-            return getFileMetadata(file);
-          } catch (err) {
-            log.error(`Failed to get metadata of ${file.bucket}/${file.filename} in s3`);
-            throw(err);
-          }
-        }));
-        // currentFiles = await getFilesMetadata(lambdaOutput.payload.granules[0].files);
+        currentFiles = await getFilesMetadata(lambdaOutput.payload.granules[0].files);
         expect(currentFiles.length).toEqual(5);
       });
 

--- a/example/spec/parallel/ingestGranule/IngestGranuleDuplicateHandlingSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleDuplicateHandlingSpec.js
@@ -5,7 +5,8 @@ const path = require('path');
 const { Collection } = require('@cumulus/api/models');
 const {
   aws: { parseS3Uri, s3 },
-  testUtils: { randomString }
+  testUtils: { randomString },
+  log
 } = require('@cumulus/common');
 const {
   addCollections,
@@ -23,6 +24,7 @@ const {
   createTimestampedTestId,
   createTestDataPath,
   createTestSuffix,
+  getFileMetadata, // temporarily added for logging
   getFilesMetadata
 } = require('../../helpers/testUtils');
 const { setupTestGranuleForIngest } = require('../../helpers/granuleUtils');
@@ -134,7 +136,18 @@ describe('When the Ingest Granules workflow is configured\n', () => {
 
       it('MoveGranules outputs', async () => {
         lambdaOutput = await lambdaStep.getStepOutput(workflowExecution.executionArn, 'MoveGranules');
-        currentFiles = await getFilesMetadata(lambdaOutput.payload.granules[0].files);
+        // Logging to catch intermittent failures
+        const outputGranule = lambdaOutput.payload.granules[0];
+        currentFiles = await Promise.all(outputGranule.files.map((file) => {
+          log.info(`Getting metadata of ${file.bucket}/${file.filename} in s3`);
+          try {
+            return getFileMetadata(file);
+          } catch (err) {
+            log.error(`Failed to get metadata of ${file.bucket}/${file.filename} in s3`);
+            throw(err);
+          }
+        }));
+        // currentFiles = await getFilesMetadata(lambdaOutput.payload.granules[0].files);
         expect(currentFiles.length).toEqual(5);
       });
 


### PR DESCRIPTION
**Summary:** Added some simple logging to help with future debugging.

Addresses [CUMULUS-1330: IT failure: Files from move-granules not found in IngestGranuleDuplicateHandlingSpec](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1330)

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

