### PR TITLE
Update eslint import version, update failing lint due to new rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "eslint": "^5.5.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-eslint-comments": "^3.0.1",
-    "eslint-plugin-import": "^2.9.0",
+    "eslint-plugin-import": "^2.18.0",
     "eslint-plugin-jsdoc": "^3.7.1",
     "eslint-plugin-lodash": "^2.7.0",
     "eslint-plugin-node": "^7.0.1",

--- a/tasks/discover-pdrs/tests/force.js
+++ b/tasks/discover-pdrs/tests/force.js
@@ -6,7 +6,6 @@ const os = require('os');
 const fs = require('fs-extra');
 const { RemoteResourceError } = require('@cumulus/common/errors');
 
-const { discoverPdrs } = require('..');
 
 const { recursivelyDeleteS3Bucket, s3, uploadS3Files } = require('@cumulus/common/aws');
 const {
@@ -14,6 +13,7 @@ const {
   validateConfig,
   validateOutput
 } = require('@cumulus/common/test-utils');
+const { discoverPdrs } = require('..');
 
 test.beforeEach(async (t) => {
   const inputPath = path.join(__dirname, 'fixtures', 'input.json');

--- a/tasks/discover-pdrs/tests/index.js
+++ b/tasks/discover-pdrs/tests/index.js
@@ -5,7 +5,6 @@ const path = require('path');
 const fs = require('fs-extra');
 const { FTPError, RemoteResourceError } = require('@cumulus/common/errors');
 
-const { discoverPdrs } = require('..');
 
 const { recursivelyDeleteS3Bucket, s3 } = require('@cumulus/common/aws');
 const {
@@ -14,6 +13,7 @@ const {
   validateConfig,
   validateOutput
 } = require('@cumulus/common/test-utils');
+const { discoverPdrs } = require('..');
 
 test.beforeEach(async (t) => {
   const inputPath = path.join(__dirname, 'fixtures', 'input.json');


### PR DESCRIPTION
Update eslint rules to account for newly pushed version of the 'import' eslint plugin. 

See https://github.com/benmosher/eslint-plugin-import/blob/master/CHANGELOG.md for more on what/why


