### PR TITLE
Fix example parsepdr workflow configuration

### DIFF
--- a/docs/data-cookbooks/choice-states.md
+++ b/docs/data-cookbooks/choice-states.md
@@ -14,14 +14,14 @@ If the comparison evaluates to `true`, the `Next` state is followed.
 
 ## Example
 
-In [examples/workflows/sips.yml](https://github.com/nasa/cumulus/blob/master/example/workflows/sips.yml) the `ParsePdr` workflow uses a `Choice` state, `CheckAgainChoice`, to terminate the workflow once `isFinished: true` is returned by the `CheckStatus` state.
+In [examples/workflows/sips.yml](https://github.com/nasa/cumulus/blob/master/example/workflows/sips.yml) the `ParsePdr` workflow uses a `Choice` state, `CheckAgainChoice`, to terminate the workflow once `cumulus_meta.isPdrFinished: true` is returned by the `CheckStatus` state.
 
 The `CheckAgainChoice` state definition requires an input object of the following structure:
 
 ```json
 {
-  "payload": {
-    "isFinished": false
+  "cumulus_meta": {
+    "isPdrFinished": false
   }
 }
 ```
@@ -32,10 +32,10 @@ Given the above input to the `CheckAgainChoice` state, the workflow would transi
     CheckAgainChoice:
       Type: Choice
       Choices:
-        - Variable: $.payload.isFinished
+        - Variable: $.cumulus_meta.isPdrFinished
           BooleanEquals: false
           Next: PdrStatusReport
-        - Variable: $.payload.isFinished
+        - Variable: $.cumulus_meta.isPdrFinished
           BooleanEquals: true
           Next: StopStatus
 ```
@@ -44,7 +44,7 @@ Given the above input to the `CheckAgainChoice` state, the workflow would transi
 
 Understanding the complete `ParsePdr` workflow is not necessary to understanding how `Choice` states work, but `ParsePdr` provides an example of how `Choice` states can be used to create a loop in a Cumulus workflow.
 
-In the complete `ParsePdr` workflow definition, the state `QueueGranules` is followed by `CheckStatus`. From `CheckStatus` a loop starts: Given `CheckStatus` returns `payload.isFinished: false`, `CheckStatus` is followed by `CheckAgainChoice` is followed by `PdrStatusReport` is followed by `WaitForSomeTime`, which returns to `CheckStatus`. Once `CheckStatus` returns `payload.isFinished: true`, `CheckAgainChoice` proceeds to `StopStatus`.
+In the complete `ParsePdr` workflow definition, the state `QueueGranules` is followed by `CheckStatus`. From `CheckStatus` a loop starts: Given `CheckStatus` returns `cumulus_meta.isPdrFinished: false`, `CheckStatus` is followed by `CheckAgainChoice` is followed by `PdrStatusReport` is followed by `WaitForSomeTime`, which returns to `CheckStatus`. Once `CheckStatus` returns `cumulus_meta.isPdrFinished: true`, `CheckAgainChoice` proceeds to `StopStatus`.
 
 ![Execution graph of SIPS ParsePdr workflow in AWS Step Functions console](assets/sips-parse-pdr.png)
 

--- a/example/workflows/sips.yml
+++ b/example/workflows/sips.yml
@@ -450,9 +450,6 @@ ParsePdr:
           Next: StopStatus
       Next: CheckAgainChoice
     CheckAgainChoice:
-      CumulusConfig:
-        cumulus_message:
-          input: '{$}'
       Type: Choice
       Choices:
         - Variable: $.cumulus_meta.isPdrFinished

--- a/example/workflows/sips.yml
+++ b/example/workflows/sips.yml
@@ -432,6 +432,13 @@ ParsePdr:
           Next: StopStatus
       Next: CheckStatus
     CheckStatus:
+      CumulusConfig:
+        cumulus_message:
+          outputs:
+            - source: '{$}'
+              destination: '{$.payload}'
+            - source: '{$.isFinished}'
+              destination: '{$.cumulus_meta.isPdrFinished}'
       Type: Task
       Resource: ${PdrStatusCheckLambdaFunction.Arn}
       Retry:
@@ -443,12 +450,15 @@ ParsePdr:
           Next: StopStatus
       Next: CheckAgainChoice
     CheckAgainChoice:
+      CumulusConfig:
+        cumulus_message:
+          input: '{$}'
       Type: Choice
       Choices:
-        - Variable: $.payload.isFinished
+        - Variable: $.cumulus_meta.isPdrFinished
           BooleanEquals: false
           Next: PdrStatusReport
-        - Variable: $.payload.isFinished
+        - Variable: $.cumulus_meta.isPdrFinished
           BooleanEquals: true
           Next: StopStatus
       Default: StopStatus


### PR DESCRIPTION
**Summary:** Summary of changes

## Issue

In example `ParsePdr` workflow, `CheckStatus` task output cumulus message is saved to s3, and `payload.isFinished` is not available to `choice` state `CheckAgainChoice`.

```json
{
  "name": "CheckStatus",
  "output": {
    "cumulus_meta": {
      "message_source": "sfn",
      "isPdrFinished": false,
      "execution_name": "b298e76f-1609-4ee2-9432-483228b36518",
      "state_machine": "arn:aws:states:us-east-1:596205514787:stateMachine:JlTestIntegrationParsePdrStateMachine-FMnyQnelyFQ4",
      "workflow_start_time": 1562335861053,
      "parentExecutionArn": "arn:aws:states:us-east-1:596205514787:execution:JlTestIntegrationDiscoverAndQueuePdrsStateMachine-ri6ktuP5h51L:7c56e56e-e80f-46b0-b7ed-322719ea97b6",
      "system_bucket": "cumulus-test-sandbox-internal",
      "queueName": "startSF"
    },
    "replace": {
      "Bucket": "cumulus-test-sandbox-internal",
      "Key": "events/824956ac-216f-45b1-815c-88a5987ffc77"
    }
  }
}
```

## Changes

* Update `CumulusConfig` of `CheckStatus` to save output `isFinished` to `cumulus_meta.isPdrFinished`, and make it available to `CheckAgainChoice`.

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

