### PR TITLE
Fixes 1098 - AWS X-ray for AWS lambdas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 -  We have encountered transient lambda service errors in our integration testing. Please handle transient service errors following [these guidelines](https://docs.aws.amazon.com/step-functions/latest/dg/bp-lambda-serviceexception.html). The workflows in the `example/workflows` folder have been updated with retries configured for these errors.
 
+- **1098&& Enables AWS x-ray for lambda
+
 -  **CUMULUS-799** added additional IAM permissions to support reading CloudWatch and API Gateway, so **you will have to redeploy your IAM stack.**
 
 -  **CUMULUS-800** Several items:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 -  We have encountered transient lambda service errors in our integration testing. Please handle transient service errors following [these guidelines](https://docs.aws.amazon.com/step-functions/latest/dg/bp-lambda-serviceexception.html). The workflows in the `example/workflows` folder have been updated with retries configured for these errors.
 
-- **1098&& Enables AWS x-ray for lambda
+- **1098** Enables AWS x-ray for lambda
 
 -  **CUMULUS-799** added additional IAM permissions to support reading CloudWatch and API Gateway, so **you will have to redeploy your IAM stack.**
 

--- a/packages/deployment/app/cloudformation.template.yml
+++ b/packages/deployment/app/cloudformation.template.yml
@@ -453,6 +453,8 @@ Resources:
     {{/each}}
       Handler: {{this.handler}}
       MemorySize: {{this.memory}}
+      TracingConfig:
+        Mode: Active
 {{# if this.apiRole }}
       Role: {{../iams.lambdaApiGatewayRoleArn}}
 {{else if this.distributionRole}}

--- a/packages/deployment/app/cloudformation.template.yml
+++ b/packages/deployment/app/cloudformation.template.yml
@@ -453,8 +453,10 @@ Resources:
     {{/each}}
       Handler: {{this.handler}}
       MemorySize: {{this.memory}}
+      {{# if ../xray}}
       TracingConfig:
         Mode: Active
+      {{/if}}
 {{# if this.apiRole }}
       Role: {{../iams.lambdaApiGatewayRoleArn}}
 {{else if this.distributionRole}}


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [1098: Enable x-ray]

## Changes

* Enables AWS X-ray.

NOTE that x-ray has some APIs you can call to instrument lambdas more. At some point it may be helpful to use these, but I haven't hit an issue where I needed that yet.

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Adhoc testing
- [ ] Integration tests

