### PR TITLE
update set-bamboo-env-variables with docsearch environment variables

### DIFF
--- a/bamboo/set-bamboo-env-variables.sh
+++ b/bamboo/set-bamboo-env-variables.sh
@@ -30,6 +30,8 @@ declare -a param_list=(
   "bamboo_SECRET_EARTHDATA_CLIENT_ID"
   "bamboo_SECRET_EARTHDATA_CLIENT_PASSWORD"
   "bamboo_SECRET_SECURITY_GROUP"
+  "bamboo_SECRET_DOCSEARCH_INDEX_NAME"
+  "bamboo_SECRET_DOCSEARCH_API_KEY"
 )
 regex='bamboo(_SECRET)?_(.*)'
 


### PR DESCRIPTION
Search for our docs is broken. This PR will fix it in master - there is a twin PR that fixes it in a backport PR @Jkovarik is working on. https://github.com/nasa/cumulus/pull/1118
