### PR TITLE
CUMULUS-1356: Delete config store entry on collection delete

### DIFF
--- a/packages/api/models/collections.js
+++ b/packages/api/models/collections.js
@@ -133,11 +133,12 @@ class Collection extends Manager {
 
     // Since the `create` method uses the collection's `dataType` when calling
     // `CollectionConfigStore.put`, we must also use `dataType` to delete it
-    // from the store.  However, we have may only the collection's name and
+    // from the store.  However, we may only have the collection's name and
     // version, so in that case we need to retrieve the full collection object
-    // in order to retrieve its `dataType`.
+    // in order to retrieve its `dataType`.  If the item does not exist, then
+    // fall back to using the specified name.
     const dataType = item.dataType
-      || (await this.get({ name, version })).dataType;
+      || (await this.get(item).catch(() => ({}))).dataType;
     await this.collectionConfigStore.delete(dataType || name, version);
 
     return super.delete({ name, version });

--- a/packages/api/models/collections.js
+++ b/packages/api/models/collections.js
@@ -137,8 +137,8 @@ class Collection extends Manager {
     // version, so in that case we need to retrieve the full collection object
     // in order to retrieve its `dataType`.  If the item does not exist, then
     // fall back to using the specified name.
-    const dataType = item.dataType
-      || (await this.get(item).catch(() => ({}))).dataType;
+    const { dataType } = item.dataType
+      ? item : await this.get(item).catch(() => item);
     await this.collectionConfigStore.delete(dataType || name, version);
 
     return super.delete({ name, version });

--- a/packages/api/tests/models/test-collections-model.js
+++ b/packages/api/tests/models/test-collections-model.js
@@ -105,3 +105,13 @@ test('Collection.delete() deletes a collection', async (t) => {
     { message: new RegExp(`${collectionId}`) }
   );
 });
+
+test('Collection.delete() does not throw exception when attempting to delete'
+  + ' a collection that does not exist', async (t) => {
+  const name = randomString();
+  const version = randomString();
+
+  t.false(await collectionsModel.exists(name, version));
+  await collectionsModel.delete({ name, version });
+  t.false(await collectionsModel.exists(name, version));
+});

--- a/packages/integration-tests/index.js
+++ b/packages/integration-tests/index.js
@@ -10,6 +10,7 @@ const uuidv4 = require('uuid/v4');
 const fs = require('fs-extra');
 const pLimit = require('p-limit');
 const pMap = require('p-map');
+const { constructCollectionId } = require('@cumulus/common');
 
 const {
   stringUtils: { globalReplace }
@@ -360,7 +361,8 @@ async function addCollections(stackName, bucketName, dataDirectory, postfix,
       collection.duplicateHandling = duplicateHandling;
     }
     const c = new Collection();
-    console.log(`Adding collection ${collection.name}___${collection.version}`);
+    const id = constructCollectionId(collection.name, collection.version);
+    console.log(`Adding collection ${id}`);
     return c.delete(collection)
       .then(() => api.addCollectionApi({ prefix: stackName, collection }));
   }));
@@ -397,7 +399,8 @@ async function deleteCollections(stackName, bucketName, collections, postfix) {
       collection.dataType += postfix;
     }
     const c = new Collection();
-    console.log(`Deleting collection ${collection.name}___${collection.version}`);
+    const id = constructCollectionId(collection.name, collection.version);
+    console.log(`Deleting collection ${id}`);
     return c.delete(collection);
   });
 


### PR DESCRIPTION
**Summary** 

In `packages/api/models/collections.js`, the `Collection.delete` method
now removes the specified collection from the collection configuration
store, which is necessary for reversing the behavior of the `create` method
in which the collection is added to the collection configuration store.

Addresses [CUMULUS-1356: Delete config store entry on collection delete](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1356)

## Changes

* The `delete` method of the Collection model now removes the specified
item's collection config store entry based upon the item's `dataType`
(or `name`, if `dataType` is missing) and version.  Prior to this
change, this behavior was missing.  Also added missing JSDoc
documentation.
* Added `.idea/` to `.gitignore` to ignore JetBrains project files.
* Arranged `Fixed` items in `CHANGELOG.md` in ascending order by Jira
issue ID for improved visual display, but more importantly to reduce the
likelihood of merge conflicts.  By always adding to either the top or
bottom of the list, the likelihood of merge conflicts is greater.  The
same should be done for the `Added` and `Changed` items, but given that
this issue is classified as a fix, only the `Fixed` list was adjusted
prior to inserting this issue into the list.

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests