### PR TITLE
CUMULUS-1356: Delete config store entry on collection delete

### DIFF
--- a/packages/integration-tests/index.js
+++ b/packages/integration-tests/index.js
@@ -682,8 +682,15 @@ async function buildWorkflow(
   setProcessEnvironment(stackName, bucketName);
 
   const template = await getWorkflowTemplate(stackName, bucketName, workflowName);
-  const collectionInfo = collection ? await new Collection().get(collection) : {};
-  const providerInfo = provider ? await new Provider().get(provider) : {};
+  const collectionInfo = collection
+    ? await new Collection().get({
+      name: collection.name,
+      version: collection.version
+    })
+    : {};
+  const providerInfo = provider
+    ? await new Provider().get({ id: provider.id })
+    : {};
 
   template.meta.collection = collectionInfo;
   template.meta.provider = providerInfo;


### PR DESCRIPTION
**Summary** 

In `packages/api/models/collections.js`, the `Collection.delete` method
now removes the specified collection from the collection configuration
store, which is necessary for reversing the behavior of the `create` method
in which the collection is added to the collection configuration store.

Addresses [CUMULUS-1356: Delete config store entry on collection delete](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1356)

## Changes

* The `delete` method of the Collection model now removes the specified
item's collection config store entry based upon the item's `dataType`
(or `name`, if `dataType` is missing) and version.  Prior to this
change, this behavior was missing.  Also added missing JSDoc
documentation.
* Added `.idea/` to `.gitignore` to ignore JetBrains project files.
* Arranged `Fixed` items in `CHANGELOG.md` in ascending order by Jira
issue ID for improved visual display, but more importantly to reduce the
likelihood of merge conflicts.  By always adding to either the top or
bottom of the list, the likelihood of merge conflicts is greater.  The
same should be done for the `Added` and `Changed` items, but given that
this issue is classified as a fix, only the `Fixed` list was adjusted
prior to inserting this issue into the list.

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests