### PR TITLE
CUMULUS-1356: Delete config store entry on collection delete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ search_index.json
 /jsconfig.json
 /gh-pages
 website/i18n/en.json
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,15 +125,20 @@ If you deploy with no distribution app your deployment will succeed but you may 
 
 ### Fixed
 
-- **CUMULUS-1374**
-  - Addressed audit concerns (https://www.npmjs.com/advisories/782) in api package
+- **CUMULUS-796**
+  - Added production information (collection ShortName and Version, granuleId) to EMS distribution report
+  - Added functionality to send daily distribution reports to EMS
 
 - **CUMULUS-1319**
   - Fixed a bug where granule ingest times were not being stored to the database
 
-- **CUMULUS-796**
-  - Added production information (collection ShortName and Version, granuleId) to EMS distribution report
-  - Added functionality to send daily distribution reports to EMS
+- **CUMULUS-1356**
+  - The `Collection` model's `delete` method now _removes_ the specified item
+    from the collection config store that was inserted by the `create` method.
+    Previously, this behavior was missing.
+
+- **CUMULUS-1374**
+  - Addressed audit concerns (https://www.npmjs.com/advisories/782) in api package
 
 ### BREAKING CHANGES
 

--- a/example/spec/parallel/ingestGranule/IngestUMMGSuccessSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestUMMGSuccessSpec.js
@@ -110,6 +110,7 @@ describe('The S3 Ingest Granules workflow configured to ingest UMM-G', () => {
   process.env.ExecutionsTable = `${config.stackName}-ExecutionsTable`;
   const executionModel = new Execution();
   process.env.CollectionsTable = `${config.stackName}-CollectionsTable`;
+  process.env.system_bucket = config.bucket;
   const collectionModel = new Collection();
   process.env.ProvidersTable = `${config.stackName}-ProvidersTable`;
   const providerModel = new Provider();
@@ -239,28 +240,39 @@ describe('The S3 Ingest Granules workflow configured to ingest UMM-G', () => {
     let files;
     let resourceURLs;
     let accessToken;
+    let beforeAllError;
 
     beforeAll(async () => {
       postToCmrOutput = await lambdaStep.getStepOutput(workflowExecution.executionArn, 'PostToCmr');
-      if (postToCmrOutput === null) throw new Error(`Failed to get the PostToCmr step's output for ${workflowExecution.executionArn}`);
+      if (postToCmrOutput === null) {
+        beforeAllError = new Error(`Failed to get the PostToCmr step's output for ${workflowExecution.executionArn}`);
+      }
 
-      granule = postToCmrOutput.payload.granules[0];
-      files = granule.files;
-      process.env.CMR_ENVIRONMENT = 'UAT';
-      const result = await Promise.all([
-        getOnlineResources(granule),
-        // Login with Earthdata and get access token.
-        getEarthdataAccessToken({
-          redirectUri: process.env.DISTRIBUTION_REDIRECT_ENDPOINT,
-          requestOrigin: process.env.DISTRIBUTION_ENDPOINT
-        })
-      ]);
+      try {
+        granule = postToCmrOutput.payload.granules[0];
+        files = granule.files;
+        process.env.CMR_ENVIRONMENT = 'UAT';
+        const result = await Promise.all([
+          getOnlineResources(granule),
+          // Login with Earthdata and get access token.
+          getEarthdataAccessToken({
+            redirectUri: process.env.DISTRIBUTION_REDIRECT_ENDPOINT,
+            requestOrigin: process.env.DISTRIBUTION_ENDPOINT
+          })
+        ]);
 
-      onlineResources = result[0];
-      resourceURLs = onlineResources.map((resource) => resource.URL);
+        onlineResources = result[0];
+        resourceURLs = onlineResources.map((resource) => resource.URL);
 
-      const accessTokenResponse = result[1];
-      accessToken = accessTokenResponse.accessToken;
+        const accessTokenResponse = result[1];
+        accessToken = accessTokenResponse.accessToken;
+      } catch (e) {
+        beforeAllError = e;
+      }
+    });
+
+    beforeEach(() => {
+      if (beforeAllError) fail(beforeAllError);
     });
 
     afterAll(async () => {

--- a/packages/api/models/collections.js
+++ b/packages/api/models/collections.js
@@ -39,7 +39,7 @@ class Collection extends Manager {
    * by collection `name`, with `version` as the sort key, both of which are of
    * type `S`.  The table schema is defined by the
    * {@link collectionSchema collection schema}.
-   * </p>
+   *
    * Collections created by this model are also put into a
    * {@link CollectionConfigStore} upon {@link #create creation} and removed
    * from it when {@link #delete deleted}.  The store is

--- a/packages/api/models/collections.js
+++ b/packages/api/models/collections.js
@@ -133,11 +133,12 @@ class Collection extends Manager {
 
     // Since the `create` method uses the collection's `dataType` when calling
     // `CollectionConfigStore.put`, we must also use `dataType` to delete it
-    // from the store.  However, we have may only the collection's name and
+    // from the store.  However, we may only have the collection's name and
     // version, so in that case we need to retrieve the full collection object
-    // in order to retrieve its `dataType`.
+    // in order to retrieve its `dataType`.  If the item does not exist, then
+    // fall back to using the specified name.
     const dataType = item.dataType
-      || (await this.get({ name, version })).dataType;
+      || (await this.get(item).catch(() => ({}))).dataType;
     await this.collectionConfigStore.delete(dataType || name, version);
 
     return super.delete({ name, version });

--- a/packages/api/models/collections.js
+++ b/packages/api/models/collections.js
@@ -2,7 +2,7 @@
 
 const { CollectionConfigStore } = require('@cumulus/common');
 const Manager = require('./base');
-const collectionSchema = require('./schemas').collection;
+const { collection: collectionSchema } = require('./schemas');
 const Rule = require('./rules');
 const { AssociatedRulesError, BadRequestError } = require('../lib/errors');
 
@@ -32,6 +32,23 @@ class Collection extends Manager {
     item.files.forEach((file) => checkRegex(file.regex, file.sampleFileName));
   }
 
+  /**
+   * Creates a new Collection model for managing storage and retrieval of
+   * collections against a DynamoDB table. The name of the table is specified
+   * by the environment variable `CollectionsTable`.  The table is partitioned
+   * by collection `name`, with `version` as the sort key, both of which are of
+   * type `S`.  The table schema is defined by the
+   * {@link collectionSchema collection schema}.
+   * </p>
+   * Collections created by this model are also put into a
+   * {@link CollectionConfigStore} upon {@link #create creation} and removed
+   * from it when {@link #delete deleted}.  The store is
+   * {@link CollectionConfigStore#constructor created} by using the S3 bucket
+   * name and CloudFormation stack name given by the values of the environment
+   * variables `system_bucket` and `stackName`, respectively.
+   *
+   * @see Manager#constructor
+   */
   constructor() {
     super({
       tableName: process.env.CollectionsTable,
@@ -47,30 +64,32 @@ class Collection extends Manager {
   }
 
   /**
-   * Check if a given collection exists
+   * Returns `true` if the collection with the specified name and version
+   * exists; `false` otherwise.
    *
    * @param {string} name - collection name
    * @param {string} version - collection version
-   * @returns {boolean}
+   * @returns {boolean} `true` if the collection with the specified name and
+   *    version exists; `false` otherwise
    */
   async exists(name, version) {
     return super.exists({ name, version });
   }
 
   /**
-   * Creates a collection and puts it into a collection configuration store.
-   * Uses the item's `dataType` (if specified, otherwise, it's `name`) and
-   * `version` as the key for putting the item in a config store specific to
-   * the S3 bucket and stack given by the environment variables `system_bucket`
-   * and `stackName`, respectively.
+   * Creates the specified collection and puts it into the collection
+   * configuration store that was specified during this model's construction.
+   * Uses the specified item's `dataType` (if specified, otherwise, it's `name`)
+   * and `version` as the key for putting the item in the config store.
    *
    * @param {Object} item - the collection configuration
    * @param {string} [item.dataType] - the collection's data type
    * @param {string} item.name - the collection name
    * @param {string} item.version - the collection version
+   * @returns {Promise<Object>} the created record
+   * @see #constructor
    * @see Manager#create
    * @see CollectionConfigStore#put
-   * @returns {Promise<Object>} the created record
    */
   async create(item) {
     const { dataType, name, version } = item;
@@ -80,20 +99,28 @@ class Collection extends Manager {
   }
 
   /**
-   * Deletes a collection and removes it from the corresponding collection
-   * configuration store that was used during {@link #create creation}.
+   * Deletes the specified collection and removes it from the corresponding
+   * collection configuration store that was specified during this model's
+   * construction, where it was stored upon {@link #create creation}, unless
+   * the collection has associated rules.
    *
-   * @param {Object} params - the collection configuration
-   * @param {string} params.name - the collection name
-   * @param {string} params.version - the collection version
+   * @param {Object} item - collection parameters
+   * @param {string} [item.dataType] - the collection data type; if not
+   *    specified, the collection is retrieved in order to determine its data
+   *    type, and if there is no data type, the name is used instead when
+   *    deleting the collection from the collection store
+   * @param {string} item.name - the collection name
+   * @param {string} item.version - the collection version
+   * @returns {Promise<Object>} promise that resolves to the de-serialized data
+   *    returned from the request
    * @throws {AssociatedRulesError} if the collection has associated rules
-   * @returns {Promise<Object>} the de-serialized data returned from the request
+   * @see #constructor
    * @see #create
    * @see Manager#delete
    * @see CollectionConfigStore#delete
    */
-  async delete(params = {}) {
-    const { name, version } = params;
+  async delete(item) {
+    const { name, version } = item;
     const associatedRuleNames = (await this.getAssociatedRules(name, version))
       .map((rule) => rule.name);
 
@@ -106,10 +133,11 @@ class Collection extends Manager {
 
     // Since the `create` method uses the collection's `dataType` when calling
     // `CollectionConfigStore.put`, we must also use `dataType` to delete it
-    // from the store.  However, we have only the collection's name and version,
-    // so we need to retrieve the full collection object in order to retrieve
-    // its dataType.
-    const { dataType } = await super.get({ name, version });
+    // from the store.  However, we have may only the collection's name and
+    // version, so in that case we need to retrieve the full collection object
+    // in order to retrieve its `dataType`.
+    const dataType = item.dataType
+      || (await this.get({ name, version })).dataType;
     await this.collectionConfigStore.delete(dataType || name, version);
 
     return super.delete({ name, version });

--- a/packages/api/models/collections.js
+++ b/packages/api/models/collections.js
@@ -137,8 +137,8 @@ class Collection extends Manager {
     // version, so in that case we need to retrieve the full collection object
     // in order to retrieve its `dataType`.  If the item does not exist, then
     // fall back to using the specified name.
-    const dataType = item.dataType
-      || (await this.get(item).catch(() => ({}))).dataType;
+    const { dataType } = item.dataType
+      ? item : await this.get(item).catch(() => item);
     await this.collectionConfigStore.delete(dataType || name, version);
 
     return super.delete({ name, version });

--- a/packages/api/tests/models/test-collections-model.js
+++ b/packages/api/tests/models/test-collections-model.js
@@ -105,3 +105,13 @@ test('Collection.delete() deletes a collection', async (t) => {
     { message: new RegExp(`${collectionId}`) }
   );
 });
+
+test('Collection.delete() does not throw exception when attempting to delete'
+  + ' a collection that does not exist', async (t) => {
+  const name = randomString();
+  const version = randomString();
+
+  t.false(await collectionsModel.exists(name, version));
+  await collectionsModel.delete({ name, version });
+  t.false(await collectionsModel.exists(name, version));
+});

--- a/packages/common/collection-config-store.js
+++ b/packages/common/collection-config-store.js
@@ -35,7 +35,7 @@ class CollectionConfigStore {
    * Fetch a collection config from S3 (or cache if available)
    *
    * @param {string} dataType - the name of the collection config to fetch
-   * @param {number} dataVersion - the version of the collection config to fetch
+   * @param {string} dataVersion - the version of the collection config to fetch
    * @returns {Object} the fetched collection config
    */
   async get(dataType, dataVersion) {
@@ -52,7 +52,7 @@ class CollectionConfigStore {
         }).promise();
       } catch (err) {
         if (err.code === 'NoSuchKey') {
-          throw new Error(`A collection config for data type "${dataType}__${dataVersion}" was not found.`);
+          throw new Error(`A collection config for data type "${collectionId}" was not found.`);
         }
 
         if (err.code === 'NoSuchBucket') {

--- a/packages/common/tests/collection-config-store.js
+++ b/packages/common/tests/collection-config-store.js
@@ -3,21 +3,24 @@
 const test = require('ava');
 const { recursivelyDeleteS3Bucket, s3, s3ObjectExists } = require('../aws');
 const { randomString } = require('../test-utils');
-const { CollectionConfigStore } = require('../collection-config-store');
+const {
+  CollectionConfigStore,
+  constructCollectionId
+} = require('../collection-config-store');
 
 test.beforeEach(async (t) => {
   t.context.stackName = randomString();
   t.context.dataType = randomString();
   t.context.dataVersion = '6';
-
   t.context.collectionConfig = { name: randomString() };
-
   t.context.bucket = randomString();
-  await s3().createBucket({ Bucket: t.context.bucket }).promise();
-
   // Utility function to return the S3 key of a collection config
-  t.context.collectionConfigKey = (dataType, dataVersion) =>
-    `${t.context.stackName}/collections/${dataType}___${dataVersion}.json`;
+  t.context.collectionConfigKey = (dataType, dataVersion) => {
+    const collectionId = constructCollectionId(dataType, dataVersion);
+    return `${t.context.stackName}/collections/${collectionId}.json`;
+  };
+
+  await s3().createBucket({ Bucket: t.context.bucket }).promise();
 });
 
 test.afterEach((t) =>
@@ -29,145 +32,171 @@ test.afterEach((t) =>
     }));
 
 test.serial('get() fetches a collection config from S3', async (t) => {
+  const {
+    bucket,
+    collectionConfig,
+    collectionConfigKey,
+    dataType,
+    dataVersion,
+    stackName
+  } = t.context;
+
   await s3().putObject({
-    Bucket: t.context.bucket,
-    Key: t.context.collectionConfigKey(t.context.dataType, t.context.dataVersion),
-    Body: JSON.stringify(t.context.collectionConfig)
+    Bucket: bucket,
+    Key: collectionConfigKey(dataType, dataVersion),
+    Body: JSON.stringify(collectionConfig)
   }).promise();
 
-  const collectionConfigStore = new CollectionConfigStore(t.context.bucket, t.context.stackName);
-  const fetchedCollectionConfig = await collectionConfigStore.get(
-    t.context.dataType,
-    t.context.dataVersion
-  );
+  const collectionConfigStore = new CollectionConfigStore(bucket, stackName);
+  const fetchedCollectionConfig = await collectionConfigStore.get(dataType,
+    dataVersion);
 
-  t.deepEqual(fetchedCollectionConfig, t.context.collectionConfig);
+  t.deepEqual(fetchedCollectionConfig, collectionConfig);
 });
 
 test.serial('get() does not hit S3 for a cached collection config', async (t) => {
+  const {
+    bucket,
+    collectionConfig,
+    collectionConfigKey,
+    dataType,
+    dataVersion,
+    stackName
+  } = t.context;
+
   await s3().putObject({
-    Bucket: t.context.bucket,
-    Key: t.context.collectionConfigKey(t.context.dataType, t.context.dataVersion),
-    Body: JSON.stringify(t.context.collectionConfig)
+    Bucket: bucket,
+    Key: collectionConfigKey(dataType, dataVersion),
+    Body: JSON.stringify(collectionConfig)
   }).promise();
 
-  const collectionConfigStore = new CollectionConfigStore(t.context.bucket, t.context.stackName);
+  const collectionConfigStore = new CollectionConfigStore(bucket, stackName);
 
   // Fetch the collection config once so it's in the cache
-  await collectionConfigStore.get(t.context.dataType, t.context.dataVersion);
+  await collectionConfigStore.get(dataType, dataVersion);
 
   // Delete the S3 bucket so the config can't be fetched from S3
-  await recursivelyDeleteS3Bucket(t.context.bucket);
+  await recursivelyDeleteS3Bucket(bucket);
 
   // This get() should use the cache
-  const fetchedCollectionConfig = await collectionConfigStore.get(
-    t.context.dataType,
-    t.context.dataVersion
-  );
+  const fetchedCollectionConfig = await collectionConfigStore.get(dataType,
+    dataVersion);
 
-  t.deepEqual(fetchedCollectionConfig, t.context.collectionConfig);
+  t.deepEqual(fetchedCollectionConfig, collectionConfig);
 });
 
 test.serial('get() throws an exception if the collection config could not be found', async (t) => {
+  const { bucket, dataVersion, stackName } = t.context;
   const invalidDataType = randomString();
-  const collectionConfigStore = new CollectionConfigStore(t.context.bucket, t.context.stackName);
+  const collectionConfigStore = new CollectionConfigStore(bucket, stackName);
+  const collectionId = constructCollectionId(invalidDataType, dataVersion);
 
-  try {
-    await collectionConfigStore.get(invalidDataType, t.context.dataVersion);
-    t.fail('Expected an error to be thrown');
-  } catch (err) {
-    t.is(err.message, `A collection config for data type "${invalidDataType}__${t.context.dataVersion}" was not found.`);
-  }
+  await t.throwsAsync(
+    async () => collectionConfigStore.get(invalidDataType, dataVersion),
+    { message: new RegExp(`${collectionId}`) }
+  );
 });
 
 test.serial('get() throws an exception if the bucket does not exist', async (t) => {
+  const { dataType, dataVersion, stackName } = t.context;
   const invalidBucket = randomString();
-  const collectionConfigStore = new CollectionConfigStore(invalidBucket, t.context.stackName);
+  const collectionConfigStore = new CollectionConfigStore(invalidBucket,
+    stackName);
 
-  try {
-    await collectionConfigStore.get(t.context.dataType, t.context.dataVersion);
-    t.fail('Expected an error to be thrown');
-  } catch (err) {
-    t.is(err.message, `Collection config bucket does not exist: ${invalidBucket}`);
-  }
+  await t.throwsAsync(
+    async () => collectionConfigStore.get(dataType, dataVersion),
+    { message: new RegExp(`${invalidBucket}`) }
+  );
 });
 
 test.serial('put() stores a collection config to S3', async (t) => {
-  const collectionConfigStore = new CollectionConfigStore(t.context.bucket, t.context.stackName);
-  await collectionConfigStore.put(
-    t.context.dataType,
-    t.context.dataVersion,
-    t.context.collectionConfig
-  );
+  const {
+    bucket,
+    collectionConfig,
+    collectionConfigKey,
+    dataType,
+    dataVersion,
+    stackName
+  } = t.context;
+  const collectionConfigStore = new CollectionConfigStore(bucket, stackName);
+  await collectionConfigStore.put(dataType, dataVersion, collectionConfig);
 
   const getObjectResponse = await s3().getObject({
-    Bucket: t.context.bucket,
-    Key: t.context.collectionConfigKey(t.context.dataType, t.context.dataVersion)
+    Bucket: bucket,
+    Key: collectionConfigKey(dataType, dataVersion)
   }).promise();
 
   const storedCollectionConfig = JSON.parse(getObjectResponse.Body.toString());
-  t.deepEqual(storedCollectionConfig, t.context.collectionConfig);
+  t.deepEqual(storedCollectionConfig, collectionConfig);
 });
 
 test.serial('put() updates the cache with the new collection config', async (t) => {
-  const collectionConfigStore = new CollectionConfigStore(t.context.bucket, t.context.stackName);
-
-  const { dataType, dataVersion, collectionConfig } = t.context;
+  const {
+    bucket,
+    dataType,
+    dataVersion,
+    collectionConfig,
+    stackName
+  } = t.context;
+  const collectionConfigStore = new CollectionConfigStore(bucket, stackName);
 
   await collectionConfigStore.put(dataType, dataVersion, collectionConfig);
 
   // Delete the S3 bucket so the config can't be fetched from S3
-  await recursivelyDeleteS3Bucket(t.context.bucket);
+  await recursivelyDeleteS3Bucket(bucket);
 
   // This get() should use the cache
-  const fetchedCollectionConfig = await collectionConfigStore.get(
-    dataType,
-    dataVersion
-  );
+  const fetchedCollectionConfig = await collectionConfigStore.get(dataType,
+    dataVersion);
 
   t.deepEqual(fetchedCollectionConfig, collectionConfig);
 });
 
 test.serial('delete() removes the collection config from S3', async (t) => {
-  const bucket = t.context.bucket;
-  const collectionConfigKey = t.context.collectionConfigKey(
-    t.context.dataType,
-    t.context.dataVersion
-  );
+  const {
+    bucket,
+    collectionConfig,
+    collectionConfigKey,
+    dataType,
+    dataVersion,
+    stackName
+  } = t.context;
+  const key = collectionConfigKey(dataType, dataVersion);
+  const s3Object = { Bucket: bucket, Key: key };
+  const collectionConfigStore = new CollectionConfigStore(bucket, stackName);
 
   // Store the collection config to S3
-  await (new CollectionConfigStore(bucket, t.context.stackName))
-    .put(t.context.dataType, t.context.dataVersion, t.context.collectionConfig);
+  await collectionConfigStore.put(dataType, dataVersion, collectionConfig);
 
   // Verify that the collection config is in S3.  Will throw an error
-  t.true(await s3ObjectExists({ Bucket: bucket, Key: collectionConfigKey }));
+  t.true(await s3ObjectExists(s3Object));
 
   // Delete the collection config
-  await (new CollectionConfigStore(bucket, t.context.stackName))
-    .delete(t.context.dataType, t.context.dataVersion);
+  await collectionConfigStore.delete(dataType, dataVersion);
 
   // Verify that the collection config is no longer in S3
-  t.false(await s3ObjectExists({ Bucket: bucket, Key: collectionConfigKey }));
+  t.false(await s3ObjectExists(s3Object));
 });
 
 test('delete() the collection config from the cache', async (t) => {
-  const collectionConfigStore = new CollectionConfigStore(t.context.bucket, t.context.stackName);
+  const {
+    bucket,
+    collectionConfig,
+    dataType,
+    dataVersion,
+    stackName
+  } = t.context;
+  const collectionConfigStore = new CollectionConfigStore(bucket, stackName);
 
   // Store the collection config to S3, which will also cache it
-  await collectionConfigStore.put(
-    t.context.dataType,
-    t.context.dataVersion,
-    t.context.collectionConfig
-  );
+  await collectionConfigStore.put(dataType, dataVersion, collectionConfig);
 
   // Delete the collection config, which should clear it from the cache
-  await collectionConfigStore.delete(t.context.dataType, t.context.dataVersion);
+  await collectionConfigStore.delete(dataType, dataVersion);
 
   // Try to get the config, which should hit S3 and fail if it isn't cached
-  try {
-    await collectionConfigStore.get(t.context.dataType, t.context.dataVersion);
-    t.fail('Expected an error to be thrown');
-  } catch (err) {
-    t.is(err.message, `A collection config for data type "${t.context.dataType}__${t.context.dataVersion}" was not found.`);
-  }
+  await t.throwsAsync(
+    async () => collectionConfigStore.get(dataType, dataVersion),
+    { message: new RegExp(`${constructCollectionId(dataType, dataVersion)}`) }
+  );
 });

--- a/packages/integration-tests/index.js
+++ b/packages/integration-tests/index.js
@@ -682,8 +682,15 @@ async function buildWorkflow(
   setProcessEnvironment(stackName, bucketName);
 
   const template = await getWorkflowTemplate(stackName, bucketName, workflowName);
-  const collectionInfo = collection ? await new Collection().get(collection) : {};
-  const providerInfo = provider ? await new Provider().get(provider) : {};
+  const collectionInfo = collection
+    ? await new Collection().get({
+      name: collection.name,
+      version: collection.version
+    })
+    : {};
+  const providerInfo = provider
+    ? await new Provider().get({ id: provider.id })
+    : {};
 
   template.meta.collection = collectionInfo;
   template.meta.provider = providerInfo;

--- a/packages/integration-tests/index.js
+++ b/packages/integration-tests/index.js
@@ -10,6 +10,7 @@ const uuidv4 = require('uuid/v4');
 const fs = require('fs-extra');
 const pLimit = require('p-limit');
 const pMap = require('p-map');
+const { constructCollectionId } = require('@cumulus/common');
 
 const {
   stringUtils: { globalReplace }
@@ -360,7 +361,8 @@ async function addCollections(stackName, bucketName, dataDirectory, postfix,
       collection.duplicateHandling = duplicateHandling;
     }
     const c = new Collection();
-    console.log(`Adding collection ${collection.name}___${collection.version}`);
+    const id = constructCollectionId(collection.name, collection.version);
+    console.log(`Adding collection ${id}`);
     return c.delete(collection)
       .then(() => api.addCollectionApi({ prefix: stackName, collection }));
   }));
@@ -397,7 +399,8 @@ async function deleteCollections(stackName, bucketName, collections, postfix) {
       collection.dataType += postfix;
     }
     const c = new Collection();
-    console.log(`Deleting collection ${collection.name}___${collection.version}`);
+    const id = constructCollectionId(collection.name, collection.version);
+    console.log(`Deleting collection ${id}`);
     return c.delete(collection);
   });
 


### PR DESCRIPTION
**Summary** 

In `packages/api/models/collections.js`, the `Collection.delete` method
now removes the specified collection from the collection configuration
store, which is necessary for reversing the behavior of the `create` method
in which the collection is added to the collection configuration store.

Addresses [CUMULUS-1356: Delete config store entry on collection delete](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1356)

## Changes

* The `delete` method of the Collection model now removes the specified
item's collection config store entry based upon the item's `dataType`
(or `name`, if `dataType` is missing) and version.  Prior to this
change, this behavior was missing.  Also added missing JSDoc
documentation.
* Added `.idea/` to `.gitignore` to ignore JetBrains project files.
* Arranged `Fixed` items in `CHANGELOG.md` in ascending order by Jira
issue ID for improved visual display, but more importantly to reduce the
likelihood of merge conflicts.  By always adding to either the top or
bottom of the list, the likelihood of merge conflicts is greater.  The
same should be done for the `Added` and `Changed` items, but given that
this issue is classified as a fix, only the `Fixed` list was adjusted
prior to inserting this issue into the list.

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests