### PR TITLE
CUMULUS 1356 delete config store on model delete

### DIFF
--- a/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
@@ -329,6 +329,7 @@ describe('The S3 Ingest Granules workflow', () => {
 
       if (postToCmrOutput === null) {
         beforeAllError = new Error(`Failed to get the PostToCmr step's output for ${workflowExecution.executionArn}`);
+        return;
       }
 
       try {

--- a/example/spec/parallel/ingestGranule/IngestUMMGSuccessSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestUMMGSuccessSpec.js
@@ -246,6 +246,7 @@ describe('The S3 Ingest Granules workflow configured to ingest UMM-G', () => {
       postToCmrOutput = await lambdaStep.getStepOutput(workflowExecution.executionArn, 'PostToCmr');
       if (postToCmrOutput === null) {
         beforeAllError = new Error(`Failed to get the PostToCmr step's output for ${workflowExecution.executionArn}`);
+        return;
       }
 
       try {

--- a/packages/integration-tests/index.js
+++ b/packages/integration-tests/index.js
@@ -341,9 +341,9 @@ function addCustomUrlPathToCollectionFiles(collection, customFilePath) {
  * @param {string} stackName - Cloud formation stack name
  * @param {string} bucketName - S3 internal bucket name
  * @param {string} dataDirectory - the directory of collection json files
- * @param {string} postfix - string to append to collection name
- * @param {string} customFilePath
- * @param {boolean} duplicateHandling
+ * @param {string} [postfix] - string to append to collection name
+ * @param {string} [customFilePath]
+ * @param {string} [duplicateHandling]
  * @returns {Promise.<number>} number of collections added
  */
 async function addCollections(stackName, bucketName, dataDirectory, postfix,
@@ -682,11 +682,9 @@ async function buildWorkflow(
   setProcessEnvironment(stackName, bucketName);
 
   const template = await getWorkflowTemplate(stackName, bucketName, workflowName);
+  const { name, version } = collection || {};
   const collectionInfo = collection
-    ? await new Collection().get({
-      name: collection.name,
-      version: collection.version
-    })
+    ? await new Collection().get({ name, version })
     : {};
   const providerInfo = provider
     ? await new Provider().get({ id: provider.id })


### PR DESCRIPTION
**Summary** 

In `packages/api/models/collections.js`, the `Collection.delete` method
now removes the specified collection from the collection configuration
store, which is necessary for reversing the behavior of the `create` method
in which the collection is added to the collection configuration store.

Addresses [CUMULUS-1356: Delete config store entry on collection delete](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1356)

## Changes

* The `delete` method of the Collection model now removes the specified
item's collection config store entry based upon the item's `dataType`
(or `name`, if `dataType` is missing) and version.  Prior to this
change, this behavior was missing.  Also added missing JSDoc
documentation.
* Added `.idea/` to `.gitignore` to ignore JetBrains project files.
* Arranged `Fixed` items in `CHANGELOG.md` in ascending order by Jira
issue ID for improved visual display, but more importantly to reduce the
likelihood of merge conflicts.  By always adding to either the top or
bottom of the list, the likelihood of merge conflicts is greater.  The
same should be done for the `Added` and `Changed` items, but given that
this issue is classified as a fix, only the `Fixed` list was adjusted
prior to inserting this issue into the list.

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests