### PR TITLE
Add wait for granule status to IngestGranuleFailureSpec 

### DIFF
--- a/example/spec/parallel/ingestGranule/IngestGranuleFailureSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleFailureSpec.js
@@ -172,7 +172,7 @@ describe('The Ingest Granule failure workflow', () => {
       await waitForModelStatus(
         granuleModel,
         { granuleId: inputPayload.granules[0].granuleId },
-        'completed'
+        'failed'
       );
 
       const granuleResponse = await granulesApiTestUtils.getGranule({

--- a/example/spec/parallel/ingestGranule/IngestGranuleFailureSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleFailureSpec.js
@@ -13,6 +13,9 @@ const {
 } = require('@cumulus/integration-tests');
 
 const {
+  waitForModelStatus
+} = require('../../helpers/apiUtils');
+const {
   loadConfig,
   uploadTestDataToBucket,
   deleteFolder,
@@ -166,6 +169,12 @@ describe('The Ingest Granule failure workflow', () => {
     });
 
     it('fails the granule with the error message', async () => {
+      await waitForModelStatus(
+        granuleModel,
+        { granuleId: inputPayload.granules[0].granuleId },
+        'completed'
+      );
+
       const granuleResponse = await granulesApiTestUtils.getGranule({
         prefix: config.stackName,
         granuleId: inputPayload.granules[0].granuleId


### PR DESCRIPTION
Follow up to #1142 

Saw this failure in https://ci.earthdata.nasa.gov/download/CUM-CBA1197-DIS/build_logs/CUM-CBA1197-DIS-6.log, which seems symptomatic of the same race condition for granule record updates, so adding the same fix here as in CUMULUS-1433

```
build	09-Aug-2019 13:59:27	[36m1) The Ingest Granule failure workflow[39mAdding collection MOD09GQ_test-mboyd-int-IngestGranuleFailure-1565372820955___006
build	09-Aug-2019 13:59:27	adding provider s3_provider_test-mboyd-int-IngestGranuleFailure-1565372820955
build	09-Aug-2019 13:59:27	
build	09-Aug-2019 13:59:27	granule id: MOD09GQ.A1608985.0jowSE.006.5054145644915
build	09-Aug-2019 13:59:27	Starting workflow: IngestGranule. Execution ARN arn:aws:states:********:********:execution:mboydIntIngestGranuleStateMachine-BbOt1l2vGsdi:aaee9e20-08e9-446f-9b11-f41906fe409b
build	09-Aug-2019 13:59:27	
build	09-Aug-2019 13:59:27	.   [32m✔ completes execution with failure status[39m
build	09-Aug-2019 13:59:27	
build	09-Aug-2019 13:59:27	   [36m2) When a workflow task is configured to catch a specific error and branch and the error is thrown by a Cumulus task[39m
build	09-Aug-2019 13:59:27	.      [32m✔ branches appropriately according to the CMA output[39m
build	09-Aug-2019 13:59:27	.      [32m✔ propagates the error message to CMA output for next step[39m
build	09-Aug-2019 13:59:27	.      [32m✔ logs the execution with the error message[39m
build	09-Aug-2019 13:59:27	F      [31m✖ fails the granule with the error message (3 failures)[39m
build	09-Aug-2019 13:59:27	suiteDone: 1.834 secs "When a workflow task is configured to catch a specific error and branch and the error is thrown by a Cumulus task" at Fri Aug 09 2019 17:47:34 GMT+0000 (UTC)
build	09-Aug-2019 13:59:27	Deleting collection MOD09GQ_test-mboyd-int-IngestGranuleFailure-1565372820955___006
build	09-Aug-2019 13:59:27	Deleting provider s3_provider_test-mboyd-int-IngestGranuleFailure-1565372820955
build	09-Aug-2019 13:59:27	
build	09-Aug-2019 13:59:27	suiteDone: 34.34 secs "The Ingest Granule failure workflow" at Fri Aug 09 2019 17:47:35 GMT+0000 (UTC)
build	09-Aug-2019 13:59:27	
build	09-Aug-2019 13:59:27	
build	09-Aug-2019 13:59:27	Failures:
build	09-Aug-2019 13:59:27	1) The Ingest Granule failure workflow When a workflow task is configured to catch a specific error and branch and the error is thrown by a Cumulus task fails the granule with the error message
build	09-Aug-2019 13:59:27	  Message:
build	09-Aug-2019 13:59:27	    Expected 'running' to be 'failed'.
build	09-Aug-2019 13:59:27	  Stack:
build	09-Aug-2019 13:59:27	    Error: Expected 'running' to be 'failed'.
build	09-Aug-2019 13:59:27	        at <Jasmine>
build	09-Aug-2019 13:59:27	        at UserContext.it (/data/bamboo/bamboo-agent-home/xml-data/build-dir/CUM-CBA1197-DIS/source/cumulus/example/spec/parallel/ingestGranule/IngestGranuleFailureSpec.js:175:30)
build	09-Aug-2019 13:59:27	        at <Jasmine>
build	09-Aug-2019 13:59:27	        at process._tickDomainCallback (internal/process/next_tick.js:228:7)
build	09-Aug-2019 13:59:27	  Message:
build	09-Aug-2019 13:59:27	    Expected undefined to be 'FileNotFound'.
build	09-Aug-2019 13:59:27	  Stack:
build	09-Aug-2019 13:59:27	    Error: Expected undefined to be 'FileNotFound'.
build	09-Aug-2019 13:59:27	        at <Jasmine>
build	09-Aug-2019 13:59:27	        at UserContext.it (/data/bamboo/bamboo-agent-home/xml-data/build-dir/CUM-CBA1197-DIS/source/cumulus/example/spec/parallel/ingestGranule/IngestGranuleFailureSpec.js:176:35)
build	09-Aug-2019 13:59:27	        at <Jasmine>
build	09-Aug-2019 13:59:27	        at process._tickDomainCallback (internal/process/next_tick.js:228:7)
build	09-Aug-2019 13:59:27	  Message:
build	09-Aug-2019 13:59:27	    SyntaxError: Unexpected token u in JSON at position 0
build	09-Aug-2019 13:59:27	  Stack:
build	09-Aug-2019 13:59:27	        at <Jasmine>
build	09-Aug-2019 13:59:27	        at UserContext.it (/data/bamboo/bamboo-agent-home/xml-data/build-dir/CUM-CBA1197-DIS/source/cumulus/example/spec/parallel/ingestGranule/IngestGranuleFailureSpec.js:177:19)
build	09-Aug-2019 13:59:27	        at <Jasmine>
build	09-Aug-2019 13:59:27	        at process._tickDomainCallback (internal/process/next_tick.js:228:7)
build	09-Aug-2019 13:59:27	
build	09-Aug-2019 13:59:27	5 specs, 1 failure
build	09-Aug-2019 13:59:27	Finished in 34.347 seconds
build	09-Aug-2019 13:59:27	
```