### PR TITLE
CUMULUS-1436: sf-semaphore-down handles non-successful executions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,8 +91,8 @@ If you deploy with no distribution app your deployment will succeed but you may 
     - `isSfExecutionEvent()` returns true if event is from Step Functions
     - `isTerminalSfStatus()` determines if a Step Function status from a Cloudwatch event is a terminal status
     - `getSfEventStatus()` gets the Step Function status from a Cloudwatch event
-    - `getSfEventMessage()` extracts and parses the Step Function output messsage from a Cloudwatch event
-    - `getSfEventMessageObject()` extracts and parses Step Function message object from a Cloudwatch event
+    - `getSfEventDetailValue()` extracts a Step Function event detail field from a Cloudwatch event
+    - `getSfEventMessageObject()` extracts and parses Step Function detail object from a Cloudwatch event
 
 - **CUMULUS-1429**
   - Added `tf-modules/data-persistence` Terraform module which includes resources for data persistence in Cumulus:

--- a/packages/api/lambdas/sf-semaphore-down.js
+++ b/packages/api/lambdas/sf-semaphore-down.js
@@ -38,7 +38,8 @@ const isDecrementEvent = (event, executionMessage) =>
  * @param {Object} event - incoming event from Cloudwatch
  */
 async function handleSemaphoreDecrementTask(event) {
-  const eventMessage = getSfEventMessageObject(event);
+  let eventMessage = getSfEventMessageObject(event, 'output');
+  if (!eventMessage) eventMessage = getSfEventMessageObject(event, 'input', '{}');
   const executionMessage = await pullStepFunctionEvent(eventMessage);
   if (isDecrementEvent(event, executionMessage)) {
     const queueName = getQueueName(eventMessage);

--- a/packages/api/tests/lambdas/test-sf-semaphore-down.js
+++ b/packages/api/tests/lambdas/test-sf-semaphore-down.js
@@ -22,44 +22,44 @@ const createCloudwatchEventMessage = ({
   status,
   queueName,
   source = sfEventSource
-}) => ({
-  source,
-  detail: {
-    status,
-    output: JSON.stringify({
-      cumulus_meta: {
-        execution_name: randomString(),
-        queueName
-      },
-      meta: {
-        queueExecutionLimits: {
-          [queueName]: 5
-        }
+}) => {
+  const message = JSON.stringify({
+    cumulus_meta: {
+      execution_name: randomString(),
+      queueName
+    },
+    meta: {
+      queueExecutionLimits: {
+        [queueName]: 5
       }
-    })
-  }
-});
+    }
+  });
+  const detail = (status === 'SUCCEEDED'
+    ? { status, output: message }
+    : { status, input: message });
+  return { source, detail };
+};
 
 const createCloudwatchPackagedEventMessage = ({
   status,
   queueName,
   source = sfEventSource
-}) => ({
-  source,
-  detail: {
-    status,
-    output: JSON.stringify({
-      cumulus_meta: {
-        execution_name: randomString(),
-        queueName
-      },
-      replace: {
-        Bucket: 'cumulus-sandbox-testing',
-        Key: 'stubbedKey'
-      }
-    })
-  }
-});
+}) => {
+  const message = JSON.stringify({
+    cumulus_meta: {
+      execution_name: randomString(),
+      queueName
+    },
+    replace: {
+      Bucket: 'cumulus-sandbox-testing',
+      Key: 'stubbedKey'
+    }
+  });
+  const detail = (status === 'SUCCEEDED'
+    ? { status, output: message }
+    : { status, input: message });
+  return { source, detail };
+};
 
 
 const createExecutionMessage = ((queueName) => (

--- a/packages/api/tests/lambdas/test-sf-semaphore-down.js
+++ b/packages/api/tests/lambdas/test-sf-semaphore-down.js
@@ -198,16 +198,14 @@ test('sfSemaphoreDown lambda throws error when attempting to decrement empty sem
   );
 });
 
-test('sfSemaphoreDown lambda throws error for invalid event message', async (t) => {
-  await t.throwsAsync(
-    () => handleSemaphoreDecrementTask({
-      source: sfEventSource,
-      detail: {
-        status: 'SUCCEEDED',
-        output: 'invalid message'
-      }
-    })
-  );
+test('sfSemaphoreDown lambda returns not a valid event for invalid event message', async (t) => {
+  t.is(await handleSemaphoreDecrementTask({
+    source: sfEventSource,
+    detail: {
+      status: 'SUCCEEDED',
+      output: 'invalid message'
+    }
+  }), 'Not a valid decrement event, no operation performed');
 });
 
 test('sfSemaphoreDown lambda decrements semaphore for s3-stored event message', async (t) => {

--- a/packages/common/cloudwatch-event.js
+++ b/packages/common/cloudwatch-event.js
@@ -36,29 +36,32 @@ const getSfEventStatus = (event) => get(event, 'detail.status');
  * Get the Step Function output message from a Cloudwatch Event
  *
  * @param {Object} event - A Cloudwatch event
+ * @param {string} field - Field to pull from 'detail', i.e. 'input' or 'output'
  * @param {any} [defaultValue] - A default value for the message, if none exists
  * @returns {any} - Output message from Step Function
  */
-const getSfEventMessage = (event, defaultValue) => get(event, 'detail.output', defaultValue);
+const getSfEventDetailValue = (event, field, defaultValue) => get(event, `detail.${field}`, defaultValue);
 
 /**
  * Get the Step Function output message from a Cloudwatch Event
  *
  * @param {Object} event - A Cloudwatch event
- * @returns {Object} - Output message object from Step Function
+ * @param {string} messageSource - 'input' or 'output' from Step Function
+ * @param {string} defaultValue - defaultValue to fetch if no event message object is found
+ * @returns {Object} - Message object from Step Function
  */
-const getSfEventMessageObject = (event) => {
-  const message = getSfEventMessage(event, '{}');
+const getSfEventMessageObject = (event, messageSource, defaultValue) => {
+  const message = getSfEventDetailValue(event, messageSource, defaultValue);
   try {
     return JSON.parse(message);
   } catch (e) {
-    log.error(`Could not parse ${message}`);
+    log.error(`Could not parse '${message}'`);
     return null;
   }
 };
 
 module.exports = {
-  getSfEventMessage,
+  getSfEventDetailValue,
   getSfEventMessageObject,
   getSfEventStatus,
   isSfExecutionEvent,

--- a/packages/common/sns-event.js
+++ b/packages/common/sns-event.js
@@ -30,7 +30,7 @@ const getSnsEventMessageObject = (event) => {
   try {
     return JSON.parse(message);
   } catch (e) {
-    log.error(`Could not parse ${message}`);
+    log.error(`Could not parse '${message}'`);
     return null;
   }
 };


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-1436: Lambda sfSemaphoreDown throws intermittent TypeError](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1436)

## Changes

* Fix `sf-semaphore-down` to handle non-successful executions correctly.
* Update unit tests to reflect actual input conditions (non-successful executions don't have `output`).

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

