### PR TITLE
CUMULUS-1211 Propagate granule discovery errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,11 @@ If you deploy with no distribution app your deployment will succeed but you may 
   - Added production information (collection ShortName and Version, granuleId) to EMS distribution report
   - Added functionality to send daily distribution reports to EMS
 
+- **CUMULUS-1211**
+  - Errors thrown during granule discovery are no longer swallowed and ignored.
+    Rather, errors are propagated to allow for proper error-handling and
+    meaningful messaging.
+
 - **CUMULUS-1319**
   - Fixed a bug where granule ingest times were not being stored to the database
 

--- a/packages/ingest/granule.js
+++ b/packages/ingest/granule.js
@@ -115,32 +115,26 @@ class Discover {
    * @returns {Array<Object>} a list of discovered granules
    */
   async discover() {
-    let discoveredFiles = [];
-    try {
-      discoveredFiles = (await this.list())
-        // Make sure the file matches the granuleIdExtraction
-        .filter((file) => file.name.match(this.collection.granuleIdExtraction))
-        // Make sure there is a config for this type of file
-        .filter((file) => this.fileTypeConfigForFile(file))
-        // Add additional granule-related properties to the file
-        .map((file) => this.setGranuleInfo(file));
-    } catch (error) {
-      log.error('discover exception', error);
-    }
+    const discoveredFiles = (await this.list())
+      // Make sure the file matches the granuleIdExtraction
+      .filter((file) => file.name.match(this.collection.granuleIdExtraction))
+      // Make sure there is a config for this type of file
+      .filter((file) => this.fileTypeConfigForFile(file))
+      // Add additional granule-related properties to the file
+      .map((file) => this.setGranuleInfo(file));
 
     // Group the files by granuleId
     const filesByGranuleId = groupBy(discoveredFiles, (file) => file.granuleId);
+    const { dataType, version } = this.collection;
 
     // Build and return the granules
-    const granuleIds = Object.keys(filesByGranuleId);
-    return granuleIds
-      .map((granuleId) => ({
-        granuleId,
-        dataType: this.collection.dataType,
-        version: this.collection.version,
-        // Remove the granuleId property from each file
-        files: filesByGranuleId[granuleId].map((file) => omit(file, 'granuleId'))
-      }));
+    return Object.entries(filesByGranuleId).map(([granuleId, files]) => ({
+      granuleId,
+      dataType,
+      version,
+      // Remove the granuleId property from each file
+      files: files.map((file) => omit(file, 'granuleId'))
+    }));
   }
 }
 


### PR DESCRIPTION
Addresses [CUMULUS-1211: DiscoverGranules/s3 discovery ignores access failures](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1211)

Removed try/catch block from `Discover.discover` method in
`packages/ingest/granule.js` that was ignoring errors thrown by all subclass
implementations of the `list` method for discovering granules.  All errors are
now propagated.

Added unit test to `tasks/discover-granules/tests/index.js` to confirm that
errors are propagated out of the `discoverGranules` function defined in
`tasks/discover-granules/index.js`, which invokes the `Discover.discover` method.
Additionally, refactored the unit tests to remove obsolete test code and code
duplication.

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

