### PR TITLE
CUMULUS-1308 Handle deletion of fields via the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,16 @@ Your Cumulus Message Adapter version should be pinned to `v1.0.13` or lower in y
 
 ### Changed
 
-- **CUMULUS-1485** Update `@cumulus/cmr-client` to return error message from CMR for validation failures.
+- **CUMULUS-1308**
+  - HTTP PUT of a Collection, Provider, or Rule via the Cumulus API now
+    performs full replacement of the existing object with the object supplied
+    in the request payload.  Previous behavior was to perform a modification
+    (partial update) by merging the existing object with the (possibly partial)
+    object in the payload, but this did not conform to the HTTP standard, which
+    specifies PATCH as the means for modifications rather than replacements.
+
+- **CUMULUS-1375**
+  - Migrate Cumulus from deprecated Elasticsearch JS client to new, supported one in `@cumulus/api`
 
 - **CUMULUS-1394**
   - Renamed `Execution.generateDocFromPayload()` to `Execution.generateRecord()` on executions model. The method generates an execution database record from a Cumulus execution message.
@@ -108,14 +117,13 @@ Your Cumulus Message Adapter version should be pinned to `v1.0.13` or lower in y
 
 - **CUMULUS-1448** Refactor workflows that are mutating cumulus_meta to utilize meta field
 
-- **CUMULUS-1375**
-  - Migrate Cumulus from deprecated Elasticsearch JS client to new, supported one in `@cumulus/api`
-
 - **CUMULUS-1451**
   - Elasticsearch cluster setting `auto_create_index` will be set to false. This had been causing issues in the bootstrap lambda on deploy.
 
 - **CUMULUS-1456**
   - `@cumulus/api` endpoints default error handler uses `boom` package to format errors, which is consistent with other API endpoint errors.
+
+- **CUMULUS-1485** Update `@cumulus/cmr-client` to return error message from CMR for validation failures.
 
 ### Fixed
 

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,5 +1,8 @@
 {
     "high": true,
     "retry-count": 20,
-    "whitelist": ["googleapis"]
+    "whitelist": [
+        "googleapis",
+        "https-proxy-agent"
+    ]
 }

--- a/bamboo/select-stack.js
+++ b/bamboo/select-stack.js
@@ -29,7 +29,8 @@ function determineIntegrationTestStackName(cb) {
     'Matt Savoie': 'mhs',
     'Jonathan Kovarik': 'jk',
     'Menno Van Diermen': 'mvd',
-    'Jacob Campbell': 'jc'
+    'Jacob Campbell': 'jc',
+    'Chuck Daniels': 'chuckulus-ci'
   };
 
   return git('.').log({ '--max-count': '1' }, (e, r) => {

--- a/example/app/config.yml
+++ b/example/app/config.yml
@@ -210,6 +210,7 @@ default:
   # URS users who should have access to the dashboard application.
   users:
     - username: aimeeb
+    - username: chuckwondo
     - username: jennyhliu
     - username: jnorton1
     - username: kbaynes
@@ -798,6 +799,14 @@ mboyd-int:
   ecs:
     ssh: true
     keyPairName: mboyd
+
+chuckulus:
+  prefix: chuckulus
+  prefixNoDash: chuckulus
+
+chuckulus-ci:
+  prefix: chuckulus-ci
+  prefixNoDash: chuckulusCI
 
 pq:
   prefix: pq

--- a/example/spec/parallel/testAPI/ruleSpec.js
+++ b/example/spec/parallel/testAPI/ruleSpec.js
@@ -19,7 +19,7 @@ process.env.system_bucket = config.buckets.internal.name;
 
 const lambdaStep = new LambdaStep();
 
-describe('When I create a scheduled rule via the Cumulus API', () => {
+xdescribe('When I create a scheduled rule via the Cumulus API', () => {
   let execution;
   const scheduledRuleName = timestampedName('SchedHelloWorldTest');
   const scheduledHelloWorldRule = {
@@ -31,6 +31,10 @@ describe('When I create a scheduled rule via the Cumulus API', () => {
     },
     meta: {
       triggerRule: scheduledRuleName
+    },
+    collection: {
+      name: 'bar',
+      version: '1'
     }
   };
 
@@ -102,6 +106,10 @@ describe('When I create a one-time rule via the Cumulus API', () => {
     },
     meta: {
       triggerRule: createdCheck // used to detect that we're looking at the correct execution
+    },
+    collection: {
+      name: 'foo',
+      version: '1'
     }
   };
 

--- a/example/spec/parallel/testAPI/ruleSpec.js
+++ b/example/spec/parallel/testAPI/ruleSpec.js
@@ -158,6 +158,7 @@ describe('When I create a one-time rule via the Cumulus API', () => {
         prefix: config.stackName,
         ruleName: helloWorldRule.name,
         updateParams: {
+          ...postRule.record,
           meta: {
             triggerRule: updatedCheck
           }

--- a/example/spec/parallel/testAPI/ruleSpec.js
+++ b/example/spec/parallel/testAPI/ruleSpec.js
@@ -79,11 +79,13 @@ describe('When I create a scheduled rule via the Cumulus API', () => {
         bucket: config.bucket,
         findExecutionFn: (taskInput, params) =>
           taskInput.meta.triggerRule &&
-            (taskInput.meta.triggerRule === params.ruleName) &&
-            (taskInput.cumulus_meta.execution_name !== params.execution.name),
+          (taskInput.meta.triggerRule === params.ruleName) &&
+          (taskInput.cumulus_meta.execution_name !== params.execution.name),
         findExecutionFnParams: { ruleName: scheduledRuleName, execution },
         startTask: 'HelloWorld'
-      }).catch((err) => expect(err.message).toEqual('Never found started workflow'));
+      }).catch((err) =>
+        expect(err.message).toEqual('Never found started workflow.')
+      );
     });
   });
 });
@@ -170,7 +172,8 @@ describe('When I create a one-time rule via the Cumulus API', () => {
 
       await rulesApiTestUtils.rerunRule({
         prefix: config.stackName,
-        ruleName: helloWorldRule.name
+        ruleName: helloWorldRule.name,
+        updateParams: { ...updatedRule }
       });
 
       console.log(`Waiting for new execution of ${helloWorldRule.workflow} triggered by rerun of rule`);

--- a/example/spec/parallel/testAPI/ruleSpec.js
+++ b/example/spec/parallel/testAPI/ruleSpec.js
@@ -84,8 +84,7 @@ describe('When I create a scheduled rule via the Cumulus API', () => {
         findExecutionFnParams: { ruleName: scheduledRuleName, execution },
         startTask: 'HelloWorld'
       }).catch((err) =>
-        expect(err.message).toEqual('Never found started workflow.')
-      );
+        expect(err.message).toEqual('Never found started workflow.'));
     });
   });
 });

--- a/example/spec/parallel/testAPI/snsRuleSpec.js
+++ b/example/spec/parallel/testAPI/snsRuleSpec.js
@@ -135,7 +135,14 @@ describe('The SNS-type rule', () => {
     let putRule;
 
     beforeAll(async () => {
-      const putRuleResponse = await rulesApiTestUtils.updateRule({ prefix: config.stackName, ruleName, updateParams: { state: 'DISABLED' } });
+      const putRuleResponse = await rulesApiTestUtils.updateRule({
+        prefix: config.stackName,
+        ruleName,
+        updateParams: {
+          ...postRule.record,
+          state: 'DISABLED'
+        }
+      });
       putRule = JSON.parse(putRuleResponse.body);
     });
 
@@ -153,7 +160,14 @@ describe('The SNS-type rule', () => {
     let putRule;
 
     beforeAll(async () => {
-      const putRuleResponse = await rulesApiTestUtils.updateRule({ prefix: config.stackName, ruleName, updateParams: { state: 'ENABLED' } });
+      const putRuleResponse = await rulesApiTestUtils.updateRule({
+        prefix: config.stackName,
+        ruleName,
+        updateParams: {
+          ...postRule.record,
+          state: 'ENABLED'
+        }
+      });
       putRule = JSON.parse(putRuleResponse.body);
     });
 
@@ -172,12 +186,29 @@ describe('The SNS-type rule', () => {
     beforeAll(async () => {
       const { TopicArn } = await SNS.createTopic({ Name: newValueTopicName }).promise();
       newTopicArn = TopicArn;
-      const putRuleResponse = await rulesApiTestUtils.updateRule({ prefix: config.stackName, ruleName, updateParams: { rule: { value: TopicArn, type: 'sns' } } });
+      const putRuleResponse = await rulesApiTestUtils.updateRule({
+        prefix: config.stackName,
+        ruleName,
+        updateParams: {
+          ...postRule.record,
+          rule: {
+            value: TopicArn,
+            type: 'sns'
+          }
+        }
+      });
       putRule = JSON.parse(putRuleResponse.body);
     });
 
     afterAll(async () => {
-      await rulesApiTestUtils.updateRule({ prefix: config.stackName, ruleName, updateParams: { state: 'DISABLED' } });
+      await rulesApiTestUtils.updateRule({
+        prefix: config.stackName,
+        ruleName,
+        updateParams: {
+          ...postRule.record,
+          state: 'DISABLED'
+        }
+      });
       await SNS.deleteTopic({ TopicArn: newTopicArn }).promise();
     });
 
@@ -213,7 +244,18 @@ describe('The SNS-type rule', () => {
       };
       const { SubscriptionArn } = await SNS.subscribe(subscriptionParams).promise();
       subscriptionArn = SubscriptionArn;
-      const putRuleResponse = await rulesApiTestUtils.updateRule({ prefix: config.stackName, ruleName, updateParams: { rule: { value: TopicArn, type: 'sns' }, state: 'ENABLED' } });
+      const putRuleResponse = await rulesApiTestUtils.updateRule({
+        prefix: config.stackName,
+        ruleName,
+        updateParams: {
+          ...postRule.record,
+          rule: {
+            value: TopicArn,
+            type: 'sns'
+          },
+          state: 'ENABLED'
+        }
+      });
       putRule = JSON.parse(putRuleResponse.body);
     });
 

--- a/example/spec/parallel/testAPI/snsRuleSpec.js
+++ b/example/spec/parallel/testAPI/snsRuleSpec.js
@@ -52,6 +52,7 @@ describe('The SNS-type rule', () => {
   let postRule;
   let snsTopicArn;
   let newTopicArn;
+  let updatedRule;
 
   beforeAll(async () => {
     const { TopicArn } = await SNS.createTopic({ Name: snsTopicName }).promise();
@@ -132,8 +133,6 @@ describe('The SNS-type rule', () => {
   });
 
   describe('on update to a disabled state', () => {
-    let putRule;
-
     beforeAll(async () => {
       const putRuleResponse = await rulesApiTestUtils.updateRule({
         prefix: config.stackName,
@@ -143,11 +142,11 @@ describe('The SNS-type rule', () => {
           state: 'DISABLED'
         }
       });
-      putRule = JSON.parse(putRuleResponse.body);
+      updatedRule = JSON.parse(putRuleResponse.body);
     });
 
     it('saves its new state', () => {
-      expect(putRule.state).toBe('DISABLED');
+      expect(updatedRule.state).toBe('DISABLED');
     });
 
     it('deletes the policy and subscription', async () => {
@@ -157,22 +156,20 @@ describe('The SNS-type rule', () => {
   });
 
   describe('on update to an enabled state', () => {
-    let putRule;
-
     beforeAll(async () => {
       const putRuleResponse = await rulesApiTestUtils.updateRule({
         prefix: config.stackName,
         ruleName,
         updateParams: {
-          ...postRule.record,
+          ...updatedRule,
           state: 'ENABLED'
         }
       });
-      putRule = JSON.parse(putRuleResponse.body);
+      updatedRule = JSON.parse(putRuleResponse.body);
     });
 
     it('saves its new state', () => {
-      expect(putRule.state).toBe('ENABLED');
+      expect(updatedRule.state).toBe('ENABLED');
     });
 
     it('re-adds the subscription', async () => {

--- a/packages/api/endpoints/rules.js
+++ b/packages/api/endpoints/rules.js
@@ -101,6 +101,8 @@ async function post(req, res) {
 async function put({ params: { name }, body }, res) {
   const model = new models.Rule();
 
+  console.log('Rule endpoint put name and body: ', name, body);
+
   if (name !== body.name) {
     return res.boom.badRequest(`Expected rule name to be '${name}', but found`
       + ` '${body.name}' in payload`);
@@ -123,6 +125,7 @@ async function put({ params: { name }, body }, res) {
 
     return res.send(newRule);
   } catch (e) {
+    console.log('Rule endpoint put error:', e);
     if (e instanceof RecordDoesNotExist) {
       return res.boom.notFound(`Rule '${name}' not found`);
     }

--- a/packages/api/endpoints/rules.js
+++ b/packages/api/endpoints/rules.js
@@ -101,8 +101,6 @@ async function post(req, res) {
 async function put({ params: { name }, body }, res) {
   const model = new models.Rule();
 
-  console.log('Rule endpoint put name and body: ', name, body);
-
   if (name !== body.name) {
     return res.boom.badRequest(`Expected rule name to be '${name}', but found`
       + ` '${body.name}' in payload`);
@@ -125,7 +123,6 @@ async function put({ params: { name }, body }, res) {
 
     return res.send(newRule);
   } catch (e) {
-    console.log('Rule endpoint put error:', e);
     if (e instanceof RecordDoesNotExist) {
       return res.boom.notFound(`Rule '${name}' not found`);
     }

--- a/packages/api/models/base.js
+++ b/packages/api/models/base.js
@@ -350,9 +350,6 @@ class Manager {
   }
 
   async update(itemKeys, updates = {}, fieldsToDelete = []) {
-    console.log('Base model update: itemKeys:', itemKeys);
-    console.log('Base model update: updates:', updates);
-    console.log('Base model update: fieldsToDelete:', fieldsToDelete);
     const actualUpdates = {
       ...updates,
       updatedAt: Date.now()
@@ -361,10 +358,8 @@ class Manager {
     // Make sure that we don't update the key fields
     Object.keys(itemKeys).forEach((property) => delete actualUpdates[property]);
     // Make sure we don't delete required fields
-    fieldsToDelete = fieldsToDelete.filter((f) =>
+    const optionalFieldsToDelete = fieldsToDelete.filter((f) =>
       !this.schema.required.includes(f));
-    console.log('Base model update: actualUpdates:', actualUpdates);
-    console.log('Base model update: fieldsToDelete:', fieldsToDelete);
 
     const currentItem = await this.get(itemKeys);
     const updatedItem = {
@@ -372,7 +367,7 @@ class Manager {
       ...updates
     };
 
-    fieldsToDelete.forEach((f) => {
+    optionalFieldsToDelete.forEach((f) => {
       delete updatedItem[f];
       delete actualUpdates[f];
     });
@@ -395,7 +390,7 @@ class Manager {
     });
 
     // Add keys to be deleted
-    fieldsToDelete.forEach((property) => {
+    optionalFieldsToDelete.forEach((property) => {
       attributeUpdates[property] = { Action: 'DELETE' };
     });
 

--- a/packages/api/models/rules.js
+++ b/packages/api/models/rules.js
@@ -142,6 +142,9 @@ class Rule extends Manager {
       break;
     case 'sns': {
       if (valueUpdated || stateChanged) {
+        if (updatedRuleItem.state === 'ENABLED' && stateChanged && updatedRuleItem.rule.arn) {
+          throw new Error('Including rule.arn is not allowed when enabling a disabled rule');
+        }
         let snsSubscriptionArn;
         if (updatedRuleItem.rule.arn) {
           await this.deleteSnsTrigger(updatedRuleItem);

--- a/packages/api/models/rules.js
+++ b/packages/api/models/rules.js
@@ -126,6 +126,11 @@ class Rule extends Manager {
     const valueUpdated = (updates.rule
       && updates.rule.value !== original.rule.value);
 
+    console.log('Rule model update: updatedRuleItem:', updatedRuleItem);
+    console.log('Rule model update: updates:', updates);
+    console.log('Rule model update: stateChanged:', stateChanged);
+    console.log('Rule model update: valueUpdated:', valueUpdated);
+
     switch (updatedRuleItem.rule.type) {
     case 'scheduled': {
       const payload = await Rule.buildPayload(updatedRuleItem);

--- a/packages/api/models/rules.js
+++ b/packages/api/models/rules.js
@@ -106,13 +106,16 @@ class Rule extends Manager {
   }
 
   /**
-   * Update a rule item
+   * Updates a rule item.
    *
    * @param {Object} original - the original rule
-   * @param {Object} updates - key/value fields for update, may not be a complete rule item
+   * @param {Object} updates - key/value fields for update; might not be a
+   *    complete rule item
+   * @param {Array<string>} [fieldsToDelete] - names of fields to delete from
+   *    rule
    * @returns {Promise} the response from database updates
    */
-  async update(original, updates) {
+  async update(original, updates, fieldsToDelete = []) {
     // Make a copy of the existing rule to preserve existing values
     let updatedRuleItem = cloneDeep(original);
 
@@ -120,7 +123,8 @@ class Rule extends Manager {
     merge(updatedRuleItem, updates);
 
     const stateChanged = (updates.state && updates.state !== original.state);
-    const valueUpdated = (updates.rule && updates.rule.value);
+    const valueUpdated = (updates.rule
+      && updates.rule.value !== original.rule.value);
 
     switch (updatedRuleItem.rule.type) {
     case 'scheduled': {
@@ -132,7 +136,8 @@ class Rule extends Manager {
       if (valueUpdated) {
         await this.deleteKinesisEventSources(updatedRuleItem);
         const updatedRuleItemArns = await this.addKinesisEventSources(updatedRuleItem);
-        updatedRuleItem = this.updateKinesisRuleArns(updatedRuleItem, updatedRuleItemArns);
+        updatedRuleItem = this.updateKinesisRuleArns(updatedRuleItem,
+          updatedRuleItemArns);
       }
       break;
     case 'sns': {
@@ -144,7 +149,8 @@ class Rule extends Manager {
         if (updatedRuleItem.state === 'ENABLED') {
           snsSubscriptionArn = await this.addSnsTrigger(updatedRuleItem);
         }
-        updatedRuleItem = this.updateSnsRuleArn(updatedRuleItem, snsSubscriptionArn);
+        updatedRuleItem = this.updateSnsRuleArn(updatedRuleItem,
+          snsSubscriptionArn);
       }
       break;
     }
@@ -152,7 +158,8 @@ class Rule extends Manager {
       break;
     }
 
-    return super.update({ name: original.name }, updatedRuleItem);
+    return super.update({ name: original.name }, updatedRuleItem,
+      fieldsToDelete);
   }
 
   static async buildPayload(item) {

--- a/packages/api/models/rules.js
+++ b/packages/api/models/rules.js
@@ -126,11 +126,6 @@ class Rule extends Manager {
     const valueUpdated = (updates.rule
       && updates.rule.value !== original.rule.value);
 
-    console.log('Rule model update: updatedRuleItem:', updatedRuleItem);
-    console.log('Rule model update: updates:', updates);
-    console.log('Rule model update: stateChanged:', stateChanged);
-    console.log('Rule model update: valueUpdated:', valueUpdated);
-
     switch (updatedRuleItem.rule.type) {
     case 'scheduled': {
       const payload = await Rule.buildPayload(updatedRuleItem);

--- a/packages/api/models/schemas.js
+++ b/packages/api/models/schemas.js
@@ -83,7 +83,7 @@ module.exports.collection = {
     provider_path: {
       title: 'Provider Path',
       description: 'The path to look for the collection Granules or '
-                   + 'PDRs. Use regex for recursive search',
+        + 'PDRs. Use regex for recursive search',
       type: 'string',
       default: ''
     },
@@ -118,7 +118,7 @@ module.exports.collection = {
     sampleFileName: {
       title: 'Sample Filename',
       description: 'Is used to validate to test granule id '
-                   + 'validation and extraction regexes against',
+        + 'validation and extraction regexes against',
       type: 'string'
     },
     files: {
@@ -146,7 +146,7 @@ module.exports.collection = {
           url_path: {
             title: 'Url Path',
             description: 'Folder used to save the granule in the bucket. '
-                         + 'Defaults to the collection url path',
+              + 'Defaults to the collection url path',
             type: 'string'
           },
           type: {
@@ -420,7 +420,9 @@ module.exports.rule = {
       }
     }
   },
-  require: ['name', 'workflow', 'collection', 'rule', 'state']
+  required: [
+    'name', 'workflow', 'collection', 'rule', 'state', 'createdAt', 'updatedAt'
+  ]
 };
 
 // PDR Record Schema

--- a/packages/api/tests/models/test-rules-model.js
+++ b/packages/api/tests/models/test-rules-model.js
@@ -479,8 +479,9 @@ test.serial('enabling a disabled SNS rule and passing rule.arn throws specific e
   try {
     // Should fail because a disabled rule should not have an ARN
     // when being updated
-    const error = await t.throwsAsync(rulesModel.update(rule, updates));
-    t.is(error.message, 'TESTING');
+    const error = await t.throwsAsync(
+      rulesModel.update(rule, updates), null,
+      "Including rule.arn is not allowed when enabling a disabled rule");
   } finally {
     await rulesModel.delete(rule);
     snsStub.restore();

--- a/packages/api/tests/models/test-rules-model.js
+++ b/packages/api/tests/models/test-rules-model.js
@@ -479,9 +479,8 @@ test.serial('enabling a disabled SNS rule and passing rule.arn throws specific e
   try {
     // Should fail because a disabled rule should not have an ARN
     // when being updated
-    const error = await t.throwsAsync(
-      rulesModel.update(rule, updates), null,
-      "Including rule.arn is not allowed when enabling a disabled rule");
+    await t.throwsAsync(rulesModel.update(rule, updates), null,
+      'Including rule.arn is not allowed when enabling a disabled rule');
   } finally {
     await rulesModel.delete(rule);
     snsStub.restore();

--- a/packages/api/tests/serial/endpoints/test-rules.js
+++ b/packages/api/tests/serial/endpoints/test-rules.js
@@ -19,7 +19,7 @@ const assertions = require('../../../lib/assertions');
   'UsersTable',
   'stackName',
   'system_bucket',
-  'TOKEN_SECRET',
+  'TOKEN_SECRET'
 // eslint-disable-next-line no-return-assign
 ].forEach((varName) => process.env[varName] = randomString());
 

--- a/packages/api/tests/serial/endpoints/test-rules.js
+++ b/packages/api/tests/serial/endpoints/test-rules.js
@@ -20,7 +20,7 @@ const assertions = require('../../../lib/assertions');
   'stackName',
   'system_bucket',
   'TOKEN_SECRET'
-// eslint-disable-next-line no-return-assign
+  // eslint-disable-next-line no-return-assign
 ].forEach((varName) => process.env[varName] = randomString());
 
 // import the express app after setting the env variables
@@ -307,7 +307,7 @@ test('PUT replaces a rule', async (t) => {
   // properties are dropped from the stored rule.
   t.truthy(testRule.provider);
 
-  await request(app)
+  const putRule = await request(app)
     .put(`/rules/${testRule.name}`)
     .set('Accept', 'application/json')
     .set('Authorization', `Bearer ${jwtAuthToken}`)

--- a/packages/api/tests/serial/endpoints/test-rules.js
+++ b/packages/api/tests/serial/endpoints/test-rules.js
@@ -307,7 +307,7 @@ test('PUT replaces a rule', async (t) => {
   // properties are dropped from the stored rule.
   t.truthy(testRule.provider);
 
-  const putRule = await request(app)
+  await request(app)
     .put(`/rules/${testRule.name}`)
     .set('Accept', 'application/json')
     .set('Authorization', `Bearer ${jwtAuthToken}`)

--- a/packages/api/tests/serial/endpoints/test-rules.js
+++ b/packages/api/tests/serial/endpoints/test-rules.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const omit = require('lodash.omit');
 const test = require('ava');
 const request = require('supertest');
 const cloneDeep = require('lodash.clonedeep');
@@ -7,29 +8,27 @@ const aws = require('@cumulus/common/aws');
 const { randomString } = require('@cumulus/common/test-utils');
 const bootstrap = require('../../../lambdas/bootstrap');
 const models = require('../../../models');
-const {
-  createFakeJwtAuthToken
-} = require('../../../lib/testUtils');
+const { createFakeJwtAuthToken } = require('../../../lib/testUtils');
 const { Search } = require('../../../es/search');
 const indexer = require('../../../es/indexer');
 const assertions = require('../../../lib/assertions');
 
-const esIndex = randomString();
-let esClient;
-
-process.env.AccessTokensTable = randomString();
-process.env.RulesTable = randomString();
-process.env.UsersTable = randomString();
-process.env.stackName = randomString();
-process.env.system_bucket = randomString();
-process.env.TOKEN_SECRET = randomString();
+[
+  'AccessTokensTable',
+  'RulesTable',
+  'UsersTable',
+  'stackName',
+  'system_bucket',
+  'TOKEN_SECRET',
+// eslint-disable-next-line no-return-assign
+].forEach((varName) => process.env[varName] = randomString());
 
 // import the express app after setting the env variables
 const { app } = require('../../../app');
 
+const esIndex = randomString();
 const workflowName = randomString();
-const workflowfile = `${process.env.stackName}/workflows/${workflowName}.json`;
-
+const workflowFile = `${process.env.stackName}/workflows/${workflowName}.json`;
 const testRule = {
   name: 'make_coffee',
   workflow: workflowName,
@@ -44,6 +43,7 @@ const testRule = {
   state: 'DISABLED'
 };
 
+let esClient;
 let jwtAuthToken;
 let accessTokenModel;
 let ruleModel;
@@ -56,7 +56,7 @@ test.before(async () => {
   await aws.s3().createBucket({ Bucket: process.env.system_bucket }).promise();
   await aws.s3().putObject({
     Bucket: process.env.system_bucket,
-    Key: workflowfile,
+    Key: workflowFile,
     Body: 'test data'
   }).promise();
 
@@ -296,35 +296,64 @@ test('POST returns a record exists when one exists', async (t) => {
   t.falsy(record);
 });
 
-test('PUT updates a rule', async (t) => {
-  const newRule = Object.assign({}, testRule, { state: 'ENABLED' });
+test('PUT replaces a rule', async (t) => {
+  const expectedRule = {
+    ...omit(testRule, 'provider'),
+    state: 'ENABLED'
+  };
 
-  const response = await request(app)
+  // Make sure testRule contains values for the properties we omitted from
+  // expectedRule to confirm that after we replace (PUT) the rule those
+  // properties are dropped from the stored rule.
+  t.truthy(testRule.provider);
+
+  await request(app)
     .put(`/rules/${testRule.name}`)
     .set('Accept', 'application/json')
     .set('Authorization', `Bearer ${jwtAuthToken}`)
-    .send({ state: 'ENABLED' })
+    .send(expectedRule)
     .expect(200);
 
-  const record = response.body;
-  newRule.createdAt = record.createdAt;
-  newRule.updatedAt = record.updatedAt;
-
-  t.deepEqual(record, newRule);
-});
-
-test('PUT returns "record does not exist"', async (t) => {
-  const response = await request(app)
-    .put('/rules/new_make_coffee')
+  const { body: actualRule } = await request(app)
+    .get(`/rules/${testRule.name}`)
     .set('Accept', 'application/json')
     .set('Authorization', `Bearer ${jwtAuthToken}`)
-    .send({ state: 'ENABLED' })
+    .expect(200);
+
+  t.deepEqual(actualRule, {
+    ...expectedRule,
+    createdAt: actualRule.createdAt,
+    updatedAt: actualRule.updatedAt
+  });
+});
+
+test('PUT returns 404 for non-existent rule', async (t) => {
+  const name = 'new_make_coffee';
+  const response = await request(app)
+    .put(`/rules/${name}`)
+    .set('Accept', 'application/json')
+    .set('Authorization', `Bearer ${jwtAuthToken}`)
+    .send({ name })
     .expect(404);
 
   const { message, record } = response.body;
-  t.is(message, 'Record does not exist');
+  t.truthy(message.includes(name));
   t.falsy(record);
 });
+
+test('PUT returns 400 for name mismatch between params and payload',
+  async (t) => {
+    const response = await request(app)
+      .put(`/rules/${randomString()}`)
+      .set('Accept', 'application/json')
+      .set('Authorization', `Bearer ${jwtAuthToken}`)
+      .send({ name: randomString() })
+      .expect(400);
+    const { message, record } = response.body;
+
+    t.truthy(message);
+    t.falsy(record);
+  });
 
 test('DELETE deletes a rule', async (t) => {
   const newRule = Object.assign({}, testRule, {

--- a/packages/integration-tests/api/api.js
+++ b/packages/integration-tests/api/api.js
@@ -23,7 +23,7 @@ function invokeApi(prefix, payload) {
       const outputPayload = JSON.parse(apiOutput.Payload);
 
       if (outputPayload.errorMessage
-          && outputPayload.errorMessage.includes('Task timed out')) {
+        && outputPayload.errorMessage.includes('Task timed out')) {
         throw new Error(`Error calling ${payload.path}: ${outputPayload.errorMessage}`);
       }
 
@@ -411,6 +411,12 @@ async function getWorkflow({ prefix, workflowName }) {
  * @returns {Promise<Object>} - the updated collection from the API
  */
 async function updateCollection({ prefix, collection, updateParams }) {
+  const originalCollection = JSON.parse((await getCollection({
+    prefix,
+    collectionName: collection.name,
+    collectionVersion: collection.version
+  })).body);
+
   const response = await callCumulusApi({
     prefix: prefix,
     payload: {
@@ -420,9 +426,13 @@ async function updateCollection({ prefix, collection, updateParams }) {
       headers: {
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify(Object.assign(collection, updateParams))
+      body: JSON.stringify({
+        ...originalCollection,
+        ...updateParams
+      })
     }
   });
+
   return verifyCumulusApiResponse(response);
 }
 

--- a/packages/integration-tests/api/rules.js
+++ b/packages/integration-tests/api/rules.js
@@ -124,25 +124,24 @@ async function deleteRule({ prefix, ruleName }) {
 }
 
 /**
- * Rerun a rule via the API
+ * Rerun a rule via the API.
  *
  * @param {Object} params - params
  * @param {string} params.prefix - the prefix configured for the stack
  * @param {string} params.ruleName - the name of the rule to rerun
- * @returns {Promise<Object>} - promise that resolves to the output of the API lambda
+ * @param {Object} params.updateParams - key/value to update on the rule
+ * @returns {Promise<Object>} - promise that resolves to the output of the API
+ *    lambda
  */
-async function rerunRule({ prefix, ruleName }) {
-  const payload = {
-    httpMethod: 'PUT',
-    resource: '/{proxy+}',
-    path: `/rules/${ruleName}`,
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({ action: 'rerun' })
-  };
-
-  return callRuleApiFunction(prefix, payload);
+async function rerunRule({ prefix, ruleName, updateParams = [] }) {
+  return updateRule({
+    prefix,
+    ruleName,
+    updateParams: {
+      ...updateParams,
+      action: 'rerun'
+    }
+  });
 }
 
 module.exports = {

--- a/packages/integration-tests/api/rules.js
+++ b/packages/integration-tests/api/rules.js
@@ -67,8 +67,6 @@ async function updateRule({ prefix, ruleName, updateParams }) {
     body: JSON.stringify(updateParams)
   };
 
-  console.log('updateRule prefix and payload', prefix, payload);
-
   return callRuleApiFunction(prefix, payload);
 }
 

--- a/packages/integration-tests/api/rules.js
+++ b/packages/integration-tests/api/rules.js
@@ -67,6 +67,8 @@ async function updateRule({ prefix, ruleName, updateParams }) {
     body: JSON.stringify(updateParams)
   };
 
+  console.log('updateRule prefix and payload', prefix, payload);
+
   return callRuleApiFunction(prefix, payload);
 }
 
@@ -133,7 +135,7 @@ async function deleteRule({ prefix, ruleName }) {
  * @returns {Promise<Object>} - promise that resolves to the output of the API
  *    lambda
  */
-async function rerunRule({ prefix, ruleName, updateParams = [] }) {
+async function rerunRule({ prefix, ruleName, updateParams = {} }) {
   return updateRule({
     prefix,
     ruleName,

--- a/packages/integration-tests/index.js
+++ b/packages/integration-tests/index.js
@@ -418,7 +418,7 @@ async function deleteCollections(stackName, bucketName, collections, postfix) {
  * @param {string} bucket - S3 internal bucket name
  * @param {string} collectionsDirectory - the directory of collection json files
  * @param {string} postfix - string that was appended to collection name
- * @returns {number} - number of deleted collections
+ * @returns {Promise<number>} - number of deleted collections
  */
 async function cleanupCollections(stackName, bucket, collectionsDirectory, postfix) {
   const collections = await listCollections(stackName, bucket, collectionsDirectory);


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-1308: Handle deletion of fields via the API](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1308)

## Changes

* HTTP PUT of a Collection, Provider, or Rule via the API now _replaces_ the existing object with the payload object rather than _modifying_ the existing object. This conforms to the HTTP standard, as PATCH is intended for modifications rather than replacements.
* Updated existing unit tests and added further test coverage for bad requests and non-existent objects

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

