### PR TITLE
Move UMMG validation to a separate module and add tests

### DIFF
--- a/packages/cmr-client/CMR.js
+++ b/packages/cmr-client/CMR.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const got = require('got');
-const get = require('lodash.get');
 const publicIp = require('public-ip');
 const Logger = require('@cumulus/logger');
 
@@ -9,7 +8,7 @@ const searchConcept = require('./searchConcept');
 const ingestConcept = require('./ingestConcept');
 const deleteConcept = require('./deleteConcept');
 const getUrl = require('./getUrl');
-const ValidationError = require('./ValidationError');
+const { ummVersion, validateUMMG } = require('./UmmUtils');
 
 const log = new Logger({ sender: 'cmr-client' });
 
@@ -18,57 +17,6 @@ const logDetails = {
 };
 
 const IP_TIMEOUT_MS = 1 * 1000;
-
-/**
- * Find the UMM version as a decimal string.
- * If a version cannot be found on the input object
- * version 1.4 is assumed and returned.
- *
- * @param {Object} umm - UMM metadata object
- * @returns {string} UMM version for the given object
- *
- * @private
- */
-function ummVersion(umm) {
-  return get(umm, 'MetadataSpecification.Version', '1.4');
-}
-
-/**
- * Posts a given xml string to the validate endpoint of CMR
- * and promises true if valid.
- *
- * @param {string} ummMetadata - the UMM object
- * @param {string} identifier - the document identifier
- * @param {string} provider - the CMR provider
- * @returns {Promise<boolean>} returns true if the document is valid
- *
- * @private
- */
-async function validateUMMG(ummMetadata, identifier, provider) {
-  const version = ummVersion(ummMetadata);
-  let result;
-
-  try {
-    result = await got.post(`${getUrl('validate', provider)}granule/${identifier}`, {
-      json: true,
-      body: ummMetadata,
-      headers: {
-        Accept: 'application/json',
-        'Content-type': `application/vnd.nasa.cmr.umm+json;version=${version}`
-      }
-    });
-
-    if (result.statusCode === 200) {
-      return true;
-    }
-  } catch (e) {
-    result = e.response;
-  }
-
-  throw new ValidationError(
-    `Validation was not successful, CMR error message: ${JSON.stringify(result.body.errors)}`
-  );
-}
 
 /**
  * Returns a valid a CMR token

--- a/packages/cmr-client/UmmUtils.js
+++ b/packages/cmr-client/UmmUtils.js
@@ -13,9 +13,7 @@ const ValidationError = require('./ValidationError');
  * @param {Object} umm - UMM metadata object
  * @returns {string} UMM version for the given object
  */
-function ummVersion(umm) {
-  return get(umm, 'MetadataSpecification.Version', '1.4');
-}
+const ummVersion = (umm) => get(umm, 'MetadataSpecification.Version', '1.4');
 
 /**
  * Posts a given XML string to the validate endpoint of CMR and throws an
@@ -26,7 +24,7 @@ function ummVersion(umm) {
  * @param {string} provider - the CMR provider
  * @returns {Promise<undefined>}
  */
-async function validateUMMG(ummMetadata, identifier, provider) {
+const validateUMMG = async (ummMetadata, identifier, provider) => {
   const version = ummVersion(ummMetadata);
 
   const { statusCode, body } = await got.post(
@@ -45,7 +43,7 @@ async function validateUMMG(ummMetadata, identifier, provider) {
   if (statusCode === 200) return;
 
   throw new ValidationError(`Validation was not successful, CMR error message: ${JSON.stringify(body.errors)}`);
-}
+};
 
 module.exports = {
   ummVersion,

--- a/packages/cmr-client/UmmUtils.js
+++ b/packages/cmr-client/UmmUtils.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const get = require('lodash.get');
+const got = require('got');
+const getUrl = require('./getUrl');
+const ValidationError = require('./ValidationError');
+
+/**
+ * Find the UMM version as a decimal string.
+ * If a version cannot be found on the input object
+ * version 1.4 is assumed and returned.
+ *
+ * @param {Object} umm - UMM metadata object
+ * @returns {string} UMM version for the given object
+ */
+function ummVersion(umm) {
+  return get(umm, 'MetadataSpecification.Version', '1.4');
+}
+
+/**
+ * Posts a given XML string to the validate endpoint of CMR and throws an
+ * exception if it is not valid
+ *
+ * @param {string} ummMetadata - the UMM object
+ * @param {string} identifier - the document identifier
+ * @param {string} provider - the CMR provider
+ * @returns {Promise<undefined>}
+ */
+async function validateUMMG(ummMetadata, identifier, provider) {
+  const version = ummVersion(ummMetadata);
+
+  const { statusCode, body } = await got.post(
+    `${getUrl('validate', provider)}granule/${identifier}`,
+    {
+      json: true,
+      body: ummMetadata,
+      headers: {
+        Accept: 'application/json',
+        'Content-type': `application/vnd.nasa.cmr.umm+json;version=${version}`
+      },
+      throwHttpErrors: false
+    }
+  );
+
+  if (statusCode === 200) return;
+
+  throw new ValidationError(`Validation was not successful, CMR error message: ${JSON.stringify(body.errors)}`);
+}
+
+module.exports = {
+  ummVersion,
+  validateUMMG
+};

--- a/packages/cmr-client/package.json
+++ b/packages/cmr-client/package.json
@@ -43,7 +43,6 @@
     "jsdoc-to-markdown": "^4.0.1",
     "lodash.some": "^4.6.0",
     "nock": "^10.0.6",
-    "rewire": "^4.0.1",
     "sinon": "^7.1.1"
   }
 }

--- a/packages/cmr-client/tests/test-UmmUtils.js
+++ b/packages/cmr-client/tests/test-UmmUtils.js
@@ -2,12 +2,9 @@
 
 const test = require('ava');
 const nock = require('nock');
-const rewire = require('rewire');
-
-const cmr = rewire('../CMR');
-const validateUMMG = cmr.__get__('validateUMMG');
 const ValidationError = require('../ValidationError');
 const validate = require('../validate');
+const { ummVersion, validateUMMG } = require('../UmmUtils');
 
 const cmrError = 'Granule start date [2016-01-09T11:41:12.027Z] is later than granule end date [2016-01-09T11:40:45.032Z].';
 
@@ -25,14 +22,18 @@ const ummValidationError = {
   ]
 };
 
-const xmlValidationError = `
-<?xml version="1.0" encoding="UTF-8"?>
-<errors><error>
-  <path>Temporal</path>
-  <errors>
-    <error>${cmrError}</error>
-  </errors>
-</error></errors>`;
+test.before(() => {
+  nock.disableNetConnect();
+  nock.enableNetConnect('127.0.0.1');
+});
+
+test.afterEach.always(() => {
+  nock.cleanAll();
+});
+
+test.after.always(() => {
+  nock.enableNetConnect();
+});
 
 test.serial('CMR.validateUMMG UMMG validation succeeds', async (t) => {
   nock('https://cmr.uat.earthdata.nasa.gov')
@@ -62,7 +63,6 @@ test.serial('CMR.validateUMMG UMMG validation fails with error messages from CMR
   } catch (e) {
     t.true(e instanceof ValidationError);
     t.true(e.message.includes(cmrError));
-    t.pass();
   }
 });
 
@@ -82,6 +82,15 @@ test.serial('cmr-client.validate XML validation succeeds', async (t) => {
 });
 
 test.serial('cmr-client.validate XML validation fails with error messages from CMR', async (t) => {
+  const xmlValidationError = `
+<?xml version="1.0" encoding="UTF-8"?>
+<errors><error>
+  <path>Temporal</path>
+  <errors>
+    <error>${cmrError}</error>
+  </errors>
+</error></errors>`;
+
   nock('https://cmr.uat.earthdata.nasa.gov')
     .post(`/ingest/providers/${provider}/validate/granule/${granuleId}`)
     .reply(422, xmlValidationError);
@@ -94,6 +103,70 @@ test.serial('cmr-client.validate XML validation fails with error messages from C
   } catch (e) {
     t.true(e instanceof ValidationError);
     t.true(e.message.includes(cmrError));
-    t.pass();
   }
+});
+
+test.serial('validateUMMG calls post with correct metadata version when metadata version available', async (t) => {
+  const identifier = 'fakeIdentifier';
+  const metadata = {
+    restOfMetadataUpHere: 'still fake',
+    MetadataSpecification: {
+      URL: 'https://cdn.earthdata.nasa.gov/umm/granule/v1.5',
+      Name: 'UMM-G',
+      Version: '1.5'
+    }
+  };
+
+  nock('https://cmr.uat.earthdata.nasa.gov')
+    .matchHeader('Accept', 'application/json')
+    .matchHeader('Content-type', 'application/vnd.nasa.cmr.umm+json;version=1.5')
+    .post(`/ingest/providers/${provider}/validate/granule/${identifier}`)
+    .reply(200);
+
+  process.env.CMR_ENVIRONMENT = 'UAT';
+  await validateUMMG(metadata, identifier, provider);
+
+  t.true(nock.isDone());
+});
+
+test.serial('validateUMMG calls post with default version (1.4) when metadata version unavailable', async (t) => {
+  const identifier = 'fakeIdentifier';
+  const metadata = {
+    restOfMetadataUpHere: 'still fake',
+    MissingMetadataSpecification: 'nothing here'
+  };
+
+  nock('https://cmr.uat.earthdata.nasa.gov')
+    .matchHeader('Accept', 'application/json')
+    .matchHeader('Content-type', 'application/vnd.nasa.cmr.umm+json;version=1.4')
+    .post(`/ingest/providers/${provider}/validate/granule/${identifier}`)
+    .reply(200);
+
+  process.env.CMR_ENVIRONMENT = 'UAT';
+  await validateUMMG(metadata, identifier, provider);
+
+  t.true(nock.isDone());
+});
+
+
+test('ummVersion returns UMM version if found on metadata object.', (t) => {
+  const metadata = {
+    restOfMetadataUpHere: 'it is all fake',
+    MetadataSpecification: {
+      URL: 'https://cdn.earthdata.nasa.gov/umm/granule/v1.5',
+      Name: 'UMM-G',
+      Version: '1.5'
+    }
+  };
+
+  t.is(ummVersion(metadata), '1.5');
+});
+
+test('ummVersion returns default version 1.4 if object has no metadata specification.', (t) => {
+  const metadata = {
+    restOfMetadataUpHere: 'still fake',
+    MissingMetadataSpecification: 'nothing here'
+  };
+
+  t.is(ummVersion(metadata), '1.4');
 });


### PR DESCRIPTION
The `validateUMMG` function, which was being tested in this PR, was not exported from `CMR.js`, which made it awkward to test. Before being migrated from the `cmrjs` package a few months back, it was a stand-alone function and had a number of existing tests. This PR:

* Moves `validateUMMG()` into a `UmmUtils` module and updates dependent code accordingly
* Moves the existing tests `validateUMMG()` tests from `@cumulus/cmrjs` to `@cumulus/cmr-client`
* Moves `ummVersion()` into a `UmmUtils` module and updates dependent code accordingly
* Moves the existing tests `ummVersion()` tests from `@cumulus/cmrjs` to `@cumulus/cmr-client`
* Adds a test for `CMR.ingestUMMGranule()` which verifies that an exception is thrown when validation fails