### PR TITLE
CUMULUS-1595: Add wait for failed execution to avoid race condition

### DIFF
--- a/example/spec/parallel/ingestGranule/IngestGranuleFailureSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleFailureSpec.js
@@ -101,12 +101,13 @@ describe('The Ingest Granule failure workflow', () => {
 
   describe('When a workflow task is configured to catch a specific error and branch and the error is thrown by a Cumulus task', () => {
     let execution;
+    let executionArn;
     let executionStatus;
     let syncGranFailedDetail;
     let syncGranStepOutput;
 
     beforeAll(async () => {
-      const executionArn = workflowExecution.executionArn;
+      executionArn = workflowExecution.executionArn;
       const executionResponse = await executionsApiTestUtils.getExecution({
         prefix: config.stackName,
         arn: executionArn
@@ -168,6 +169,11 @@ describe('The Ingest Granule failure workflow', () => {
     });
 
     it('logs the execution with the error message', async () => {
+      await waitForModelStatus(
+        executionModel,
+        { arn: executionArn },
+        'failed'
+      );
       expect(execution.error.Error).toBe(syncGranFailedDetail.error);
       expect(JSON.parse(execution.error.Cause)).toEqual(JSON.parse(syncGranFailedDetail.cause));
     });


### PR DESCRIPTION
Fixes [CUMULUS-1595](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1595). I've run the test 60+ times continuously and haven't seen it fail with this error again.

