### PR TITLE
CUMULUS-1513: support SQS-type rule in the Cumulus API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Added `GET /token` endpoint for SAML authorization when cumulus is protected by Launchpad.
     This lets a user retieve a token by hand that can be presented to the API.
 
+- **CUMULUS-1513**
+  - Added `sqs`-type rule support in the Cumulus API `@cumulus/api`
+  - Added `sqsMessageConsumer` lambda which processes messages from the SQS queues configured in the `sqs` rules.
+
 ### Changed
 
 - **CUMULUS-1453**

--- a/docs/data-cookbooks/setup.md
+++ b/docs/data-cookbooks/setup.md
@@ -68,10 +68,11 @@ _The above optional attributes are not shown in the example provided, but they h
 
 ## Rules
 
-Rules are used by to start processing workflows and the transformation process. Rules can be invoked manually, based on a schedule, or can be configured to be triggered by either events in [Kinesis](data-cookbooks/cnm-workflow.md) or SNS messages. The current best way to understand rules is to take a look at the [schema](https://github.com/nasa/cumulus/tree/master/packages/api/models/schemas.js) (specifically the object assigned to `module.exports.rule`). Rules can be viewed, edited, added, and removed from the Cumulus dashboard under the "Rules" navigation tab. Additionally, they can be managed via the [rules api](https://nasa.github.io/cumulus-api/?language=Python#list-rules).
+Rules are used by to start processing workflows and the transformation process. Rules can be invoked manually, based on a schedule, or can be configured to be triggered by either events in [Kinesis](data-cookbooks/cnm-workflow.md), SNS messages or SQS messages. The current best way to understand rules is to take a look at the [schema](https://github.com/nasa/cumulus/tree/master/packages/api/models/schemas.js) (specifically the object assigned to `module.exports.rule`). Rules can be viewed, edited, added, and removed from the Cumulus dashboard under the "Rules" navigation tab. Additionally, they can be managed via the [rules api](https://nasa.github.io/cumulus-api/?language=Python#list-rules).
 
 The Cumulus Core repository has an example of a Kinesis rule [here](https://github.com/nasa/cumulus/blob/master/example/data/rules/L2_HR_PIXC_kinesisRule.json).
 An example of an SNS rule configuration is [here](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json).
+An example of an SQS rule configuration is [here](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/data/rules/sqs/MOD09GQ_006_sqsRule.json)
 
 |Key  |Value  |Required|Description|
 |:---:|:-----:|:------:|-----------|
@@ -94,7 +95,7 @@ An example of an SNS rule configuration is [here](https://github.com/nasa/cumulu
 
 |Key|Value|Required|Description|
 |:---:|:-----:|:------:|-----------|
-|type|`"kinesis"`|Yes|<code>("onetime"&#124;"scheduled"&#124;"kinesis"&#124;"sns")</code> type of scheduling/workflow kick-off desired|
+|type|`"kinesis"`|Yes|<code>("onetime"&#124;"scheduled"&#124;"kinesis"&#124;"sns"&#124;"sqs")</code> type of scheduling/workflow kick-off desired|
 |value|`<String> Object`|Depends|Discussion of valid values is [below](#rule-value)|
 
 ### rule-value
@@ -105,3 +106,4 @@ The `rule - value` entry depends on the type of run:
 * If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 * If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 * If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)
+* If this is an sqs rule, this must be an existing `${SQS_QueueUrl}` that your account has permissions to access. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/data/rules/sqs/MOD09GQ_006_sqsRule.json)

--- a/example/app/config.yml
+++ b/example/app/config.yml
@@ -212,6 +212,7 @@ default:
     - username: aimeeb
     - username: chuckwondo
     - username: jennyhliu
+    - username: jhliu
     - username: jnorton1
     - username: kbaynes
     - username: kkelly
@@ -483,6 +484,7 @@ mth:
 jl:
   prefix: jl-test-integration
   prefixNoDash: JlTestIntegration
+  useWorkflowLambdaVersions: false
   buckets:
     private:
       name: jl-test-integration-private
@@ -530,6 +532,11 @@ jl:
   oauth:
     provider: launchpad
     userGroup: GSFC-Cumulus-Dev
+  samlConfig:
+    entityID: 'https://cumulus-sandbox.earthdata.nasa.gov/jl-test-integration'
+    assertionConsumerService: 'https://5hlnofihz8.execute-api.us-east-1.amazonaws.com:8000/dev/saml/auth'
+    idpLogin: 'https://auth.launchpad-sbx.nasa.gov/affwebservices/public/saml2sso'
+    launchpadMetadataPath: 's3://{{buckets.internal.name}}/{{prefix}}/launchpad/launchpad-sbx-metadata.xml'
 
 gitc:
   prefix: {{PREFIX}}

--- a/example/spec/parallel/helloWorld/HelloWorldEcsSpec.js
+++ b/example/spec/parallel/helloWorld/HelloWorldEcsSpec.js
@@ -42,7 +42,11 @@ describe('The Hello World workflow using ECS and kes CMA', () => {
 
   describe('the sf-sns-report task has published a sns message and', () => {
     it('the execution record is added to DynamoDB', async () => {
-      const record = await executionModel.get({ arn: workflowExecution.executionArn });
+      const record = await waitForModelStatus(
+        executionModel,
+        { arn: workflowExecution.executionArn },
+        'completed'
+      );
       expect(record.status).toEqual('completed');
     });
   });

--- a/example/spec/parallel/testAPI/data/rules/sqs/MOD09GQ_006_sqsRule.json
+++ b/example/spec/parallel/testAPI/data/rules/sqs/MOD09GQ_006_sqsRule.json
@@ -1,0 +1,17 @@
+{
+  "collection": {
+    "name": "MOD09GQ",
+    "version": "006"
+  },
+  "name": "MOD09GQ_006_sqsRule",
+  "provider": "s3_provider",
+  "meta": {
+    "metaflag": "testmeta"
+  },
+  "rule": {
+    "type": "sqs",
+    "value": "{{queueUrl}}"
+  },
+  "state": "ENABLED",
+  "workflow": "testworkflow"
+}

--- a/example/spec/parallel/testAPI/sqsRuleSpec.js
+++ b/example/spec/parallel/testAPI/sqsRuleSpec.js
@@ -1,0 +1,145 @@
+'use strict';
+
+const fs = require('fs-extra');
+const { stringUtils: { globalReplace } } = require('@cumulus/common');
+const { sqs, receiveSQSMessages } = require('@cumulus/common/aws');
+const { Granule } = require('@cumulus/api/models');
+const {
+  addCollections,
+  addRules,
+  addProviders,
+  granulesApi: granulesApiTestUtils,
+  cleanupProviders,
+  cleanupCollections,
+  rulesList,
+  deleteRules
+} = require('@cumulus/integration-tests');
+
+const { waitForModelStatus } = require('../../helpers/apiUtils');
+const { setupTestGranuleForIngest } = require('../../helpers/granuleUtils');
+
+const {
+  loadConfig,
+  uploadTestDataToBucket,
+  deleteFolder,
+  createTimestampedTestId,
+  createTestDataPath,
+  createTestSuffix
+} = require('../../helpers/testUtils');
+
+const config = loadConfig();
+const testId = createTimestampedTestId(config.stackName, 'sqsRule');
+const testSuffix = createTestSuffix(testId);
+const testDataFolder = createTestDataPath(testId);
+const ruleSuffix = globalReplace(testSuffix, '-', '_');
+
+const inputPayloadFilename = './spec/parallel/ingestGranule/IngestGranule.input.payload.json';
+const providersDir = './data/providers/s3/';
+const collectionsDir = './data/collections/s3_MOD09GQ_006';
+const collection = { name: `MOD09GQ${testSuffix}`, version: '006' };
+const provider = { id: `s3_provider${testSuffix}` };
+const workflowName = 'IngestGranule';
+
+const granuleRegex = '^MOD09GQ\\.A[\\d]{7}\\.[\\w]{6}\\.006\\.[\\d]{13}$';
+
+const ruleDirectory = './spec/parallel/testAPI/data/rules/sqs';
+const ruleOverride = {
+  name: `MOD09GQ_006_sqsRule${ruleSuffix}`,
+  collection: {
+    name: collection.name,
+    version: collection.version
+  },
+  provider: provider.id,
+  workflow: workflowName
+};
+
+let queueUrl;
+
+async function setupCollectionAndTestData() {
+  const s3data = [
+    '@cumulus/test-data/granules/MOD09GQ.A2016358.h13v04.006.2016360104606.hdf.met',
+    '@cumulus/test-data/granules/MOD09GQ.A2016358.h13v04.006.2016360104606.hdf',
+    '@cumulus/test-data/granules/MOD09GQ.A2016358.h13v04.006.2016360104606_ndvi.jpg'
+  ];
+
+  // populate collections, providers and test data
+  await Promise.all([
+    uploadTestDataToBucket(config.bucket, s3data, testDataFolder),
+    addCollections(config.stackName, config.bucket, collectionsDir, testSuffix),
+    addProviders(config.stackName, config.bucket, providersDir, config.bucket, testSuffix)
+  ]);
+}
+
+async function cleanUp() {
+  console.log(`\nDeleting ${ruleOverride.name}`);
+  const rules = await rulesList(config.stackName, config.bucket, ruleDirectory);
+  await deleteRules(config.stackName, config.bucket, rules, ruleSuffix);
+  await Promise.all([
+    deleteFolder(config.bucket, testDataFolder),
+    cleanupCollections(config.stackName, config.bucket, collectionsDir, testSuffix),
+    cleanupProviders(config.stackName, config.bucket, providersDir, testSuffix),
+    sqs().deleteQueue({ QueueUrl: queueUrl }).promise()
+  ]);
+}
+
+async function ingestGranule(queue) {
+  const inputPayloadJson = fs.readFileSync(inputPayloadFilename, 'utf8');
+  // update test data filepaths
+  const inputPayload = await setupTestGranuleForIngest(config.bucket, inputPayloadJson, granuleRegex, testSuffix, testDataFolder);
+  const granuleId = inputPayload.granules[0].granuleId;
+  await sqs().sendMessage({ QueueUrl: queue, MessageBody: JSON.stringify(inputPayload) }).promise();
+  return granuleId;
+}
+
+describe('The SQS rule', () => {
+  let ruleList = [];
+  beforeAll(async () => {
+    await setupCollectionAndTestData();
+
+    // create SQS queue and add rule
+    const queueName = `${testId}Queue`;
+    const { QueueUrl } = await sqs().createQueue({ QueueName: queueName }).promise();
+    queueUrl = QueueUrl;
+    config.queueUrl = queueUrl;
+
+    ruleList = await addRules(config, ruleDirectory, ruleOverride);
+  });
+
+  afterAll(async () => {
+    await cleanUp();
+  });
+
+  it('SQS rules are added', async () => {
+    expect(ruleList.length).toBe(1);
+    expect(ruleList[0].rule.value).toBe(queueUrl);
+  });
+
+  describe('When posting a message to the configured SQS queue', () => {
+    let granuleId;
+    process.env.GranulesTable = `${config.stackName}-GranulesTable`;
+    const granuleModel = new Granule();
+    beforeAll(async () => {
+      granuleId = await ingestGranule(queueUrl);
+    });
+
+    afterAll(async () => {
+      await granulesApiTestUtils.deleteGranule({ prefix: config.stackName, granuleId: granuleId });
+    });
+
+    it('workflow is kicked off, and the granule from the message is successfully ingested', async () => {
+      const record = await waitForModelStatus(
+        granuleModel,
+        { granuleId },
+        'completed'
+      );
+      expect(record.granuleId).toBe(granuleId);
+      expect(record.execution.includes(workflowName)).toBe(true);
+    });
+
+    it('messages are picked up from the queue', async () => {
+      const sqsOptions = { numOfMessages: 1, timeout: 40, waitTimeSeconds: 2 };
+      const messages = await receiveSQSMessages(queueUrl, sqsOptions);
+      expect(messages.length).toBe(0);
+    });
+  });
+});

--- a/example/workflows/helloworld.yml
+++ b/example/workflows/helloworld.yml
@@ -31,7 +31,7 @@ EcsHelloWorldWorkflow:
         collection: '{$.meta.collection}'
       Type: Task
       Resource: ${EcsTaskHelloWorldActivity}
-      TimeoutSeconds: 60
+      TimeoutSeconds: 120
       Retry:
         - ErrorEquals:
             - States.Timeout
@@ -57,7 +57,7 @@ EcsKesCMAHelloWorldWorkflow:
         collection: '{$.meta.collection}'
       Type: Task
       Resource: ${EcsTaskHelloWorldKesCmaActivity}
-      TimeoutSeconds: 60
+      TimeoutSeconds: 120
       Retry:
         - ErrorEquals:
             - States.Timeout

--- a/packages/api/config/lambdas.yml
+++ b/packages/api/config/lambdas.yml
@@ -280,3 +280,16 @@ reportPdrs:
   launchInVpc: true
   tables:
     - PdrsTable
+
+sqsMessageConsumer:
+  handler: index.handler
+  timeout: 100
+  memory: 256
+  source: 'node_modules/@cumulus/api/dist/sqsMessageConsumer/'
+  launchInVpc: true
+  tables:
+    - RulesTable
+    - CollectionsTable
+    - ProvidersTable
+  envs:
+    system_bucket: '{{system_bucket}}'

--- a/packages/api/es/search.js
+++ b/packages/api/es/search.js
@@ -8,7 +8,7 @@
 const has = require('lodash.has');
 const omit = require('lodash.omit');
 const aws = require('aws-sdk');
-const Connection = require('aws-elasticsearch-connector');
+const { AmazonConnection } = require('aws-elasticsearch-connector');
 const elasticsearch = require('@elastic/elasticsearch');
 const { inTestMode } = require('@cumulus/common/test-utils');
 const queries = require('./queries');
@@ -57,7 +57,7 @@ const esProdConfig = async (host) => {
 
   return {
     node,
-    Connection,
+    Connection: AmazonConnection,
     awsConfig: {
       credentials: aws.config.credentials
     },

--- a/packages/api/lambdas/sqs-message-consumer.js
+++ b/packages/api/lambdas/sqs-message-consumer.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const log = require('@cumulus/common/log');
+const { Consumer } = require('@cumulus/ingest/consumer');
+const rulesHelpers = require('../lib/rulesHelpers');
+const Rule = require('../models/rules');
+
+
+/**
+ * Looks up enabled 'sqs'-type rules, and processes the messages from
+ * the SQS queues defined in the rules.
+ *
+ * @param {Object} event - lambda input message
+ * @param {Function} dispatchFn - dispatch function
+ * @returns {[Promises]} Array of promises. Each promise is resolved when
+ * messages from SQS queue are processed
+ */
+async function processQueues(event, dispatchFn) {
+  const model = new Rule();
+  const rules = await model.getRulesByTypeAndState('sqs', 'ENABLED');
+
+  const messageLimit = event.messageLimit || 1;
+  const timeLimit = event.timeLimit || 240;
+
+  await Promise.all(rules.map((rule) => {
+    const queueUrl = rule.rule.value;
+    const consumer = new Consumer({
+      queueUrl: queueUrl,
+      messageLimit,
+      timeLimit
+    });
+    log.info(`processQueues for rule ${rule.name} and queue ${queueUrl}`);
+    return consumer.consume(dispatchFn.bind({ rule: rule }));
+  }));
+}
+
+/**
+ * process an SQS message
+ *
+ * @param {Object} message - incoming queue message
+ * @returns {Promise} - promise resolved when the message is dispatched
+ *
+ */
+function dispatch(message) {
+  const input = Object.assign({}, message.Body);
+  return rulesHelpers.queueMessageForRule(this.rule, input);
+}
+
+/**
+ * Looks up enabled 'sqs'-type rules, and processes the messages from
+ * the SQS queues defined in the rules.
+ *
+ * @param {*} event - lambda event
+ * @param {string} event.messageLimit - number of messages to read from SQS for
+ *   this execution (default 1)
+ * @param {string} event.timeLimit - how many seconds the lambda function will
+ *   remain active and query the queue (default 240 s)
+ * @param {*} context - lambda context
+ * @param {*} cb - callback function to explicitly return information back to the caller.
+ * @returns {(error|string)} Success message or error
+ */
+function handler(event, context, cb) {
+  return processQueues(event, dispatch)
+    .catch((err) => {
+      cb(err);
+    });
+}
+
+module.exports = {
+  handler
+};

--- a/packages/api/lib/rulesHelpers.js
+++ b/packages/api/lib/rulesHelpers.js
@@ -2,11 +2,11 @@ const { schedule } = require('../lambdas/sf-scheduler');
 const Rule = require('../models/rules');
 
 /**
- * Queue a workflow message for the kinesis rule with the message passed
- * to kinesis as the payload
+ * Queue a workflow message for the kinesis/sqs rule with the message passed
+ * to stream/queue as the payload
  *
  * @param {Object} rule - rule to queue the message for
- * @param {Object} eventObject - message passed to kinesis
+ * @param {Object} eventObject - message passed to stream/queue
  * @returns {Promise} promise resolved when the message is queued
  */
 async function queueMessageForRule(rule, eventObject) {

--- a/packages/api/models/rules.js
+++ b/packages/api/models/rules.js
@@ -59,6 +59,7 @@ class Rule extends Manager {
       }
       break;
     }
+    case 'sqs':
     default:
       break;
     }
@@ -157,6 +158,11 @@ class Rule extends Manager {
       }
       break;
     }
+    case 'sqs':
+      if (valueUpdated && !(await aws.sqsQueueExists(updatedRuleItem.rule.value))) {
+        throw new Error(`SQS queue ${updatedRuleItem.rule.value} does not exist or your account does not have permissions to access it`);
+      }
+      break;
     default:
       break;
     }
@@ -227,6 +233,11 @@ class Rule extends Manager {
       }
       break;
     }
+    case 'sqs':
+      if (!(await aws.sqsQueueExists(newRuleItem.rule.value))) {
+        throw new Error(`SQS queue ${newRuleItem.rule.value} does not exist or your account does not have permissions to access it`);
+      }
+      break;
     default:
       throw new Error('Type not supported');
     }
@@ -411,6 +422,30 @@ class Rule extends Manager {
       SubscriptionArn: item.rule.arn
     };
     return aws.sns().unsubscribe(subscriptionParams).promise();
+  }
+
+  /**
+   * get all rules with specified type and state
+   *
+   * @param {string} type - rule type
+   * @param {string} state - rule state
+   * @returns {Promise<Object>}
+   */
+  async getRulesByTypeAndState(type, state) {
+    const scanResult = await this.scan({
+      names: {
+        '#st': 'state',
+        '#rl': 'rule',
+        '#tp': 'type'
+      },
+      filter: '#st = :enabledState AND #rl.#tp = :ruleType',
+      values: {
+        ':enabledState': state,
+        ':ruleType': type
+      }
+    });
+
+    return scanResult.Items;
   }
 }
 

--- a/packages/api/models/schemas.js
+++ b/packages/api/models/schemas.js
@@ -380,7 +380,7 @@ module.exports.rule = {
       properties: {
         type: {
           type: 'string',
-          enum: ['onetime', 'scheduled', 'sns', 'kinesis']
+          enum: ['onetime', 'scheduled', 'sns', 'kinesis', 'sqs']
         },
         // Value is multi-use.   For a kinesis rule this is the target stream arn, for
         // a scheduled event it's the schedule pattern (e.g. cron), for a one-time rule.

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -56,7 +56,7 @@
     "@elastic/elasticsearch": "^5.6.20",
     "@mapbox/dyno": "^1.4.2",
     "ajv": "^5.2.2",
-    "aws-elasticsearch-connector": "^8.1.3",
+    "aws-elasticsearch-connector": "^8.2.0",
     "aws-sdk": "^2.238.1",
     "aws-serverless-express": "^3.3.5",
     "body-parser": "^1.18.3",

--- a/packages/api/tests/lambdas/test-sqs-message-consumer.js
+++ b/packages/api/tests/lambdas/test-sqs-message-consumer.js
@@ -1,0 +1,127 @@
+'use strict';
+
+const rewire = require('rewire');
+const sinon = require('sinon');
+const test = require('ava');
+const range = require('lodash.range');
+
+const aws = require('@cumulus/common/aws');
+const { randomString } = require('@cumulus/common/test-utils');
+const models = require('../../models');
+const { fakeRuleFactoryV2 } = require('../../lib/testUtils');
+const rulesHelpers = require('../../lib/rulesHelpers');
+
+const sqsMessageConsumer = rewire('../../lambdas/sqs-message-consumer');
+const processQueues = sqsMessageConsumer.__get__('processQueues');
+const dispatch = sqsMessageConsumer.__get__('dispatch');
+
+process.env.RulesTable = `RulesTable_${randomString()}`;
+process.env.stackName = randomString();
+process.env.system_bucket = randomString();
+
+const workflow = randomString();
+const workflowfile = `${process.env.stackName}/workflows/${workflow}.json`;
+
+let rulesModel;
+let queueUrls = [];
+let createdRules = [];
+const event = { messageLimit: 10, timeLimit: 100 };
+const queueMessageStub = sinon.stub(rulesHelpers, 'queueMessageForRule');
+
+async function createRules() {
+  queueUrls = await Promise.all(range(2).map(() => aws.createQueue(randomString())));
+  const rules = [
+    fakeRuleFactoryV2({
+      workflow,
+      rule: {
+        type: 'onetime'
+      },
+      state: 'ENABLED'
+    }),
+    fakeRuleFactoryV2({
+      workflow,
+      rule: {
+        type: 'sqs',
+        value: queueUrls[0]
+      },
+      state: 'ENABLED'
+    }),
+    fakeRuleFactoryV2({
+      workflow,
+      rule: {
+        type: 'sqs',
+        value: queueUrls[1]
+      },
+      state: 'DISABLED'
+    })
+  ];
+
+  return Promise.all(
+    rules.map((rule) => rulesModel.create(rule))
+  );
+}
+
+test.before(async () => {
+  // create Rules table
+  rulesModel = new models.Rule();
+  await rulesModel.createTable();
+  await aws.s3().createBucket({ Bucket: process.env.system_bucket }).promise();
+  await aws.s3().putObject({
+    Bucket: process.env.system_bucket,
+    Key: workflowfile,
+    Body: JSON.stringify({ testworkflow: 'workflowconfig' })
+  }).promise();
+  createdRules = await createRules();
+});
+
+test.after.always(async () => {
+  // cleanup table
+  await rulesModel.deleteTable();
+  await aws.recursivelyDeleteS3Bucket(process.env.system_bucket);
+  await Promise.all(
+    queueUrls.map((queueUrl) => aws.sqs().deleteQueue({ QueueUrl: queueUrl }).promise())
+  );
+  queueMessageStub.restore();
+});
+
+test.afterEach.always(() => {
+  queueMessageStub.resetHistory();
+});
+
+test.serial('processQueues does nothing when there is no message', async (t) => {
+  await processQueues(event, dispatch);
+  t.is(queueMessageStub.notCalled, true);
+});
+
+test.serial('processQueues processes messages from the ENABLED sqs rule', async (t) => {
+  const queueMessageFromEnabledRuleStub = queueMessageStub
+    .withArgs(createdRules[1], sinon.match.any);
+
+  // send two messages to the queue of the ENABLED sqs rule
+  await Promise.all(
+    range(2).map(() =>
+      aws.sqs().sendMessage(
+        { QueueUrl: queueUrls[0], MessageBody: JSON.stringify({ testdata: randomString() }) }
+      ).promise())
+  );
+
+  // send three messages to the queue of the DISABLED sqs rule
+  await Promise.all(
+    range(3).map(() =>
+      aws.sqs().sendMessage(
+        { QueueUrl: queueUrls[1], MessageBody: JSON.stringify({ testdata: randomString() }) }
+      ).promise())
+  );
+  await processQueues(event, dispatch);
+
+  // verify only messages from ENABLED rule are processed
+  t.is(queueMessageStub.calledTwice, true);
+  t.is(queueMessageFromEnabledRuleStub.calledTwice, true);
+
+  // messages are picked up from the correct queue
+  const sqsOptions = { numOfMessages: 10, timeout: 40, waitTimeSeconds: 2 };
+  const messagesFromQueue0 = await aws.receiveSQSMessages(queueUrls[0], sqsOptions);
+  t.is(messagesFromQueue0.length, 0);
+  const messagesFromQueue1 = await aws.receiveSQSMessages(queueUrls[1], sqsOptions);
+  t.is(messagesFromQueue1.length, 3);
+});

--- a/packages/api/tests/models/test-rules-model.js
+++ b/packages/api/tests/models/test-rules-model.js
@@ -3,6 +3,7 @@
 const test = require('ava');
 const sinon = require('sinon');
 const cloneDeep = require('lodash.clonedeep');
+const range = require('lodash.range');
 
 const aws = require('@cumulus/common/aws');
 const { randomString, randomId } = require('@cumulus/common/test-utils');
@@ -672,4 +673,80 @@ test('update preserves nested keys', async (t) => {
 
   t.is(updatedRule.meta.foo, 'bar');
   t.deepEqual(updatedRule.meta.testObject, newTestObject);
+});
+
+test('getRulesByTypeAndState returns list of rules', async (t) => {
+  const queueUrl = await aws.createQueue(randomString());
+  const rules = [
+    fakeRuleFactoryV2({
+      workflow,
+      rule: {
+        type: 'onetime'
+      },
+      state: 'ENABLED'
+    }),
+    fakeRuleFactoryV2({
+      workflow,
+      rule: {
+        type: 'sqs',
+        value: queueUrl
+      },
+      state: 'ENABLED'
+    }),
+    fakeRuleFactoryV2({
+      workflow,
+      rule: {
+        type: 'onetime'
+      },
+      state: 'DISABLED'
+    })
+  ];
+  const createdRules = await Promise.all(
+    rules.map((rule) => rulesModel.create(rule))
+  );
+
+  aws.sqs().deleteQueue({ QueueUrl: queueUrl }).promise();
+
+  const result = await rulesModel.getRulesByTypeAndState('onetime', 'ENABLED');
+  t.truthy(result.find((rule) => rule.name === createdRules[0].name));
+  t.falsy(result.find((rule) => rule.name === createdRules[1].name));
+  t.falsy(result.find((rule) => rule.name === createdRules[2].name));
+});
+
+test('create, update and delete sqs type rule', async (t) => {
+  const queueUrls = await Promise.all(range(2).map(() => aws.createQueue(randomString())));
+
+  const rule = fakeRuleFactoryV2({
+    workflow,
+    rule: {
+      type: 'sqs',
+      value: queueUrls[0]
+    },
+    state: 'ENABLED'
+  });
+
+  const createdRule = await rulesModel.create(rule);
+  t.deepEqual(createdRule.rule, rule.rule);
+
+  const testObject = {
+    key: randomString()
+  };
+  const updates = {
+    name: rule.name,
+    meta: {
+      testObject: testObject
+    },
+    rule: {
+      value: queueUrls[1]
+    }
+  };
+
+  const updatedRule = await rulesModel.update(createdRule, updates);
+  t.deepEqual(updatedRule.meta.testObject, testObject);
+  t.is(updatedRule.rule.value, queueUrls[1]);
+
+  await rulesModel.delete(updatedRule);
+  await Promise.all(
+    queueUrls.map((queueUrl) => aws.sqs().deleteQueue({ QueueUrl: queueUrl }).promise())
+  );
 });

--- a/packages/api/webpack.config.js
+++ b/packages/api/webpack.config.js
@@ -29,7 +29,8 @@ module.exports = {
     reportPdrs: './lambdas/report-pdrs.js',
     sfScheduler: './lambdas/sf-scheduler.js',
     sfSemaphoreDown: './lambdas/sf-semaphore-down.js',
-    sfStarter: './lambdas/sf-starter.js'
+    sfStarter: './lambdas/sf-starter.js',
+    sqsMessageConsumer: './lambdas/sqs-message-consumer.js'
   },
   devtool: 'inline-source-map',
   resolve: {

--- a/packages/common/aws.js
+++ b/packages/common/aws.js
@@ -934,6 +934,23 @@ exports.deleteSQSMessage = improveStackTrace(
 );
 
 /**
+ * Test if an SQS queue exists
+ *
+ * @param {Object} queue - queue name or url
+ * @returns {Promise<boolean>} - a Promise that will resolve to a boolean indicating
+ *                               if the queue exists
+ */
+exports.sqsQueueExists = (queue) => {
+  const QueueName = queue.split('/').pop();
+  return exports.sqs().getQueueUrl({ QueueName }).promise()
+    .then(() => true)
+    .catch((e) => {
+      if (e.code === 'AWS.SimpleQueueService.NonExistentQueue') return false;
+      throw e;
+    });
+};
+
+/**
  * Returns execution ARN from a statement machine Arn and executionName
  *
  * @param {string} stateMachineArn - state machine ARN

--- a/packages/common/tests/test-aws.js
+++ b/packages/common/tests/test-aws.js
@@ -355,3 +355,12 @@ test('getFileBucketAndKey throws UnparsableFileLocationError if location cannot 
     UnparsableFileLocationError
   );
 });
+
+test('sqsQueueExists detects if the queue does not exist or is not accessible', async (t) => {
+  const queueUrl = await aws.createQueue(randomString());
+  const queueName = queueUrl.split('/').pop();
+  t.true(await aws.sqsQueueExists(queueUrl));
+  t.true(await aws.sqsQueueExists(queueName));
+  t.false(await aws.sqsQueueExists(randomString()));
+  await aws.sqs().deleteQueue({ QueueUrl: queueUrl }).promise();
+});

--- a/packages/deployment/app/cloudformation.template.yml
+++ b/packages/deployment/app/cloudformation.template.yml
@@ -384,7 +384,7 @@ Resources:
         {{# each this.targets}}
         - Id: {{@../key}}WatcherScheduler
           {{# if input}}
-          Input: {{input}}
+          Input: '{{{ToJson this.input}}}'
           {{/if}}
           Arn:
             Fn::GetAtt:

--- a/packages/deployment/app/config.yml
+++ b/packages/deployment/app/config.yml
@@ -305,6 +305,15 @@ default:
       targets:
         - lambda: publishReports
 
+    sqsMessageConsumer:
+      schedule: rate(1 minute)
+      state: ENABLED
+      targets:
+        - lambda: sqsMessageConsumer
+          input:
+            messageLimit: '{{sqs_consumer_rate}}'
+            timeLimit: 60
+
   useWorkflowLambdaVersions: true
 
   stepFunctions: !!files ['workflows.yml']

--- a/packages/integration-tests/index.js
+++ b/packages/integration-tests/index.js
@@ -59,14 +59,14 @@ const lambdaStep = new LambdaStep();
  *   table
  * @param {string} params.id - the id of the AsyncOperation
  * @param {string} params.status - the status to wait for
- * @param {number} params.retries - the number of times to retry Default: 5
+ * @param {number} params.retries - the number of times to retry Default: 10
  * @returns {Promise<Object>} - the AsyncOperation object
  */
 async function waitForAsyncOperationStatus({
   TableName,
   id,
   status,
-  retries = 5
+  retries = 10
 }) {
   const { Item } = await dynamodb().getItem({
     TableName,


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-1513: support SQS-type rule in the Cumulus API](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1513)

## Changes

* Added `sqs`-type rule support in the Cumulus API `@cumulus/api`
* Added `sqsMessageConsumer` lambda which processes messages from the SQS queues configured in the `sqs` rules.
* Added integration test

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Adhoc testing
- [x] Integration tests

