### PR TITLE
Speed up integration tests

### DIFF
--- a/example/scripts/run_test.sh
+++ b/example/scripts/run_test.sh
@@ -2,14 +2,22 @@
 
 set +e
 
-specName=$(echo $2 | rev | cut -d'/' -f 1 | cut -d'.' -f 2 | rev)
-outputPath="$1/$specName.txt"
+specName=$(echo "$2" | rev | cut -d'/' -f 1 | cut -d'.' -f 2 | rev)
+outputPath="${1}/${specName}-running.txt"
 
-echo $(date "+%Y%m%d-%H:%M:%S") run test $2 and output to $outputPath
+TIMESTAMP=$(date "+%Y-%m-%dT%H:%M:%S")
+echo "$TIMESTAMP jasmine $2 STARTED"
 
 jasmine "$2" > "$outputPath" 2>&1
 result=$?
 
-echo $(date "+%Y%m%d-%H:%M:%S") test $2 completed with result $result
+TIMESTAMP=$(date "+%Y-%m-%dT%H:%M:%S")
+if [ "$result" -eq "0" ]; then
+  echo "$TIMESTAMP jasmine $2 PASSED"
+  mv "$outputPath" "$1/${specName}-passed.txt"
+else
+  echo "$TIMESTAMP jasmine $2 FAILED"
+  mv "$outputPath" "$1/${specName}-failed.txt"
+fi
 
 exit $result

--- a/example/scripts/tests-parallel.sh
+++ b/example/scripts/tests-parallel.sh
@@ -14,14 +14,13 @@ testOutputDir=scripts/test_output
 rm -r -f $testOutputDir
 mkdir -p $testOutputDir
 
-echo "" | ./node_modules/.bin/parallel -j 4 sh scripts/run_test.sh  $testOutputDir ::: $TESTS
+echo "" | ./node_modules/.bin/parallel -j 0 sh scripts/run_test.sh  $testOutputDir ::: $TESTS
 result=$?
 echo parallel tests complete: $result suite failures
 
 # print test output to console
-for testFile in $testOutputDir/*; do
-  cat $testFile
-done
+find "$testOutputDir" -mindepth 1 -maxdepth 1 -name '*-passed.txt' -exec cat {} \;
+find "$testOutputDir" -mindepth 1 -maxdepth 1 -name '*-failed.txt' -exec cat {} \;
 
 rm -rf $testOutputDir
 

--- a/packages/integration-tests/index.js
+++ b/packages/integration-tests/index.js
@@ -153,7 +153,7 @@ async function getExecutionStatus(executionArn) {
  *
  * @param {string} executionArn - ARN of the execution
  * @param {number} [timeout=600] - the time, in seconds, to wait for the
- *   execution to reach a terminal
+ *   execution to reach a terminal state
  * @returns {string} status
  */
 async function waitForCompletedExecution(executionArn, timeout = 600) {

--- a/packages/integration-tests/index.js
+++ b/packages/integration-tests/index.js
@@ -9,6 +9,7 @@ const Handlebars = require('handlebars');
 const uuidv4 = require('uuid/v4');
 const fs = require('fs-extra');
 const pLimit = require('p-limit');
+const pWaitFor = require('p-wait-for');
 const pMap = require('p-map');
 
 const { pullStepFunctionEvent } = require('@cumulus/common/aws');
@@ -132,16 +133,19 @@ function getWorkflowArn(stackName, bucketName, workflowName) {
 /**
  * Get the status of a given execution
  *
- * If the execution does not exist, this will return 'RUNNING'.  This seems
- * surprising in the "don't surprise users of your code" sort of way.  If it
- * does not exist then the calling code should probably know that.  Something
- * to be refactored another day.
+ * If the execution does not exist, this will return 'STARTING'.
  *
  * @param {string} executionArn - ARN of the execution
  * @returns {Promise<string>} status
  */
 async function getExecutionStatus(executionArn) {
-  return (await StepFunctions.describeExecution({ executionArn })).status;
+  try {
+    const { status } = await StepFunctions.describeExecution({ executionArn });
+    return status;
+  } catch (err) {
+    if (err.code === 'ExecutionDoesNotExist') return 'STARTING';
+    throw err;
+  }
 }
 
 /**
@@ -149,50 +153,25 @@ async function getExecutionStatus(executionArn) {
  *
  * @param {string} executionArn - ARN of the execution
  * @param {number} [timeout=600] - the time, in seconds, to wait for the
- *   execution to reach a non-RUNNING state
+ *   execution to reach a terminal
  * @returns {string} status
  */
 async function waitForCompletedExecution(executionArn, timeout = 600) {
-  let executionStatus;
-  let iteration = 0;
-  const sleepPeriodMs = 5000;
-  const maxMinutesWaitedForExecutionStart = 5;
-  const iterationsPerMinute = Math.floor(60000 / sleepPeriodMs);
-  const maxIterationsToStart = Math.floor(maxMinutesWaitedForExecutionStart * iterationsPerMinute);
+  let status;
 
-  const stopTime = Date.now() + (timeout * 1000);
-
-  /* eslint-disable no-await-in-loop */
-  do {
-    iteration += 1;
-    try {
-      executionStatus = await getExecutionStatus(executionArn);
-    } catch (err) {
-      if (!(err.code === 'ExecutionDoesNotExist') || iteration > maxIterationsToStart) {
-        console.log(`waitForCompletedExecution failed: ${err.code}, arn: ${executionArn}`);
-        throw err;
-      }
-      console.log("Execution does not exist... assuming it's still starting up.");
-      executionStatus = 'STARTING';
+  await pWaitFor(
+    async () => {
+      status = await getExecutionStatus(executionArn);
+      console.log(`${executionArn} status: ${status}`);
+      return status !== 'STARTING' && status !== 'RUNNING';
+    },
+    {
+      interval: 2000,
+      timeout: timeout * 1000
     }
-    if (executionStatus === 'RUNNING') {
-      // Output a 'heartbeat' every minute
-      if (!(iteration % iterationsPerMinute)) console.log('Execution running....');
-    }
-    await sleep(sleepPeriodMs);
-  } while (['RUNNING', 'STARTING'].includes(executionStatus) && Date.now() < stopTime);
-  /* eslint-enable no-await-in-loop */
+  );
 
-  if (executionStatus === 'RUNNING') {
-    const executionHistory = await StepFunctions.getExecutionHistory({
-      executionArn,
-      maxResults: 100
-    });
-    console.log(`waitForCompletedExecution('${executionArn}') timed out after ${timeout} seconds`);
-    console.log('Execution History:');
-    console.log(executionHistory);
-  }
-  return executionStatus;
+  return status;
 }
 
 /**


### PR DESCRIPTION
* Run all parallel integration tests at once, rather than 4 at a time
* When printing output of parallel integration tests, print successful test logs first and failing test logs last
* Update parallel test timestamps to ISO-8601
* Simplify `waitForCompletedExecution()` by using `pWaitFor()`

In local testing, this took my parallel integration tests from 11:19 down to 5:25, a more than 50% reduction in runtime.