### PR TITLE
CUMULUS-1625: Restore consumer rate in terraform deployment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Added `GET /token` endpoint for SAML authorization when cumulus is protected by Launchpad.
     This lets a user retieve a token by hand that can be presented to the API.
 
+- **CUMULUS-1625**
+  - Added `sf_start_rate` variable to the `ingest` Terraform module, equivalent to `sqs_consumer_rate` in the old model, but will not be automatically applied to custom queues as that was.
+
 ### Changed
 
 - **CUMULUS-1453**

--- a/tf-modules/ingest/cloudwatch-events.tf
+++ b/tf-modules/ingest/cloudwatch-events.tf
@@ -9,7 +9,7 @@ resource "aws_cloudwatch_event_target" "background_processing_watcher" {
   rule = aws_cloudwatch_event_rule.background_processing_watcher.name
   arn  = aws_lambda_function.sqs2sfThrottle.arn
   input = jsonencode({
-    messageLimit = var.sf_start_rate ? var.sf_start_rate : 500
+    messageLimit = var.sf_start_rate == null ? 500 : var.sf_start_rate
     queueUrl     = aws_sqs_queue.background_processing.id
     timeLimit    = 60
   })
@@ -41,7 +41,7 @@ resource "aws_cloudwatch_event_target" "start_sf_watcher" {
   rule = aws_cloudwatch_event_rule.start_sf_watcher.name
   arn  = aws_lambda_function.sqs2sf.arn
   input = jsonencode({
-    messageLimit = var.sf_start_rate ? var.sf_start_rate : 500
+    messageLimit = var.sf_start_rate == null ? 500 : var.sf_start_rate
     queueUrl     = aws_sqs_queue.start_sf.id
     timeLimit    = 60
   })

--- a/tf-modules/ingest/cloudwatch-events.tf
+++ b/tf-modules/ingest/cloudwatch-events.tf
@@ -9,7 +9,7 @@ resource "aws_cloudwatch_event_target" "background_processing_watcher" {
   rule = aws_cloudwatch_event_rule.background_processing_watcher.name
   arn  = aws_lambda_function.sqs2sfThrottle.arn
   input = jsonencode({
-    messageLimit = 500
+    messageLimit = var.sf_start_rate ? var.sf_start_rate : 500
     queueUrl     = aws_sqs_queue.background_processing.id
     timeLimit    = 60
   })
@@ -41,7 +41,7 @@ resource "aws_cloudwatch_event_target" "start_sf_watcher" {
   rule = aws_cloudwatch_event_rule.start_sf_watcher.name
   arn  = aws_lambda_function.sqs2sf.arn
   input = jsonencode({
-    messageLimit = 500
+    messageLimit = var.sf_start_rate ? var.sf_start_rate : 500
     queueUrl     = aws_sqs_queue.start_sf.id
     timeLimit    = 60
   })

--- a/tf-modules/ingest/variables.tf
+++ b/tf-modules/ingest/variables.tf
@@ -100,6 +100,11 @@ variable "queue_execution_limits" {
   default = {}
 }
 
+variable "sf_start_rate" {
+  type    = number
+  default = null
+}
+
 variable "system_bucket" {
   type = string
 }


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-1625: Restore sqs_consumer_rate in TF deployment.](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1625)

## Changes

* Added `sf_start_rate` var to `ingest` module.
* Documented difference in (lack of) application to custom queues in CHANGELOG.
* var name was changed both for accuracy reasons and to call attention to the implementation difference

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

