### PR TITLE
CUMULUS-1559: don't mutate cumulus_meta in TF workflows

### DIFF
--- a/example/cumulus-tf/ingest_and_publish_granule_workflow.tf
+++ b/example/cumulus-tf/ingest_and_publish_granule_workflow.tf
@@ -41,7 +41,7 @@ module "ingest_and_publish_granule_workflow" {
                 },
                 {
                   "source": "{$.process}",
-                  "destination": "{$.cumulus_meta.process}"
+                  "destination": "{$.meta.process}"
                 }
               ]
             }
@@ -75,7 +75,7 @@ module "ingest_and_publish_granule_workflow" {
         {
           "Next": "ProcessingStep",
           "StringEquals": "modis",
-          "Variable": "$.cumulus_meta.process"
+          "Variable": "$.meta.process"
         }
       ],
       "Default": "WorkflowSucceeded",
@@ -216,7 +216,7 @@ module "ingest_and_publish_granule_workflow" {
             "bucket": "{$.meta.buckets.internal.name}",
             "stack": "{$.meta.stack}",
             "cmr": "{$.meta.cmr}",
-            "process": "{$.cumulus_meta.process}"
+            "process": "{$.meta.process}"
           }
         }
       },

--- a/example/cumulus-tf/ingest_granule_catch_duplicate_error_test_workflow.tf
+++ b/example/cumulus-tf/ingest_granule_catch_duplicate_error_test_workflow.tf
@@ -41,7 +41,7 @@ module "ingest_granule_catch_duplicate_error_test_workflow" {
                 },
                 {
                   "source": "{$.process}",
-                  "destination": "{$.cumulus_meta.process}"
+                  "destination": "{$.meta.process}"
                 }
               ]
             }
@@ -81,7 +81,7 @@ module "ingest_granule_catch_duplicate_error_test_workflow" {
       "Type": "Choice",
       "Choices": [
         {
-          "Variable": "$.cumulus_meta.process",
+          "Variable": "$.meta.process",
           "StringEquals": "modis",
           "Next": "ProcessingStep"
         }

--- a/example/cumulus-tf/ingest_granule_workflow.tf
+++ b/example/cumulus-tf/ingest_granule_workflow.tf
@@ -41,7 +41,7 @@ module "ingest_granule_workflow" {
                 },
                 {
                   "source": "{$.process}",
-                  "destination": "{$.cumulus_meta.process}"
+                  "destination": "{$.meta.process}"
                 }
               ]
             }
@@ -74,7 +74,7 @@ module "ingest_granule_workflow" {
       "Type": "Choice",
       "Choices": [
         {
-          "Variable": "$.cumulus_meta.process",
+          "Variable": "$.meta.process",
           "StringEquals": "modis",
           "Next": "ProcessingStep"
         }

--- a/example/cumulus-tf/sync_granule_catch_duplicate_error_test_workflow.tf
+++ b/example/cumulus-tf/sync_granule_catch_duplicate_error_test_workflow.tf
@@ -37,7 +37,7 @@ module "sync_granule_catch_duplicate_error_test" {
                 },
                 {
                   "source": "{$.process}",
-                  "destination": "{$.cumulus_meta.process}"
+                  "destination": "{$.meta.process}"
                 }
               ]
             }

--- a/example/cumulus-tf/sync_granule_workflow.tf
+++ b/example/cumulus-tf/sync_granule_workflow.tf
@@ -37,7 +37,7 @@ module "sync_granule_workflow" {
                 },
                 {
                   "source": "{$.process}",
-                  "destination": "{$.cumulus_meta.process}"
+                  "destination": "{$.meta.process}"
                 }
               ]
             }


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-1559: Migrate OX Work](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1559)

## Changes

* Carry over work performed in #1178 (CUMULUS-1448) to Terraform workflows.

## PR Checklist

- [x] Unit tests
- [x] Adhoc testing
- [x] Integration tests

