### PR TITLE
CUMULUS-1631 Deploy S3 access test lambda to us-west on example deployment

### DIFF
--- a/example/cumulus-tf/main.tf
+++ b/example/cumulus-tf/main.tf
@@ -114,9 +114,10 @@ resource "aws_lambda_permission" "sns_s3_test" {
 }
 
 module "s3_access_test_lambda" {
-  source = "./modules/s3_access_test"
+  source                     = "./modules/s3_access_test"
+  description                = "Lambda for integration testing direct S3 access"
 
-  prefix = var.prefix
+  prefix                     = var.prefix
   lambda_processing_role_arn = module.cumulus.lambda_processing_role_arn
-  region = "us-west-2"
+  region                     = "us-west-2"
 }

--- a/example/cumulus-tf/main.tf
+++ b/example/cumulus-tf/main.tf
@@ -112,3 +112,11 @@ resource "aws_lambda_permission" "sns_s3_test" {
   principal     = "sns.amazonaws.com"
   source_arn    = module.cumulus.report_executions_sns_topic_arn
 }
+
+module "s3_access_test_lambda" {
+  source = "./modules/s3_access_test"
+
+  prefix = var.prefix
+  lambda_processing_role_arn = module.cumulus.lambda_processing_role_arn
+  region = "us-west-2"
+}

--- a/example/cumulus-tf/modules/s3_access_test/main.tf
+++ b/example/cumulus-tf/modules/s3_access_test/main.tf
@@ -1,0 +1,20 @@
+locals {
+  default_tags = {
+    Deployment = var.prefix
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_lambda_function" "s3_acccess_test" {
+  function_name    = "${var.prefix}-s3AccessTest"
+  filename         = "${path.module}/../../../lambdas/s3AccessTest/lambda.zip"
+  source_code_hash = filebase64sha256("${path.module}/../../../lambdas/s3AccessTest/lambda.zip")
+  handler          = "index.handler"
+  role             = var.lambda_processing_role_arn
+  runtime          = "nodejs8.10"
+
+  tags = local.default_tags
+}

--- a/example/cumulus-tf/modules/s3_access_test/variables.tf
+++ b/example/cumulus-tf/modules/s3_access_test/variables.tf
@@ -1,0 +1,12 @@
+variable "prefix" {
+  type = string
+}
+
+variable "region" {
+  type = string
+  default = "us-west-2"
+}
+
+variable "lambda_processing_role_arn" {
+  type = string
+}


### PR DESCRIPTION
**Summary:** Add deploy of s3 access test lambda to us-west-2 to example deployment for integration tests

Addresses [CUMULUS-1631](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1631)

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [X] Adhoc testing
- [ ] Integration tests

