### PR TITLE
CUMULUS-1100: Ensure all log groups have retention policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- **CUMULUS-1100**
+  - Added 30-day retention properties to all log groups that were missing those policies.
+
 - **CUMULUS-1396**
   - Added `@cumulus/common/sfnStep`:
     - `LambdaStep` - A class for retrieving and parsing input and output to Lambda steps in AWS Step Functions

--- a/example/fake-server.yml
+++ b/example/fake-server.yml
@@ -176,6 +176,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub '${Prefix}EcsLogs'
+      RetentionInDays: 30
 
   FakeProviderECSService:
     Type: AWS::ECS::Service

--- a/packages/deployment/app/cloudformation.template.yml
+++ b/packages/deployment/app/cloudformation.template.yml
@@ -970,6 +970,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: {{../prefix}}-{{@key}}EcsLogs
+      RetentionInDays: 30
 
   {{@key}}EcsLogSubscription:
     Type: AWS::Logs::SubscriptionFilter
@@ -1253,6 +1254,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: {{../prefix}}-{{@key}}EcsLogs
+      RetentionInDays: 30
 
   {{@key}}EcsLogSubscription:
     Type: AWS::Logs::SubscriptionFilter

--- a/tf-modules/archive/async_operation.tf
+++ b/tf-modules/archive/async_operation.tf
@@ -1,5 +1,6 @@
 resource "aws_cloudwatch_log_group" "async_operation" {
   name = "${var.prefix}-AsyncOperationEcsLogs"
+  retention_in_days = 30
   tags = local.default_tags
 }
 

--- a/tf-modules/cumulus_ecs_service/main.tf
+++ b/tf-modules/cumulus_ecs_service/main.tf
@@ -7,6 +7,7 @@ data "aws_region" "current" {}
 
 resource "aws_cloudwatch_log_group" "default" {
   name = "${local.full_name}EcsLogs"
+  retention_in_days = 30
   tags = var.tags
 }
 

--- a/tf-modules/ingest/post-to-cmr-task.tf
+++ b/tf-modules/ingest/post-to-cmr-task.tf
@@ -29,6 +29,7 @@ resource "aws_lambda_function" "post_to_cmr_task" {
 
 resource "aws_cloudwatch_log_group" "post_to_cmr_task" {
   name = "/aws/lambda/${aws_lambda_function.post_to_cmr_task.function_name}"
+  retention_in_days = 30
   tags = local.default_tags
 }
 

--- a/tf-modules/ingest/sync-granule-task.tf
+++ b/tf-modules/ingest/sync-granule-task.tf
@@ -29,6 +29,7 @@ resource "aws_lambda_function" "sync_granule_task" {
 
 resource "aws_cloudwatch_log_group" "sync_granule_task" {
   name = "/aws/lambda/${aws_lambda_function.sync_granule_task.function_name}"
+  retention_in_days = 30
   tags = local.default_tags
 }
 


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-1100: Add Retention policy for Lambdas and Services logGroups](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1100)

## Changes

* Add missing log group retention properties.

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Adhoc testing
- [x] Integration tests

