### PR TITLE
Add GIT_PR to the dotfile, as it's required for abort scripts

### DIFF
--- a/bamboo/set-bamboo-env-variables.sh
+++ b/bamboo/set-bamboo-env-variables.sh
@@ -54,6 +54,7 @@ export GIT_SHA=$(git rev-parse HEAD)
 ## Always set GIT_PR true if master branch
 if [[ $BRANCH == master ]]; then
   export GIT_PR=true
+  echo export GIT_PR=true >> .bamboo_env_vars
 fi
 
 ## This should take a blank value from the global options, and

--- a/example/deployments/jk-tf.tfvars
+++ b/example/deployments/jk-tf.tfvars
@@ -1,1 +1,1 @@
-prefix = "jk2-tf"
+prefix = "jk-tf"


### PR DESCRIPTION
Update to env vars script to fix master breakage. 

We need to write the GIT_PR status to the artifact as some scripts rely on sourcing that and not the full setup script for abort.   