### PR TITLE
[CUMULUS-1544] Allow Querying Metrics Elasticsearch form Bulk Granule endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- **CUMULUS-1544**
+  - Updated the `/granules/bulk` endpoint to correctly query Elasticsearch when
+  granule ids are not provided.
+
 - **CUMULUS-1580**
   - Added `/granules/bulk` endpoint to `@cumulus/api` to perform bulk actions on granules given either a list of granule ids or an Elasticsearch query and the workflow to perform.
 

--- a/bamboo/select-stack.js
+++ b/bamboo/select-stack.js
@@ -31,7 +31,8 @@ function determineIntegrationTestStackName(cb) {
     'Menno Van Diermen': 'mvd',
     'Jacob Campbell': 'jc',
     ifestus: 'jc',
-    'Chuck Daniels': 'chuckulus-ci'
+    'Chuck Daniels': 'chuckulus-ci',
+    'Brian Tennity': 'bt-tf'
   };
 
   return git('.').log({ '--max-count': '1' }, (e, r) => {

--- a/bamboo/select-stack.js
+++ b/bamboo/select-stack.js
@@ -32,7 +32,7 @@ function determineIntegrationTestStackName(cb) {
     'Jacob Campbell': 'jc',
     ifestus: 'jc',
     'Chuck Daniels': 'chuckulus-ci',
-    'Brian Tennity': 'bt-tf'
+    'Brian Tennity': 'bt-ci'
   };
 
   return git('.').log({ '--max-count': '1' }, (e, r) => {

--- a/example/app/config.yml
+++ b/example/app/config.yml
@@ -813,3 +813,35 @@ chuckulus-ci:
 pq:
   prefix: pq
   prefixNoDash: pq
+
+bt:
+  prefix: bt
+  prefixNoDash: bt
+  logToSharedDestination: '{{SHARED_LOG_DESTINATION_ARN}}'
+  users:
+    - username: brian.tennity
+
+bt-sit:
+  prefix: bt-sit
+  prefixNoDash: btSit
+  cma_layer: '{{sit_cma_layer}}'
+  buckets:
+    internal:
+      name: bt-sit-internal
+      type: internal
+    private:
+      name: bt-sit-private
+      type: private
+    protected:
+      name: cumulus-sit-protected
+      type: protected
+    public:
+      name: cumulus-sit-public
+      type: public
+    protected-2:
+      name: cumulus-sit-protected
+      type: protected
+    dashboard:
+      name: bt-sit-dashboard
+      type: shared
+

--- a/example/config.yml
+++ b/example/config.yml
@@ -27,3 +27,7 @@ mhs3:
 
 mhs2:
   bucket: mhs2-internal
+
+bt-tf:
+  bucket: bt-internal
+

--- a/example/cumulus-tf/main.tf
+++ b/example/cumulus-tf/main.tf
@@ -103,6 +103,10 @@ module "cumulus" {
 
   token_secret = var.token_secret
 
+  metrics_es_host     = var.metrics_es_host
+  metrics_es_password = var.metrics_es_password
+  metrics_es_username = var.metrics_es_username
+
   archive_api_users = [
     "chuckwondo",
     "jennyhliu",

--- a/example/cumulus-tf/main.tf
+++ b/example/cumulus-tf/main.tf
@@ -103,10 +103,6 @@ module "cumulus" {
 
   token_secret = var.token_secret
 
-  metrics_es_host     = var.metrics_es_host
-  metrics_es_password = var.metrics_es_password
-  metrics_es_username = var.metrics_es_username
-
   archive_api_users = [
     "chuckwondo",
     "jennyhliu",

--- a/example/cumulus-tf/main.tf
+++ b/example/cumulus-tf/main.tf
@@ -120,7 +120,8 @@ module "cumulus" {
     "mboyd",
     "menno.vandiermen",
     "mhuffnagle2",
-    "pquinn1"
+    "pquinn1",
+    "brian.tennity"
   ]
 
   distribution_url = var.distribution_url

--- a/example/cumulus-tf/terraform.tfvars.example
+++ b/example/cumulus-tf/terraform.tfvars.example
@@ -73,7 +73,7 @@ saml_launchpad_metadata_path    = "s3 url to identity provider public metadata x
 key_name      = "MY-KEY"
 
 # Optional
-metrics_es_host = "https://xxxxxxxxxx.cloudfront.net"
+metrics_es_host = "xxxxxxxxxx.cloudfront.net"
 metrics_es_username = "user"
 metrics_es_password = "password"
 

--- a/example/deployments/bt-ci-tf.tfvars
+++ b/example/deployments/bt-ci-tf.tfvars
@@ -1,0 +1,1 @@
+prefix = "bt-ci-tf"

--- a/packages/api/endpoints/granules.js
+++ b/packages/api/endpoints/granules.js
@@ -188,6 +188,21 @@ async function bulk(req, res) {
     return res.boom.badRequest('workflowName is required.');
   }
 
+  if (!payload.ids && !payload.query) {
+    return res.boom.badRequest('One of ids or query is required');
+  }
+
+  if (payload.query
+    && !(process.env.METRICS_ES_HOST
+    && process.env.METRICS_ES_USER
+    && process.env.METRICS_ES_PASS)) {
+    return res.boom.badRequest('ELK Metrics stack not configured');
+  }
+
+  if (payload.query && !payload.index) {
+    return res.boom.badRequest('Index is required if query is sent');
+  }
+
   const asyncOperationModel = new models.AsyncOperation({
     stackName: process.env.stackName,
     systemBucket: process.env.system_bucket,
@@ -205,10 +220,14 @@ async function bulk(req, res) {
         granulesTable: process.env.GranulesTable,
         system_bucket: process.env.system_bucket,
         stackName: process.env.stackName,
-        invoke: process.env.invoke
+        invoke: process.env.invoke,
+        esHost: process.env.METRICS_ES_HOST,
+        esUser: process.env.METRICS_ES_USER,
+        esPassword: process.env.METRICS_ES_PASS
       },
       esHost: process.env.ES_HOST
     });
+
     return res.send(asyncOperation);
   } catch (err) {
     if (err.name !== 'EcsStartTaskError') throw err;

--- a/packages/api/lambdas/bulk-operation.js
+++ b/packages/api/lambdas/bulk-operation.js
@@ -49,7 +49,7 @@ async function bulkGranule(payload) {
     if (!process.env.METRICS_ES_HOST
       || !process.env.METRICS_ES_USER
       || !process.env.METRICS_ES_PASS) {
-      throw new Error('No ELK metrics stack configured.');
+      throw new Error('ELK Metrics stack not configured');
     }
 
     const query = payload.query;
@@ -101,6 +101,10 @@ async function handler(event) {
   if (!process.env.system_bucket) process.env.system_bucket = event.system_bucket;
   if (!process.env.stackName) process.env.stackName = event.stackName;
   if (!process.env.invoke) process.env.invoke = event.invoke;
+  if (!process.env.METRICS_ES_HOST) process.env.METRICS_ES_HOST = event.esHost;
+  if (!process.env.METRICS_ES_USER) process.env.METRICS_ES_USER = event.esUser;
+  if (!process.env.METRICS_ES_PASS) process.env.METRICS_ES_PASS = event.esPassword;
+
   if (event.type === 'BULK_GRANULE') {
     return bulkGranule(event.payload);
   }

--- a/packages/api/lambdas/bulk-operation.js
+++ b/packages/api/lambdas/bulk-operation.js
@@ -79,8 +79,7 @@ async function bulkGranule(payload) {
         body.hits.hits.forEach((hit) => {
           granuleIds.push(hit._source.granuleId);
         });
-
-        if (body.hits.total != granuleIds.length){
+        if (body.hits.total.value != granuleIds.length){
           responseQueue.push(
             await client.scroll({
               scrollId: body._scroll_id,
@@ -94,8 +93,11 @@ async function bulkGranule(payload) {
     }
   }
 
-  console.log('Granule IDs: ', granuleIds);
-  return applyWorkflowToGranules(granuleIds, workflowName, queueName);
+  // Remove duplicate Granule IDs
+  const uniqueGranuleIds = [...new Set(granuleIds)];
+  console.log('Granule IDs: ', uniqueGranuleIds);
+
+  return applyWorkflowToGranules(uniqueGranuleIds, workflowName, queueName);
 }
 
 async function handler(event) {

--- a/packages/api/lambdas/bulk-operation.js
+++ b/packages/api/lambdas/bulk-operation.js
@@ -3,7 +3,7 @@ const elasticsearch = require('@elastic/elasticsearch');
 const log = require('@cumulus/common/log');
 
 const GranuleModel = require('../models/granules');
-const SCROLL_SIZE = 500 // default size in Kibana
+const SCROLL_SIZE = 500; // default size in Kibana
 
 function applyWorkflowToGranules(granuleIds, workflowName, queueName) {
   const granuleModelClient = new GranuleModel();
@@ -43,7 +43,7 @@ async function bulkGranule(payload) {
   const granuleIds = payload.ids || [];
 
   // query ElasticSearch if needed
-  if (granuleIds.length == 0 && payload.query){
+  if (granuleIds.length === 0 && payload.query) {
     log.info('No granule ids detected. Searching for granules in Elasticsearch.');
 
     if (!process.env.METRICS_ES_HOST
@@ -56,46 +56,42 @@ async function bulkGranule(payload) {
     const index = payload.index;
     const responseQueue = [];
 
-    const esUrl = 'https://' + process.env.METRICS_ES_USER + ':' +
-      process.env.METRICS_ES_PASS + '@' + process.env.METRICS_ES_HOST;
+    const esUrl = `https://${process.env.METRICS_ES_USER}:${
+      process.env.METRICS_ES_PASS}@${process.env.METRICS_ES_HOST}`;
     const client = new elasticsearch.Client({
       node: esUrl
     });
 
-    try {
-      const searchResponse = await client.search({
-        index: index,
-        scroll: '30s',
-        size: SCROLL_SIZE,
-        _source: ['granuleId'],
-        body: query
+    const searchResponse = await client.search({
+      index: index,
+      scroll: '30s',
+      size: SCROLL_SIZE,
+      _source: ['granuleId'],
+      body: query
+    });
+
+    responseQueue.push(searchResponse);
+
+    while (responseQueue.length) {
+      const { body } = responseQueue.shift();
+
+      body.hits.hits.forEach((hit) => {
+        granuleIds.push(hit._source.granuleId);
       });
-
-      responseQueue.push(searchResponse);
-
-      while(responseQueue.length){
-        const { body } = responseQueue.shift();
-
-        body.hits.hits.forEach((hit) => {
-          granuleIds.push(hit._source.granuleId);
-        });
-        if (body.hits.total.value != granuleIds.length){
-          responseQueue.push(
-            await client.scroll({
-              scrollId: body._scroll_id,
-              scroll: '30s'
-            })
-          );
-        }
+      if (body.hits.total.value !== granuleIds.length) {
+        responseQueue.push(
+          // eslint-disable-next-line no-await-in-loop
+          await client.scroll({
+            scrollId: body._scroll_id,
+            scroll: '30s'
+          })
+        );
       }
-    } catch (e) {
-      console.log("ERROR: " + e);
     }
   }
 
   // Remove duplicate Granule IDs
   const uniqueGranuleIds = [...new Set(granuleIds)];
-  console.log('Granule IDs: ', uniqueGranuleIds);
 
   return applyWorkflowToGranules(uniqueGranuleIds, workflowName, queueName);
 }

--- a/packages/api/tests/endpoints/granules/bulk-granule.js
+++ b/packages/api/tests/endpoints/granules/bulk-granule.js
@@ -24,7 +24,10 @@ process.env = {
   EcsCluster: randomString(),
   BulkOperationLambda: randomString(),
   invoke: randomString(),
-  ES_HOST: randomString()
+  ES_HOST: randomString(),
+  METRICS_ES_HOST: randomString(),
+  METRICS_ES_USER: randomString(),
+  METRICS_ES_PASS: randomString()
 };
 
 let accessTokenModel;
@@ -78,7 +81,10 @@ test.serial('Request to granules bulk endpoint starts an async-operation with th
     granulesTable: process.env.GranulesTable,
     system_bucket: process.env.system_bucket,
     stackName: process.env.stackName,
-    invoke: process.env.invoke
+    invoke: process.env.invoke,
+    esHost: process.env.METRICS_ES_HOST,
+    esUser: process.env.METRICS_ES_USER,
+    esPassword: process.env.METRICS_ES_PASS
   });
 
   asyncOperationStartStub.restore();
@@ -118,8 +124,123 @@ test.serial('Request to granules bulk endpoint starts an async-operation with th
     granulesTable: process.env.GranulesTable,
     system_bucket: process.env.system_bucket,
     stackName: process.env.stackName,
-    invoke: process.env.invoke
+    invoke: process.env.invoke,
+    esHost: process.env.METRICS_ES_HOST,
+    esUser: process.env.METRICS_ES_USER,
+    esPassword: process.env.METRICS_ES_PASS
   });
+
+  asyncOperationStartStub.restore();
+});
+
+test.serial('Request to granules bulk endpoint returns a 400 when a query is provided with no index', async (t) => {
+  const asyncOperationId = randomString();
+  const asyncOperationStartStub = sinon.stub(models.AsyncOperation.prototype, 'start').returns(
+    new Promise((resolve) => resolve({ id: asyncOperationId }))
+  );
+  const expectedQueueName = 'backgroundProcessing';
+  const expectedWorkflowName = 'HelloWorldWorkflow';
+  const expectedQuery = { query: 'fake-query' };
+
+  const body = {
+    queueName: expectedQueueName,
+    workflowName: expectedWorkflowName,
+    query: expectedQuery
+  };
+
+  await request(app)
+    .post('/granules/bulk')
+    .set('Accept', 'application/json')
+    .set('Authorization', `Bearer ${jwtAuthToken}`)
+    .send(body)
+    .expect(400, /Index is required if query is sent/);
+
+  t.is(asyncOperationStartStub.notCalled, true);
+
+  asyncOperationStartStub.restore();
+});
+
+test.serial('Request to granules bulk endpoint returns a 400 when no IDs or Query is provided', async (t) => {
+  const asyncOperationId = randomString();
+  const asyncOperationStartStub = sinon.stub(models.AsyncOperation.prototype, 'start').returns(
+    new Promise((resolve) => resolve({ id: asyncOperationId }))
+  );
+  const expectedQueueName = 'backgroundProcessing';
+  const expectedWorkflowName = 'HelloWorldWorkflow';
+  const expectedIndex = 'my-index';
+
+  const body = {
+    queueName: expectedQueueName,
+    workflowName: expectedWorkflowName,
+    index: expectedIndex
+  };
+
+  await request(app)
+    .post('/granules/bulk')
+    .set('Accept', 'application/json')
+    .set('Authorization', `Bearer ${jwtAuthToken}`)
+    .send(body)
+    .expect(400, /One of ids or query is required/);
+
+  t.is(asyncOperationStartStub.notCalled, true);
+
+  asyncOperationStartStub.restore();
+});
+
+test.serial('Request to granules bulk endpoint returns a 400 when no workflowName is provided', async (t) => {
+  const asyncOperationId = randomString();
+  const asyncOperationStartStub = sinon.stub(models.AsyncOperation.prototype, 'start').returns(
+    new Promise((resolve) => resolve({ id: asyncOperationId }))
+  );
+  const expectedQueueName = 'backgroundProcessing';
+  const expectedIndex = 'my-index';
+  const expectedQuery = { query: 'fake-query' };
+
+  const body = {
+    queueName: expectedQueueName,
+    index: expectedIndex,
+    query: expectedQuery
+  };
+
+  await request(app)
+    .post('/granules/bulk')
+    .set('Accept', 'application/json')
+    .set('Authorization', `Bearer ${jwtAuthToken}`)
+    .send(body)
+    .expect(400, /workflowName is required/);
+
+  t.is(asyncOperationStartStub.notCalled, true);
+
+  asyncOperationStartStub.restore();
+});
+
+test.serial('Request to granules bulk endpoint returns a 400 when the Metrics ELK stack is not configured', async (t) => {
+  const asyncOperationId = randomString();
+  const asyncOperationStartStub = sinon.stub(models.AsyncOperation.prototype, 'start').returns(
+    new Promise((resolve) => resolve({ id: asyncOperationId }))
+  );
+  const expectedQueueName = 'backgroundProcessing';
+  const expectedWorkflowName = 'HelloWorldWorkflow';
+  const expectedIndex = 'my-index';
+  const expectedQuery = { query: 'fake-query' };
+
+  const body = {
+    queueName: expectedQueueName,
+    workflowName: expectedWorkflowName,
+    index: expectedIndex,
+    query: expectedQuery
+  };
+
+  process.env.METRICS_ES_USER = undefined;
+
+  await request(app)
+    .post('/granules/bulk')
+    .set('Accept', 'application/json')
+    .set('Authorization', `Bearer ${jwtAuthToken}`)
+    .send(body)
+    .expect(400, /ELK Metrics stack not configured/);
+
+  t.is(asyncOperationStartStub.notCalled, true);
 
   asyncOperationStartStub.restore();
 });

--- a/tf-modules/archive/api.tf
+++ b/tf-modules/archive/api.tf
@@ -70,6 +70,9 @@ resource "aws_lambda_function" "api" {
       ASSERT_ENDPOINT              = var.saml_assertion_consumer_service
       IDP_LOGIN                    = var.saml_idp_login
       LAUNCHPAD_METADATA_PATH      = var.saml_launchpad_metadata_path
+      METRICS_ES_HOST              = var.metrics_es_host
+      METRICS_ES_USER              = var.metrics_es_username
+      METRICS_ES_PASS              = var.metrics_es_password
     }
   }
   memory_size = 756

--- a/tf-modules/archive/bulk_operation.tf
+++ b/tf-modules/archive/bulk_operation.tf
@@ -14,7 +14,8 @@ resource "aws_lambda_function" "bulk_operation" {
       METRICS_ES_PASS  = var.metrics_es_password
       GranulesTable    = var.dynamo_tables.granules.name
       system_bucket    = var.system_bucket
-      invoke                   = var.schedule_sf_function_arn
+      invoke           = var.schedule_sf_function_arn
+      stackName        = var.prefix
     }
   }
   tags = merge(local.default_tags, { Project = var.prefix })


### PR DESCRIPTION
**Summary:** When query is sent to bulk operations endpoint, query Metrics' Elasticsearch instance for Granules

Addresses [CUMULUS-1544: Bulk Granule Prototype should communicate with Metrics ES instead of returning a baked response](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1544)

## Changes

* Updates the bulk granule operation endpoint to work with Elasticsearch queries when not given a list of IDs
* Adds my environments to the (now deprecated) KES config
* Update Terraform vars for Metrics Elasticsearch endpoints

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Adhoc testing
- [ ] Integration tests