### PR TITLE
Re-enable tests on SQS queue throttling

### DIFF
--- a/example/spec/parallel/startSF/startSfSpec.js
+++ b/example/spec/parallel/startSF/startSfSpec.js
@@ -353,10 +353,6 @@ describe('the sf-starter lambda function', () => {
       expect(messagesConsumed).toBeGreaterThan(0);
     });
 
-    /**
-     * Failing intermittently
-     * Filed CUMULUS-1367 to address
-     */
     it('to trigger workflows', async () => {
       const { executions } = await StepFunctions.listExecutions({ stateMachineArn: waitPassSfArn });
       const runningExecutions = executions.filter((execution) => execution.status === 'RUNNING');

--- a/example/spec/parallel/startSF/startSfSpec.js
+++ b/example/spec/parallel/startSF/startSfSpec.js
@@ -357,7 +357,7 @@ describe('the sf-starter lambda function', () => {
      * Failing intermittently
      * Filed CUMULUS-1367 to address
      */
-    xit('to trigger workflows', async () => {
+    it('to trigger workflows', async () => {
       const { executions } = await StepFunctions.listExecutions({ stateMachineArn: waitPassSfArn });
       const runningExecutions = executions.filter((execution) => execution.status === 'RUNNING');
       expect(runningExecutions.length).toBeLessThanOrEqual(queueMaxExecutions);


### PR DESCRIPTION
I ran this test with these changes 50+ times and had no failures. All other things being equal, it seems like we want to have tests enabled verifying that queue throttling is working as expected.