### PR TITLE
Make URS URL configurable from Cumulus module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 **Please note**:
+
 - Your workflow tasks should use `cumulus-message-adapter-js` version 1.0.10+ to utilize new granule, parentArn, asyncOperationId, and stackName fields on the logs.
+- Default value for the `urs_url` variable is now `https://uat.urs.earthdata.nasa.gov/` in the `tf-modules/cumulus` and `tf-modules/archive` Terraform modules. So deploying the `cumulus` module without a `urs_url` variable set will integrate your Cumulus deployment with the UAT URS environment.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Adds 4 new keys to `@cumulus/logger` to display granules, parentArn, asyncOperationId, and stackName.
   - Depends on `cumulus-message-adapter-js` version 1.0.10+. Cumulus tasks updated to use this version.
 
+### Fixed
+
+- Fixed `tf-modules/cumulus` module so that the `urs_url` variable is passed on to its invocation of the `tf-modules/archive` module
+
 ## [v1.16.0] - 2019-11-15
 
 ### Added

--- a/example/cumulus-tf/main.tf
+++ b/example/cumulus-tf/main.tf
@@ -51,7 +51,7 @@ module "cumulus" {
   ecs_cluster_max_size            = 2
   key_name                        = var.key_name
 
-  urs_url             = "https://uat.urs.earthdata.nasa.gov"
+  urs_url             = var.urs_url
   urs_client_id       = var.urs_client_id
   urs_client_password = var.urs_client_password
 

--- a/example/cumulus-tf/main.tf
+++ b/example/cumulus-tf/main.tf
@@ -51,7 +51,7 @@ module "cumulus" {
   ecs_cluster_max_size            = 2
   key_name                        = var.key_name
 
-  urs_url             = var.urs_url
+  urs_url             = "https://uat.urs.earthdata.nasa.gov"
   urs_client_id       = var.urs_client_id
   urs_client_password = var.urs_client_password
 

--- a/example/cumulus-tf/variables.tf
+++ b/example/cumulus-tf/variables.tf
@@ -240,9 +240,3 @@ variable "metrics_es_username" {
   type = string
   default = null
 }
-
-variable "urs_url" {
-  description = "The URL of the Earthdata login (URS) site"
-  type        = string
-  default     = "https://uat.urs.earthdata.nasa.gov/"
-}

--- a/example/cumulus-tf/variables.tf
+++ b/example/cumulus-tf/variables.tf
@@ -130,7 +130,6 @@ variable "distribution_url" {
   default = null
 }
 
-
 variable "ems_datasource" {
   type        = string
   description = "the data source of EMS reports"
@@ -240,4 +239,10 @@ variable "metrics_es_password" {
 variable "metrics_es_username" {
   type = string
   default = null
+}
+
+variable "urs_url" {
+  description = "The URL of the Earthdata login (URS) site"
+  type        = string
+  default     = "https://uat.urs.earthdata.nasa.gov/"
 }

--- a/tf-modules/archive/variables.tf
+++ b/tf-modules/archive/variables.tf
@@ -264,7 +264,7 @@ variable "sts_credentials_lambda" {
 
 variable "urs_url" {
   type        = string
-  default     = "https://urs.earthdata.nasa.gov/"
+  default     = "https://uat.urs.earthdata.nasa.gov/"
   description = "The URL of the Earthdata Login site"
 }
 

--- a/tf-modules/cumulus/archive.tf
+++ b/tf-modules/cumulus/archive.tf
@@ -48,7 +48,7 @@ module "archive" {
   saml_idp_login                  = var.saml_idp_login
   saml_launchpad_metadata_path    = var.saml_launchpad_metadata_path
 
-  urs_url             = "https://uat.urs.earthdata.nasa.gov"
+  urs_url             = var.urs_url
   urs_client_id       = var.urs_client_id
   urs_client_password = var.urs_client_password
 

--- a/tf-modules/cumulus/variables.tf
+++ b/tf-modules/cumulus/variables.tf
@@ -403,7 +403,7 @@ variable "throttled_queues" {
 variable "urs_url" {
   description = "The URL of the Earthdata login (URS) site"
   type        = string
-  default     = "https://urs.earthdata.nasa.gov/"
+  default     = "https://uat.urs.earthdata.nasa.gov/"
 }
 
 variable "vpc_id" {


### PR DESCRIPTION
Addresses an issue noticed by Mike McGann when trying to configure his Cumulus module to use a different URS environment than UAT