### PR TITLE
fix pdr extension case expectation

### DIFF
--- a/packages/ingest/pdr.js
+++ b/packages/ingest/pdr.js
@@ -60,7 +60,7 @@ class Discover {
    */
   async discover() {
     const files = await this.list();
-    const pdrs = files.filter((file) => file.name.endsWith('.PDR'));
+    const pdrs = files.filter((file) => file.name.toUpperCase().endsWith('.PDR'));
 
     if (this.force) {
       return pdrs;


### PR DESCRIPTION
**Summary:** Summary of changes

allow PDRs to end in `.pdr` instead of only `.PDR`