### PR TITLE
Update async-operation and cumulus-ecs-task references to node 10 versions

### DIFF
--- a/docs/data-cookbooks/run-tasks-in-lambda-or-docker.md
+++ b/docs/data-cookbooks/run-tasks-in-lambda-or-docker.md
@@ -107,7 +107,7 @@ module "queue_granules_service" {
 
   cluster_arn                           = module.cumulus.ecs_cluster_arn
   desired_count                         = 1
-  image                                 = "cumuluss/cumulus-ecs-task:1.3.0"
+  image                                 = "cumuluss/cumulus-ecs-task:1.4.0"
   log2elasticsearch_lambda_function_arn = module.cumulus.log2elasticsearch_lambda_function_arn
 
   cpu                = 400

--- a/example/app/config.yml
+++ b/example/app/config.yml
@@ -59,7 +59,7 @@ default:
       username: cumulususer
     services:
       EcsTaskHelloWorld:
-        image: cumuluss/cumulus-ecs-task:1.3.0
+        image: cumuluss/cumulus-ecs-task:1.4.0
         cpu: 400
         memory: 700
         count: 1

--- a/example/cumulus-tf/ecs_hello_world_workflow.tf
+++ b/example/cumulus-tf/ecs_hello_world_workflow.tf
@@ -12,7 +12,7 @@ module "hello_world_service" {
 
   cluster_arn                           = module.cumulus.ecs_cluster_arn
   desired_count                         = 1
-  image                                 = "cumuluss/cumulus-ecs-task:1.3.0"
+  image                                 = "cumuluss/cumulus-ecs-task:1.4.0"
   log2elasticsearch_lambda_function_arn = module.cumulus.log2elasticsearch_lambda_function_arn
 
   cpu                = 400

--- a/packages/deployment/app/config.yml
+++ b/packages/deployment/app/config.yml
@@ -143,7 +143,7 @@ default:
 
     tasks:
       AsyncOperation:
-        image: cumuluss/async-operation:26
+        image: cumuluss/async-operation:27
         cpu: 400
         memory: 700
         count: 1

--- a/packages/deployment/test/fixtures/config.json
+++ b/packages/deployment/test/fixtures/config.json
@@ -49,7 +49,7 @@
         "desiredInstances": 2,
         "tasks": {
             "AsyncOperation": {
-                "image": "cumuluss/async-operation:25",
+                "image": "cumuluss/async-operation:27",
                 "cpu": 400,
                 "memory": 700,
                 "count": 1,
@@ -69,7 +69,7 @@
         "publicIp": true,
         "services": {
             "EcsTaskHelloWorld": {
-                "image": "cumuluss/cumulus-ecs-task:1.2.3",
+                "image": "cumuluss/cumulus-ecs-task:1.4.0",
                 "cpu": 400,
                 "memory": 700,
                 "count": 1,
@@ -104,7 +104,7 @@
                 }
             },
             "EcsTaskHelloWorldSecond": {
-                "image": "cumuluss/cumulus-ecs-task:1.2.3",
+                "image": "cumuluss/cumulus-ecs-task:1.4.0",
                 "cpu": 400,
                 "memory": 700,
                 "count": 2,

--- a/tf-modules/archive/async_operation.tf
+++ b/tf-modules/archive/async_operation.tf
@@ -19,7 +19,7 @@ resource "aws_ecs_task_definition" "async_operation" {
         "value": "${data.aws_region.current.name}"
       }
     ],
-    "image": "cumuluss/async-operation:26",
+    "image": "cumuluss/async-operation:27",
     "memoryReservation": 700,
     "logConfiguration": {
       "logDriver": "awslogs",

--- a/tf-modules/cumulus_ecs_service/README.md
+++ b/tf-modules/cumulus_ecs_service/README.md
@@ -30,6 +30,6 @@ module "example_ecs_service" {
 
   cluster_arn                           = "arn:aws:ecs:us-east-1:1234567890:cluster/MyECSCluster1"
   desired_count                         = 1
-  image                                 = "cumuluss/cumulus-ecs-task:1.3.0"
+  image                                 = "cumuluss/cumulus-ecs-task:1.4.0"
 }
 ```


### PR DESCRIPTION

**Summary:** 

Updates cumulus-ecs-task/async-operations images to their new node 10 versions

Addresses [CUMULUS-1626: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1626)

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

