### PR TITLE
CUMULUS-1695: default to no PITR in example

### DIFF
--- a/example/data-persistence-tf/main.tf
+++ b/example/data-persistence-tf/main.tf
@@ -11,6 +11,12 @@ variable "aws_region" {
   default = "us-east-1"
 }
 
+variable "enable_point_in_time_tables" {
+  description = "DynamoDB table names that should have point in time recovery enabled"
+  type        = list(string)
+  default     = []
+}
+
 terraform {
   required_providers {
     aws = ">= 2.31.0"
@@ -26,6 +32,8 @@ module "data_persistence" {
 
   prefix                     = var.prefix
   subnet_ids                 = var.subnet_ids
+
+  enable_point_in_time_tables = var.enable_point_in_time_tables
 }
 
 output "dynamo_tables" {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-1695: Turn off PITR on core team dynamo tables](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1695)

## Changes

* Turn off PITR for example deployments by default.

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

