### PR TITLE
CUMULUS-1040: Remove cyclic dependency

### DIFF
--- a/packages/common/CloudFormationGateway.js
+++ b/packages/common/CloudFormationGateway.js
@@ -1,12 +1,45 @@
 'use strict';
 
-const AWSCloudFormationGateway = require('@cumulus/aws-client/CloudFormationGateway');
+const pRetry = require('p-retry');
+const { isThrottlingException } = require('@cumulus/errors');
 const { deprecate } = require('./util');
+const log = require('./log');
 
-class CloudFormationGateway extends AWSCloudFormationGateway {
+const privates = new WeakMap();
+
+class CloudFormationGateway {
   constructor(cloudFormationService) {
     deprecate('@cumulus/common/CloudFormationGateway', '1.17.0', '@cumulus/aws-client/CloudFormationGateway');
-    super(cloudFormationService);
+    privates.set(this, { cloudFormationService });
+  }
+
+  /**
+   * Get the status of a CloudFormation stack
+   *
+   * @param {string} StackName
+   * @returns {string} the stack status
+   */
+  async getStackStatus(StackName) {
+    const { cloudFormationService } = privates.get(this);
+
+    return pRetry(
+      async () => {
+        try {
+          const stackDetails = await cloudFormationService.describeStacks({
+            StackName
+          }).promise();
+
+          return stackDetails.Stacks[0].StackStatus;
+        } catch (err) {
+          if (isThrottlingException(err)) throw new Error('Trigger retry');
+          throw new pRetry.AbortError(err);
+        }
+      },
+      {
+        maxTimeout: 5000,
+        onFailedAttempt: () => log.debug('ThrottlingException when calling cloudformation.describeStacks(), will retry.')
+      }
+    );
   }
 }
 

--- a/packages/common/DynamoDb.js
+++ b/packages/common/DynamoDb.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const DynamoDb = require('@cumulus/aws-client/DynamoDb');
 const { RecordDoesNotExist } = require('@cumulus/errors');
 const { improveStackTrace } = require('./aws');
 const { deprecate } = require('./util');

--- a/packages/common/aws.js
+++ b/packages/common/aws.js
@@ -21,7 +21,7 @@ const Logger = require('@cumulus/logger');
 
 const { unicodeEscape } = require('./string');
 const { inTestMode, testAwsClient } = require('./test-utils');
-const { deprecate, isNil } = require('./util');
+const { deprecate, isNil, setErrorStack } = require('./util');
 
 const log = new Logger({ sender: 'common/aws' });
 const noop = () => {}; // eslint-disable-line lodash/prefer-noop
@@ -158,7 +158,7 @@ exports.improveStackTrace = (fn) =>
       Error.captureStackTrace(tracerError);
       return await fn(...args);
     } catch (err) {
-      exports.setErrorStack(err, tracerError.stack);
+      setErrorStack(err, tracerError.stack);
       err.message = `${err.message}; Function params: ${JSON.stringify(args, null, 2)}`;
       throw err;
     }
@@ -279,7 +279,7 @@ exports.s3TagSetToQueryString = (tagset) => {
 exports.deleteS3Object = exports.improveStackTrace(
   (bucket, key) => {
     deprecate('@cumulus/common/aws/deleteS3Object', '1.17.0', '@cumulus/aws-client/S3/deleteS3Object');
-    exports.s3().deleteObject({ Bucket: bucket, Key: key }).promise();
+    return exports.s3().deleteObject({ Bucket: bucket, Key: key }).promise();
   }
 );
 
@@ -379,7 +379,7 @@ exports.downloadS3File = (s3Obj, filepath) => {
 exports.headObject = exports.improveStackTrace(
   (Bucket, Key) => {
     deprecate('@cumulus/common/aws/headObject', '1.17.0', '@cumulus/aws-client/S3/headObject');
-    exports.s3().headObject({ Bucket, Key }).promise();
+    return exports.s3().headObject({ Bucket, Key }).promise();
   }
 );
 
@@ -422,7 +422,7 @@ exports.s3GetObjectTagging = exports.improveStackTrace(
 exports.s3PutObjectTagging = exports.improveStackTrace(
   (Bucket, Key, Tagging) => {
     deprecate('@cumulus/common/aws/s3PutObjectTagging', '1.17.0', '@cumulus/aws-client/S3/s3PutObjectTagging');
-    exports.s3().putObjectTagging({
+    return exports.s3().putObjectTagging({
       Bucket,
       Key,
       Tagging

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -41,7 +41,6 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cumulus/aws-client": "1.17.0-alpha4",
     "@cumulus/checksum": "1.17.0",
     "@cumulus/errors": "1.17.0-alpha",
     "@cumulus/logger": "1.17.0",

--- a/packages/common/string.js
+++ b/packages/common/string.js
@@ -13,9 +13,18 @@
 const compose = require('lodash.flowright');
 const curry = require('lodash.curry');
 
-const stepFunctionUtils = require('@cumulus/aws-client/StepFunctions');
-
 const { deprecate, isNull, negate } = require('./util');
+
+/**
+ * Given a character, replaces the JS unicode-escape sequence for the character
+ *
+ * @param {char} char - The character to escape
+ * @returns {string} The unicode escape sequence for char
+ *
+ * @private
+ */
+const unicodeEscapeCharacter = (char) =>
+  ['\\u', `0000${char.charCodeAt().toString(16)}`.slice(-4)].join('');
 
 /**
  * Given a string, replaces all characters matching the passed regex with their unicode
@@ -29,7 +38,7 @@ const { deprecate, isNull, negate } = require('./util');
  */
 const unicodeEscape = (str, regex = /[\s\S]/g) => {
   deprecate('@cumulus/common/string/unicodeEscape', '1.17.0', '@cumulus/aws-client/StepFunctions/unicodeEscape');
-  return stepFunctionUtils.unicodeEscape(str, regex);
+  return str.replace(regex, unicodeEscapeCharacter);
 };
 
 /**

--- a/packages/common/test-utils.js
+++ b/packages/common/test-utils.js
@@ -8,22 +8,221 @@ const path = require('path');
 const RandExp = require('randexp');
 const fs = require('fs-extra');
 
-const testUtils = require('@cumulus/aws-client/test-utils');
-const { deprecate } = require('./util');
+const { deprecate, isNil } = require('./util');
+
+// From https://github.com/localstack/localstack/blob/master/README.md
+const localStackPorts = {
+  stepfunctions: 10000, // add a fake port to support test overrides
+  apigateway: 4567,
+  cloudformation: 4581,
+  cloudwatch: 4582,
+  cloudwatchevents: 4582,
+  cloudwatchlogs: 4586,
+  dynamodb: 4564,
+  es: 4571,
+  firehose: 4573,
+  iam: 4593,
+  kinesis: 4568,
+  lambda: 4574,
+  redshift: 4577,
+  route53: 4580,
+  s3: 4572,
+  secretsmanager: 4584,
+  ses: 4579,
+  sns: 4575,
+  sqs: 4576,
+  ssm: 4583,
+  sts: 4592
+};
 
 exports.inTestMode = () => {
   deprecate('@cumulus/common/test-utils/inTestMode', '1.17.0', '@cumulus/aws-client/test-utils/inTestMode');
-  return testUtils.inTestMode();
+  return process.env.NODE_ENV === 'test';
 };
 
 exports.getLocalstackEndpoint = (identifier) => {
   deprecate('@cumulus/common/test-utils/getLocalstackEndpoint', '1.17.0', '@cumulus/aws-client/test-utils/getLocalstackEndpoint');
-  return testUtils.getLocalstackEndpoint(identifier);
+  const key = `LOCAL_${identifier.toUpperCase()}_HOST`;
+  if (process.env[key]) {
+    return `http://${process.env[key]}:${localStackPorts[identifier]}`;
+  }
+
+  return `http://${process.env.LOCALSTACK_HOST}:${localStackPorts[identifier]}`;
 };
+
+/**
+ * Create an AWS service object that talks to LocalStack.
+ *
+ * This function expects that the LOCALSTACK_HOST environment variable will be set.
+ *
+ * @param {Function} Service - an AWS service object constructor function
+ * @param {Object} options - options to pass to the service object constructor function
+ * @returns {Object} - an AWS service object
+ */
+function localStackAwsClient(Service, options) {
+  if (!process.env.LOCALSTACK_HOST) {
+    throw new Error('The LOCALSTACK_HOST environment variable is not set.');
+  }
+
+  const serviceIdentifier = Service.serviceIdentifier;
+
+  const localStackOptions = Object.assign({}, options, {
+    accessKeyId: 'my-access-key-id',
+    secretAccessKey: 'my-secret-access-key',
+    region: 'us-east-1',
+    endpoint: exports.getLocalstackEndpoint(serviceIdentifier)
+  });
+
+  if (serviceIdentifier === 's3') localStackOptions.s3ForcePathStyle = true;
+
+  return new Service(localStackOptions);
+}
+
+/**
+ * Create a function which will allow methods of an AWS service interface object
+ * to be wrapped.
+ *
+ * When invoked, this returned function will take two arguments:
+ * - methodName - the name of the service interface object method to wrap
+ * - dataHandler - a handler function which will be used to process the result
+ *     of invoking `methodName`
+ *
+ * @param {Object} client - AWS Service interface object
+ * @returns {Function} function taking a client method name and a dataHandler
+ *   function to be called upon completion of the client method with return
+ *   value of the client method and the original parameters passed into the
+ *   client method
+ *
+ * @example
+ * const s3 = new AWS.S3();
+ *
+ * // Initialize wrapper for AWS S3 service interface object
+ * const s3Wrapper = awsServiceInterfaceMethodWrapper(s3);
+ *
+ * // Add a "RequestParams" property to the result, which shows what params were
+ * // used in the `listObjects` request.  This is, obviously, a very contrived
+ * // example.
+ * s3Wrapper(
+ *   'listObjects',
+ *   (data, params) => ({ ...data, RequestParams: params })
+ * );
+ *
+ * const result = await s3().listObjects({ Bucket: 'my-bucket' }).promise();
+ *
+ * assert(result.RequestParams.Bucket === 'my-bucket');
+ */
+const awsServiceInterfaceMethodWrapper = (client) => {
+  const originalFunctions = {};
+
+  return (methodName, dataHandler) => {
+    originalFunctions[methodName] = client[methodName];
+
+    // eslint-disable-next-line no-param-reassign
+    client[methodName] = (params = {}, callback) => {
+      if (callback) {
+        return originalFunctions[methodName].call(
+          client,
+          params,
+          (err, data) => {
+            if (err) callback(err);
+            callback(null, dataHandler(data, params));
+          }
+        );
+      }
+
+      return {
+        promise: () => originalFunctions[methodName].call(client, params).promise()
+          .then((data) => dataHandler(data, params))
+      };
+    };
+  };
+};
+
+/**
+ * Test if a given AWS service is supported by LocalStack.
+ *
+ * @param {Function} Service - an AWS service object constructor function
+ * @returns {boolean} true or false depending on whether the service is
+ *   supported by LocalStack
+ */
+function localstackSupportedService(Service) {
+  const serviceIdentifier = Service.serviceIdentifier;
+  return Object.keys(localStackPorts).includes(serviceIdentifier);
+}
 
 exports.testAwsClient = (Service, options) => {
   deprecate('@cumulus/common/test-utils/testAwsClient', '1.17.0', '@cumulus/aws-client/test-utils/testAwsClient');
-  return testUtils.getLocalstackEndpoint(Service, options);
+  if (Service.serviceIdentifier === 'lambda') {
+    // This is all a workaround for a Localstack bug where the Lambda event source mapping state
+    // is not respected and is always 'Enabled'. To work around this, we keep the state of each
+    // event source mapping internally and override the event source mapping functions to set
+    // and use the internal states. This can be removed when the Localstack issue is fixed.
+    const lambdaClient = localStackAwsClient(Service, options);
+
+    const eventSourceMappingStates = {};
+
+    const deleteState = (UUID) => {
+      delete eventSourceMappingStates[UUID];
+    };
+
+    const getState = (UUID) => eventSourceMappingStates[UUID];
+
+    const setState = (state, UUID) => {
+      eventSourceMappingStates[UUID] = state;
+    };
+
+    const lambdaWrapper = awsServiceInterfaceMethodWrapper(lambdaClient);
+
+    lambdaWrapper(
+      'createEventSourceMapping',
+      (data, params) => {
+        setState((isNil(params.Enabled) || params.Enabled) ? 'Enabled' : 'Disabled', data.UUID);
+        return { ...data, State: getState(data.UUID) };
+      }
+    );
+
+    lambdaWrapper(
+      'deleteEventSourceMapping',
+      (data, params) => {
+        deleteState(params.UUID);
+        return { ...data, State: '' };
+      }
+    );
+
+    lambdaWrapper(
+      'getEventSourceMapping',
+      (data) => ({ ...data, State: getState(data.UUID) })
+    );
+
+    lambdaWrapper(
+      'listEventSourceMappings',
+      (data) => ({
+        ...data,
+        EventSourceMappings: data.EventSourceMappings
+          .filter((esm) => Object.keys(eventSourceMappingStates).includes(esm.UUID))
+          .map((esm) => ({ ...esm, State: getState(esm.UUID) }))
+      })
+    );
+
+    lambdaWrapper(
+      'updateEventSourceMapping',
+      (data, params) => {
+        if (!isNil(params.Enabled)) {
+          const enabled = isNil(params.Enabled) || params.Enabled;
+          setState(enabled ? 'Enabled' : 'Disabled', data.UUID);
+        }
+        return { ...data, State: getState(data.UUID) };
+      }
+    );
+
+    return lambdaClient;
+  }
+
+  if (localstackSupportedService(Service)) {
+    return localStackAwsClient(Service, options);
+  }
+
+  return {};
 };
 
 /**

--- a/packages/common/util.js
+++ b/packages/common/util.js
@@ -18,8 +18,6 @@ const os = require('os');
 const path = require('path');
 const mime = require('mime-types');
 
-const utils = require('@cumulus/aws-client/utils');
-
 const log = require('./log');
 
 /**
@@ -145,7 +143,11 @@ exports.isNil = (x) => exports.isNull(x) || exports.isUndefined(x);
  */
 exports.setErrorStack = (error, newStack) => {
   exports.deprecate('@cumulus/common/util/setErrorStack', '1.17.0', '@cumulus/aws-client/utils/setErrorStack');
-  utils.setErrorStack(error, newStack);
+  // eslint-disable-next-line no-param-reassign
+  error.stack = [
+    error.stack.split('\n')[0],
+    ...newStack.split('\n').slice(1)
+  ].join('\n');
 };
 
 /**

--- a/tf-modules/distribution/index.js
+++ b/tf-modules/distribution/index.js
@@ -15,7 +15,7 @@ const urljoin = require('url-join');
 
 const { AccessToken } = require('@cumulus/api/models');
 const { isLocalApi } = require('@cumulus/api/lib/testUtils');
-const aws = require('@cumulus/common/aws');
+const awsServices = require('@cumulus/aws-client/services');
 const { randomId } = require('@cumulus/common/test-utils');
 const { RecordDoesNotExist } = require('@cumulus/common/errors');
 
@@ -40,7 +40,7 @@ async function requestTemporaryCredentialsFromNgap(username) {
     userid: username // <- used by NGAP
   });
 
-  return aws.lambda().invoke({
+  return awsServices.lambda().invoke({
     FunctionName,
     Payload
   }).promise();
@@ -91,7 +91,7 @@ function getConfigurations() {
     accessTokenModel: new AccessToken(),
     authClient: earthdataLoginClient,
     distributionUrl: process.env.DISTRIBUTION_ENDPOINT,
-    s3Client: aws.s3()
+    s3Client: awsServices.s3()
   };
 }
 

--- a/tf-modules/distribution/index.js
+++ b/tf-modules/distribution/index.js
@@ -15,10 +15,9 @@ const urljoin = require('url-join');
 
 const { AccessToken } = require('@cumulus/api/models');
 const { isLocalApi } = require('@cumulus/api/lib/testUtils');
-const { lambda } = require('@cumulus/common/aws');
+const aws = require('@cumulus/common/aws');
 const { randomId } = require('@cumulus/common/test-utils');
 const { RecordDoesNotExist } = require('@cumulus/common/errors');
-const { s3 } = require('@cumulus/common/aws');
 
 const log = new Logger({ sender: 's3credentials' });
 
@@ -41,7 +40,7 @@ async function requestTemporaryCredentialsFromNgap(username) {
     userid: username // <- used by NGAP
   });
 
-  return lambda().invoke({
+  return aws.lambda().invoke({
     FunctionName,
     Payload
   }).promise();
@@ -58,6 +57,7 @@ async function requestTemporaryCredentialsFromNgap(username) {
 async function s3credentials(req, res) {
   const username = req.authorizedMetadata.userName;
   const credentials = await requestTemporaryCredentialsFromNgap(username);
+  console.log(credentials);
   const creds = JSON.parse(credentials.Payload);
   if (Object.keys(creds).some((key) => ['errorMessage', 'errorType', 'stackTrace'].includes(key))) {
     log.error(credentials.Payload);
@@ -91,7 +91,7 @@ function getConfigurations() {
     accessTokenModel: new AccessToken(),
     authClient: earthdataLoginClient,
     distributionUrl: process.env.DISTRIBUTION_ENDPOINT,
-    s3Client: s3()
+    s3Client: aws.s3()
   };
 }
 

--- a/tf-modules/distribution/package.json
+++ b/tf-modules/distribution/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@cumulus/api": "1.17.0",
+    "@cumulus/aws-client": "1.17.0-alpha4",
     "@cumulus/common": "1.17.0",
     "@cumulus/logger": "1.17.0",
     "aws-serverless-express": "^3.3.6",

--- a/tf-modules/distribution/tests/test-index.js
+++ b/tf-modules/distribution/tests/test-index.js
@@ -4,11 +4,10 @@ const test = require('ava');
 const sinon = require('sinon');
 const request = require('supertest');
 
+const awsServices = require('@cumulus/aws-client/services');
 const {
   randomId
 } = require('@cumulus/common/test-utils');
-
-const aws = require('@cumulus/common/aws');
 
 const EarthdataLoginClient = require('@cumulus/api/lib/EarthdataLogin');
 
@@ -59,7 +58,7 @@ test('An authorized s3credential requeste invokes NGAPs request for credentials 
   const fakeCredential = { Payload: JSON.stringify({ fake: 'credential' }) };
 
   const spy = sinon.spy(() => Promise.resolve(fakeCredential));
-  sinon.stub(aws, 'lambda').callsFake(() => ({
+  sinon.stub(awsServices, 'lambda').callsFake(() => ({
     invoke: (params) => ({
       promise: () => spy(params)
     })


### PR DESCRIPTION
- Remove cyclic dependency of `@cumulus/common` on `@cumulus/aws-client` (because `aws-client` depends on `common` for functions like `randomString` in tests)

This does leave code duplicated between the `aws-client` and `common` packages, but the deprecated code in `common` after a future release. And the rest of the codebase has been updated to use the `aws-client` package in other PRs.