### PR TITLE
Cumulus 1711 - Update compose stacks 

### DIFF
--- a/bamboo/Dockerfile
+++ b/bamboo/Dockerfile
@@ -4,4 +4,3 @@ RUN apt update && npm config set unsafe-perm true &&\
     apt install -y netcat zip jq rsync zip python-pip && \
     apt-get install -y python-pip && pip install awscli && \
     npm install -g npm
-RUN git clone https://github.com/nasa/cumulus && cd cumulus && npm install --no-package-lock && npx lerna bootstrap --no-ci --force-local --ignore-scripts && rm -Rf ./example/node_modules

--- a/bamboo/Dockerfile-ci
+++ b/bamboo/Dockerfile-ci
@@ -1,0 +1,2 @@
+FROM cumuluss/cumulus-build-env:build
+RUN git clone https://github.com/nasa/cumulus && cd cumulus && npm install --no-package-lock && npx lerna bootstrap --no-ci --force-local --ignore-scripts && rm -Rf ./example/node_modules

--- a/bamboo/docker-compose-local.yml
+++ b/bamboo/docker-compose-local.yml
@@ -6,6 +6,7 @@ services:
       - ../packages/test-data/keys/ssh_client_rsa_key.pub:/etc/authorized_keys/user
       - ../packages/test-data:/data
   build_env:
+    image: cumuluss/cumulus-build-env:latest
     volumes:
       - ../:/source/cumulus
       - ../packages/test-data:/tmp/cumulus_unit_test_data

--- a/bamboo/docker-compose.yml
+++ b/bamboo/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     environment:
       SERVICES: "kinesis,lambda,s3,secretsmanager,sns,sqs,dynamodb,cloudwatch,cloudwatchlogs"
   build_env:
-    image: maven.earthdata.nasa.gov/cumulus:latest
+    image: maven.earthdata.nasa.gov/cumulus:test
     volumes:
       - ../:/source/cumulus
       - /tmp/cumulus_unit_test_data:/tmp/cumulus_unit_test_data

--- a/bamboo/docker-compose.yml
+++ b/bamboo/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     environment:
       SERVICES: "kinesis,lambda,s3,secretsmanager,sns,sqs,dynamodb,cloudwatch,cloudwatchlogs"
   build_env:
-    image: maven.earthdata.nasa.gov/cumulus:test
+    image: maven.earthdata.nasa.gov/cumulus:latest
     volumes:
       - ../:/source/cumulus
       - /tmp/cumulus_unit_test_data:/tmp/cumulus_unit_test_data

--- a/bamboo/docker-compose.yml
+++ b/bamboo/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     environment:
       SERVICES: "kinesis,lambda,s3,secretsmanager,sns,sqs,dynamodb,cloudwatch,cloudwatchlogs"
   build_env:
-    image: jlkovarik/cumulus-build-env:test4
+    image: maven.earthdata.nasa.gov/cumulus:latest
     volumes:
       - ../:/source/cumulus
       - /tmp/cumulus_unit_test_data:/tmp/cumulus_unit_test_data


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-1711: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1711)

This PR splits the Dockerfile into two files, and updates the CI compose stack to utilize the local maven cache for unit tests, and updates the local-stack configuration to pull from the public dockerhub image. 


