### PR TITLE
Fix message template for passphrase/secret names

### DIFF
--- a/tf-modules/ingest/message_template.tf
+++ b/tf-modules/ingest/message_template.tf
@@ -77,7 +77,7 @@ locals {
         username           = var.cmr_username
         provider           = var.cmr_provider
         clientId           = var.cmr_client_id
-        passwordSecretName = length(var.cmr_password) == 0 ? null : aws_secretsmanager_secret.message_template_cmr_password.name
+        passwordSecretName = length(var.cmr_password) == 0 ? "" : aws_secretsmanager_secret.message_template_cmr_password.name
         cmrEnvironment     = var.cmr_environment
         cmrLimit           = var.cmr_limit
         cmrPageSize        = var.cmr_page_size
@@ -85,7 +85,7 @@ locals {
       launchpad = {
         api         = var.launchpad_api
         certificate = var.launchpad_certificate
-        passphraseSecretName = length(var.launchpad_passphrase) == 0 ? null : aws_secretsmanager_secret.message_template_launchpad_passphrase.name
+        passphraseSecretName = length(var.launchpad_passphrase) == 0 ? "" : aws_secretsmanager_secret.message_template_launchpad_passphrase.name
       }
       distribution_endpoint = var.distribution_url
       collection            = {}


### PR DESCRIPTION
I got this error when running the `IngestAndPublishGranule` workflow on my most recent deployment:

```
{
  "error": "CumulusMessageAdapterExecutionError",
  "cause": {
    "errorType": "CumulusMessageAdapterExecutionError",
    "errorMessage": "CMA process failed (Command failed with exit code 1: /opt/cma loadNestedEvent)\n\n                 Trace: Command failed with exit code 1: /opt/cma loadNestedEvent\nUnexpected error:<class 'jsonschema.exceptions.ValidationError'>. config schema: None is not of type u'string'\n\nFailed validating u'type' in schema[u'properties'][u'launchpad'][u'properties'][u'passphraseSecretName']:\n    {u'type': u'string'}\n\nOn instance[u'launchpad'][u'passphraseSecretName']:\n    None}\n\n\n\n                 STDERR: Unexpected error:<class 'jsonschema.exceptions.ValidationError'>. config schema: None is not of type u'string'\n\nFailed validating u'type' in schema[u'properties'][u'launchpad'][u'properties'][u'passphraseSecretName']:\n    {u'type': u'string'}\n\nOn instance[u'launchpad'][u'passphraseSecretName']:\n    None",
```

The cause is that the `meta.launchpad.passphraseSecretName` value in the workflow message template was defaulting to `null`, since my deployment is not using Launchpad. And since `passphraseSecretName` is a required config for the `post-to-cmr` task (as the error shows), the CMA was failing the task. The solution is to default `passphraseSecretName` to an empty string instead of `null` in the message template.