### PR TITLE
set SIT distribution url in CI

### DIFF
--- a/bamboo/set-bamboo-env-variables.sh
+++ b/bamboo/set-bamboo-env-variables.sh
@@ -112,6 +112,7 @@ if [[ $bamboo_NGAP_ENV = "SIT" ]]; then
   export TFSTATE_BUCKET=$bamboo_SIT_TFSTATE_BUCKET
   export TFSTATE_LOCK_TABLE=$bamboo_SIT_TFSTATE_LOCK_TABLE
   export SHARED_LOG_DESTINATION_ARN=$bamboo_SIT_SHARED_LOG_DESTINATION_ARN
+  export TF_VAR_distribution_url=$bamboo_SIT_TEA_CLOUDFRONT_URL
   DEPLOYMENT=$bamboo_SIT_DEPLOYMENT
 fi
 


### PR DESCRIPTION
**Summary:** Summary of changes

Use the cloudfront URL provided by NGAP in CI.

## Changes

* Set cloudfront URL `TF_VAR_` env in CI so that it is not set for sandbox deployments.

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

