### PR TITLE
Add build/prepare steps for python-processing lambda activity

### DIFF
--- a/example/lambdas/python-processing/package.json
+++ b/example/lambdas/python-processing/package.json
@@ -13,7 +13,8 @@
     "python-lint": "pylint *.py",
     "lint": "npm run python-lint",
     "build": "pip install -r requirements-dev.txt && pip install -r requirements.txt",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "install-python-deps": "pip install -r requirements-dev.txt && pip install -r requirements.txt"
   },
   "publishConfig": {
     "access": "private"

--- a/example/lambdas/python-processing/package.json
+++ b/example/lambdas/python-processing/package.json
@@ -12,8 +12,8 @@
     "test": "python -m unittest",
     "python-lint": "pylint *.py",
     "lint": "npm run python-lint",
-    "build": "true",
-    "prepare": "true"
+    "build": "pip install -r requirements-dev.txt && pip install -r requirements.txt",
+    "prepare": "npm run build"
   },
   "publishConfig": {
     "access": "private"

--- a/example/lambdas/python-processing/test/test_process_activity.py
+++ b/example/lambdas/python-processing/test/test_process_activity.py
@@ -1,8 +1,7 @@
 
 import unittest
 
-from unittest.mock import MagicMock
-from mock import patch
+from unittest.mock import MagicMock, patch
 
 from process_activity import PythonProcess
 


### PR DESCRIPTION
This is needed (unlike the reference processing activity) as this
activity has unit tests.

**Summary:**
Updates process activity such that pip install occurs on bootstrap - this is to facilitate local development.     This should already occur if the 'helper' npm 'install-python-deps' is run. 

Also fixes a bad legacy mock import.



