### PR TITLE
Kill the new kinesis streams that can be stranded in failed tests.

### DIFF
--- a/tf-modules/internal/cumulus-test-cleanup/reap-kinesis.js
+++ b/tf-modules/internal/cumulus-test-cleanup/reap-kinesis.js
@@ -18,7 +18,7 @@ function getStreams() {
 }
 
 function filterOld(streams) {
-  const matcher = /(Error|Trigger|SourceTest)-(\d{13})-(Kinesis|Lambda)/;
+  const matcher = /(Error|Trigger|SourceTest|KinesisReplayTest)-(\d{13})-(Kinesis|Lambda|Replay)/;
   const results = streams.map((s) => {
     if (s.match(matcher)) {
       const streamDate = Number(s.match(matcher)[2]);


### PR DESCRIPTION
This will reap all kinesis streams.

**Summary:** Update reap-kinesis to find new streams.

We will still have to redeploy the test-clean-up to the account.

I found this debugging my Integration tests.