### PR TITLE
Use p-limit for concurrency in index-from-database

### DIFF
--- a/packages/api/lambdas/index-from-database.js
+++ b/packages/api/lambdas/index-from-database.js
@@ -42,6 +42,7 @@ async function indexFromDatabase(esIndex, tables, esHost) {
   await Promise.all([
     indexModel(esClient, tables.collectionsTable, esIndex, indexer.indexCollection),
     indexModel(esClient, tables.executionsTable, esIndex, indexer.indexExecution),
+    indexModel(esClient, tables.asyncOperationsTable, esIndex, indexer.indexAsyncOperation),
     indexModel(esClient, tables.granulesTable, esIndex, indexer.indexGranule),
     indexModel(esClient, tables.pdrsTable, esIndex, indexer.indexPdr),
     indexModel(esClient, tables.providersTable, esIndex, indexer.indexProvider),

--- a/tf-modules/archive/index_from_database.tf
+++ b/tf-modules/archive/index_from_database.tf
@@ -12,6 +12,7 @@ resource "aws_lambda_function" "index_from_database" {
       CMR_ENVIRONMENT = var.cmr_environment
       ES_HOST         = var.elasticsearch_hostname
       stackName       = var.prefix
+      ES_CONCURRENCY  = var.es_concurrency
     }
   }
   tags = var.tags

--- a/tf-modules/archive/variables.tf
+++ b/tf-modules/archive/variables.tf
@@ -335,3 +335,9 @@ variable "log_destination_arn" {
   default = "N/A"
   description = "A shared AWS:Log:Destination that receives logs from log_groups"
 }
+
+variable "es_concurrency" {
+  type = number
+  default = 10
+  description = "Maximum number of concurrent requests to send to Elasticsearch. Used in index-from-database operation"
+}


### PR DESCRIPTION
**Summary:** 

When running a large elasticsearch indexing operation, sending all indexing requests at once results in an error from Elasticsearch: `es_rejected_execution_exception`. I also noticed that making a large indexing request causes memory consumption to spike to 100% very quickly. This PR uses `p-limit` to enable setting a maximum number of concurrent requests when indexing items from each DynamoDB table being indexed.

It is also worth considering if we should use p-limit on the call to `Promise.all([indexModel..., indexModel..., indexModel` since right now I believe p-limit is being to limit the number of concurrent requests for each table separately, as opposed to items for all tables.

## Changes

* Add `ES_CONCURRENCY` / `es_concurrency` variable to index_from_database terraform module
* Use ES_CONCURRENCY or default in `index-from-database` lambda function call to index items in DynamoDB

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [x] Adhoc testing
- [ ] Integration tests

