### PR TITLE
[CUMULUS-1974] Fix @cumulus/api webpack config for missing underscore object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - **CUMULUS-1854**
   - Rule schema is validated before starting workflows or creating event source mappings
 
+- **CUMULUS-1974**
+  - Fixed @cumulus/api webpack config for missing underscore object due to underscore update
+
 ### Deprecated
 
 - **CUMULUS-1799** - Deprecated the following code. For cases where the code was moved into another package, the new code location is noted:

--- a/packages/api/webpack.config.js
+++ b/packages/api/webpack.config.js
@@ -43,6 +43,7 @@ module.exports = {
     alias: {
       'saml2-js': 'saml2-js/lib-js/saml2.js',
       ejs: 'ejs/ejs.min.js',
+      underscore: 'underscore/underscore.js',
       handlebars: 'handlebars/dist/handlebars.js'
     }
   },


### PR DESCRIPTION
With underscore 1.10.0( 1.10.2 latest), webpack looks `module` entry over `main` entry, and this results in wrong import.