### PR TITLE
Update api package to use ava 3.8

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -100,7 +100,7 @@
   },
   "devDependencies": {
     "@cumulus/test-data": "1.22.1",
-    "ava": "^2.1.0",
+    "ava": "^3.8.2",
     "babel-loader": "^8.0.6",
     "babel-plugin-source-map-support": "^2.1.1",
     "babel-preset-env": "^1.7.0",

--- a/packages/api/tests/endpoints/providers/create-provider.js
+++ b/packages/api/tests/endpoints/providers/create-provider.js
@@ -41,7 +41,7 @@ let accessTokenModel;
 const providerDoesNotExist = async (t, providerId) => {
   await t.throwsAsync(
     () => providerModel.get({ id: providerId }),
-    RecordDoesNotExist
+    { instanceOf: RecordDoesNotExist }
   );
 };
 

--- a/packages/api/tests/es/test-es-indexer.js
+++ b/packages/api/tests/es/test-es-indexer.js
@@ -411,7 +411,7 @@ test.serial('delete a provider record', async (t) => {
 
   await t.throwsAsync(
     () => esClient.get({ index: esAlias, type, id: testRecord.id }),
-    'Response Error'
+    { message: 'Response Error' }
   );
 });
 
@@ -494,7 +494,7 @@ test.serial('Create new index - index already exists', async (t) => {
 
   await t.throwsAsync(
     () => indexer.createIndex(esClient, newIndex),
-    IndexExistsError,
+    { instanceOf: IndexExistsError },
     `Index ${newIndex} exists and cannot be created.`
   );
 

--- a/packages/api/tests/lambdas/test-kinesis-consumer.js
+++ b/packages/api/tests/lambdas/test-kinesis-consumer.js
@@ -315,7 +315,7 @@ test.serial('An SNS fallback retry, should throw an error if message does not in
 
   const error = await t.throwsAsync(
     () => handler(snsEvent, {}, testCallback),
-    'validation failed'
+    { message: 'validation failed' }
   );
 
   t.is(error.errors[0].message, 'should have required property \'collection\'');
@@ -342,7 +342,7 @@ test.serial('An SNS Fallback retry, should throw an error if message collection 
 
   const error = await t.throwsAsync(
     () => handler(snsEvent, {}, testCallback),
-    'validation failed'
+    { message: 'validation failed' }
   );
 
   t.is(error.errors[0].dataPath, '.collection');
@@ -370,7 +370,7 @@ test.serial('An SNS Fallback retry, should throw an error if message is invalid 
 
   await t.throws(
     () => handler(snsEvent, {}, testCallback),
-    'Unexpected end of JSON input'
+    { message: 'Unexpected end of JSON input' }
   );
 });
 

--- a/packages/api/tests/lambdas/test-manual-consumer.js
+++ b/packages/api/tests/lambdas/test-manual-consumer.js
@@ -32,7 +32,7 @@ test.serial('configureTimestampEnvs throws error when invalid endTimestamp is pr
   };
   t.throws(
     () => manualConsumer.configureTimestampEnvs(event),
-    `endTimestamp ${event.endTimestamp} is not a valid input for new Date().`
+    { message: `endTimestamp ${event.endTimestamp} is not a valid input for new Date().` }
   );
   delete process.env.endTimestamp;
 });
@@ -43,7 +43,7 @@ test.serial('configureTimestampEnvs throws error when invalid startTimestamp is 
   };
   t.throws(
     () => manualConsumer.configureTimestampEnvs(event),
-    `startTimestamp ${event.startTimestamp} is not a valid input for new Date().`
+    { message: `startTimestamp ${event.startTimestamp} is not a valid input for new Date().` }
   );
   delete process.env.endTimestamp;
 });

--- a/packages/api/tests/lambdas/test-sf-starter.js
+++ b/packages/api/tests/lambdas/test-sf-starter.js
@@ -131,19 +131,19 @@ test(
   (t) =>
     t.throwsAsync(
       () => handleEvent(createRuleInput()),
-      'queueUrl is missing'
+      { message: 'queueUrl is missing' }
     )
 );
 
 test('handleEvent throws error when timeLimit is <= 0', async (t) => {
   await t.throwsAsync(
     () => handleEvent(createRuleInput('test', 0)),
-    'timeLimit must be greater than 0'
+    { message: 'timeLimit must be greater than 0' }
   );
 
   await t.throwsAsync(
     () => handleEvent(createRuleInput('test', -1)),
-    'timeLimit must be greater than 0'
+    { message: 'timeLimit must be greater than 0' }
   );
 });
 
@@ -162,7 +162,7 @@ test.serial('handleEvent returns the number of messages consumed', async (t) => 
 test('incrementAndDispatch throws error for message without queue name', async (t) => {
   await t.throwsAsync(
     () => incrementAndDispatch({ Body: createWorkflowMessage() }),
-    'cumulus_meta.queueName not set in message'
+    { message: 'cumulus_meta.queueName not set in message' }
   );
 });
 
@@ -171,7 +171,7 @@ test('incrementAndDispatch throws error for message with no maximum executions v
 
   await t.throwsAsync(
     () => incrementAndDispatch({ Body: createWorkflowMessage(queueName) }),
-    `Could not determine maximum executions for queue ${queueName}`
+    { message: `Could not determine maximum executions for queue ${queueName}` }
   );
 });
 
@@ -230,7 +230,7 @@ test('incrementAndDispatch throws error when trying to increment priority semaph
 
   await t.throwsAsync(
     () => incrementAndDispatch({ Body: createWorkflowMessage(queueName, maxExecutions) }),
-    ResourcesLockedError
+    { instanceOf: ResourcesLockedError }
   );
 });
 

--- a/packages/api/tests/lib/EarthdataLogin.js
+++ b/packages/api/tests/lib/EarthdataLogin.js
@@ -20,7 +20,7 @@ test('The EarthdataLogin constructor throws a TypeError if clientId is not speci
       redirectUri: 'http://www.example.com/cb'
     });
   },
-  TypeError);
+  { instanceOf: TypeError });
 
   t.is(err.message, 'clientId is required');
 });
@@ -33,7 +33,7 @@ test('The EarthdataLogin constructor throws a TypeError if clientPassword is not
       redirectUri: 'http://www.example.com/cb'
     });
   },
-  TypeError);
+  { instanceOf: TypeError });
 
   t.is(err.message, 'clientPassword is required');
 });
@@ -46,7 +46,7 @@ test('The EarthdataLogin constructor throws a TypeError if earthdataLoginUrl is 
       redirectUri: 'http://www.example.com/cb'
     });
   },
-  TypeError);
+  { instanceOf: TypeError });
 
   t.is(err.message, 'earthdataLoginUrl is required');
 });
@@ -60,7 +60,7 @@ test('The EarthdataLogin constructor throws a TypeError if earthdataLoginUrl is 
       redirectUri: 'http://www.example.com/cb'
     });
   },
-  TypeError);
+  { instanceOf: TypeError });
 });
 
 test('The EarthdataLogin constructor throws a TypeError if redirectUri is not specified', (t) => {
@@ -71,7 +71,7 @@ test('The EarthdataLogin constructor throws a TypeError if redirectUri is not sp
       earthdataLoginUrl: 'http://www.example.com'
     });
   },
-  TypeError);
+  { instanceOf: TypeError });
 
   t.is(err.message, 'redirectUri is required');
 });
@@ -85,7 +85,7 @@ test('The EarthdataLogin constructor throws a TypeError if redirectUri is not a 
       redirectUri: 'asdf'
     });
   },
-  TypeError);
+  { instanceOf: TypeError });
 });
 
 test('EarthdataLogin.getAuthorizationUrl() returns the correct URL when no state is specified', (t) => {
@@ -243,7 +243,7 @@ test.serial('EarthdataLogin.getAccessToken() throws an OAuth2AuthenticationFailu
 
   await t.throwsAsync(
     () => earthdataLogin.getAccessToken('authorization-code'),
-    OAuth2AuthenticationFailure
+    { instanceOf: OAuth2AuthenticationFailure }
   );
 
   t.true(tokenRequest.isDone());
@@ -263,7 +263,7 @@ test.serial('EarthdataLogin.getAccessToken() throws an OAuth2AuthenticationError
 
   await t.throwsAsync(
     () => earthdataLogin.getAccessToken('authorization-code'),
-    OAuth2AuthenticationError
+    { instanceOf: OAuth2AuthenticationError }
   );
 
   t.true(tokenRequest.isDone());
@@ -385,7 +385,7 @@ test.serial('EarthdataLogin.refreshAccessToken() throws an OAuth2AuthenticationF
 
   await t.throwsAsync(
     () => earthdataLogin.refreshAccessToken('invalid-refresh-token'),
-    OAuth2AuthenticationFailure
+    { instanceOf: OAuth2AuthenticationFailure }
   );
 
   t.true(tokenRequest.isDone());
@@ -405,7 +405,7 @@ test.serial('EarthdataLogin.refreshAccessToken() throws an OAuth2AuthenticationE
 
   await t.throwsAsync(
     () => earthdataLogin.refreshAccessToken('refresh-token'),
-    OAuth2AuthenticationError
+    { instanceOf: OAuth2AuthenticationError }
   );
 
   t.true(tokenRequest.isDone());

--- a/packages/api/tests/lib/GoogleOAuth2.js
+++ b/packages/api/tests/lib/GoogleOAuth2.js
@@ -8,7 +8,7 @@ test('The GoogleOAuth2 constructor throws a TypeError if googleOAuth2Client is n
   const err = t.throws(() => {
     new GoogleOAuth2(null, {});
   },
-  TypeError);
+  { instanceOf: TypeError });
 
   t.is(err.message, 'googleOAuth2Client is required');
 });
@@ -17,7 +17,7 @@ test('The GoogleOAuth2 constructor throws a TypeError if googlePlusPeopleClient 
   const err = t.throws(() => {
     new GoogleOAuth2({}, null);
   },
-  TypeError);
+  { instanceOf: TypeError });
 
   t.is(err.message, 'googlePlusPeopleClient is required');
 });

--- a/packages/api/tests/lib/GranuleFilesCache/test-batchUpdate.js
+++ b/packages/api/tests/lib/GranuleFilesCache/test-batchUpdate.js
@@ -116,7 +116,7 @@ test.serial('batchUpdate() will throw an exception if a put request does not con
         }
       ]
     }),
-    AggregateError
+    { instanceOf: AggregateError }
   );
 
   const errors = Array.from(error);
@@ -134,7 +134,7 @@ test.serial('batchUpdate() will throw an exception if a put request does not con
         }
       ]
     }),
-    AggregateError
+    { instanceOf: AggregateError }
   );
 
   const errors = Array.from(error);
@@ -152,7 +152,7 @@ test.serial('batchUpdate() will throw an exception if a put request does not con
         }
       ]
     }),
-    AggregateError
+    { instanceOf: AggregateError }
   );
 
   const errors = Array.from(error);
@@ -169,7 +169,7 @@ test.serial('batchUpdate() will throw an exception if a delete request does not 
         }
       ]
     }),
-    AggregateError
+    { instanceOf: AggregateError }
   );
 
   const errors = Array.from(error);
@@ -186,7 +186,7 @@ test.serial('batchUpdate() will throw an exception if a delete request does not 
         }
       ]
     }),
-    AggregateError
+    { instanceOf: AggregateError }
   );
 
   const errors = Array.from(error);

--- a/packages/api/tests/models/test-base-model.js
+++ b/packages/api/tests/models/test-base-model.js
@@ -41,14 +41,14 @@ test.afterEach.always(
 test('The Manager constructor throws an exception if the tableName property is not set', (t) => {
   t.throws(
     () => (new Manager({ tableHash: {} })),
-    TypeError
+    { instanceOf: TypeError }
   );
 });
 
 test('The Manager constructor throws an exception if the tableHash property is not set', (t) => {
   t.throws(
     () => (new Manager({ tableName: 'asdf' })),
-    TypeError
+    { instanceOf: TypeError }
   );
 });
 

--- a/packages/api/tests/models/test-collections-model.js
+++ b/packages/api/tests/models/test-collections-model.js
@@ -125,7 +125,7 @@ test.serial('Collection.create() throws InvalidRegexError for invalid granuleIdE
     collectionsModel.create(fakeCollectionFactory({
       granuleIdExtraction: '*'
     })),
-    InvalidRegexError
+    { instanceOf: InvalidRegexError }
   );
 });
 
@@ -135,7 +135,7 @@ test.serial('Collection.create() throws UnmatchedRegexError for non-matching gra
       granuleIdExtraction: '(1234)',
       sampleFileName: 'abcd'
     })),
-    UnmatchedRegexError
+    { instanceOf: UnmatchedRegexError }
   );
 });
 
@@ -145,7 +145,7 @@ test.serial('Collection.create() throws UnmatchedRegexError for granuleIdExtract
       granuleIdExtraction: '1234',
       sampleFileName: '1234'
     })),
-    UnmatchedRegexError
+    { instanceOf: UnmatchedRegexError }
   );
 });
 
@@ -154,7 +154,7 @@ test.serial('Collection.create() throws InvalidRegexError for invalid granuleId 
     collectionsModel.create(fakeCollectionFactory({
       granuleId: '*'
     })),
-    InvalidRegexError
+    { instanceOf: InvalidRegexError }
   );
 });
 
@@ -165,7 +165,7 @@ test.serial('Collection.create() throws UnmatchedRegexError for non-matching gra
       sampleFileName: '1234',
       granuleId: 'abcd'
     })),
-    UnmatchedRegexError
+    { instanceOf: UnmatchedRegexError }
   );
 });
 
@@ -178,7 +178,7 @@ test.serial('Collection.create() throws InvalidRegexError for invalid file.regex
         sampleFileName: 'filename'
       }]
     })),
-    InvalidRegexError
+    { instanceOf: InvalidRegexError }
   );
 });
 
@@ -191,7 +191,7 @@ test.serial('Collection.create() throws UnmatchedRegexError for non-matching fil
         sampleFileName: 'filename'
       }]
     })),
-    UnmatchedRegexError
+    { instanceOf: UnmatchedRegexError }
   );
 });
 

--- a/packages/api/tests/models/test-pdrs-model.js
+++ b/packages/api/tests/models/test-pdrs-model.js
@@ -69,7 +69,7 @@ test('generatePdrRecord() throws error if message.payload.pdr.name is not set', 
       pdr: {}
     }
   }),
-  'Could not find name on PDR object {}');
+  { message: 'Could not find name on PDR object {}' });
 });
 
 test('generatePdrRecord() sets correct progress value for running PDR', async (t) => {


### PR DESCRIPTION
This will make moving `devDependencies` to the top-level `package.json` much easier, since that top-level version will be 3.8 and would break tests in this package.