### PR TITLE
Don't build example lambdas on bootstrap-no-build

### DIFF
--- a/example/lambdas/asyncOperations/package.json
+++ b/example/lambdas/asyncOperations/package.json
@@ -8,7 +8,7 @@
     "node": ">=10.16.3"
   },
   "scripts": {
-    "prepare": "rm -f lambda.zip && zip -q lambda.zip index.js",
+    "package": "rm -f lambda.zip && zip -q lambda.zip index.js",
     "python-lint": "true"
   },
   "publishConfig": {

--- a/example/lambdas/python-processing/package.json
+++ b/example/lambdas/python-processing/package.json
@@ -13,7 +13,7 @@
     "python-lint": "pylint *.py",
     "lint": "npm run python-lint",
     "build": "pip install -r requirements-dev.txt && pip install -r requirements.txt",
-    "prepare": "npm run build",
+    "package": "npm run build",
     "install-python-deps": "pip install -r requirements-dev.txt && pip install -r requirements.txt"
   },
   "publishConfig": {

--- a/example/lambdas/python-reference-activity/package.json
+++ b/example/lambdas/python-reference-activity/package.json
@@ -13,7 +13,7 @@
     "python-lint": "pylint *.py",
     "lint": "npm run python-lint",
     "build": "true",
-    "prepare": "true"
+    "package": "true"
   },
   "publishConfig": {
     "access": "private"

--- a/example/lambdas/python-reference-task/package.json
+++ b/example/lambdas/python-reference-task/package.json
@@ -15,7 +15,7 @@
     "lint": "npm run python-lint",
     "clean": "rm -rf dist && rm -rf lib && mkdir dist && mkdir lib",
     "build": "npm run clean && pip install -r requirements-dev.txt && pip install -r requirements.txt -t ./dist && cp *.py ./dist/ && cd ./dist && zip -q ./lambda.zip -x *.json -r .* && cd ..",
-    "prepare": "npm run build",
+    "package": "npm run build",
     "install-python-deps": "pip install -r requirements-dev.txt && pip install -r requirements.txt"
   },
   "ava": {

--- a/example/lambdas/s3AccessTest/package.json
+++ b/example/lambdas/s3AccessTest/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "true",
-    "prepare": "rm -f lambda.zip && zip -q lambda.zip index.js",
+    "package": "rm -f lambda.zip && zip -q lambda.zip index.js",
     "python-lint": "true"
   },
   "publishConfig": {

--- a/example/lambdas/snsS3Test/package.json
+++ b/example/lambdas/snsS3Test/package.json
@@ -8,7 +8,7 @@
     "node": ">=10.16.3"
   },
   "scripts": {
-    "prepare": "rm -f lambda.zip && zip -q lambda.zip index.js",
+    "package": "rm -f lambda.zip && zip -q lambda.zip index.js",
     "test": "true",
     "python-lint": "true"
   },

--- a/example/lambdas/versionUpTest/package.json
+++ b/example/lambdas/versionUpTest/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "true",
-    "prepare": "rm -f lambda.zip && zip -q lambda.zip index.js",
+    "package": "rm -f lambda.zip && zip -q lambda.zip index.js",
     "python-lint": "true"
   },
   "publishConfig": {

--- a/example/package.json
+++ b/example/package.json
@@ -19,7 +19,7 @@
     "parallel-tests": "sh scripts/tests-parallel.sh",
     "redeploy-test": "jasmine spec/standalone/redeployment/*.js",
     "all-tests": "npm run parallel-tests && jasmine && npm run redeploy-test",
-    "prepare": "for x in lambdas/*; do cd $x && npm run prepare && cd -; done",
+    "package": "for x in lambdas/*; do cd $x && npm run package && cd -; done",
     "python-lint": "for x in lambdas/*; do cd $x && npm run python-lint && cd -; done",
     "install-python-deps": "for x in lambdas/*; do cd $x && npm run install-python-deps || true && cd -; done"
   },


### PR DESCRIPTION
Lambda zip files used during deployment are built using `npm run package`. The lambdas in the `example` directory, though, were still being built during the `prepare` step, which is run as part of `npm run bootstrap-no-build`. This fixes that, which speeds up the runtime of `bootstrap-no-build`.