### PR TITLE
Increase ava timeout

### DIFF
--- a/example/lambdas/python-reference-task/package.json
+++ b/example/lambdas/python-reference-task/package.json
@@ -19,7 +19,8 @@
     "install-python-deps": "pip install -r requirements-dev.txt && pip install -r requirements.txt"
   },
   "ava": {
-    "serial": true
+    "serial": true,
+    "timeout": "15m"
   },
   "publishConfig": {
     "access": "private"

--- a/example/package.json
+++ b/example/package.json
@@ -11,7 +11,8 @@
     "files": [
       "./scripts/tests/**/*.js"
     ],
-    "verbose": true
+    "verbose": true,
+    "timeout": "15m"
   },
   "scripts": {
     "test": "ava && for x in lambdas/*; do cd $x && npm run test && cd -; done",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -29,7 +29,8 @@
     "files": [
       "tests/**"
     ],
-    "verbose": true
+    "verbose": true,
+    "timeout": "15m"
   },
   "nyc": {
     "exclude": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -32,7 +32,8 @@
       "!tests/endpoints/fixtures/**/*.js"
     ],
     "fail-fast": true,
-    "verbose": true
+    "verbose": true,
+    "timeout": "15m"
   },
   "nyc": {
     "exclude": [

--- a/packages/aws-client/package.json
+++ b/packages/aws-client/package.json
@@ -35,7 +35,8 @@
     "files": [
       "tests/**/*.js"
     ],
-    "verbose": true
+    "verbose": true,
+    "timeout": "15m"
   },
   "nyc": {
     "exclude": [

--- a/packages/checksum/package.json
+++ b/packages/checksum/package.json
@@ -19,6 +19,9 @@
     "tsc": "tsc",
     "prepare": "npm run tsc"
   },
+  "ava": {
+    "timeout": "15m"
+  },
   "nyc": {
     "exclude": [
       "tests"

--- a/packages/cmr-client/package.json
+++ b/packages/cmr-client/package.json
@@ -11,7 +11,8 @@
     "debug": "NODE_ENV=test node --inspect-brk node_modules/ava/profile.js --serial tests/*.js"
   },
   "ava": {
-    "fail-fast": true
+    "fail-fast": true,
+    "timeout": "15m"
   },
   "nyc": {
     "exclude": [

--- a/packages/cmrjs/package.json
+++ b/packages/cmrjs/package.json
@@ -11,7 +11,8 @@
     "debug": "NODE_ENV=test node --inspect-brk node_modules/ava/profile.js --serial tests/*.js"
   },
   "ava": {
-    "serial": true
+    "serial": true,
+    "timeout": "15m"
   },
   "nyc": {
     "exclude": [

--- a/packages/collection-config-store/package.json
+++ b/packages/collection-config-store/package.json
@@ -29,7 +29,8 @@
     "files": [
       "tests/**"
     ],
-    "verbose": true
+    "verbose": true,
+    "timeout": "15m"
   },
   "nyc": {
     "exclude": [

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -30,7 +30,8 @@
     "files": [
       "tests/**"
     ],
-    "verbose": true
+    "verbose": true,
+    "timeout": "15m"
   },
   "nyc": {
     "exclude": [

--- a/packages/ingest/package.json
+++ b/packages/ingest/package.json
@@ -16,7 +16,8 @@
   "ava": {
     "files": [
       "!test/fixtures/**/*"
-    ]
+    ],
+    "timeout": "15m"
   },
   "nyc": {
     "exclude": [

--- a/packages/launchpad-auth/package.json
+++ b/packages/launchpad-auth/package.json
@@ -29,7 +29,8 @@
     "files": [
       "tests/**"
     ],
-    "verbose": true
+    "verbose": true,
+    "timeout": "15m"
   },
   "nyc": {
     "exclude": [

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -29,6 +29,9 @@
     "test": "ava",
     "tsc": "tsc"
   },
+  "ava": {
+    "timeout": "15m"
+  },
   "nyc": {
     "exclude": [
       "test"

--- a/packages/message/package.json
+++ b/packages/message/package.json
@@ -30,7 +30,8 @@
     "files": [
       "tests/**"
     ],
-    "verbose": true
+    "verbose": true,
+    "timeout": "15m"
   },
   "nyc": {
     "exclude": [

--- a/packages/pvl/package.json
+++ b/packages/pvl/package.json
@@ -11,7 +11,8 @@
     "test-coverage": "nyc ava"
   },
   "ava": {
-    "serial": true
+    "serial": true,
+    "timeout": "15m"
   },
   "nyc": {
     "exclude": [

--- a/packages/sftp-client/package.json
+++ b/packages/sftp-client/package.json
@@ -23,7 +23,8 @@
     "test": "ava"
   },
   "ava": {
-    "verbose": true
+    "verbose": true,
+    "timeout": "15m"
   },
   "nyc": {
     "exclude": [

--- a/packages/tf-inventory/package.json
+++ b/packages/tf-inventory/package.json
@@ -20,7 +20,8 @@
       "tests/**"
     ],
     "fail-fast": true,
-    "verbose": true
+    "verbose": true,
+    "timeout": "15m"
   },
   "nyc": {
     "exclude": [

--- a/tasks/discover-granules/package.json
+++ b/tasks/discover-granules/package.json
@@ -28,7 +28,8 @@
   "ava": {
     "files": [
       "!tests/fixtures/**/*"
-    ]
+    ],
+    "timeout": "15m"
   },
   "nyc": {
     "exclude": [

--- a/tasks/discover-pdrs/package.json
+++ b/tasks/discover-pdrs/package.json
@@ -27,7 +27,8 @@
   "ava": {
     "files": [
       "!tests/fixtures/**/*"
-    ]
+    ],
+    "timeout": "15m"
   },
   "nyc": {
     "exclude": [

--- a/tasks/files-to-granules/package.json
+++ b/tasks/files-to-granules/package.json
@@ -24,6 +24,9 @@
   "engines": {
     "node": ">=10.16.3"
   },
+  "ava": {
+    "timeout": "15m"
+  },
   "nyc": {
     "exclude": [
       "tests"

--- a/tasks/hello-world/package.json
+++ b/tasks/hello-world/package.json
@@ -22,7 +22,8 @@
     "package": "npm run build && (cd dist && zip -q -r lambda.zip index.js schemas)"
   },
   "ava": {
-    "serial": true
+    "serial": true,
+    "timeout": "15m"
   },
   "publishConfig": {
     "access": "public"

--- a/tasks/hyrax-metadata-updates/package.json
+++ b/tasks/hyrax-metadata-updates/package.json
@@ -31,7 +31,8 @@
     ],
     "fail-fast": true,
     "serial": true,
-    "verbose": true
+    "verbose": true,
+    "timeout": "15m"
   },
   "nyc": {
     "exclude": [

--- a/tasks/move-granules/package.json
+++ b/tasks/move-granules/package.json
@@ -31,7 +31,8 @@
     ],
     "fail-fast": true,
     "serial": true,
-    "verbose": true
+    "verbose": true,
+    "timeout": "15m"
   },
   "nyc": {
     "exclude": [

--- a/tasks/parse-pdr/package.json
+++ b/tasks/parse-pdr/package.json
@@ -25,6 +25,9 @@
     "watch": "rm -rf dist && mkdir dist && cp -R schemas dist/ && webpack --progress -w",
     "package": "npm run build && (cd dist && zip -q -r lambda.zip index.js schemas)"
   },
+  "ava": {
+    "timeout": "15m"
+  },
   "nyc": {
     "exclude": [
       "tests"

--- a/tasks/pdr-status-check/package.json
+++ b/tasks/pdr-status-check/package.json
@@ -27,7 +27,8 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "ava": {
-    "serial": true
+    "serial": true,
+    "timeout": "15m"
   },
   "nyc": {
     "exclude": [

--- a/tasks/post-to-cmr/package.json
+++ b/tasks/post-to-cmr/package.json
@@ -26,7 +26,8 @@
     "package": "npm run build && (cd dist && zip -q -r lambda.zip index.js schemas)"
   },
   "ava": {
-    "serial": true
+    "serial": true,
+    "timeout": "15m"
   },
   "nyc": {
     "exclude": [

--- a/tasks/queue-granules/package.json
+++ b/tasks/queue-granules/package.json
@@ -24,6 +24,9 @@
     "watch": "rm -rf dist && mkdir dist && cp -R schemas dist/ && webpack --progress -w",
     "package": "npm run build && (cd dist && zip -q -r lambda.zip index.js schemas)"
   },
+  "ava": {
+    "timeout": "15m"
+  },
   "nyc": {
     "exclude": [
       "tests"

--- a/tasks/queue-pdrs/package.json
+++ b/tasks/queue-pdrs/package.json
@@ -24,6 +24,9 @@
     "watch": "rm -rf dist && mkdir dist && cp -R schemas dist/ && webpack --progress -w",
     "package": "npm run build && (cd dist && zip -q -r lambda.zip index.js schemas)"
   },
+  "ava": {
+    "timeout": "15m"
+  },
   "nyc": {
     "exclude": [
       "tests"

--- a/tasks/sf-sqs-report/package.json
+++ b/tasks/sf-sqs-report/package.json
@@ -25,6 +25,9 @@
     "watch": "rm -rf dist && mkdir dist && webpack --progress -w",
     "package": "npm run build && npm run build-lambda-zips"
   },
+  "ava": {
+    "timeout": "15m"
+  },
   "nyc": {
     "exclude": [
       "tests"

--- a/tasks/sync-granule/package.json
+++ b/tasks/sync-granule/package.json
@@ -31,7 +31,8 @@
     "verbose": true,
     "files": [
       "!tests/fixtures/**/*"
-    ]
+    ],
+    "timeout": "15m"
   },
   "nyc": {
     "exclude": [

--- a/tf-modules/distribution/package.json
+++ b/tf-modules/distribution/package.json
@@ -10,6 +10,9 @@
     "package": "npm run build",
     "test": "ava"
   },
+  "ava": {
+    "timeout": "15m"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/tf-modules/s3-replicator/package.json
+++ b/tf-modules/s3-replicator/package.json
@@ -9,6 +9,9 @@
   "scripts": {
     "test": "ava"
   },
+  "ava": {
+    "timeout": "15m"
+  },
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
Ava has added a default test timeout of 10s. Unfortunately, some of our tests can take longer than that.

This PR bumps that timeout to a ridiculous 15 minutes, to be on the safe side and get our tests passing reliably again. At some point, we need to start lowering that number and address the tests that are timing out.