### PR TITLE
Prevent redeployment of unchanged Lambdas

### DIFF
--- a/bin/zip.js
+++ b/bin/zip.js
@@ -1,12 +1,21 @@
 'use strict';
 
+/**
+ * This script should be used to build zip files for deployment to Lambda. It
+ * hard-codes the timestamp of each file in the generatd zip so that identical
+ * files with different timestamps will result in an identical Lambda.
+ */
+
 const fs = require('fs');
 const archiver = require('archiver');
 
 const isDirectory = (x) => fs.statSync(x).isDirectory();
 
+// The first command line argument is the name of the zip file to generate. The
+// other arguments are the files to add to the zip.
 const [zipPath, ...files] = process.argv.slice(2);
 
+// https://en.wikipedia.org/wiki/2009_Stanley_Cup_Finals#Game_seven
 const date = new Date('2009-06-12');
 
 const archive = archiver('zip');

--- a/bin/zip.js
+++ b/bin/zip.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const fs = require('fs');
+const archiver = require('archiver');
+
+const isDirectory = (x) => fs.statSync(x).isDirectory();
+
+const [zipPath, ...files] = process.argv.slice(2);
+
+const date = new Date('2009-06-12');
+
+const archive = archiver('zip');
+
+archive.pipe(fs.createWriteStream(zipPath));
+
+files
+  .filter((x) => x !== '.')
+  .forEach(
+    (name) => {
+      if (isDirectory(name)) {
+        archive.directory(name, undefined, { date });
+      } else {
+        archive.append(fs.createReadStream(name), { date, name });
+      }
+    }
+  );
+
+archive.finalize();

--- a/bin/zip.js
+++ b/bin/zip.js
@@ -2,7 +2,7 @@
 
 /**
  * This script should be used to build zip files for deployment to Lambda. It
- * hard-codes the timestamp of each file in the generatd zip so that identical
+ * hard-codes the timestamp of each file in the generated zip so that identical
  * files with different timestamps will result in an identical Lambda.
  */
 
@@ -15,6 +15,7 @@ const isDirectory = (x) => fs.statSync(x).isDirectory();
 // other arguments are the files to add to the zip.
 const [zipPath, ...files] = process.argv.slice(2);
 
+// I had to pick a date to use for all of the files, so why not
 // https://en.wikipedia.org/wiki/2009_Stanley_Cup_Finals#Game_seven
 const date = new Date('2009-06-12');
 

--- a/example/lambdas/asyncOperations/package.json
+++ b/example/lambdas/asyncOperations/package.json
@@ -8,7 +8,7 @@
     "node": ">=10.16.3"
   },
   "scripts": {
-    "package": "rm -f lambda.zip && zip -q lambda.zip index.js",
+    "package": "rm -f lambda.zip && node ../../../bin/zip.js lambda.zip index.js",
     "python-lint": "true"
   },
   "publishConfig": {

--- a/example/lambdas/python-reference-task/package.json
+++ b/example/lambdas/python-reference-task/package.json
@@ -14,7 +14,7 @@
     "python-lint": "pylint *.py",
     "lint": "npm run python-lint",
     "clean": "rm -rf dist && rm -rf lib && mkdir dist && mkdir lib",
-    "build": "npm run clean && pip install -r requirements-dev.txt && pip install -r requirements.txt -t ./dist && cp *.py ./dist/ && cd ./dist && zip -q ./lambda.zip -x *.json -r .* && cd ..",
+    "build": "npm run clean && pip install -r requirements-dev.txt && pip install -r requirements.txt -t ./dist && cp *.py ./dist/ && cd ./dist && find . -type f | egrep -v '\\.json$' | xargs node ../../../../bin/zip.js lambda.zip && cd ..",
     "package": "npm run build",
     "install-python-deps": "pip install -r requirements-dev.txt && pip install -r requirements.txt"
   },

--- a/example/lambdas/s3AccessTest/package.json
+++ b/example/lambdas/s3AccessTest/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "true",
-    "package": "rm -f lambda.zip && zip -q lambda.zip index.js",
+    "package": "rm -f lambda.zip && node ../../../bin/zip.js lambda.zip index.js",
     "python-lint": "true"
   },
   "publishConfig": {

--- a/example/lambdas/snsS3Test/package.json
+++ b/example/lambdas/snsS3Test/package.json
@@ -8,7 +8,7 @@
     "node": ">=10.16.3"
   },
   "scripts": {
-    "package": "rm -f lambda.zip && zip -q lambda.zip index.js",
+    "package": "rm -f lambda.zip && node ../../../bin/zip.js lambda.zip index.js",
     "test": "true",
     "python-lint": "true"
   },

--- a/example/lambdas/versionUpTest/package.json
+++ b/example/lambdas/versionUpTest/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "true",
-    "package": "rm -f lambda.zip && zip -q lambda.zip index.js",
+    "package": "rm -f lambda.zip && node ../../../bin/zip.js lambda.zip index.js",
     "python-lint": "true"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
+    "archiver": "^4.0.1",
     "fs-extra": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -23,7 +23,7 @@
     "reset-tables": "LOCALSTACK_HOST=localhost NODE_ENV=test FAKE_AUTH=true cumulus-api reset-tables",
     "link-api-bin": "sh ./bin/link-api-bin.sh",
     "package": "npm run build && npm run link-api-bin && npm run build-lambda-zips",
-    "build-lambda-zips": "for x in $(ls dist); do (cd dist/${x} && rm -f lambda.zip && find . | xargs zip -q lambda.zip && echo zipped ${x}); done"
+    "build-lambda-zips": "for x in $(ls dist); do (cd dist/${x} && rm -f lambda.zip && find . | xargs node ../../../../bin/zip.js lambda.zip && echo zipped ${x}); done"
   },
   "ava": {
     "files": [

--- a/tasks/discover-granules/package.json
+++ b/tasks/discover-granules/package.json
@@ -20,7 +20,7 @@
     "local": "node index.js | pino",
     "build": "rm -rf dist && mkdir dist && cp -R schemas dist/ && ../../node_modules/.bin/webpack",
     "watch": "rm -rf dist && mkdir dist && cp -R schemas dist/ && ../../node_modules/.bin/webpack --progress -w",
-    "package": "npm run build && (cd dist && zip -q -r lambda.zip index.js schemas)"
+    "package": "npm run build && (cd dist && node ../../../bin/zip.js lambda.zip index.js schemas)"
   },
   "publishConfig": {
     "access": "public"

--- a/tasks/discover-pdrs/package.json
+++ b/tasks/discover-pdrs/package.json
@@ -19,7 +19,7 @@
     "test-coverage": "../../node_modules/.bin/nyc npm test",
     "build": "rm -rf dist && mkdir dist && cp -R schemas dist/ && ../../node_modules/.bin/webpack",
     "watch": "rm -rf dist && mkdir dist && cp -R schemas dist/ && ../../node_modules/.bin/webpack --progress -w",
-    "package": "npm run build && (cd dist && zip -q -r lambda.zip index.js schemas)"
+    "package": "npm run build && (cd dist && node ../../../bin/zip.js lambda.zip index.js schemas)"
   },
   "publishConfig": {
     "access": "public"

--- a/tasks/files-to-granules/package.json
+++ b/tasks/files-to-granules/package.json
@@ -19,7 +19,7 @@
     "test-coverage": "../../node_modules/.bin/nyc npm test",
     "build": "rm -rf dist && mkdir dist && cp -R schemas dist/ && ../../node_modules/.bin/webpack",
     "watch": "rm -rf dist && mkdir dist && cp -R schemas dist/ && ../../node_modules/.bin/webpack --progress -w",
-    "package": "npm run build && (cd dist && zip -q -r lambda.zip index.js schemas)"
+    "package": "npm run build && (cd dist && node ../../../bin/zip.js lambda.zip index.js schemas)"
   },
   "engines": {
     "node": ">=10.16.3"

--- a/tasks/hello-world/package.json
+++ b/tasks/hello-world/package.json
@@ -19,7 +19,7 @@
     "test-coverage": "../../node_modules/.bin/nyc npm test",
     "build": "rm -rf dist && mkdir dist && cp -R schemas dist/ && ../../node_modules/.bin/webpack",
     "watch": "rm -rf dist && mkdir dist && cp -R schemas dist/ && ../../node_modules/.bin/webpack --progress -w",
-    "package": "npm run build && (cd dist && zip -q -r lambda.zip index.js schemas)"
+    "package": "npm run build && (cd dist && node ../../../bin/zip.js lambda.zip index.js schemas)"
   },
   "ava": {
     "serial": true,

--- a/tasks/hyrax-metadata-updates/package.json
+++ b/tasks/hyrax-metadata-updates/package.json
@@ -23,7 +23,7 @@
     "debug": "NODE_ENV=test node --inspect-brk node_modules/ava/profile.js --serial tests/*.js",
     "build": "rm -rf dist && mkdir dist && cp -R schemas dist/ && ../../node_modules/.bin/webpack",
     "watch": "rm -rf dist && mkdir dist && cp -R schemas dist/ && ../../node_modules/.bin/webpack --progress -w",
-    "package": "npm run build && (cd dist && zip -q -r lambda.zip index.js schemas)"
+    "package": "npm run build && (cd dist && node ../../../bin/zip.js lambda.zip index.js schemas)"
   },
   "ava": {
     "files": [

--- a/tasks/move-granules/package.json
+++ b/tasks/move-granules/package.json
@@ -23,7 +23,7 @@
     "debug": "NODE_ENV=test node --inspect-brk node_modules/ava/profile.js --serial tests/*.js",
     "build": "rm -rf dist && mkdir dist && cp -R schemas dist/ && ../../node_modules/.bin/webpack",
     "watch": "rm -rf dist && mkdir dist && cp -R schemas dist/ && ../../node_modules/.bin/webpack --progress -w",
-    "package": "npm run build && (cd dist && zip -q -r lambda.zip index.js schemas)"
+    "package": "npm run build && (cd dist && node ../../../bin/zip.js lambda.zip index.js schemas)"
   },
   "ava": {
     "files": [

--- a/tasks/parse-pdr/package.json
+++ b/tasks/parse-pdr/package.json
@@ -23,7 +23,7 @@
     "test-coverage": "../../node_modules/.bin/nyc npm test",
     "build": "rm -rf dist && mkdir dist && cp -R schemas dist/ && ../../node_modules/.bin/webpack",
     "watch": "rm -rf dist && mkdir dist && cp -R schemas dist/ && ../../node_modules/.bin/webpack --progress -w",
-    "package": "npm run build && (cd dist && zip -q -r lambda.zip index.js schemas)"
+    "package": "npm run build && (cd dist && node ../../../bin/zip.js lambda.zip index.js schemas)"
   },
   "ava": {
     "timeout": "15m"

--- a/tasks/pdr-status-check/package.json
+++ b/tasks/pdr-status-check/package.json
@@ -17,7 +17,7 @@
     "test-coverage": "../../node_modules/.bin/nyc npm test",
     "build": "rm -rf dist && mkdir dist && cp -R schemas dist/ && ../../node_modules/.bin/webpack",
     "watch": "rm -rf dist && mkdir dist && cp -R schemas dist/ && ../../node_modules/.bin/webpack --progress -w",
-    "package": "npm run build && (cd dist && zip -q -r lambda.zip index.js schemas)"
+    "package": "npm run build && (cd dist && node ../../../bin/zip.js lambda.zip index.js schemas)"
   },
   "homepage": "https://github.com/nasa/cumulus/tree/master/tasks/pdr-status-check",
   "repository": {

--- a/tasks/post-to-cmr/package.json
+++ b/tasks/post-to-cmr/package.json
@@ -23,7 +23,7 @@
     "debug": "NODE_ENV=test node --inspect-brk node_modules/ava/profile.js --serial tests/*.js",
     "build": "rm -rf dist && mkdir dist && cp -R schemas dist/ && ../../node_modules/.bin/webpack",
     "watch": "rm -rf dist && mkdir dist && cp -R schemas dist/ && ../../node_modules/.bin/webpack --progress -w",
-    "package": "npm run build && (cd dist && zip -q -r lambda.zip index.js schemas)"
+    "package": "npm run build && (cd dist && node ../../../bin/zip.js lambda.zip index.js schemas)"
   },
   "ava": {
     "serial": true,

--- a/tasks/queue-granules/package.json
+++ b/tasks/queue-granules/package.json
@@ -22,7 +22,7 @@
     "test-coverage": "../../node_modules/.bin/nyc npm test",
     "build": "rm -rf dist && mkdir dist && cp -R schemas dist/ && ../../node_modules/.bin/webpack",
     "watch": "rm -rf dist && mkdir dist && cp -R schemas dist/ && ../../node_modules/.bin/webpack --progress -w",
-    "package": "npm run build && (cd dist && zip -q -r lambda.zip index.js schemas)"
+    "package": "npm run build && (cd dist && node ../../../bin/zip.js lambda.zip index.js schemas)"
   },
   "ava": {
     "timeout": "15m"

--- a/tasks/queue-pdrs/package.json
+++ b/tasks/queue-pdrs/package.json
@@ -22,7 +22,7 @@
     "test-coverage": "../../node_modules/.bin/nyc npm test",
     "build": "rm -rf dist && mkdir dist && cp -R schemas dist/ && ../../node_modules/.bin/webpack",
     "watch": "rm -rf dist && mkdir dist && cp -R schemas dist/ && ../../node_modules/.bin/webpack --progress -w",
-    "package": "npm run build && (cd dist && zip -q -r lambda.zip index.js schemas)"
+    "package": "npm run build && (cd dist && node ../../../bin/zip.js lambda.zip index.js schemas)"
   },
   "ava": {
     "timeout": "15m"

--- a/tasks/sf-sns-report/package.json
+++ b/tasks/sf-sns-report/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "rm -rf dist && mkdir dist && ../../node_modules/.bin/webpack",
-    "build-lambda-zips": "(cd dist && rm -f lambda.zip && zip -q lambda.zip index.js)",
+    "build-lambda-zips": "(cd dist && rm -f lambda.zip && node ../../../bin/zip.js lambda.zip index.js)",
     "watch": "rm -rf dist && mkdir dist && ../../node_modules/.bin/webpack --progress -w",
     "package": "npm run build && npm run build-lambda-zips"
   },

--- a/tasks/sf-sqs-report/package.json
+++ b/tasks/sf-sqs-report/package.json
@@ -21,7 +21,7 @@
     "test": "../../node_modules/.bin/ava",
     "test-coverage": "../../node_modules/.bin/nyc npm test",
     "build": "rm -rf dist && mkdir dist && ../../node_modules/.bin/webpack",
-    "build-lambda-zips": "(cd dist && rm -f lambda.zip && zip -q lambda.zip index.js)",
+    "build-lambda-zips": "(cd dist && rm -f lambda.zip && node ../../../bin/zip.js lambda.zip index.js)",
     "watch": "rm -rf dist && mkdir dist && ../../node_modules/.bin/webpack --progress -w",
     "package": "npm run build && npm run build-lambda-zips"
   },

--- a/tasks/sync-granule/package.json
+++ b/tasks/sync-granule/package.json
@@ -22,7 +22,7 @@
     "test-coverage": "../../node_modules/.bin/nyc npm test",
     "build": "rm -rf dist && mkdir dist && cp -R schemas dist/ && ../../node_modules/.bin/webpack",
     "watch": "rm -rf dist && mkdir dist && cp -R schemas dist/ && ../../node_modules/.bin/webpack --progress -w",
-    "package": "npm run build && (cd dist && zip -q -r lambda.zip $(ls | grep -v lambda.zip))"
+    "package": "npm run build && (cd dist && rm -f lambda.zip && node ../../../bin/zip.js lambda.zip index.js schemas)"
   },
   "author": "Cumulus Authors",
   "license": "Apache-2.0",

--- a/tasks/test-processing/package.json
+++ b/tasks/test-processing/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "../../node_modules/.bin/webpack",
     "watch": "../../node_modules/.bin/webpack --progress -w",
-    "package": "npm run build && (cd dist && zip -q -r lambda.zip $(ls | grep -v lambda.zip))"
+    "package": "npm run build && (cd dist && node ../../../bin/zip.js lambda.zip $(ls | grep -v lambda.zip))"
   },
   "author": "Cumulus Authors",
   "license": "Apache-2.0",

--- a/tf-modules/distribution/package.json
+++ b/tf-modules/distribution/package.json
@@ -6,7 +6,7 @@
     "node": ">=10.16.3"
   },
   "scripts": {
-    "build": "../../node_modules/.bin/webpack && (cd dist && rm -f package.zip && zip -q src.zip index.js)",
+    "build": "../../node_modules/.bin/webpack && (cd dist && rm -f package.zip && node ../../../bin/zip.js src.zip index.js)",
     "package": "npm run build",
     "test": "../../node_modules/.bin/ava"
   },

--- a/tf-modules/internal/cumulus-test-cleanup/package.json
+++ b/tf-modules/internal/cumulus-test-cleanup/package.json
@@ -7,9 +7,9 @@
     "node": ">=10.16.3"
   },
   "scripts": {
-    "build": "rm -rf dist && mkdir dist && webpack",
-    "watch": "rm -rf dist && mkdir dist && webpack --progress -w",
-    "package": "npm run build && (cd dist && zip -q -r lambda.zip index.js)"
+    "build": "rm -rf dist && mkdir dist && ../../../node_modules/.bin/webpack",
+    "watch": "rm -rf dist && mkdir dist && ../../../node_modules/.bin/webpack --progress -w",
+    "package": "npm run build && (cd dist && node ../../../../bin/zip.js lambda.zip index.js)"
   },
   "author": "Cumulus Authors",
   "license": "Apache-2.0",


### PR DESCRIPTION
Every time we build the zip files for our Lambda functions, the checksum of those Lambdas was changing, which was resulting in all of the Lambdas being redeployed. This was happening even if there were no actual changes to the Lambda function. This was being caused by the changing timestamps of the files being inserted into the zip files.

I have added `bin/zip.js`, which builds a zip file but hard-codes the timestamp of the files in the zip file. Since we are just using the zip to deploy a Lambda function, the timestamp really doesn't matter.

I updated all of the scripts that generate the Lambda zip files to use this script and verified that only Lambdas that have actually changed are being deployed as a result.

Incidentally, because we are not using `package-lock.json` files, we are still going to see Lambdas redeployed when we have not made any changes, because there could be patch releases of some package that the Lambda depends on.