### PR TITLE
getExecutionWithStatus retries if the execution does not exist

### DIFF
--- a/example/spec/parallel/testAPI/ruleSpec.js
+++ b/example/spec/parallel/testAPI/ruleSpec.js
@@ -236,20 +236,16 @@ describe('When I create a one-time rule via the Cumulus API', () => {
   });
 
   describe('When listing the rules via the API', () => {
-    it('the rule is returned with the listed rules', async (done) => {
-      const ruleSearchParams = {
-        name: helloWorldRule.name,
-        'meta.triggerRule': updatedCheck
-      };
-      try {
-        await waitForRuleInList(config.stackName, ruleSearchParams);
-        done();
-      } catch (error) {
-        fail(
-          `Could not find rule with params ${JSON.stringify(ruleSearchParams)}`,
-          error
-        );
-      }
+    it('the rule is returned with the listed rules', async () => {
+      await expectAsync(
+        waitForRuleInList(
+          config.stackName,
+          {
+            name: helloWorldRule.name,
+            'meta.triggerRule': updatedCheck
+          }
+        )
+      ).toBeResolved();
     });
   });
 });

--- a/packages/integration-tests/Executions.js
+++ b/packages/integration-tests/Executions.js
@@ -89,6 +89,7 @@ const getExecutionWithStatus = async (params) =>
       try {
         execution = await getExecution(pick(params, ['prefix', 'arn', 'callback']));
       } catch (err) {
+        if (err.name === 'ExecutionNotFoundError') throw err;
         throw new pRetry.AbortError(`Error fetching execution ${params.arn}: ${err}`);
       }
 

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -20,7 +20,8 @@
   "scripts": {
     "build": "rm -rf dist && mkdir dist && ../../node_modules/.bin/webpack",
     "build-docs": "../../node_modules/.bin/jsdoc2md --template README.hbs Collections.js Executions.js Granules.js Providers.js Rules.js > README.md",
-    "package": "npm run build"
+    "package": "npm run build",
+    "test": "../../node_modules/.bin/ava"
   },
   "author": "Cumulus Authors",
   "license": "Apache-2.0",

--- a/packages/integration-tests/tests/test-Executions.js
+++ b/packages/integration-tests/tests/test-Executions.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const test = require('ava');
+const cryptoRandomString = require('crypto-random-string');
+const { getExecutionWithStatus } = require('../Executions');
+
+const randomId = (prefix, separator = '-') =>
+  `${prefix}${separator}${cryptoRandomString({ length: 6 })}`;
+
+test('getExecutionWithStatus() will retry if the execution does not exist', async (t) => {
+  const arn = randomId('arn');
+  const prefix = randomId('prefix');
+
+  const callback = (() => {
+    let callCount = 0;
+
+    return async () => {
+      callCount += 1;
+
+      if (callCount === 1) {
+        return {
+          body: JSON.stringify({ statusCode: 404 })
+        };
+      }
+
+      return {
+        body: JSON.stringify({
+          statusCode: 200,
+          status: 'completed'
+        })
+      };
+    };
+  })();
+
+  await t.notThrowsAsync(
+    getExecutionWithStatus({
+      prefix,
+      arn,
+      status: 'completed',
+      timeout: 1,
+      callback
+    })
+  );
+});


### PR DESCRIPTION
The `getExecutionWithStatus` function was not retrying if the execution did not yet exist. Fixed it so that it will retry even if the execution does not exist.