### PR TITLE
Make granule deletion faster

### DIFF
--- a/packages/api/lib/FileUtils.js
+++ b/packages/api/lib/FileUtils.js
@@ -128,5 +128,7 @@ module.exports = {
   filterDatabaseProperties,
   getChecksum,
   getFileName,
-  setS3FileSize
+  setS3FileSize,
+  getBucket,
+  getKey
 };

--- a/packages/api/models/granules.js
+++ b/packages/api/models/granules.js
@@ -77,6 +77,10 @@ class Granule extends Manager {
     return translateGranule(await super.get(...args));
   }
 
+  getRecord({ granuleId }) {
+    return super.get({ granuleId });
+  }
+
   async batchGet(...args) {
     const result = cloneDeep(await super.batchGet(...args));
 

--- a/packages/api/tests/endpoints/test-granules.js
+++ b/packages/api/tests/endpoints/test-granules.js
@@ -627,6 +627,51 @@ test('DELETE for a granule with a file not present in S3 succeeds', async (t) =>
   t.is(response.status, 200);
 });
 
+test('Deleting a granule with the old file format succeeds', async (t) => {
+  const granuleBucket = randomId('granuleBucket');
+
+  const key = randomId('key');
+  const newGranule = fakeGranuleFactoryV2({
+    published: false,
+    files: [
+      {
+        filename: `s3://${granuleBucket}/${key}`
+      }
+    ]
+  });
+
+  await createBucket(granuleBucket);
+
+  await putObject({
+    Bucket: granuleBucket,
+    Key: key,
+    Body: 'asdf'
+  });
+
+  // create a new unpublished granule
+  const baseModel = new models.Manager({
+    tableName: process.env.GranulesTable,
+    tableHash: { name: 'granuleId', type: 'S' },
+    tableAttributes: [{ name: 'collectionId', type: 'S' }],
+    validate: false
+  });
+
+  await baseModel.create(newGranule);
+
+  const response = await request(app)
+    .delete(`/granules/${newGranule.granuleId}`)
+    .set('Accept', 'application/json')
+    .set('Authorization', `Bearer ${jwtAuthToken}`)
+    .expect(200);
+
+  t.is(response.body.detail, 'Record deleted');
+
+  // verify the file is deleted
+  t.false(await fileExists(granuleBucket, key));
+
+  await recursivelyDeleteS3Bucket(granuleBucket);
+});
+
 test.serial('move a granule with no .cmr.xml file', async (t) => {
   const bucket = process.env.system_bucket;
   const secondBucket = randomId('second');

--- a/packages/api/tests/models/granules/test-granules-model.js
+++ b/packages/api/tests/models/granules/test-granules-model.js
@@ -391,6 +391,23 @@ test('get() will correctly return a granule file stored using the new schema', a
   );
 });
 
+test('getRecord() returns a granule record from the database', async (t) => {
+  const granule = fakeGranuleFactoryV2();
+
+  await awsServices.dynamodbDocClient().put({
+    TableName: process.env.GranulesTable,
+    Item: granule
+  }).promise();
+
+  const granuleModel = new Granule();
+
+  const fetchedGranule = await granuleModel.getRecord({
+    granuleId: granule.granuleId
+  });
+
+  t.is(fetchedGranule.granuleId, granule.granuleId);
+});
+
 test('batchGet() will translate old-style granule files into the new schema', async (t) => {
   const oldFile = {
     bucket: 'my-bucket',


### PR DESCRIPTION
I noticed that the test for deleting a granule with a file that does not exist in S3 was taking a long time (7 seconds). I tracked the problem down to the fact that, when you call `GranuleModel.get()` (which `del` was doing), it fetches each of the files in the granule to determine their size. The `getObjectSize` function retries getting a non-existent file three times, so that was the cause of the 7-second delay.

Because deleting a granule does not require knowing the size of the granule, I added a `getRecord` method to the `Granules` model which only returns the raw DB record. I then updated the granules endpoint's `del` function to use `getRecord`.