### PR TITLE
CUMULUS-2010: Update launchpadSaml to support multiple userGroup attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - **CUMULUS-1997**
   - Updated all CMR operations to use configured authentication scheme
+- **CUMULUS-2010**
+  - Updated `@cumulus/api/launchpadSaml` to support multiple userGroup attributes from the SAML response
 
 ## [v1.23.2] 2020-05-22
 

--- a/packages/api/endpoints/launchpadSaml.js
+++ b/packages/api/endpoints/launchpadSaml.js
@@ -105,19 +105,21 @@ const authorizedUserGroup = (samlUserGroup, authorizedGroup) => {
 const parseSamlResponse = (samlResponse) => {
   let username;
   let accessToken;
-  let userGroup;
+  let userGroups;
   try {
     const attributes = samlResponse.user.attributes;
     username = get(attributes, 'UserId', get(attributes, 'UserID'))[0];
     accessToken = samlResponse.user.session_index;
-    userGroup = samlResponse.user.attributes.userGroup[0];
+    userGroups = samlResponse.user.attributes.userGroup;
   } catch (error) {
     throw new Error(
       `invalid SAML response received ${JSON.stringify(samlResponse)}`
     );
   }
 
-  if (!authorizedUserGroup(userGroup, process.env.oauth_user_group)) {
+  const validGroups = userGroups.filter((userGroup) =>
+    authorizedUserGroup(userGroup, process.env.oauth_user_group));
+  if (validGroups.length === 0) {
     throw new Error(
       `User not authorized for this application ${username} not a member of userGroup: ${process.env.oauth_user_group}`
     );


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2010: Update launchpadSaml to support multiple userGroup attributes from the SAML response](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2010)

## PR Checklist

- [x ] Update CHANGELOG
- [ ] Unit tests
- [x ] Adhoc testing
- [ ] Integration tests

