### PR TITLE
Make eslint unicorn/catch-error-name a warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -151,7 +151,7 @@ module.exports = {
     'node/no-missing-require': 'off',
 
     'unicorn/better-regex': 'off',
-    'unicorn/catch-error-name': 'off',
+    'unicorn/catch-error-name': 'warn',
     'unicorn/consistent-function-scoping': 'off',
     'unicorn/explicit-length-check': 'off',
     'unicorn/filename-case': 'off',


### PR DESCRIPTION
Due to the large number of occurrences, making this a warning until we can get the count down.