### PR TITLE
[CUMULUS-2016] Upgrade TEA to build 79

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - The `globalConnectionLimit` property of providers is now optional and
     defaults to "unlimited"
 - **CUMULUS-1997**
-  - Added optional `launchpad` configuration to `@cumulus/hyrax-metadata-updates` task config schema.
+  - Added optional `launchpad` configuration to
+    `@cumulus/hyrax-metadata-updates` task config schema.
 - **CUMULUS-2016**
   - Upgrade TEA to version 79
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,8 +69,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - The `globalConnectionLimit` property of providers is now optional and
     defaults to "unlimited"
 - **CUMULUS-1997**
-  - Added optional `launchpad` configuration to
-    `@cumulus/hyrax-metadata-updates` task config schema.
+  - Added optional `launchpad` configuration to `@cumulus/hyrax-metadata-updates` task config schema.
+- **CUMULUS-2016**
+  - Upgrade TEA to version 79
 
 ### Fixed
 

--- a/tf-modules/distribution/main.tf
+++ b/tf-modules/distribution/main.tf
@@ -54,7 +54,7 @@ data "aws_lambda_invocation" "tea_map_cache" {
 }
 
 module "thin_egress_app" {
-  source = "s3::https://s3.amazonaws.com/cumulus-test-sandbox-private/tea-terraform-manual_build.zip"
+  source = "s3::https://s3.amazonaws.com/asf.public.code/thin-egress-app/tea-terraform-build.79.zip"
 
   auth_base_url                      = var.urs_url
   bucket_map_file                    = var.bucket_map_key == null ? aws_s3_bucket_object.bucket_map_yaml[0].key : var.bucket_map_key


### PR DESCRIPTION
**Summary:** Upgrade TEA to build 79

Addresses [CUMULUS-2016: Upgrade TEA to latest version](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2016)

## Changes

* Upgrade TEA To build 79

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

