### PR TITLE
CUMULUS-2019: add infix search to es query builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **CUMULUS-2019**
+  - Add `infix` search to es query builder `@cumulus/api/es/es/queries` to support partial matching of the keywords
+
+
 ### BREAKING CHANGES
 
 - **CUMULUS-1969**

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/api",
-  "version": "1.23.3-alpha.0",
+  "version": "1.24.1-alpha.0",
   "description": "Lambda functions for handling all daac's API operations",
   "main": "index.js",
   "engines": {

--- a/packages/api/tests/es/test-queries.js
+++ b/packages/api/tests/es/test-queries.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const test = require('ava');
+
+const { randomId } = require('@cumulus/common/test-utils');
+
+const indexer = require('../../es/indexer');
+const { Search } = require('../../es/search');
+const { fakeGranuleFactoryV2 } = require('../../lib/testUtils');
+const { bootstrapElasticSearch } = require('../../lambdas/bootstrap');
+
+const granules = [
+  fakeGranuleFactoryV2(),
+  fakeGranuleFactoryV2({ granuleId: randomId('granprefix') }),
+  fakeGranuleFactoryV2({ granuleId: randomId('granprefix'), status: 'failed' }),
+  fakeGranuleFactoryV2({ status: 'failed' })
+];
+
+let esClient;
+const esIndex = randomId('esindex');
+const esAlias = randomId('esalias');
+process.env.ES_INDEX = esAlias;
+
+test.before(async () => {
+  // create the elasticsearch index and add mapping
+  await bootstrapElasticSearch('fakehost', esIndex, esAlias);
+  esClient = await Search.es();
+
+  await Promise.all(
+    granules.map((granule) => indexer.indexGranule(esClient, granule, esAlias))
+  );
+});
+
+test.after.always(async () => {
+  await esClient.indices.delete({ index: esIndex });
+});
+
+test('Search with prefix returns correct granules', async (t) => {
+  const prefix = 'granprefix';
+  const params = {
+    limit: 50,
+    page: 1,
+    order: 'desc',
+    sort_by: 'timestamp',
+    prefix
+  };
+
+  const es = new Search(
+    { queryStringParameters: params },
+    'granule',
+    process.env.ES_INDEX
+  );
+
+  const queryResult = await es.query();
+
+  t.is(queryResult.meta.count, 2);
+  t.is(queryResult.results.length, 2);
+  queryResult.results.map((granule) =>
+    t.true([granules[1].granuleId, granules[2].granuleId].includes(granule.granuleId)));
+});
+
+test('Search with infix returns correct granules', async (t) => {
+  const granuleId = granules[2].granuleId;
+  const _infix = granuleId.substring(4, 14);
+  const params = {
+    limit: 50,
+    page: 1,
+    order: 'desc',
+    sort_by: 'timestamp',
+    status: 'failed',
+    infix: _infix
+  };
+
+  const es = new Search(
+    { queryStringParameters: params },
+    'granule',
+    process.env.ES_INDEX
+  );
+
+  const queryResult = await es.query();
+
+  t.is(queryResult.meta.count, 1);
+  t.is(queryResult.results.length, 1);
+  t.is(queryResult.results[0].granuleId, granuleId);
+});

--- a/packages/api/tests/es/test-queries.js
+++ b/packages/api/tests/es/test-queries.js
@@ -11,7 +11,7 @@ const { bootstrapElasticSearch } = require('../../lambdas/bootstrap');
 
 const granules = [
   fakeGranuleFactoryV2(),
-  fakeGranuleFactoryV2({ granuleId: randomId('granprefix') }),
+  fakeGranuleFactoryV2({ granuleId: randomId('granprefix123') }),
   fakeGranuleFactoryV2({ granuleId: randomId('granprefix'), status: 'failed' }),
   fakeGranuleFactoryV2({ status: 'failed' })
 ];
@@ -61,14 +61,14 @@ test('Search with prefix returns correct granules', async (t) => {
 
 test('Search with infix returns correct granules', async (t) => {
   const granuleId = granules[2].granuleId;
-  const _infix = granuleId.substring(4, 14);
+  const infix = granuleId.substring(4, 14);
   const params = {
     limit: 50,
     page: 1,
     order: 'desc',
     sort_by: 'timestamp',
     status: 'failed',
-    infix: _infix
+    infix
   };
 
   const es = new Search(
@@ -82,4 +82,29 @@ test('Search with infix returns correct granules', async (t) => {
   t.is(queryResult.meta.count, 1);
   t.is(queryResult.results.length, 1);
   t.is(queryResult.results[0].granuleId, granuleId);
+});
+
+test('Search with both prefix and infix returns correct granules', async (t) => {
+  const prefix = 'granprefix';
+  const infix = 'fix123';
+  const params = {
+    limit: 50,
+    page: 1,
+    order: 'desc',
+    sort_by: 'timestamp',
+    prefix,
+    infix
+  };
+
+  const es = new Search(
+    { queryStringParameters: params },
+    'granule',
+    process.env.ES_INDEX
+  );
+
+  const queryResult = await es.query();
+
+  t.is(queryResult.meta.count, 1);
+  t.is(queryResult.results.length, 1);
+  t.is(queryResult.results[0].granuleId, granules[1].granuleId);
 });


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2019: Dashboard Search Module: support partial matching](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2019)

## Changes

* add infix search to es query builder

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

