### PR TITLE
Deprecate the collection-config-store package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Deprecated
 
+- `@cumulus/collection-config-store`
 - `@cumulus/common/util.sleep()`
 
 ### Removed

--- a/packages/collection-config-store/index.js
+++ b/packages/collection-config-store/index.js
@@ -6,6 +6,7 @@
  * @module collection-config-store
  */
 
+const { deprecate } = require('@cumulus/common/util');
 const {
   deleteS3Object,
   getJsonS3Object,
@@ -35,6 +36,12 @@ class CollectionConfigStore {
    * @param {string} stackName - the Cumulus deployment stack name
    */
   constructor(bucket, stackName) {
+    deprecate(
+      '@cumulus/collection-config-store',
+      '1.23.2',
+      '@cumulus/api-client/collections.getCollection()'
+    );
+
     this.bucket = bucket;
     this.stackName = stackName;
     this.cache = {};

--- a/packages/collection-config-store/package.json
+++ b/packages/collection-config-store/package.json
@@ -39,6 +39,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cumulus/aws-client": "1.23.2",
+    "@cumulus/common": "1.23.2",
     "@cumulus/message": "1.23.2"
   }
 }


### PR DESCRIPTION
Now that we have the api client, there is no need for the collection config store. It was only a way to grant clients access to collection config info, which they can now get cleanly through the API.