### PR TITLE
Update CI scripts to not call python dependency install concurrently

### DIFF
--- a/bamboo/bootstrap-lint-audit.sh
+++ b/bamboo/bootstrap-lint-audit.sh
@@ -15,5 +15,5 @@ if [[ $USE_CACHED_BOOTSTRAP == true ]]; then ## Change into cached cumulus, pull
 fi
 
 npm install --ignore-scripts --no-package-lock
-./node_modules/.bin/lerna run install-python-deps
+npm run install-python-deps
 ln -s /dev/stdout ./lerna-debug.log

--- a/bamboo/bootstrap-unit-tests.sh
+++ b/bamboo/bootstrap-unit-tests.sh
@@ -29,7 +29,7 @@ done
 
 ## Setup the build env container once it's started
 $docker_command "npm install --error --no-progress -g nyc; cd $UNIT_TEST_BUILD_DIR; git fetch --all; git checkout $GIT_SHA; npm install --error --no-progress; npm run bootstrap-no-build-quiet || true; npm run bootstrap-no-build-quiet"
-$docker_command "cd $UNIT_TEST_BUILD_DIR/example; npm run install-python-deps"
+$docker_command "cd $UNIT_TEST_BUILD_DIR; npm run install-python-deps"
 
 # Wait for the FTP server to be available
 while ! $docker_command  'curl --connect-timeout 5 -sS -o /dev/null ftp://testuser:testpass@127.0.0.1/README.md'; do

--- a/example/package.json
+++ b/example/package.json
@@ -16,7 +16,6 @@
   },
   "scripts": {
     "all-tests": "npm run parallel-tests && ../node_modules/.bin/jasmine && npm run redeploy-test",
-    "install-python-deps": "for x in lambdas/*; do cd $x && npm run install-python-deps || true && cd -; done",
     "int-test": "../node_modules/.bin/jasmine && npm run parallel-tests",
     "package": "for x in lambdas/*; do cd $x && npm run package && cd -; done",
     "parallel-tests": "sh scripts/tests-parallel.sh",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "eslint": "eslint --ext .js --ext .ts .",
     "remove-locks": "lerna exec 'rm -f package-lock.json'",
     "install-locks": "lerna exec --no-sort -- npm i --package-lock-only --no-audit",
+    "install-python-deps": "lerna run install-python-deps --concurrency 1",
     "lint": "npm run lint-package-json && npm run eslint && lerna run python-lint && npm run lint-md",
     "lint-md": "markdownlint docs/**/*.md docs/*.md tf-modules/**/*.md tf-modules/*.md",
     "lint-package-json": "npmPkgJsonLint .",


### PR DESCRIPTION
- Updates CI scripts to use `package.json` 'install python-deps'
  script
- Remove unneeded `install-python-deps` script from
  example/package.json
- Set concurrency to 1 for `install-python-deps` script
