### PR TITLE
Fixes Integration tests for opendap link type change

### DIFF
--- a/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
+++ b/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
@@ -314,7 +314,7 @@ describe('When there are granule differences and granule reconciliation is run',
     // TBD update to 1 after the s3credentials url has type 'VIEW RELATED INFORMATION' (CUMULUS-1182)
     // Cumulus 670 has a fix for the issue noted above from 1182.  Setting to 1.
     expect(report.filesInCumulusCmr.onlyInCmr.filter((file) => file.GranuleUR === publishedGranuleId).length)
-      .toBe(1);
+      .toBe(2);
   });
 
   it('deletes a reconciliation report through the Cumulus API', async () => {

--- a/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
@@ -528,7 +528,7 @@ describe('The S3 Ingest Granules workflow', () => {
         'GET DATA',
         'VIEW RELATED INFORMATION',
         'VIEW RELATED INFORMATION',
-        'VIEW RELATED INFORMATION',
+        'GET DATA',
         'GET RELATED VISUALIZATION'
       ];
       const cmrUrls = resource.map((r) => r.URL);


### PR DESCRIPTION
was: 'VIEW RELATED INFORMATION'
is:  'GET DATA'

**Summary:** updates integration tests for new CMR response.

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [X ] Integration tests