### PR TITLE
Temporarily whiteilst dot-prop from the dev dependencies

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -2,5 +2,5 @@
     "high": true,
     "pass-enoaudit": true,
     "retry-count": 20,
-    "whitelist": ["https-proxy-agent"]
+    "whitelist": ["https-proxy-agent", "dot-prop"]
 }


### PR DESCRIPTION
Audit fails on the following deps:

@cumulus/core@1.0.0 
├─┬ ava@3.11.0
│ └─┬ update-notifier@4.1.0
│   └─┬ configstore@5.0.1
│     └── dot-prop@5.2.0  deduped
├── dot-prop@5.2.0
└─┬ lerna@3.22.1
  ├─┬ @lerna/add@3.21.0
  │ └─┬ @lerna/command@3.21.0
  │   └─┬ @lerna/project@3.21.0
  │     └── dot-prop@4.2.0
  └─┬ @lerna/version@3.22.1
    └─┬ @lerna/conventional-commits@3.22.0
      └─┬ conventional-changelog-angular@5.0.10
        └─┬ compare-func@1.3.4
          └── dot-prop@3.0.0

Pinning at the root forces ava to pull the right deduped dependency,
but lerna/etc are hard set on dot-prop v4/v3.

This will be sorted when lerna merges:

https://github.com/lerna/lerna/pull/2678

or 

https://github.com/lerna/lerna/pull/2677

and

https://github.com/lerna/lerna/pull/2676

**Summary:** Summary of changes

Addresses [CUMULUS-2117: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2117)

