### PR TITLE
Ensure that process.env.NODE_ENV is not overridden in webpack bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "babel-plugin-source-map-support": "^2.1.1",
     "babel-preset-env": "^1.7.0",
     "cookie-parser": "^1.4.5",
-    "copy-webpack-plugin": "^4.6.0",
+    "copy-webpack-plugin": "^6.0.3",
     "coveralls": "^3.0.0",
     "create-test-server": "^3.0.1",
     "crypto-random-string": "^3.2.0",
@@ -134,7 +134,7 @@
     "tsc-watch": "^4.2.8",
     "typescript": "^3.9.0",
     "uuid": "^3.2.1",
-    "webpack": "~4.5.0",
+    "webpack": "^4.44.1",
     "webpack-cli": "^3.3.5",
     "xml2js": "^0.4.19"
   },

--- a/packages/api/webpack.config.js
+++ b/packages/api/webpack.config.js
@@ -86,5 +86,8 @@ module.exports = {
   node: {
     __dirname: false,
     __filename: false
+  },
+  optimization: {
+    nodeEnv: false
   }
 };

--- a/packages/api/webpack.config.js
+++ b/packages/api/webpack.config.js
@@ -48,9 +48,14 @@ module.exports = {
   },
   plugins: [
     // templates to use saml2.js, dependency problem with xml-encryption package
-    new CopyPlugin([
-      { from: 'node_modules/xml-encryption/lib/templates', to: 'app/templates' }
-    ])
+    new CopyPlugin({
+      patterns: [
+        {
+          from: 'node_modules/xml-encryption/lib/templates',
+          to: 'app/templates'
+        }
+      ]
+    })
   ],
   output: {
     libraryTarget: 'commonjs2',

--- a/packages/integration-tests/webpack.config.js
+++ b/packages/integration-tests/webpack.config.js
@@ -36,5 +36,8 @@ module.exports = {
     ],
   },
   devtool: 'inline-source-map',
-  target: 'node'
+  target: 'node',
+  optimization: {
+    nodeEnv: false
+  }
 };

--- a/packages/s3-credentials-endpoint/webpack.config.js
+++ b/packages/s3-credentials-endpoint/webpack.config.js
@@ -43,5 +43,8 @@ module.exports = {
     warningsFilter: [
       /critical dependency:/i
     ],
+  },
+  optimization: {
+    nodeEnv: false
   }
 };

--- a/tasks/add-missing-file-checksums/webpack.config.js
+++ b/tasks/add-missing-file-checksums/webpack.config.js
@@ -10,5 +10,8 @@ module.exports = {
   },
   externals: ['aws-sdk'],
   target: 'node',
-  devtool: 'eval-cheap-module-source-map'
+  devtool: 'eval-cheap-module-source-map',
+  optimization: {
+    nodeEnv: false
+  }
 };

--- a/tasks/discover-granules/webpack.config.js
+++ b/tasks/discover-granules/webpack.config.js
@@ -36,5 +36,8 @@ module.exports = {
     ],
   },
   devtool: 'inline-source-map',
-  target: 'node'
+  target: 'node',
+  optimization: {
+    nodeEnv: false
+  }
 };

--- a/tasks/discover-pdrs/webpack.config.js
+++ b/tasks/discover-pdrs/webpack.config.js
@@ -36,5 +36,8 @@ module.exports = {
     ],
   },
   devtool: 'inline-source-map',
-  target: 'node'
+  target: 'node',
+  optimization: {
+    nodeEnv: false
+  }
 };

--- a/tasks/files-to-granules/webpack.config.js
+++ b/tasks/files-to-granules/webpack.config.js
@@ -36,5 +36,8 @@ module.exports = {
     ],
   },
   devtool: 'inline-source-map',
-  target: 'node'
+  target: 'node',
+  optimization: {
+    nodeEnv: false
+  }
 };

--- a/tasks/hello-world/webpack.config.js
+++ b/tasks/hello-world/webpack.config.js
@@ -36,5 +36,8 @@ module.exports = {
     ],
   },
   devtool: 'inline-source-map',
-  target: 'node'
+  target: 'node',
+  optimization: {
+    nodeEnv: false
+  }
 };

--- a/tasks/hyrax-metadata-updates/webpack.config.js
+++ b/tasks/hyrax-metadata-updates/webpack.config.js
@@ -36,5 +36,8 @@ module.exports = {
     ],
   },
   devtool: 'inline-source-map',
-  target: 'node'
+  target: 'node',
+  optimization: {
+    nodeEnv: false
+  }
 };

--- a/tasks/move-granules/webpack.config.js
+++ b/tasks/move-granules/webpack.config.js
@@ -36,5 +36,8 @@ module.exports = {
     ],
   },
   devtool: 'inline-source-map',
-  target: 'node'
+  target: 'node',
+  optimization: {
+    nodeEnv: false
+  }
 };

--- a/tasks/parse-pdr/webpack.config.js
+++ b/tasks/parse-pdr/webpack.config.js
@@ -36,5 +36,8 @@ module.exports = {
     ],
   },
   devtool: 'inline-source-map',
-  target: 'node'
+  target: 'node',
+  optimization: {
+    nodeEnv: false
+  }
 };

--- a/tasks/pdr-status-check/webpack.config.js
+++ b/tasks/pdr-status-check/webpack.config.js
@@ -36,5 +36,8 @@ module.exports = {
     ],
   },
   devtool: 'inline-source-map',
-  target: 'node'
+  target: 'node',
+  optimization: {
+    nodeEnv: false
+  }
 };

--- a/tasks/post-to-cmr/webpack.config.js
+++ b/tasks/post-to-cmr/webpack.config.js
@@ -36,5 +36,8 @@ module.exports = {
     ],
   },
   devtool: 'inline-source-map',
-  target: 'node'
+  target: 'node',
+  optimization: {
+    nodeEnv: false
+  }
 };

--- a/tasks/queue-granules/webpack.config.js
+++ b/tasks/queue-granules/webpack.config.js
@@ -36,5 +36,8 @@ module.exports = {
     ],
   },
   devtool: 'inline-source-map',
-  target: 'node'
+  target: 'node',
+  optimization: {
+    nodeEnv: false
+  }
 };

--- a/tasks/queue-pdrs/webpack.config.js
+++ b/tasks/queue-pdrs/webpack.config.js
@@ -36,5 +36,8 @@ module.exports = {
     ],
   },
   devtool: 'inline-source-map',
-  target: 'node'
+  target: 'node',
+  optimization: {
+    nodeEnv: false
+  }
 };

--- a/tasks/sf-sns-report/webpack.config.js
+++ b/tasks/sf-sns-report/webpack.config.js
@@ -36,5 +36,8 @@ module.exports = {
     ]
   },
   devtool: 'inline-source-map',
-  target: 'node'
+  target: 'node',
+  optimization: {
+    nodeEnv: false
+  }
 };

--- a/tasks/sf-sqs-report/webpack.config.js
+++ b/tasks/sf-sqs-report/webpack.config.js
@@ -36,5 +36,8 @@ module.exports = {
     ]
   },
   devtool: 'inline-source-map',
-  target: 'node'
+  target: 'node',
+  optimization: {
+    nodeEnv: false
+  }
 };

--- a/tasks/sync-granule/webpack.config.js
+++ b/tasks/sync-granule/webpack.config.js
@@ -36,5 +36,8 @@ module.exports = {
     ],
   },
   devtool: 'inline-source-map',
-  target: 'node'
+  target: 'node',
+  optimization: {
+    nodeEnv: false
+  }
 };

--- a/tasks/test-processing/webpack.config.js
+++ b/tasks/test-processing/webpack.config.js
@@ -44,5 +44,8 @@ module.exports = {
     ],
   },
   devtool: 'inline-source-map',
-  target: 'node'
+  target: 'node',
+  optimization: {
+    nodeEnv: false
+  }
 };

--- a/tf-modules/internal/cumulus-test-cleanup/webpack.config.js
+++ b/tf-modules/internal/cumulus-test-cleanup/webpack.config.js
@@ -36,5 +36,8 @@ module.exports = {
     ],
   },
   devtool: 'inline-source-map',
-  target: 'node'
+  target: 'node',
+  optimization: {
+    nodeEnv: false
+  }
 };


### PR DESCRIPTION
Webpack uses process.env.NODE_ENV to determine whether your bundle is for development, production, etc. Unfortunately, Webpack also [**injects this environment variable into your compiled code**](https://webpack.js.org/plugins/environment-plugin/), which in our case resulted in our helper that determines if we are in local test mode was being overwritten from:

`export const inTestMode = () => process.env.NODE_ENV === 'test';`

to:

`exports.inTestMode = () => "development" === 'test';`

Lucky for us, when we deploy our bundled Lambda code to AWS, we want `inTestMode()` to evaluate to `false`, so it was doing the right thing by accident. However, I don't think we want to rely on accidental code behavior, so this PR ensures that `process.env.NODE_ENV` will not be overwritten in our compiled code bundles