### PR TITLE
PR feedback on S3 changes in CUMULUS-1955

### DIFF
--- a/packages/aws-client/package.json
+++ b/packages/aws-client/package.json
@@ -37,10 +37,7 @@
     "files": [
       "tests/**/*.js"
     ],
-    "verbose": true,
-    "nonSemVerExperiments": {
-      "likeAssertion": true
-    }
+    "verbose": true
   },
   "author": "Cumulus Authors",
   "license": "Apache-2.0",

--- a/packages/aws-client/src/S3.ts
+++ b/packages/aws-client/src/S3.ts
@@ -357,15 +357,17 @@ export const s3PutObjectTagging = improveStackTrace(
  * @example
  * const obj = await getObject(s3(), { Bucket: 'b', Key: 'k' })
  *
- * @param {AWS.S3} s3Client
- * @param {AWS.S3.GetObjectRequest} params
- * @returns {Promise<AWS.S3.GetObjectOutput>}
+ * @param {AWS.S3} s3 - an `AWS.S3` instance
+ * @param {AWS.S3.GetObjectRequest} params - parameters object to pass through
+ *   to `AWS.S3.getObject()`
+ * @returns {Promise<AWS.S3.GetObjectOutput>} response from `AWS.S3.getObject()`
+ *   as a Promise
  */
 export const getObject = (
-  s3Client: { getObject: GetObjectPromiseMethod },
+  // eslint-disable-next-line no-shadow
+  s3: { getObject: GetObjectPromiseMethod },
   params: AWS.S3.GetObjectRequest
-): Promise<AWS.S3.GetObjectOutput> =>
-  s3Client.getObject(params).promise();
+): Promise<AWS.S3.GetObjectOutput> => s3.getObject(params).promise();
 
 /**
  * Get an object from S3, waiting for it to exist and, if specified, have the

--- a/packages/aws-client/src/utils.ts
+++ b/packages/aws-client/src/utils.ts
@@ -68,34 +68,3 @@ export const retryOnThrottlingException = <T, U extends unknown[]>(
         () => fn(...args).catch(retryIfThrottlingException),
         { maxTimeout: 5000, ...options }
       );
-
-const retryIfMissingObjectError = (error: Error & { statusCode?: number }) => {
-  const { statusCode } = error;
-
-  if (statusCode && [404, 412].includes(statusCode)) throw error;
-  throw new pRetry.AbortError(error);
-};
-
-/**
- * Returns a function that wraps the specified function, but will retry the
- * wrapped function when it throws a "not found" (404) or "pre-condition failed"
- * (412) error, based upon the specified retry options.
- *
- * @param {Function} fn - function (that returns a Promise) to retry on error
- * @param {Object} options - retry options
- * @returns {Function} a function that will retry the specified function when
- *    it throws a "not found" or "pre-condition failed" error (i.e., the
- *    `statusCode` property of the error is either 404 or 412)
- * @see https://github.com/sindresorhus/p-retry#options
- * @see https://github.com/tim-kos/node-retry#retryoperationoptions
- * @see https://github.com/tim-kos/node-retry#retrytimeoutsoptions
- */
-export const retryOnMissingObjectError = <T, U extends unknown[]>(
-  fn: (...args: U) => Promise<T>,
-  options: pRetry.Options = {}
-) =>
-    (...args: U) =>
-      pRetry(
-        () => fn(...args).catch(retryIfMissingObjectError),
-        { maxTimeout: 5000, ...options }
-      );

--- a/packages/aws-client/tests/S3/test-getObject.js
+++ b/packages/aws-client/tests/S3/test-getObject.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const test = require('ava');
+const cryptoRandomString = require('crypto-random-string');
+const { s3 } = require('../../services');
+const S3 = require('../../S3');
+
+test('getObject() returns a NoSuchBucket code if the bucket does not exist', async (t) => {
+  const Bucket = cryptoRandomString({ length: 12 });
+
+  const error = await t.throwsAsync(
+    S3.getObject(s3(), { Bucket, Key: 'fdsa' })
+  );
+
+  t.is(error.code, 'NoSuchBucket');
+});
+
+test('getObject() returns a NoSuchKey code if the object does not exist', async (t) => {
+  const Bucket = cryptoRandomString({ length: 12 });
+  const Key = cryptoRandomString({ length: 12 });
+
+  await S3.createBucket(Bucket);
+  t.teardown(() => S3.recursivelyDeleteS3Bucket(Bucket));
+
+  const error = await t.throwsAsync(S3.getObject(s3(), { Bucket, Key }));
+
+  t.is(error.code, 'NoSuchKey');
+});

--- a/packages/aws-client/tests/S3/test-waitForObject.js
+++ b/packages/aws-client/tests/S3/test-waitForObject.js
@@ -1,0 +1,124 @@
+'use strict';
+
+const test = require('ava');
+const { waitForObject } = require('../../S3');
+
+test('waitForObject() returns the requested object', async (t) => {
+  const Bucket = 'my-bucket';
+  const Key = 'my-key';
+
+  const s3Client = {
+    getObject: (params) => {
+      t.is(params.Bucket, Bucket);
+      t.is(params.Key, Key);
+
+      return {
+        promise: async () => 'asdf'
+      };
+    }
+  };
+
+  const result = await waitForObject(s3Client, { Bucket, Key });
+
+  t.is(result, 'asdf');
+});
+
+test('waitForObject() does not retry if the requested bucket does not exist', async (t) => {
+  const Bucket = 'my-bucket';
+  const Key = 'my-key';
+
+  let callCount = 0;
+
+  const s3Client = {
+    getObject: (params) => {
+      t.is(params.Bucket, Bucket);
+      t.is(params.Key, Key);
+
+      callCount += 1;
+
+      const error = new Error('Bucket does not exist');
+      error.code = 'NoSuchBucket';
+
+      return { promise: () => Promise.reject(error) };
+    }
+  };
+
+  await t.throwsAsync(
+    waitForObject(
+      s3Client,
+      { Bucket, Key },
+      { minTimeout: 1, retries: 1 }
+    ),
+    { message: 'Bucket does not exist' }
+  );
+
+  t.is(callCount, 1);
+});
+
+test('waitForObject() retries if the requested object does not exist', async (t) => {
+  const Bucket = 'my-bucket';
+  const Key = 'my-key';
+
+  let callCount = 0;
+
+  const s3Client = {
+    getObject: (params) => {
+      t.is(params.Bucket, Bucket);
+      t.is(params.Key, Key);
+
+      callCount += 1;
+
+      if (callCount === 1) {
+        const error = new Error('Object does not exist');
+        error.code = 'NoSuchKey';
+
+        return { promise: () => Promise.reject(error) };
+      }
+
+      return { promise: () => Promise.resolve('asdf') };
+    }
+  };
+
+  const result = await waitForObject(
+    s3Client,
+    { Bucket, Key },
+    { minTimeout: 1, retries: 1 }
+  );
+
+  t.is(callCount, 2);
+  t.is(result, 'asdf');
+});
+
+test('waitForObject() retries if the wrong etag was returned', async (t) => {
+  const Bucket = 'my-bucket';
+  const Key = 'my-key';
+
+  let callCount = 0;
+
+  const s3Client = {
+    getObject: (params) => {
+      t.is(params.Bucket, Bucket);
+      t.is(params.Key, Key);
+
+      callCount += 1;
+
+      if (callCount === 1) {
+        const error = new Error('Incorrect etag');
+        error.code = 'PreconditionFailed';
+
+        return { promise: () => Promise.reject(error) };
+      }
+
+      return { promise: () => Promise.resolve('asdf') };
+    }
+  };
+
+  const result = await waitForObject(
+    s3Client,
+    { Bucket, Key, IfMatch: 'some-etag' },
+    { minTimeout: 1, retries: 1 }
+  );
+
+  t.is(callCount, 2);
+  t.is(result, 'asdf');
+});

--- a/packages/aws-client/tests/test-utils.js
+++ b/packages/aws-client/tests/test-utils.js
@@ -1,26 +1,9 @@
 const path = require('path');
 const test = require('ava');
 
-const { throttleOnce } = require('../test-utils');
-const {
-  retryOnMissingObjectError,
-  retryOnThrottlingException
-} = require('../utils');
 const { getObject } = require('../S3');
 const { s3 } = require('../services');
 
-const throwOnce = (error, fn) => {
-  let thrown = false;
-
-  return (...args) => {
-    if (!thrown) {
-      thrown = true;
-      throw error;
-    }
-
-    return fn(...args);
-  };
-};
 test('better stack traces', async (t) => {
   const f = () => getObject(s3(), { Bucket: 'asdf', Key: 'jkl;' });
   const g = () => f();
@@ -31,38 +14,4 @@ test('better stack traces', async (t) => {
   } catch (error) {
     t.true(error.stack.includes(path.basename(__filename)));
   }
-});
-
-test('retryOnThrottlingException properly retries after ThrottlingException', async (t) => {
-  const asyncSquare = (x) => Promise.resolve(x * x);
-  const throttledAsyncSquare = throttleOnce(asyncSquare);
-  const throttledAsyncSquareWithRetries = retryOnThrottlingException(throttledAsyncSquare);
-
-  t.is(await throttledAsyncSquareWithRetries(3), 9);
-});
-
-test('retryOnMissingObjectError properly retries after 404 Error', async (t) => {
-  const asyncSquare = (x) => Promise.resolve(x * x);
-  const throwingAsyncSquare = throwOnce(
-    Object.assign(new Error(), { statusCode: 404 }),
-    asyncSquare
-  );
-  const throwingAsyncSquareWithRetries = retryOnMissingObjectError(
-    throwingAsyncSquare
-  );
-
-  t.is(await throwingAsyncSquareWithRetries(3), 9);
-});
-
-test('retryOnMissingObjectError properly retries after 412 Error', async (t) => {
-  const asyncSquare = (x) => Promise.resolve(x * x);
-  const throwingAsyncSquare = throwOnce(
-    Object.assign(new Error(), { statusCode: 412 }),
-    asyncSquare
-  );
-  const throwingAsyncSquareWithRetries = retryOnMissingObjectError(
-    throwingAsyncSquare
-  );
-
-  t.is(await throwingAsyncSquareWithRetries(3), 9);
 });

--- a/packages/cmrjs/src/cmr-utils.js
+++ b/packages/cmrjs/src/cmr-utils.js
@@ -10,14 +10,13 @@ const urljoin = require('url-join');
 const xml2js = require('xml2js');
 const {
   buildS3Uri,
-  getObject,
   parseS3Uri,
   promiseS3Upload,
   s3GetObjectTagging,
-  s3TagSetToQueryString
+  s3TagSetToQueryString,
+  waitForObject
 } = require('@cumulus/aws-client/S3');
 const { s3 } = require('@cumulus/aws-client/services');
-const { retryOnMissingObjectError } = require('@cumulus/aws-client/utils');
 const { getSecretString } = require('@cumulus/aws-client/SecretsManager');
 const launchpad = require('@cumulus/launchpad-auth');
 const log = require('@cumulus/common/log');
@@ -199,12 +198,12 @@ async function publish2CMR(cmrPublishObject, creds) {
  */
 function getObjectByFilename(filename, etag) {
   const { Bucket, Key } = parseS3Uri(filename);
-  const retryGetObject = retryOnMissingObjectError(getObject, { retries: 5 });
+
   const params = etag
     ? { Bucket, Key, IfMatch: etag }
     : { Bucket, Key };
 
-  return retryGetObject(s3(), params);
+  return waitForObject(s3(), params, { retries: 5 });
 }
 
 /**

--- a/tasks/add-missing-file-checksums/src/index.ts
+++ b/tasks/add-missing-file-checksums/src/index.ts
@@ -24,7 +24,7 @@ const parseS3Uri = (uri: string) => {
 };
 
 const calculateGranuleFileChecksum = async (params: {
-  s3: { getObject: S3.GetObjectMethod },
+  s3: { getObject: S3.GetObjectCreateReadStreamMethod },
   algorithm: string,
   granuleFile: GranuleFile
 }) => {
@@ -51,7 +51,7 @@ const skipGranuleFileUpdate = (granuleFile: GranuleFile) =>
   || granuleFileDoesNotHaveFilename(granuleFile);
 
 export const addChecksumToGranuleFile = async (params: {
-  s3: { getObject: S3.GetObjectMethod },
+  s3: { getObject: S3.GetObjectCreateReadStreamMethod },
   algorithm: string,
   granuleFile: GranuleFile
 }) => {
@@ -75,7 +75,7 @@ export const addChecksumToGranuleFile = async (params: {
 };
 
 const addFileChecksumsToGranule = async (params: {
-  s3: { getObject: S3.GetObjectMethod },
+  s3: { getObject: S3.GetObjectCreateReadStreamMethod },
   algorithm: string,
   granule: Granule
 }) => {

--- a/tasks/add-missing-file-checksums/tests/test-index.ts
+++ b/tasks/add-missing-file-checksums/tests/test-index.ts
@@ -8,7 +8,7 @@ import { handler, addChecksumToGranuleFile } from '../src';
 const randomString = () => cryptoRandomString({ length: 10 });
 
 const test = anyTest as TestInterface<{
-  stubS3: { getObject: S3.GetObjectMethod }
+  stubS3: { getObject: S3.GetObjectCreateReadStreamMethod }
 }>;
 
 test.before((t) => {


### PR DESCRIPTION
This PR is meant to clarify some of the discussions that we're having in #1787.

Regarding [this comment](https://github.com/nasa/cumulus/pull/1787/files?file-filters%5B%5D=.ts#r465804425), I need to clarify what I'd meant in our discussion. I'd like to see a clean `getObject` function here that does two things: 1) takes an S3 client as a parameter to facilitate testing and 2) returns a `Promise`, to make calling it simpler. I don't have a problem with another function in this module that will attempt to get an object and retry if that object does not exist, or if the specified etag does not match. The `getS3Object` function in this module comes closest to that right now, but does not check etags. I've left `getS3Object` as deprecated and created a `waitForObject` function that will wait for an object to exist with the correct etag (if specified).

With the addition of `waitForObject`, the changes to `aws-client/util` are no longer needed.

The other changes here are only fixing a TS type that did not support the `promise()` function coming back from the `getObject` function.