### PR TITLE
CUMULUS-1855: Fix SyncGranule task to handle empty granules list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **CUMULUS-1855**
+  - Fixed SyncGranule task to return an empty granules list when given an empty
+    (or absent) granules list on input, rather than throwing an exception
 - **CUMULUS-1955**
   - Added `@cumulus/aws-client/S3.getObject` to get an AWS S3 object
   - Added `@cumulus/aws-client/S3.waitForObject` to get an AWS S3 object,

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "babel-plugin-source-map-support": "^2.1.1",
     "babel-preset-env": "^1.7.0",
     "cookie-parser": "^1.4.5",
-    "copy-webpack-plugin": "^4.6.0",
+    "copy-webpack-plugin": "^6.0.3",
     "coveralls": "^3.0.0",
     "create-test-server": "^3.0.1",
     "crypto-random-string": "^3.2.0",
@@ -134,7 +134,7 @@
     "tsc-watch": "^4.2.8",
     "typescript": "^3.9.0",
     "uuid": "^3.2.1",
-    "webpack": "~4.5.0",
+    "webpack": "^4.44.1",
     "webpack-cli": "^3.3.5",
     "xml2js": "^0.4.19"
   },

--- a/tasks/sync-granule/index.js
+++ b/tasks/sync-granule/index.js
@@ -19,7 +19,8 @@ const GranuleFetcher = require('./GranuleFetcher');
  * @param {Object[]} kwargs.granules - the granules to be ingested
  * @param {boolean} [kwargs.syncChecksumFiles=false] - if `true`, also ingest
  *    all corresponding checksum files
- * @returns {Promise<Array>} - the list of successfully ingested granules
+ * @returns {Promise<Array>} the list of successfully ingested granules, or an
+ *    empty list if the input granules was not a non-empty array of granules
  */
 async function download({
   ingest,
@@ -28,6 +29,8 @@ async function download({
   granules,
   syncChecksumFiles = false
 }) {
+  if (!Array.isArray(granules) || granules.length === 0) return [];
+
   log.debug(
     'awaiting lock.proceed in download() '
     + `bucket: ${bucket}, `

--- a/tasks/sync-granule/tests/sync_granule_test.js
+++ b/tasks/sync-granule/tests/sync_granule_test.js
@@ -130,6 +130,22 @@ test.afterEach.always((t) => Promise.all([
   recursivelyDeleteS3Bucket(t.context.protectedBucketName)
 ]));
 
+test.serial('should return empty granules list given empty granules list on input', async (t) => {
+  t.context.event.input.granules = [];
+
+  const output = await syncGranule(t.context.event);
+
+  t.deepEqual(output.granules, [], 'output granules list should be empty');
+});
+
+test.serial('should return empty granules list given no granules list on input', async (t) => {
+  delete t.context.event.input.granules;
+
+  const output = await syncGranule(t.context.event);
+
+  t.deepEqual(output.granules, [], 'output granules list should be empty');
+});
+
 test.serial('error when provider info is missing', async (t) => {
   delete t.context.event.config.provider;
 


### PR DESCRIPTION
CUMULUS-1855

Fix SyncGranule task to return empty granules list when given empty granules list on input, rather than throwing an exception.

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

