### PR TITLE
Increase timeouts

### DIFF
--- a/example/spec/parallel/discoverGranules/DiscoverGranulesDuplicateHandlingErrorSpec.js
+++ b/example/spec/parallel/discoverGranules/DiscoverGranulesDuplicateHandlingErrorSpec.js
@@ -98,7 +98,7 @@ describe('The DiscoverGranules workflow with an existing granule and duplicateHa
         (execution) =>
           get(execution, 'originalPayload.testExecutionId') === ingestGranuleRule.payload.testExecutionId,
         { timestamp__from: ingestTime },
-        { timeout: 15 }
+        { timeout: 30 }
       );
 
       // Wait for the "IngestGranule" execution to be completed
@@ -136,7 +136,7 @@ describe('The DiscoverGranules workflow with an existing granule and duplicateHa
         (execution) =>
           get(execution, 'originalPayload.testExecutionId') === discoverGranulesRule.payload.testExecutionId,
         { timestamp__from: ingestTime },
-        { timeout: 15 }
+        { timeout: 30 }
       );
     } catch (error) {
       console.log('ingestGranuleRule.payload.testExecutionId', ingestGranuleRule.payload.testExecutionId);

--- a/example/spec/parallel/discoverGranules/DiscoverGranulesDuplicateHandlingSkipSpec.js
+++ b/example/spec/parallel/discoverGranules/DiscoverGranulesDuplicateHandlingSkipSpec.js
@@ -99,7 +99,7 @@ describe('The DiscoverGranules workflow with one existing granule, one new granu
         (execution) =>
           get(execution, 'originalPayload.testExecutionId') === ingestGranuleRule.payload.testExecutionId,
         { timestamp__from: ingestTime },
-        { timeout: 15 }
+        { timeout: 30 }
       );
 
       // Wait for the "IngestGranule" execution to be completed
@@ -142,7 +142,7 @@ describe('The DiscoverGranules workflow with one existing granule, one new granu
         (execution) =>
           get(execution, 'originalPayload.testExecutionId') === discoverGranulesRule.payload.testExecutionId,
         { timestamp__from: ingestTime },
-        { timeout: 15 }
+        { timeout: 30 }
       );
 
       // Get the completed "DiscoverGranules" execution

--- a/example/spec/parallel/ingestGranule/IngestGranuleWithDuplicateHandlingErrorSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleWithDuplicateHandlingErrorSpec.js
@@ -106,7 +106,7 @@ describe('The IngestGranuleCatchDuplicateErrorTest workflow with DuplicateHandli
           return executionId === firstIngestGranuleRule.payload.testExecutionId;
         },
         { timestamp__from: ingestTime },
-        { timeout: 15 }
+        { timeout: 30 }
       );
 
       // Wait for the execution to be completed
@@ -154,7 +154,7 @@ describe('The IngestGranuleCatchDuplicateErrorTest workflow with DuplicateHandli
           return executionId === secondIngestGranuleRule.payload.testExecutionId;
         },
         { timestamp__from: ingestTime },
-        { timeout: 15 }
+        { timeout: 30 }
       );
 
       // Wait for the execution to be completed

--- a/example/spec/parallel/ingestGranule/IngestGranuleWithDuplicateHandlingVersionSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleWithDuplicateHandlingVersionSpec.js
@@ -119,7 +119,7 @@ describe('The IngestGranule workflow with DuplicateHandling="version" and a gran
           return executionId === firstIngestGranuleRule.payload.testExecutionId;
         },
         { timestamp__from: ingestTime },
-        { timeout: 15 }
+        { timeout: 30 }
       );
 
       // Wait for the execution to be completed
@@ -190,7 +190,7 @@ describe('The IngestGranule workflow with DuplicateHandling="version" and a gran
           return executionId === secondIngestGranuleRule.payload.testExecutionId;
         },
         { timestamp__from: ingestTime },
-        { timeout: 15 }
+        { timeout: 30 }
       );
 
       // Wait for the execution to be completed

--- a/example/spec/parallel/testAPI/createOneTimeRuleSpec.js
+++ b/example/spec/parallel/testAPI/createOneTimeRuleSpec.js
@@ -31,6 +31,8 @@ describe('Creating a one-time rule via the Cumulus API', () => {
 
       ingestTime = Date.now() - 1000 * 30;
 
+      console.log(`Creating rule for HelloWorldWorkflow with testExecutionId ${testExecutionId}`);
+
       rule = await createOneTimeRule(
         prefix,
         {

--- a/packages/integration-tests/Executions.js
+++ b/packages/integration-tests/Executions.js
@@ -69,6 +69,7 @@ const findExecutionArn = async (prefix, matcher, queryParameters = { }, options 
     },
     {
       retries: options.timeout,
+      minTimeout: 1000,
       maxTimeout: 1000,
     }
   );


### PR DESCRIPTION
I have seen test fails due to not waiting long enough for the workflow to kick off (I went and actually searched for it based on the testExecutionId and found it, compared the timestamps), so this is increasing the timeout.
