### PR TITLE
Mhs/cumulus 1965/allow array of collection ids on reconciliation report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Adds `collectionId` parameter to the `/reconcilationReports`
     endpoint. Setting this value will limit the scope of the reconcilation
     report to only the input collectionId when comparing Cumulus and
-    CMR.
+    CMR. `collectionId` is available an array of strings in the form `shortname___version`
 - **CUMULUS-2107**
   - Added a new task, `update-cmr-access-constraints`, that will set access constraints in CMR Metadata.
     Currently supports UMMG-JSON and Echo10XML, where it will configure `AccessConstraints` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Adds `collectionId` parameter to the `/reconcilationReports`
     endpoint. Setting this value will limit the scope of the reconcilation
     report to only the input collectionId when comparing Cumulus and
-    CMR. `collectionId` is available an array of strings in the form `shortname___version`
+    CMR. `collectionId` is provided an array of strings e.g. `[shortname___version, shortname2___version2]`
 - **CUMULUS-2107**
   - Added a new task, `update-cmr-access-constraints`, that will set access constraints in CMR Metadata.
     Currently supports UMMG-JSON and Echo10XML, where it will configure `AccessConstraints` and

--- a/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
+++ b/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
@@ -53,6 +53,7 @@ const { waitForModelStatus } = require('../../helpers/apiUtils');
 const providersDir = './data/providers/s3/';
 const collectionsDir = './data/collections/s3_MYD13Q1_006';
 const collection = { name: 'MYD13Q1', version: '006' };
+const onlyCMRCollection = {name: 'L2_HR_PIXC', version:'1'};
 
 async function findProtectedBucket(systemBucket, stackName) {
   const bucketsConfig = new BucketsConfig(
@@ -347,6 +348,11 @@ describe('When there are granule differences and granule reconciliation is run',
     it('generates an async operation through the Cumulus API', async () => {
       const response = await reconciliationReportsApi.createReconciliationReport({
         prefix: config.stackName,
+        request: { collectionId: [
+          constructCollectionId(collection.name, collection.version),
+          constructCollectionId(extraCumulusCollection.name, extraCumulusCollection.version),
+          constructCollectionId(onlyCMRCollection.name, onlyCMRCollection.version),
+        ] },
       });
 
       const responseBody = JSON.parse(response.body);
@@ -407,7 +413,7 @@ describe('When there are granule differences and granule reconciliation is run',
 
     it('generates a report showing collections that are in the CMR but not in Cumulus', () => {
       // we know CMR has collections which are not in Cumulus
-      expect(report.collectionsInCumulusCmr.onlyInCmr.length).toBeGreaterThanOrEqual(1);
+      expect(report.collectionsInCumulusCmr.onlyInCmr.length).toBe(1);
       expect(report.collectionsInCumulusCmr.onlyInCmr).not.toContain(collectionId);
     });
 

--- a/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
+++ b/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
@@ -53,7 +53,7 @@ const { waitForModelStatus } = require('../../helpers/apiUtils');
 const providersDir = './data/providers/s3/';
 const collectionsDir = './data/collections/s3_MYD13Q1_006';
 const collection = { name: 'MYD13Q1', version: '006' };
-const onlyCMRCollection = {name: 'L2_HR_PIXC', version:'1'};
+const onlyCMRCollection = { name: 'L2_HR_PIXC', version: '1' };
 
 async function findProtectedBucket(systemBucket, stackName) {
   const bucketsConfig = new BucketsConfig(

--- a/packages/api/lambdas/create-reconciliation-report.js
+++ b/packages/api/lambdas/create-reconciliation-report.js
@@ -387,7 +387,7 @@ async function reconciliationReportForGranules(params) {
   });
 
   const esGranuleSearchParamsByCollectionId = convertToESGranuleSearchParams(
-    { ...recReportParams, collectionId }
+    { ...recReportParams, collectionIds: [collectionId] }
   );
   const esGranulesIterator = new ESCollectionGranuleQueue(
     esGranuleSearchParamsByCollectionId, process.env.ES_INDEX

--- a/packages/api/lambdas/create-reconciliation-report.js
+++ b/packages/api/lambdas/create-reconciliation-report.js
@@ -731,10 +731,12 @@ function normalizeEvent(event) {
   }
 
   // TODO [MHS, 09/08/2020] Clean this up when CUMULUS-2156 is worked/completed
-  // for now, internal reports will add a new duplicate key collectionIds with
-  // the value of [ collectionId] to handle the expectations of the shared
-  // library calls to convertToESGranuleSearchParams, and convertToEsCollectionSearchParams
-  let { collectionId, ...modifiedEvent } = { ...event };
+  // for now, move input collectionId to collectionIds as array
+  // internal reports will keep existing collectionId and copy it to collectionIds
+  let { collectionIds: anyCollectionIds, collectionId, ...modifiedEvent } = { ...event };
+  if (anyCollectionIds) {
+    throw new TypeError('`collectionIds` is not a valid input key for a reconciliation report use `collectionId`.');
+  }
   if (collectionId) {
     if (reportType === 'Internal') {
       if (!isString(collectionId)) {

--- a/packages/api/lambdas/create-reconciliation-report.js
+++ b/packages/api/lambdas/create-reconciliation-report.js
@@ -735,7 +735,7 @@ function normalizeEvent(event) {
   // internal reports will keep existing collectionId and copy it to collectionIds
   let { collectionIds: anyCollectionIds, collectionId, ...modifiedEvent } = { ...event };
   if (anyCollectionIds) {
-    throw new TypeError('`collectionIds` is not a valid input key for a reconciliation report use `collectionId`.');
+    throw new TypeError('`collectionIds` is not a valid input key for a reconciliation report, use `collectionId` instead.');
   }
   if (collectionId) {
     if (reportType === 'Internal') {

--- a/packages/api/lambdas/internal-reconciliation-report.js
+++ b/packages/api/lambdas/internal-reconciliation-report.js
@@ -14,6 +14,7 @@ const { s3 } = require('@cumulus/aws-client/services');
 const { ESSearchQueue } = require('../es/esSearchQueue');
 const { Collection, Granule } = require('../models');
 const {
+  convertToDBCollectionSearchParams,
   convertToESCollectionSearchParams,
   convertToGranuleSearchParams,
   initialReportHeader,
@@ -43,7 +44,8 @@ async function internalRecReportForCollections(recReportParams) {
   );
 
   // get collections from database and sort them, since the scan result is not ordered
-  const dbCollectionsQueue = await (new Collection()).search(searchParams);
+  const dbSearchParams = convertToDBCollectionSearchParams(recReportParams);
+  const dbCollectionsQueue = await (new Collection()).search(dbSearchParams);
   const dbCollectionItems = sortBy(await dbCollectionsQueue.empty(), ['name', 'version']);
 
   let okCount = 0;

--- a/packages/api/lib/reconciliationReport.js
+++ b/packages/api/lib/reconciliationReport.js
@@ -83,10 +83,11 @@ function convertToDBCollectionSearchParams(params) {
  */
 function convertToESGranuleSearchParams(params) {
   const { collectionIds } = params;
+  const collectionIdIn = collectionIds ? collectionIds.join(',') : undefined;
   return removeNilProperties({
     updatedAt__from: dateToValue(params.startTimestamp),
     updatedAt__to: dateToValue(params.endTimestamp),
-    collectionId: collectionIds && collectionIds[0],
+    collectionId__in: collectionIdIn,
   });
 }
 

--- a/packages/api/lib/reconciliationReport.js
+++ b/packages/api/lib/reconciliationReport.js
@@ -16,22 +16,6 @@ function searchParamsForCollectionIdArray(collectionIds) {
 }
 
 /**
- * Simple converter from input reportParams to CMR searchCollection params.
- * e.g.:
- * {collectionId: "name__version"} => {short_name: 'name', version: 'version'}
- * @param {Object} reportParams
- * @returns {Object} correct paremeters to call cmr.searchCollection with.
- */
-function cmrSearchParams(reportParams) {
-  const { collectionId } = reportParams;
-  const { name, version } = collectionId
-    ? deconstructCollectionId(collectionId)
-    : {};
-  const collection = { short_name: name, version };
-  return removeNilProperties(collection);
-}
-
-/**
  * @param {string} dateable - any input valid for a JS Date contstructor.
  * @returns {number} - primitive value of input date string or undefined, if
  *                     input string not convertable.
@@ -48,14 +32,13 @@ function dateToValue(dateable) {
  */
 function convertToESCollectionSearchParams(params) {
   const { collectionIds, startTimestamp, endTimestamp } = params;
-  const collection = collectionIds && collectionIds[0]
+  const idsIn = collectionIds
     ? searchParamsForCollectionIdArray(collectionIds)
     : undefined;
-  // right now its {name:X,  version:Y}  TODO [MHS, 09/09/2020]  - make different search.
   const searchParams = {
     updatedAt__from: dateToValue(startTimestamp),
     updatedAt__to: dateToValue(endTimestamp),
-    ...collection,
+    ...idsIn,
   };
   return removeNilProperties(searchParams);
 }
@@ -166,7 +149,6 @@ function filterCMRCollections(collections, recReportParams) {
 }
 
 module.exports = {
-  cmrSearchParams,
   convertToDBCollectionSearchParams,
   convertToESCollectionSearchParams,
   convertToESGranuleSearchParams,

--- a/packages/api/lib/reconciliationReport.js
+++ b/packages/api/lib/reconciliationReport.js
@@ -1,14 +1,32 @@
 'use strict';
 
 const { removeNilProperties } = require('@cumulus/common/util');
+const { constructCollectionId } = require('@cumulus/message/Collections');
 const { deconstructCollectionId } = require('./utils');
+
+/**
+ * Simple converter from input reportParams to CMR searchCollection params.
+ * e.g.:
+ * {collectionId: "name__version"} => {short_name: 'name', version: 'version'}
+ * @param {Object} reportParams
+ * @returns {Object} correct paremeters to call cmr.searchCollection with.
+ */
+function cmrSearchParams(reportParams) {
+  const { collectionId } = reportParams;
+  const { name, version } = collectionId
+    ? deconstructCollectionId(collectionId)
+    : {};
+  const collection = { short_name: name, version };
+  return removeNilProperties(collection);
+}
+
 /**
  * @param {string} dateable - any input valid for a JS Date contstructor.
  * @returns {number} - primitive value of input date string or undefined, if
  *                     input string not convertable.
  */
 function dateToValue(dateable) {
-  const primitiveDate = (new Date(dateable)).valueOf();
+  const primitiveDate = new Date(dateable).valueOf();
   return !Number.isNaN(primitiveDate) ? primitiveDate : undefined;
 }
 
@@ -18,8 +36,12 @@ function dateToValue(dateable) {
  * @returns {Object} object of desired parameters formated for Elasticsearch collection search
  */
 function convertToESCollectionSearchParams(params) {
-  const { collectionId, startTimestamp, endTimestamp } = params;
-  const collection = collectionId ? deconstructCollectionId(collectionId) : {};
+  const { collectionIds, startTimestamp, endTimestamp } = params;
+  const collection =
+    collectionIds && collectionIds[0]
+      ? deconstructCollectionId(collectionIds[0])
+      : {};
+  // right now its {name:X,  version:Y}  TODO [MHS, 09/09/2020]  - make different search.
   const searchParams = {
     updatedAt__from: dateToValue(startTimestamp),
     updatedAt__to: dateToValue(endTimestamp),
@@ -34,11 +56,11 @@ function convertToESCollectionSearchParams(params) {
  * @returns {Object} object of desired parameters formated for Elasticsearch.
  */
 function convertToESGranuleSearchParams(params) {
-  const { collectionId } = params;
+  const { collectionIds } = params;
   return removeNilProperties({
     updatedAt__from: dateToValue(params.startTimestamp),
     updatedAt__to: dateToValue(params.endTimestamp),
-    collectionId,
+    collectionId: collectionIds && collectionIds[0],
   });
 }
 
@@ -48,7 +70,13 @@ function convertToESGranuleSearchParams(params) {
  * @returns {Object} object of desired parameters formated for Elasticsearch/DB
  */
 function convertToGranuleSearchParams(params) {
-  const { collectionId, granuleId, provider, startTimestamp, endTimestamp } = params;
+  const {
+    collectionId,
+    granuleId,
+    provider,
+    startTimestamp,
+    endTimestamp,
+  } = params;
   const searchParams = {
     updatedAt__from: dateToValue(startTimestamp),
     updatedAt__to: dateToValue(endTimestamp),
@@ -91,17 +119,34 @@ function initialReportHeader(recReportParams) {
 }
 
 /**
- * Simple converter from input reportParams to CMR searchCollection params.
- * e.g.:
- * {collectionId: "name__version"} => {short_name: 'name', version: 'version'}
- * @param {Object} reportParams
- * @returns {Object} correct paremeters to call cmr.searchCollection with.
+ * Prepare a list of collectionIds into an _id__in object
+ *
+ * @param {Array<string>} collectionIds - Array of collectionIds in the form 'name___ver'
+ * @returns {Object} - object that will return the correct terms search when
+ *                     passed to the query command.
  */
-function cmrSearchParams(reportParams) {
-  const { collectionId } = reportParams;
-  const { name, version } = collectionId ? deconstructCollectionId(collectionId) : {};
-  const collection = { short_name: name, version };
-  return removeNilProperties(collection);
+function searchParamsForCollectionIdArray(collectionIds) {
+  return { _id__in: collectionIds.join(',') };
+}
+
+/**
+ * filters the returned UMM CMR collections by the desired collectionIds
+ *
+ * @param {Array<Object>} collections - CMR.searchCollections result
+ * @param {Object} recReportParams
+ * @param {Array<string>} recReportParams.collectionIds - array of collectionIds to keep
+ * @returns {Array<string>} filtered list of collectionIds returned from CMR
+ */
+function filterCMRCollections(collections, recReportParams) {
+  const { collectionIds } = recReportParams;
+
+  const CMRCollectionIds = collections
+    .map((item) => constructCollectionId(item.umm.ShortName, item.umm.Version))
+    .sort();
+
+  if (!collectionIds) return CMRCollectionIds;
+
+  return CMRCollectionIds.filter((item) => collectionIds.includes(item));
 }
 
 module.exports = {
@@ -109,5 +154,7 @@ module.exports = {
   convertToESCollectionSearchParams,
   convertToESGranuleSearchParams,
   convertToGranuleSearchParams,
+  filterCMRCollections,
   initialReportHeader,
+  searchParamsForCollectionIdArray,
 };

--- a/packages/api/tests/es/test-queries-package.js
+++ b/packages/api/tests/es/test-queries-package.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const test = require('ava');
+const query = require('../../es/queries');
+
+test('query creates correct string for multiple collectionIds', (t) => {
+  const inputQueryParams = {
+    _id__in: 'col1___ver1,col1___ver2,col2___ver1',
+  };
+
+  const expectedQueryResult =
+    '{"query":{"bool":{"must":[{"terms":{"_id":["col1___ver1","col1___ver2","col2___ver1"]}}],"should":[],"must_not":[]}},"sort":[{"timestamp":{"order":"desc"}}]}';
+
+  const actualQueryResult = query(inputQueryParams);
+
+  t.is(JSON.stringify(actualQueryResult), expectedQueryResult);
+});

--- a/packages/api/tests/lambdas/test-create-reconciliation-report-internals.js
+++ b/packages/api/tests/lambdas/test-create-reconciliation-report-internals.js
@@ -160,6 +160,6 @@ test('normalizeEvent throws error if original input event contains collectionIds
   };
   t.throws(() => normalizeEvent(inputEvent), {
     message:
-      '`collectionIds` is not a valid input key for a reconciliation report use `collectionId`.',
+      '`collectionIds` is not a valid input key for a reconciliation report, use `collectionId` instead.',
   });
 });

--- a/packages/api/tests/lambdas/test-create-reconciliation-report-internals.js
+++ b/packages/api/tests/lambdas/test-create-reconciliation-report-internals.js
@@ -11,8 +11,8 @@ const shouldFilterByTime = CRP.__get__('shouldFilterByTime');
 const normalizeEvent = CRP.__get__('normalizeEvent');
 
 test(
-  'isOneWayReport returns true only when one or more specific parameters ' +
-    ' are present on the reconciliation report object.',
+  'isOneWayReport returns true only when one or more specific parameters '
+    + ' are present on the reconciliation report object.',
   (t) => {
     const paramsThatShouldReturnTrue = ['startTimestamp', 'endTimestamp'];
 
@@ -24,12 +24,10 @@ test(
     ];
 
     paramsThatShouldReturnTrue.map((p) =>
-      t.true(isOneWayReport({ [p]: randomId('value') }))
-    );
+      t.true(isOneWayReport({ [p]: randomId('value') })));
 
     paramsThatShouldReturnFalse.map((p) =>
-      t.false(isOneWayReport({ [p]: randomId('value') }))
-    );
+      t.false(isOneWayReport({ [p]: randomId('value') })));
 
     const allTrueKeys = paramsThatShouldReturnTrue.reduce(
       (accum, current) => ({ ...accum, [current]: randomId('value') }),
@@ -47,8 +45,8 @@ test(
 );
 
 test(
-  'shouldFilterByTime returns true only when one or more specific parameters ' +
-    ' are present on the reconciliation report object.',
+  'shouldFilterByTime returns true only when one or more specific parameters '
+    + ' are present on the reconciliation report object.',
   (t) => {
     const paramsThatShouldReturnTrue = ['updatedAt__to', 'updatedAt__from'];
     const paramsThatShouldReturnFalse = [
@@ -59,12 +57,10 @@ test(
     ];
 
     paramsThatShouldReturnTrue.map((p) =>
-      t.true(shouldFilterByTime({ [p]: randomId('value') }))
-    );
+      t.true(shouldFilterByTime({ [p]: randomId('value') })));
 
     paramsThatShouldReturnFalse.map((p) =>
-      t.false(shouldFilterByTime({ [p]: randomId('value') }))
-    );
+      t.false(shouldFilterByTime({ [p]: randomId('value') })));
 
     const allTrueKeys = paramsThatShouldReturnTrue.reduce(
       (accum, current) => ({ ...accum, [current]: randomId('value') }),

--- a/packages/api/tests/lambdas/test-create-reconciliation-report.js
+++ b/packages/api/tests/lambdas/test-create-reconciliation-report.js
@@ -28,7 +28,6 @@ const { Search } = require('../../es/search');
 const {
   handler, reconciliationReportForGranules, reconciliationReportForGranuleFiles,
 } = require('../../lambdas/create-reconciliation-report');
-
 const models = require('../../models');
 const indexer = require('../../es/indexer');
 

--- a/packages/api/tests/lambdas/test-create-reconciliation-report.js
+++ b/packages/api/tests/lambdas/test-create-reconciliation-report.js
@@ -250,14 +250,7 @@ const setupElasticAndCMRForTests = async ({ t, params = {} }) => {
 
   // Stub CMR searchCollection that filters on inputParams if present.
   CMR.prototype.searchCollections.restore();
-  sinon.stub(CMR.prototype, 'searchCollections').callsFake((inputParams) => {
-    if (inputParams && inputParams.short_name) {
-      return cmrCollections.filter((f) =>
-        f.umm.ShortName === inputParams.short_name
-          && f.umm.Version === inputParams.version);
-    }
-    return cmrCollections;
-  });
+  sinon.stub(CMR.prototype, 'searchCollections').callsFake(() => cmrCollections);
 
   await storeCollectionsToElasticsearch(
     matchingCollections

--- a/packages/api/tests/lambdas/test-internal-reconciliation-report.js
+++ b/packages/api/tests/lambdas/test-internal-reconciliation-report.js
@@ -116,7 +116,11 @@ test.serial('reconciliationReportForCollections reports discrepancy of collectio
 
   // collectionId matches the collection with conflicts
   const collectionId = constructCollectionId(conflictCollInDb.name, conflictCollInDb.version);
-  const paramsCollectionId = { ...searchParams, collectionId };
+  // TODO [MHS, 09/09/2020] remove collectionIds after CUMULUS-2156 is worked
+  // (added because this test doesn't normalize the event) another alternative
+  // would be to rewire and __get__ the normalize function from
+  // create-reconciliation-report
+  const paramsCollectionId = { ...searchParams, collectionId, collectionIds: [collectionId] };
 
   report = await internalRecReportForCollections(paramsCollectionId);
   t.is(report.okCount, 0);

--- a/packages/api/tests/lib/test-reconciliationReport.js
+++ b/packages/api/tests/lib/test-reconciliationReport.js
@@ -108,7 +108,8 @@ test("filterCMRCollections filters collections by recReportParams's collectionId
     constructCollectionId(c.name, c.version));
 
   const expected = sortBy(targetCollections, 'name', 'version').map(
-    (collection) => constructCollectionId(collection.name, collection.version));
+    (collection) => constructCollectionId(collection.name, collection.version)
+  );
 
   const reportParams = {
     startTimestamp: 'any',

--- a/packages/api/tests/lib/test-reconciliationReport.js
+++ b/packages/api/tests/lib/test-reconciliationReport.js
@@ -116,7 +116,6 @@ test('convertToDBCollectionSearchParams returns correct search object with colle
   t.deepEqual(actual, expected);
 });
 
-
 test('filterCMRCollections returns all collections if no collectionIds on recReportParams', (t) => {
   const collections = range(25).map(() => fakeCollectionFactory());
   const expectedCollectionsIds = sortBy(collections, [


### PR DESCRIPTION
**Summary:** Updates reconciliation report endpoint to optionally take an array of collectionIds to filter 

Addresses [CUMULUS-1965: Update reconcilation report to take array of collectionIds](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1965)

## Changes

* Changes ES searches to find multiple collectionIds in both granules (aggregation) and collection searches.

DOCUMENTATION UPDATE PR: https://github.com/nasa/cumulus-api/pull/288
## PR Checklist

- [X] Update CHANGELOG
- [X] Unit tests
- [X] Adhoc testing
- [ ] Integration tests
