### PR TITLE
Ignore NGAP tags on deployed resources

### DIFF
--- a/example/cumulus-tf/main.tf
+++ b/example/cumulus-tf/main.tf
@@ -1,6 +1,6 @@
 terraform {
   required_providers {
-    aws  = ">= 2.31.0"
+    aws  = ">= 3.5.0"
     null = "~> 2.1"
   }
 }
@@ -8,6 +8,10 @@ terraform {
 provider "aws" {
   region  = var.region
   profile = var.aws_profile
+
+  ignore_tags {
+    key_prefixes = ["gsfc-ngap"]
+  }
 }
 
 provider "aws" {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -27,6 +27,7 @@
     "node": ">=12.18.0"
   },
   "dependencies": {
+    "@cumulus/common": "2.0.1",
     "@cumulus/logger": "2.0.1",
     "knex": "^0.21.5",
     "pg": "^8.3.0"


### PR DESCRIPTION
NGAP is automatically adding tags to certain resources via an hourly Lambda. These changes prevent us from deletings those tags and getting a lot of unnecessary resource changes from terraform apply.

Corresponding PR for template-deploy repo: https://github.com/nasa/cumulus-template-deploy/pull/48