### PR TITLE
Make Lambda subnet config optional

### DIFF
--- a/bamboo/bootstrap-tf-deployment.sh
+++ b/bamboo/bootstrap-tf-deployment.sh
@@ -114,7 +114,7 @@ echo "Deploying Cumulus example to $DEPLOYMENT"
   -var "data_persistence_remote_state_config={ region: \"$AWS_REGION\", bucket: \"$TFSTATE_BUCKET\", key: \"$DATA_PERSISTENCE_KEY\" }" \
   -var "region=$AWS_REGION" \
   -var "vpc_id=$VPC_ID" \
-  -var "subnet_ids=[\"$AWS_SUBNET\"]" \
+  -var "lambda_subnet_ids=[\"$AWS_SUBNET\"]" \
   -var "urs_client_id=$EARTHDATA_CLIENT_ID" \
   -var "urs_client_password=$EARTHDATA_CLIENT_PASSWORD" \
   -var "token_secret=$TOKEN_SECRET" \

--- a/example/cumulus-tf/cnm_response_task.tf
+++ b/example/cumulus-tf/cnm_response_task.tf
@@ -18,9 +18,12 @@ resource "aws_lambda_function" "cnm_response_task" {
     }
   }
 
-  vpc_config {
-    subnet_ids         = var.subnet_ids
-    security_group_ids = [aws_security_group.no_ingress_all_egress.id]
+  dynamic "vpc_config" {
+    for_each = length(var.lambda_subnet_ids) == 0 ? [] : [1]
+    content {
+      subnet_ids = var.lambda_subnet_ids
+      security_group_ids = [aws_security_group.no_ingress_all_egress.id]
+    }
   }
 
   tags = local.tags

--- a/example/cumulus-tf/cnm_to_cma_task.tf
+++ b/example/cumulus-tf/cnm_to_cma_task.tf
@@ -18,9 +18,12 @@ resource "aws_lambda_function" "cnm_to_cma_task" {
     }
   }
 
-  vpc_config {
-    subnet_ids         = var.subnet_ids
-    security_group_ids = [aws_security_group.no_ingress_all_egress.id]
+  dynamic "vpc_config" {
+    for_each = length(var.lambda_subnet_ids) == 0 ? [] : [1]
+    content {
+      subnet_ids = var.lambda_subnet_ids
+      security_group_ids = [aws_security_group.no_ingress_all_egress.id]
+    }
   }
 
   tags = local.tags

--- a/example/cumulus-tf/lambdas.tf
+++ b/example/cumulus-tf/lambdas.tf
@@ -8,9 +8,12 @@ resource "aws_lambda_function" "async_operation_fail" {
 
   tags = local.tags
 
-  vpc_config {
-    subnet_ids         = var.subnet_ids
-    security_group_ids = [aws_security_group.no_ingress_all_egress.id]
+  dynamic "vpc_config" {
+    for_each = length(var.lambda_subnet_ids) == 0 ? [] : [1]
+    content {
+      subnet_ids = var.lambda_subnet_ids
+      security_group_ids = [aws_security_group.no_ingress_all_egress.id]
+    }
   }
 }
 
@@ -24,9 +27,12 @@ resource "aws_lambda_function" "async_operation_success" {
 
   tags = local.tags
 
-  vpc_config {
-    subnet_ids         = var.subnet_ids
-    security_group_ids = [aws_security_group.no_ingress_all_egress.id]
+  dynamic "vpc_config" {
+    for_each = length(var.lambda_subnet_ids) == 0 ? [] : [1]
+    content {
+      subnet_ids = var.lambda_subnet_ids
+      security_group_ids = [aws_security_group.no_ingress_all_egress.id]
+    }
   }
 }
 
@@ -47,9 +53,12 @@ resource "aws_lambda_function" "sns_s3_executions_test" {
 
   tags = local.tags
 
-  vpc_config {
-    subnet_ids         = var.subnet_ids
-    security_group_ids = [aws_security_group.no_ingress_all_egress.id]
+  dynamic "vpc_config" {
+    for_each = length(var.lambda_subnet_ids) == 0 ? [] : [1]
+    content {
+      subnet_ids = var.lambda_subnet_ids
+      security_group_ids = [aws_security_group.no_ingress_all_egress.id]
+    }
   }
 }
 
@@ -70,9 +79,12 @@ resource "aws_lambda_function" "sns_s3_granules_test" {
 
   tags = local.tags
 
-  vpc_config {
-    subnet_ids         = var.subnet_ids
-    security_group_ids = [aws_security_group.no_ingress_all_egress.id]
+  dynamic "vpc_config" {
+    for_each = length(var.lambda_subnet_ids) == 0 ? [] : [1]
+    content {
+      subnet_ids = var.lambda_subnet_ids
+      security_group_ids = [aws_security_group.no_ingress_all_egress.id]
+    }
   }
 }
 
@@ -93,9 +105,12 @@ resource "aws_lambda_function" "sns_s3_pdrs_test" {
 
   tags = local.tags
 
-  vpc_config {
-    subnet_ids         = var.subnet_ids
-    security_group_ids = [aws_security_group.no_ingress_all_egress.id]
+  dynamic "vpc_config" {
+    for_each = length(var.lambda_subnet_ids) == 0 ? [] : [1]
+    content {
+      subnet_ids = var.lambda_subnet_ids
+      security_group_ids = [aws_security_group.no_ingress_all_egress.id]
+    }
   }
 }
 
@@ -116,8 +131,11 @@ resource "aws_lambda_function" "sns_s3_collections_test" {
 
   tags = local.tags
 
-  vpc_config {
-    subnet_ids         = var.subnet_ids
-    security_group_ids = [aws_security_group.no_ingress_all_egress.id]
+  dynamic "vpc_config" {
+    for_each = length(var.lambda_subnet_ids) == 0 ? [] : [1]
+    content {
+      subnet_ids = var.lambda_subnet_ids
+      security_group_ids = [aws_security_group.no_ingress_all_egress.id]
+    }
   }
 }

--- a/example/cumulus-tf/main.tf
+++ b/example/cumulus-tf/main.tf
@@ -55,13 +55,16 @@ module "cumulus" {
   bucket_map_key = var.bucket_map_key
 
   vpc_id            = var.vpc_id
-  lambda_subnet_ids = var.subnet_ids
+  lambda_subnet_ids = var.lambda_subnet_ids
 
   rds_security_group            = local.rds_security_group
   rds_user_access_secret_arn      = local.rds_credentials_secret_arn
 
   ecs_cluster_instance_image_id   = data.aws_ssm_parameter.ecs_image_id.value
-  ecs_cluster_instance_subnet_ids = var.subnet_ids
+  ecs_cluster_instance_subnet_ids = (var.ecs_cluster_instance_subnet_ids == null
+    ? var.lambda_subnet_ids
+    : var.ecs_cluster_instance_subnet_ids
+  )
   ecs_cluster_min_size            = 2
   ecs_cluster_desired_size        = 2
   ecs_cluster_max_size            = 3

--- a/example/cumulus-tf/main.tf
+++ b/example/cumulus-tf/main.tf
@@ -61,7 +61,7 @@ module "cumulus" {
   rds_user_access_secret_arn      = local.rds_credentials_secret_arn
 
   ecs_cluster_instance_image_id   = data.aws_ssm_parameter.ecs_image_id.value
-  ecs_cluster_instance_subnet_ids = (var.ecs_cluster_instance_subnet_ids == null
+  ecs_cluster_instance_subnet_ids = (length(var.ecs_cluster_instance_subnet_ids) == 0
     ? var.lambda_subnet_ids
     : var.ecs_cluster_instance_subnet_ids
   )

--- a/example/cumulus-tf/python-reference-task.tf
+++ b/example/cumulus-tf/python-reference-task.tf
@@ -18,12 +18,10 @@ resource "aws_lambda_function" "python_reference_task" {
   }
 
   dynamic "vpc_config" {
-    for_each = length(var.subnet_ids) == 0 ? [] : [1]
+    for_each = length(var.lambda_subnet_ids) == 0 ? [] : [1]
     content {
-      subnet_ids = var.subnet_ids
-      security_group_ids = [
-        aws_security_group.no_ingress_all_egress.id
-      ]
+      subnet_ids = var.lambda_subnet_ids
+      security_group_ids = [aws_security_group.no_ingress_all_egress.id]
     }
   }
 

--- a/example/cumulus-tf/terraform.tfvars.example
+++ b/example/cumulus-tf/terraform.tfvars.example
@@ -23,7 +23,7 @@ buckets = {
     type = "public"
   }
 }
-subnet_ids    = ["subnet-12345"]
+lambda_subnet_ids    = ["subnet-12345"]
 system_bucket = "PREFIX-internal"
 vpc_id        = "vpc-12345"
 

--- a/example/cumulus-tf/variables.tf
+++ b/example/cumulus-tf/variables.tf
@@ -133,7 +133,7 @@ variable "distribution_url" {
 
 variable "ecs_cluster_instance_subnet_ids" {
   type = list(string)
-  default = null
+  default = []
 }
 
 variable "ems_datasource" {

--- a/example/cumulus-tf/variables.tf
+++ b/example/cumulus-tf/variables.tf
@@ -93,10 +93,6 @@ variable "saml_launchpad_metadata_url" {
   default = "N/A"
 }
 
-variable "subnet_ids" {
-  type = list(string)
-}
-
 variable "system_bucket" {
   type = string
 }
@@ -132,6 +128,11 @@ variable "buckets" {
 
 variable "distribution_url" {
   type    = string
+  default = null
+}
+
+variable "ecs_cluster_instance_subnet_ids" {
+  type = list(string)
   default = null
 }
 
@@ -207,6 +208,11 @@ variable "permissions_boundary_arn" {
 variable "aws_profile" {
   type    = string
   default = null
+}
+
+variable "lambda_subnet_ids" {
+  type = list(string)
+  default = []
 }
 
 variable "log_api_gateway_to_cloudwatch" {


### PR DESCRIPTION
This PR makes a distinction between the subnet IDs used for our Lambdas and for our ECS cluster. If you are deploying outside of NGAP, subnets for Lambdas aren't required, but they are for the ECS cluster, so those two should be separate variables. To make things slightly easier, I made the ECS subnets fall back to the value of the Lambda subnets if no ECS subnets are specified.

I ran into all of this while trying to deploy Cumuls to the Development Seed AWS account.

These changes should have no effect on our existing sandbox/SIT deployments, they should just make things slightly easier for those deploying outside of NGAP.

There is a corresponding template-deploy repo that should be reviewed as well:

https://github.com/nasa/cumulus-template-deploy/pull/44/files