### PR TITLE
Mhs/cumulus 1963/granule id parameters to reconcilation reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     those found in Cumulus and only those compared to the CMR holdings. For the moment
     there is not enough information to change the internal consistency check, and S3 vs
     Cumulus comparisons are unchanged by the timestamps.
+- **CUMULUS-1963**
+  - Adds `granuleId` as input parameter to `/reconcilationReports`
+    endpoint. Limits inputs parameters to either `collectionId` or `granuleId`
+    and will fail to create the report if both are provided.  Adding granuleId
+    will find collections in Cumulus by granuleId and compare those one way
+    with those in CMR.
 - **CUMULUS-1965**
   - Adds `collectionId` parameter to the `/reconcilationReports`
     endpoint. Setting this value will limit the scope of the reconcilation

--- a/packages/api/es/collections.js
+++ b/packages/api/es/collections.js
@@ -82,13 +82,13 @@ class Collection extends BaseSearch {
   }
 
   /**
-   * Get a list of collection ids that have granules. If time params
+   * Get a list of collection ids from found granules. If time params
    * are specified the query will return collections that have granules that have been updated
-   * in that time frame.
+   * in that time frame.  If granuleIds are provided, it will filter those as well.
    *
    * @returns {Promise<Array<string>>} - list of collection ids with active granules
    */
-  async aggregateActiveGranuleCollections() {
+  async aggregateGranuleCollections() {
     if (!this.client) {
       this.client = await this.constructor.es();
     }
@@ -133,7 +133,7 @@ class Collection extends BaseSearch {
    * @returns {Promise<Object>} - query result object containing collections and their granule stats
    */
   async queryCollectionsWithActiveGranules() {
-    const collectionIds = await this.aggregateActiveGranuleCollections();
+    const collectionIds = await this.aggregateGranuleCollections();
 
     const searchParams = this._buildSearch();
     searchParams.body.query = {

--- a/packages/api/es/search.js
+++ b/packages/api/es/search.js
@@ -35,10 +35,11 @@ const getCredentials = () =>
  * @returns {string} elasticsearch local address
  */
 const getLocalEsHost = () => {
-  const prot = (process.env.LOCAL_ES_HOST_PROTOCOL) ? process.env.LOCAL_ES_HOST_PROTOCOL : 'http';
-  if (process.env.LOCAL_ES_HOST) return `${prot}://${process.env.LOCAL_ES_HOST}:9200`;
-  if (process.env.LOCALSTACK_HOST) return `${prot}://${process.env.LOCALSTACK_HOST}:4571`;
-  return `${prot}://localhost:9200`;
+  const port = process.env.LOCAL_ES_HOST_PORT || 9200;
+  const protocol = (process.env.LOCAL_ES_HOST_PROTOCOL) ? process.env.LOCAL_ES_HOST_PROTOCOL : 'http';
+  if (process.env.LOCAL_ES_HOST) return `${protocol}://${process.env.LOCAL_ES_HOST}:${port}`;
+  if (process.env.LOCALSTACK_HOST) return `${protocol}://${process.env.LOCALSTACK_HOST}:4571`;
+  return `${protocol}://localhost:9200`;
 };
 
 const esTestConfig = () => ({

--- a/packages/api/lambdas/create-reconciliation-report.js
+++ b/packages/api/lambdas/create-reconciliation-report.js
@@ -115,12 +115,9 @@ async function fetchESCollections(recReportParams) {
   let esCollectionIds;
   // [MHS, 09/02/2020] We are doing these two because we can't use
   // aggregations on scrolls yet until we update elasticsearch version.
-  log.debug(`esGranuleSearchParams ${JSON.stringify(esGranuleSearchParams)}`);
-  log.debug(`esCollectionSearchParams ${JSON.stringify(esCollectionSearchParams)}`);
   if (shouldAggregateGranulesForCollections(esGranuleSearchParams)) {
     // Build an ESCollection and call the aggregateGranuleCollections to
     // get list of collection ids that have granules that have been updated
-    log.debug(`esGranuleSearchParams ${JSON.stringify(esGranuleSearchParams)}`);
     const esCollection = new Collection({ queryStringParameters: esGranuleSearchParams }, 'collection', process.env.ES_INDEX);
     const esCollectionItems = await esCollection.aggregateGranuleCollections();
     esCollectionIds = esCollectionItems.sort();

--- a/packages/api/lambdas/create-reconciliation-report.js
+++ b/packages/api/lambdas/create-reconciliation-report.js
@@ -735,7 +735,8 @@ function isoTimestamp(dateable) {
 }
 
 /**
- * Transforms input collectionId into correct parameters for
+ * Transforms input granuleId into correct parameters for use in the
+ * Reconciliation Report lambda.
  * @param {Array<string>|string} granuleId - list of granule Ids
  * @param {string} reportType - report type
  * @param {Object} modifiedEvent - input event
@@ -761,7 +762,8 @@ function updateGranuleIds(granuleId, reportType, modifiedEvent) {
 }
 
 /**
- * Transforms input collectionId into correct parameters for
+ * Transforms input collectionId into correct parameters for use in the
+ * Reconciliation Report lambda.
  * @param {Array<string>|string} collectionId - list of collection Ids
  * @param {string} reportType - report type
  * @param {Object} modifiedEvent - input event

--- a/packages/api/lambdas/create-reconciliation-report.js
+++ b/packages/api/lambdas/create-reconciliation-report.js
@@ -116,11 +116,11 @@ async function fetchESCollections(esCollectionSearchParams, esGranuleSearchParam
   log.debug(`esGranuleSearchParams ${JSON.stringify(esGranuleSearchParams)}`);
   log.debug(`esCollectionSearchParams ${JSON.stringify(esCollectionSearchParams)}`);
   if (shouldAggregateGranules(esGranuleSearchParams)) {
-    // Build an ESCollection and call the aggregateActiveGranuleCollections to
+    // Build an ESCollection and call the aggregateGranuleCollections to
     // get list of collection ids that have granules that have been updated
     log.debug(`esGranuleSearchParams ${JSON.stringify(esGranuleSearchParams)}`);
     const esCollection = new Collection({ queryStringParameters: esGranuleSearchParams }, 'collection', process.env.ES_INDEX);
-    const esCollectionItems = await esCollection.aggregateActiveGranuleCollections();
+    const esCollectionItems = await esCollection.aggregateGranuleCollections();
     esCollectionIds = esCollectionItems.sort();
   } else {
     // return all collections

--- a/packages/api/lambdas/create-reconciliation-report.js
+++ b/packages/api/lambdas/create-reconciliation-report.js
@@ -738,23 +738,34 @@ function normalizeEvent(event) {
     throw new TypeError('`collectionIds` is not a valid input key for a reconciliation report, use `collectionId` instead.');
   }
   if (collectionId) {
+    const collectionIds = isString(collectionId) ? [collectionId] : collectionId;
     if (reportType === 'Internal') {
       if (!isString(collectionId)) {
-        throw new TypeError(`${JSON.stringify(collectionId)} is not valid input for an 'Internal' report.`);
+        throw new TypeError(`collectionId: ${JSON.stringify(collectionId)} is not valid input for an 'Internal' report.`);
       } else {
         // include both collectionIds and collectionId for Internal Reports.
-        modifiedEvent = { ...event, collectionIds: [collectionId] };
+        modifiedEvent = { ...modifiedEvent, collectionId, collectionIds: [collectionId] };
       }
     } else {
-      // transform input collectionId into an array on collectionIds
-      const collectionIds = isString(collectionId) ? [collectionId] : collectionId;
+      // add array of collectionIds
       modifiedEvent = { ...modifiedEvent, collectionIds };
     }
   }
+  // TODO [MHS, 09/15/2020] Same here, remove/cleanup when internal reports
+  // supports array of granuleIds
   if (granuleId) {
     // transform input granuleId into an array on granuleIds
     const granuleIds = isString(granuleId) ? [granuleId] : granuleId;
-    modifiedEvent = { ...modifiedEvent, granuleIds, granuleId: undefined };
+    if (reportType === 'Internal') {
+      if (!isString(granuleId)) {
+        throw new TypeError(`granuleId: ${JSON.stringify(granuleId)} is not valid input for an 'Internal' report.`);
+      } else {
+        // include both granuleId and granuleIds for Internal Reports.
+        modifiedEvent = { ...modifiedEvent, granuleId, granuleIds: [granuleId] };
+      }
+    } else {
+      modifiedEvent = { ...modifiedEvent, granuleIds };
+    }
   }
 
   return removeNilProperties({

--- a/packages/api/lambdas/create-reconciliation-report.js
+++ b/packages/api/lambdas/create-reconciliation-report.js
@@ -98,7 +98,7 @@ function shouldAggregateGranules(searchParams) {
   return [
     'updatedAt__from',
     'updatedAt__to',
-    'granuleIds',
+    'granuleId__in',
   ].some((e) => !!searchParams[e]);
 }
 
@@ -113,9 +113,12 @@ async function fetchESCollections(esCollectionSearchParams, esGranuleSearchParam
   let esCollectionIds;
   // [MHS, 09/02/2020] We are doing these two because we can't use
   // aggregations on scrolls yet until we update elasticsearch version.
-  if (shouldAggregateGranules(esCollectionSearchParams)) {
+  log.debug(`esGranuleSearchParams ${JSON.stringify(esGranuleSearchParams)}`);
+  log.debug(`esCollectionSearchParams ${JSON.stringify(esCollectionSearchParams)}`);
+  if (shouldAggregateGranules(esGranuleSearchParams)) {
     // Build an ESCollection and call the aggregateActiveGranuleCollections to
     // get list of collection ids that have granules that have been updated
+    log.debug(`esGranuleSearchParams ${JSON.stringify(esGranuleSearchParams)}`);
     const esCollection = new Collection({ queryStringParameters: esGranuleSearchParams }, 'collection', process.env.ES_INDEX);
     const esCollectionItems = await esCollection.aggregateActiveGranuleCollections();
     esCollectionIds = esCollectionItems.sort();
@@ -398,7 +401,7 @@ async function reconciliationReportForGranules(params) {
   const cmrSettings = await getCmrSettings();
   const searchParams = new URLSearchParams({ short_name: name, version: version, sort_key: ['granule_ur'] });
   cmrGranuleSearchParams(recReportParams).forEach(([paramName, paramValue]) => {
-    searchParams.add(paramName, paramValue);
+    searchParams.append(paramName, paramValue);
   });
 
   const cmrGranulesIterator = new CMRSearchConceptQueue({

--- a/packages/api/lambdas/create-reconciliation-report.js
+++ b/packages/api/lambdas/create-reconciliation-report.js
@@ -59,7 +59,7 @@ const createSearchQueueForBucket = (bucket) => new DynamoDbSearchQueue(
 
 /**
  * Checks to see if any of the included reportParams contains a value that
- * would turn a Cumulus Vs CMR comparison into a one way report.
+ * would turn a Cumulus Vs CMR collection comparison into a one way report.
  *
  * @param {Object} reportParams
  * @returns {boolean} Returns true if any tested key exists on the input
@@ -75,7 +75,7 @@ function isOneWayCollectionReport(reportParams) {
 
 /**
  * Checks to see if any of the included reportParams contains a value that
- * would turn a Cumulus Vs CMR comparison into a one way report.
+ * would turn a Cumulus Vs CMR granule comparison into a one way report.
  *
  * @param {Object} reportParams
  * @returns {boolean} Returns true if any tested key exists on the input
@@ -221,7 +221,7 @@ async function reconciliationReportForCollections(recReportParams) {
   // 'Version' as sort_key
   const cmrSettings = await getCmrSettings();
   const cmr = new CMR(cmrSettings);
-  const cmrCollectionItems = await cmr.searchConcept('collection', {}, 'umm_json');
+  const cmrCollectionItems = await cmr.searchCollections({}, 'umm_json');
   const cmrCollectionIds = filterCMRCollections(cmrCollectionItems, recReportParams);
 
   const esCollectionSearchParams = convertToESCollectionSearchParams(recReportParams);

--- a/packages/api/lib/reconciliationReport.js
+++ b/packages/api/lib/reconciliationReport.js
@@ -5,6 +5,19 @@ const { constructCollectionId } = require('@cumulus/message/Collections');
 const { deconstructCollectionId } = require('./utils');
 
 /**
+ * Extra search params to add to the cmrGranules  searchConceptQueue
+ * @param {Object} recReportParams
+ * @returns {Array[Array]} array of name/value pairs to add to the search params
+ */
+function cmrGranuleSearchParams(recReportParams) {
+  const { granuleIds } = recReportParams;
+  if (granuleIds) {
+    return granuleIds.map((gid) => ['readable_granule_name[]', gid]);
+  }
+  return [];
+}
+
+/**
  * Prepare a list of collectionIds into an _id__in object
  *
  * @param {Array<string>} collectionIds - Array of collectionIds in the form 'name___ver'
@@ -151,6 +164,7 @@ function filterCMRCollections(collections, recReportParams) {
 }
 
 module.exports = {
+  cmrGranuleSearchParams,
   convertToDBCollectionSearchParams,
   convertToESCollectionSearchParams,
   convertToESGranuleSearchParams,

--- a/packages/api/lib/reconciliationReport.js
+++ b/packages/api/lib/reconciliationReport.js
@@ -65,12 +65,14 @@ function convertToDBCollectionSearchParams(params) {
  * @returns {Object} object of desired parameters formated for Elasticsearch.
  */
 function convertToESGranuleSearchParams(params) {
-  const { collectionIds } = params;
+  const { collectionIds, granuleIds } = params;
   const collectionIdIn = collectionIds ? collectionIds.join(',') : undefined;
+  const granuleIdIn = granuleIds ? granuleIds.join(',') : undefined;
   return removeNilProperties({
     updatedAt__from: dateToValue(params.startTimestamp),
     updatedAt__to: dateToValue(params.endTimestamp),
     collectionId__in: collectionIdIn,
+    granuleIdIn__in: granuleIdIn,
   });
 }
 

--- a/packages/api/lib/reconciliationReport.js
+++ b/packages/api/lib/reconciliationReport.js
@@ -5,9 +5,10 @@ const { constructCollectionId } = require('@cumulus/message/Collections');
 const { deconstructCollectionId } = require('./utils');
 
 /**
- * Extra search params to add to the cmrGranules  searchConceptQueue
- * @param {Object} recReportParams
- * @returns {Array[Array]} array of name/value pairs to add to the search params
+ * Extra search params to add to the cmrGranules searchConceptQueue
+ *
+ * @param {Object} recReportParams - input report params
+ * @returns {Array<Array>} array of name/value pairs to add to the search params
  */
 function cmrGranuleSearchParams(recReportParams) {
   const { granuleIds } = recReportParams;
@@ -128,22 +129,24 @@ function initialReportHeader(recReportParams) {
     createStartTime,
     endTimestamp,
     startTimestamp,
-    collectionId,
-    collectionIds,
     granuleIds,
+    granuleId,
+    collectionIds,
+    collectionId,
   } = recReportParams;
 
   return {
-    reportType,
-    createStartTime: createStartTime.toISOString(),
-    createEndTime: undefined,
-    reportStartTime: startTimestamp,
-    reportEndTime: endTimestamp,
-    status: 'RUNNING',
-    error: undefined,
     collectionId,
     collectionIds,
+    createEndTime: undefined,
+    createStartTime: createStartTime.toISOString(),
+    error: undefined,
+    granuleId,
     granuleIds,
+    reportEndTime: endTimestamp,
+    reportStartTime: startTimestamp,
+    reportType,
+    status: 'RUNNING',
   };
 }
 

--- a/packages/api/lib/reconciliationReport.js
+++ b/packages/api/lib/reconciliationReport.js
@@ -78,14 +78,14 @@ function convertToDBCollectionSearchParams(params) {
  * @returns {Object} object of desired parameters formated for Elasticsearch.
  */
 function convertToESGranuleSearchParams(params) {
-  const { collectionIds, granuleIds } = params;
+  const { collectionIds, granuleIds, startTimestamp, endTimestamp } = params;
   const collectionIdIn = collectionIds ? collectionIds.join(',') : undefined;
   const granuleIdIn = granuleIds ? granuleIds.join(',') : undefined;
   return removeNilProperties({
-    updatedAt__from: dateToValue(params.startTimestamp),
-    updatedAt__to: dateToValue(params.endTimestamp),
+    updatedAt__from: dateToValue(startTimestamp),
+    updatedAt__to: dateToValue(endTimestamp),
     collectionId__in: collectionIdIn,
-    granuleIdIn__in: granuleIdIn,
+    granuleId__in: granuleIdIn,
   });
 }
 
@@ -129,6 +129,8 @@ function initialReportHeader(recReportParams) {
     endTimestamp,
     startTimestamp,
     collectionId,
+    collectionIds,
+    granuleIds,
   } = recReportParams;
 
   return {
@@ -140,6 +142,8 @@ function initialReportHeader(recReportParams) {
     status: 'RUNNING',
     error: undefined,
     collectionId,
+    collectionIds,
+    granuleIds,
   };
 }
 

--- a/packages/api/tests/es/test-collections.js
+++ b/packages/api/tests/es/test-collections.js
@@ -349,9 +349,9 @@ test.serial('query correctly queries collection by date', async (t) => {
   t.is(queryResult.results[0].name, 'coll3');
 });
 
-test.serial('aggregateActiveGranuleCollections returns only collections with granules', async (t) => {
+test.serial('aggregateGranuleCollections returns only collections with granules', async (t) => {
   const collectionSearch = new Collection({}, undefined, process.env.ES_INDEX);
-  const queryResult = await collectionSearch.aggregateActiveGranuleCollections();
+  const queryResult = await collectionSearch.aggregateGranuleCollections();
 
   const orderedResult = queryResult.sort();
 
@@ -362,14 +362,14 @@ test.serial('aggregateActiveGranuleCollections returns only collections with gra
   );
 });
 
-test.serial('aggregateActiveGranuleCollections respects date range for granules', async (t) => {
+test.serial('aggregateGranuleCollections respects date range for granules', async (t) => {
   const collectionSearch = new Collection({
     queryStringParameters: {
       updatedAt__from: (new Date(2020, 1, 25)).getTime(),
       updatedAt__to: (new Date(2020, 1, 30)).getTime(),
     },
   }, undefined, process.env.ES_INDEX);
-  const queryResult = await collectionSearch.aggregateActiveGranuleCollections();
+  const queryResult = await collectionSearch.aggregateGranuleCollections();
 
   t.deepEqual(queryResult, ['coll3___1']);
 });

--- a/packages/api/tests/lambdas/test-create-reconciliation-report-internals.js
+++ b/packages/api/tests/lambdas/test-create-reconciliation-report-internals.js
@@ -88,7 +88,7 @@ test('normalizeEvent throws error if array of collectionIds passed to Internal r
   };
   t.throws(() => normalizeEvent(inputEvent), {
     message:
-      '["someCollection___version"] is not valid input for an \'Internal\' report.',
+      'collectionId: ["someCollection___version"] is not valid input for an \'Internal\' report.',
   });
 });
 
@@ -197,4 +197,19 @@ test('normalizeEvent moves array on granuleId to granuleIds', (t) => {
 
   const actual = normalizeEvent(inputEvent);
   t.deepEqual(actual, expect);
+});
+
+test('normalizeEvent throws error if array of granuleIds is passed to Internal report', (t) => {
+  const inputEvent = {
+    systemBucket: 'systemBucket',
+    stackName: 'stackName',
+    startTimestamp: new Date().toISOString(),
+    endTimestamp: new Date().toISOString(),
+    reportType: 'Internal',
+    granuleId: ['someCollectionId1'],
+  };
+  t.throws(() => normalizeEvent(inputEvent), {
+    message:
+      'granuleId: ["someCollectionId1"] is not valid input for an \'Internal\' report.',
+  });
 });

--- a/packages/api/tests/lambdas/test-create-reconciliation-report-internals.js
+++ b/packages/api/tests/lambdas/test-create-reconciliation-report-internals.js
@@ -6,12 +6,13 @@ const rewire = require('rewire');
 const { randomId } = require('@cumulus/common/test-utils');
 
 const CRP = rewire('../../lambdas/create-reconciliation-report');
-const isOneWayReport = CRP.__get__('isOneWayReport');
+const isOneWayCollectionReport = CRP.__get__('isOneWayCollectionReport');
+const isOneWayGranuleReport = CRP.__get__('isOneWayGranuleReport');
 const shouldAggregateGranules = CRP.__get__('shouldAggregateGranules');
 const normalizeEvent = CRP.__get__('normalizeEvent');
 
 test(
-  'isOneWayReport returns true only when one or more specific parameters '
+  'isOneWayCollectionReport returns true only when one or more specific parameters '
     + ' are present on the reconciliation report object.',
   (t) => {
     const paramsThatShouldReturnTrue = ['startTimestamp', 'endTimestamp'];
@@ -24,23 +25,57 @@ test(
     ];
 
     paramsThatShouldReturnTrue.map((p) =>
-      t.true(isOneWayReport({ [p]: randomId('value') })));
+      t.true(isOneWayCollectionReport({ [p]: randomId('value') })));
 
     paramsThatShouldReturnFalse.map((p) =>
-      t.false(isOneWayReport({ [p]: randomId('value') })));
+      t.false(isOneWayCollectionReport({ [p]: randomId('value') })));
 
     const allTrueKeys = paramsThatShouldReturnTrue.reduce(
       (accum, current) => ({ ...accum, [current]: randomId('value') }),
       {}
     );
-    t.true(isOneWayReport(allTrueKeys));
+    t.true(isOneWayCollectionReport(allTrueKeys));
 
     const allFalseKeys = paramsThatShouldReturnFalse.reduce(
       (accum, current) => ({ ...accum, [current]: randomId('value') }),
       {}
     );
-    t.false(isOneWayReport(allFalseKeys));
-    t.true(isOneWayReport({ ...allTrueKeys, ...allFalseKeys }));
+    t.false(isOneWayCollectionReport(allFalseKeys));
+    t.true(isOneWayCollectionReport({ ...allTrueKeys, ...allFalseKeys }));
+  }
+);
+
+test(
+  'isOneWayGranuleReport returns true only when one or more specific parameters '
+    + ' are present on the reconciliation report object.',
+  (t) => {
+    const paramsThatShouldReturnTrue = ['startTimestamp', 'endTimestamp'];
+
+    const paramsThatShouldReturnFalse = [
+      'stackName',
+      'systemBucket',
+      'anythingAtAll',
+      'collectionId',
+    ];
+
+    paramsThatShouldReturnTrue.map((p) =>
+      t.true(isOneWayGranuleReport({ [p]: randomId('value') })));
+
+    paramsThatShouldReturnFalse.map((p) =>
+      t.false(isOneWayGranuleReport({ [p]: randomId('value') })));
+
+    const allTrueKeys = paramsThatShouldReturnTrue.reduce(
+      (accum, current) => ({ ...accum, [current]: randomId('value') }),
+      {}
+    );
+    t.true(isOneWayGranuleReport(allTrueKeys));
+
+    const allFalseKeys = paramsThatShouldReturnFalse.reduce(
+      (accum, current) => ({ ...accum, [current]: randomId('value') }),
+      {}
+    );
+    t.false(isOneWayGranuleReport(allFalseKeys));
+    t.true(isOneWayGranuleReport({ ...allTrueKeys, ...allFalseKeys }));
   }
 );
 

--- a/packages/api/tests/lambdas/test-create-reconciliation-report-internals.js
+++ b/packages/api/tests/lambdas/test-create-reconciliation-report-internals.js
@@ -9,7 +9,7 @@ const { randomId } = require('@cumulus/common/test-utils');
 const CRP = rewire('../../lambdas/create-reconciliation-report');
 const isOneWayCollectionReport = CRP.__get__('isOneWayCollectionReport');
 const isOneWayGranuleReport = CRP.__get__('isOneWayGranuleReport');
-const shouldAggregateGranules = CRP.__get__('shouldAggregateGranules');
+const shouldAggregateGranulesForCollections = CRP.__get__('shouldAggregateGranulesForCollections');
 const normalizeEvent = CRP.__get__('normalizeEvent');
 
 test(
@@ -91,7 +91,7 @@ test(
 );
 
 test(
-  'shouldAggregateGranules returns true only when one or more specific parameters ' +
+  'shouldAggregateGranulesForCollections returns true only when one or more specific parameters ' +
     ' are present on the reconciliation report object.',
   (t) => {
     const paramsThatShouldReturnTrue = ['updatedAt__to', 'updatedAt__from'];
@@ -103,25 +103,25 @@ test(
     ];
 
     paramsThatShouldReturnTrue.map((p) =>
-      t.true(shouldAggregateGranules({ [p]: randomId('value') }))
+      t.true(shouldAggregateGranulesForCollections({ [p]: randomId('value') }))
     );
 
     paramsThatShouldReturnFalse.map((p) =>
-      t.false(shouldAggregateGranules({ [p]: randomId('value') }))
+      t.false(shouldAggregateGranulesForCollections({ [p]: randomId('value') }))
     );
 
     const allTrueKeys = paramsThatShouldReturnTrue.reduce(
       (accum, current) => ({ ...accum, [current]: randomId('value') }),
       {}
     );
-    t.true(shouldAggregateGranules(allTrueKeys));
+    t.true(shouldAggregateGranulesForCollections(allTrueKeys));
 
     const allFalseKeys = paramsThatShouldReturnFalse.reduce(
       (accum, current) => ({ ...accum, [current]: randomId('value') }),
       {}
     );
-    t.false(shouldAggregateGranules(allFalseKeys));
-    t.true(shouldAggregateGranules({ ...allTrueKeys, ...allFalseKeys }));
+    t.false(shouldAggregateGranulesForCollections(allFalseKeys));
+    t.true(shouldAggregateGranulesForCollections({ ...allTrueKeys, ...allFalseKeys }));
   }
 );
 

--- a/packages/api/tests/lambdas/test-create-reconciliation-report-internals.js
+++ b/packages/api/tests/lambdas/test-create-reconciliation-report-internals.js
@@ -13,8 +13,8 @@ const shouldAggregateGranulesForCollections = CRP.__get__('shouldAggregateGranul
 const normalizeEvent = CRP.__get__('normalizeEvent');
 
 test(
-  'isOneWayCollectionReport returns true only when one or more specific parameters ' +
-    ' are present on the reconciliation report object.',
+  'isOneWayCollectionReport returns true only when one or more specific parameters '
+    + ' are present on the reconciliation report object.',
   (t) => {
     const paramsThatShouldReturnTrue = [
       'startTimestamp',
@@ -30,12 +30,10 @@ test(
     ];
 
     paramsThatShouldReturnTrue.map((p) =>
-      t.true(isOneWayCollectionReport({ [p]: randomId('value') }))
-    );
+      t.true(isOneWayCollectionReport({ [p]: randomId('value') })));
 
     paramsThatShouldReturnFalse.map((p) =>
-      t.false(isOneWayCollectionReport({ [p]: randomId('value') }))
-    );
+      t.false(isOneWayCollectionReport({ [p]: randomId('value') })));
 
     const allTrueKeys = paramsThatShouldReturnTrue.reduce(
       (accum, current) => ({ ...accum, [current]: randomId('value') }),
@@ -53,8 +51,8 @@ test(
 );
 
 test(
-  'isOneWayGranuleReport returns true only when one or more specific parameters ' +
-    ' are present on the reconciliation report object.',
+  'isOneWayGranuleReport returns true only when one or more specific parameters '
+    + ' are present on the reconciliation report object.',
   (t) => {
     const paramsThatShouldReturnTrue = ['startTimestamp', 'endTimestamp'];
 
@@ -68,12 +66,10 @@ test(
     ];
 
     paramsThatShouldReturnTrue.map((p) =>
-      t.true(isOneWayGranuleReport({ [p]: randomId('value') }))
-    );
+      t.true(isOneWayGranuleReport({ [p]: randomId('value') })));
 
     paramsThatShouldReturnFalse.map((p) =>
-      t.false(isOneWayGranuleReport({ [p]: randomId('value') }))
-    );
+      t.false(isOneWayGranuleReport({ [p]: randomId('value') })));
 
     const allTrueKeys = paramsThatShouldReturnTrue.reduce(
       (accum, current) => ({ ...accum, [current]: randomId('value') }),
@@ -91,8 +87,8 @@ test(
 );
 
 test(
-  'shouldAggregateGranulesForCollections returns true only when one or more specific parameters ' +
-    ' are present on the reconciliation report object.',
+  'shouldAggregateGranulesForCollections returns true only when one or more specific parameters '
+    + ' are present on the reconciliation report object.',
   (t) => {
     const paramsThatShouldReturnTrue = ['updatedAt__to', 'updatedAt__from'];
     const paramsThatShouldReturnFalse = [
@@ -103,12 +99,10 @@ test(
     ];
 
     paramsThatShouldReturnTrue.map((p) =>
-      t.true(shouldAggregateGranulesForCollections({ [p]: randomId('value') }))
-    );
+      t.true(shouldAggregateGranulesForCollections({ [p]: randomId('value') })));
 
     paramsThatShouldReturnFalse.map((p) =>
-      t.false(shouldAggregateGranulesForCollections({ [p]: randomId('value') }))
-    );
+      t.false(shouldAggregateGranulesForCollections({ [p]: randomId('value') })));
 
     const allTrueKeys = paramsThatShouldReturnTrue.reduce(
       (accum, current) => ({ ...accum, [current]: randomId('value') }),

--- a/packages/api/tests/lambdas/test-create-reconciliation-report-internals.js
+++ b/packages/api/tests/lambdas/test-create-reconciliation-report-internals.js
@@ -15,7 +15,7 @@ test(
   'isOneWayCollectionReport returns true only when one or more specific parameters '
     + ' are present on the reconciliation report object.',
   (t) => {
-    const paramsThatShouldReturnTrue = ['startTimestamp', 'endTimestamp'];
+    const paramsThatShouldReturnTrue = ['startTimestamp', 'endTimestamp', 'granuleIds'];
 
     const paramsThatShouldReturnFalse = [
       'stackName',
@@ -56,6 +56,8 @@ test(
       'systemBucket',
       'anythingAtAll',
       'collectionId',
+      'collectionIds',
+      'granuleIds',
     ];
 
     paramsThatShouldReturnTrue.map((p) =>

--- a/packages/api/tests/lambdas/test-create-reconciliation-report.js
+++ b/packages/api/tests/lambdas/test-create-reconciliation-report.js
@@ -155,6 +155,20 @@ async function fetchCompletedReport(reportRecord) {
     .then(JSON.parse);
 }
 
+/**
+ * Looks up and returns the granulesIds given a list of collectionIds.
+ * @param {Array<string>} collectionIds - list of collectionIds
+ * @returns {Array<string>} list of matching granuleIds
+ */
+async function granuleIdsFromCollectionIds(collectionIds) {
+  const esValues = await (new Search(
+    { queryStringParameters: { collectionId__in: collectionIds.join(',') } },
+    'granule',
+    esAlias
+  )).query();
+  return esValues.results.map((value) => value.granuleId);
+}
+
 const randomBetween = (a, b) => Math.floor(Math.random() * (b - a + 1) + a);
 const randomTimeBetween = (t1, t2) => randomBetween(t1, t2);
 
@@ -928,6 +942,103 @@ test.serial(
     const newCreateStartTime = moment(report.createStartTime);
     const newCreateEndTime = moment(report.createEndTime);
     t.true(newCreateStartTime <= newCreateEndTime);
+
+    t.is(report.reportEndTime, undefined);
+    t.is(report.reportStartTime, undefined);
+  }
+);
+
+test.serial(
+  'Generates valid ONE WAY reconciliation report with time params and filters by granuleIds when there are extra cumulus/ES and CMR collections',
+  async (t) => {
+    const { startTimestamp, endTimestamp, ...setupVars } = await setupElasticAndCMRForTests({ t });
+
+    const testCollection = [
+      setupVars.matchingCollections[3],
+      setupVars.extraCmrCollections[1],
+      setupVars.extraESCollections[1],
+      setupVars.extraESCollectionsOutOfRange[0],
+    ];
+
+    const testCollectionIds = testCollection.map((c) => constructCollectionId(c.name, c.version));
+    const testGranuleIds = await granuleIdsFromCollectionIds(testCollectionIds);
+
+    console.log(`granuleIds: ${JSON.stringify(testGranuleIds)}`);
+
+    const event = {
+      systemBucket: t.context.systemBucket,
+      stackName: t.context.stackName,
+      startTimestamp,
+      endTimestamp,
+      granuleId: testGranuleIds,
+    };
+
+    const reportRecord = await handler(event);
+    t.is(reportRecord.status, 'Generated');
+
+    const report = await fetchCompletedReport(reportRecord);
+    const collectionsInCumulusCmr = report.collectionsInCumulusCmr;
+    t.is(report.status, 'SUCCESS');
+    t.is(report.error, undefined);
+
+    t.is(collectionsInCumulusCmr.okCount, 1);
+
+    // cumulus filters collections by granuleId and only returned test one
+    t.is(collectionsInCumulusCmr.onlyInCumulus.length, 1);
+    t.true(collectionsInCumulusCmr.onlyInCumulus.includes(testCollectionIds[2]));
+
+    // ONE WAY only comparison because of input timestampes
+    t.is(collectionsInCumulusCmr.onlyInCmr.length, 0);
+
+    const reportStartTime = report.reportStartTime;
+    const reportEndTime = report.reportEndTime;
+    t.is(
+      (new Date(reportStartTime)).valueOf(),
+      startTimestamp
+    );
+    t.is(
+      (new Date(reportEndTime)).valueOf(),
+      endTimestamp
+    );
+  }
+);
+
+test.serial(
+  'When an array of granuleId exists, creates a valid one-way reconciliation report.',
+  async (t) => {
+    const setupVars = await setupElasticAndCMRForTests({ t });
+
+    const testCollection = [
+      setupVars.extraCmrCollections[3],
+      setupVars.matchingCollections[2],
+      setupVars.extraESCollections[1],
+    ];
+
+    const testCollectionIds = testCollection.map((c) => constructCollectionId(c.name, c.version));
+    const testGranuleIds = await granuleIdsFromCollectionIds(testCollectionIds);
+
+    console.log(`testGranuleIds: ${JSON.stringify(testGranuleIds)}`);
+
+    const event = {
+      systemBucket: t.context.systemBucket,
+      stackName: t.context.stackName,
+      granuleId: testGranuleIds,
+    };
+
+    const reportRecord = await handler(event);
+    t.is(reportRecord.status, 'Generated');
+
+    const report = await fetchCompletedReport(reportRecord);
+    const collectionsInCumulusCmr = report.collectionsInCumulusCmr;
+    t.is(report.status, 'SUCCESS');
+    t.is(report.error, undefined);
+
+    // Filtered by input granuleIds
+    t.is(collectionsInCumulusCmr.okCount, 1);
+    t.is(collectionsInCumulusCmr.onlyInCumulus.length, 1);
+    t.true(collectionsInCumulusCmr.onlyInCumulus.includes(testCollectionIds[2]));
+    // one way
+    t.is(collectionsInCumulusCmr.onlyInCmr.length, 0);
 
     t.is(report.reportEndTime, undefined);
     t.is(report.reportStartTime, undefined);

--- a/packages/cmr-client/src/CMRSearchConceptQueue.js
+++ b/packages/cmr-client/src/CMRSearchConceptQueue.js
@@ -3,6 +3,23 @@
 const CMR = require('./CMR');
 
 /**
+ * Shim to correctly add a default provider_short_name to the input searchParams
+ *
+ * @param {Object} params
+ * @param {Object|URLSearchParams} params.searchParams - input search
+ *  parameters for searchConceptQueue. This parameter can be either a
+ *  URLSearchParam object or a plain Object.
+ * @returns {Object|URLSearchParams} - input object appeneded with a default provider_short_name
+ */
+const provideParams = (params = { searchParams: {} }) => {
+  if (params.searchParams instanceof URLSearchParams) {
+    if (!params.searchParams.has('provider_short_name')) params.searchParams.append('provider_short_name', params.cmrSettings.provider);
+    return params.searchParams;
+  }
+  return { provider_short_name: params.cmrSettings.provider, ...params.searchParams };
+};
+
+/**
  * A class to efficiently list all of the concepts (collections/granules) from
  * CMR search, without loading them all into memory at once.  Handles paging.
  *
@@ -32,7 +49,7 @@ class CMRSearchConceptQueue {
    */
   constructor(params = { searchParams: {} }) {
     this.type = params.type;
-    this.params = { provider_short_name: params.cmrSettings.provider, ...params.searchParams };
+    this.params = provideParams(params);
     this.format = params.format;
     this.items = [];
 

--- a/packages/cmr-client/src/searchConcept.js
+++ b/packages/cmr-client/src/searchConcept.js
@@ -46,9 +46,6 @@ async function searchConcept({
 
   if (!query.has('page_size')) query.append('page_size', pageSize);
 
-  // TODO [MHS, 09/14/2020] Delete this log.
-  console.log(`query: => ${query.toString()}`);
-
   const url = `${getUrl('search', undefined, cmrEnvironment)}${type}.${format.toLowerCase()}`;
   const response = await got.get(url, { json: format.endsWith('json'), query, headers });
 

--- a/packages/cmr-client/src/searchConcept.js
+++ b/packages/cmr-client/src/searchConcept.js
@@ -41,8 +41,19 @@ async function searchConcept({
 
   const pageNum = (searchParams.page_num) ? searchParams.page_num + 1 : 1;
 
+  let query;
   // if requested, recursively retrieve all the search results for collections or granules
-  const query = { ...defaultParams, ...searchParams, page_num: pageNum };
+  if (searchParams instanceof URLSearchParams) {
+    query = new URLSearchParams(defaultParams);
+    searchParams.forEach((value, name) => {
+      query.append(name, value);
+    });
+    query.append('page_num', pageNum);
+    console.log(`query: => ${query.toString()}`);
+  } else {
+    query = { ...defaultParams, ...searchParams, page_num: pageNum };
+  }
+
   const response = await got.get(url, { json: format.endsWith('json'), query, headers });
 
   const responseItems = (format === 'echo10')

--- a/packages/cmr-client/src/searchConcept.js
+++ b/packages/cmr-client/src/searchConcept.js
@@ -35,30 +35,27 @@ async function searchConcept({
   const recordsLimit = cmrLimit || 100;
   const pageSize = searchParams.pageSize || cmrPageSize || 50;
 
-  const defaultParams = { page_size: pageSize };
+  const query =
+    searchParams instanceof URLSearchParams
+      ? searchParams
+      : new URLSearchParams(searchParams);
 
-  const url = `${getUrl('search', null, cmrEnvironment)}${type}.${format.toLowerCase()}`;
+  const pageNum = query.has('page_num') ? +query.get('page_num') + 1 : 1;
+  query.delete('page_num');
+  query.append('page_num', pageNum);
 
-  const pageNum = (searchParams.page_num) ? searchParams.page_num + 1 : 1;
+  if (!query.has('page_size')) query.append('page_size', pageSize);
 
-  let query;
-  // if requested, recursively retrieve all the search results for collections or granules
-  if (searchParams instanceof URLSearchParams) {
-    query = new URLSearchParams(defaultParams);
-    searchParams.forEach((value, name) => {
-      query.append(name, value);
-    });
-    query.append('page_num', pageNum);
-    console.log(`query: => ${query.toString()}`);
-  } else {
-    query = { ...defaultParams, ...searchParams, page_num: pageNum };
-  }
+  // TODO [MHS, 09/14/2020] Delete this log.
+  console.log(`query: => ${query.toString()}`);
 
+  const url = `${getUrl('search', undefined, cmrEnvironment)}${type}.${format.toLowerCase()}`;
   const response = await got.get(url, { json: format.endsWith('json'), query, headers });
 
-  const responseItems = (format === 'echo10')
-    ? (await parseXMLString(response.body)).results.result || []
-    : (response.body.items || response.body.feed.entry);
+  const responseItems =
+    format === 'echo10'
+      ? (await parseXMLString(response.body)).results.result || []
+      : response.body.items || response.body.feed.entry;
 
   const fetchedResults = previousResults.concat(responseItems || []);
 

--- a/packages/cmr-client/tests/test-CMRSearchConceptQueue.js
+++ b/packages/cmr-client/tests/test-CMRSearchConceptQueue.js
@@ -2,7 +2,10 @@
 
 const test = require('ava');
 const nock = require('nock');
+const rewire = require('rewire');
 const CMRSearchConceptQueue = require('../CMRSearchConceptQueue');
+const CSCQ = rewire('../CMRSearchConceptQueue');
+const provideParams = CSCQ.__get__('provideParams');
 
 test.before(() => {
   nock.cleanAll();
@@ -62,4 +65,22 @@ test('CMRSearchConceptQueue handles paging correctly.', async (t) => {
     t.deepEqual(await cmrSearchQueue.peek(), expected[i]); // eslint-disable-line no-await-in-loop
     await cmrSearchQueue.shift(); // eslint-disable-line no-await-in-loop
   }
+});
+
+test('cmrSearchQueue provides correct initial params when SearchParams are an instanceOf URLSearchParams.', (t) => {
+  const searchParams = new URLSearchParams([['key', 'param'], ['key', 'param2']]);
+  const defaultParams = { cmrSettings: { provider: 'cmrprovider' } };
+  const test1Params = { ...defaultParams, searchParams: searchParams };
+  const actual = provideParams(test1Params);
+  const expected = new URLSearchParams([['key', 'param'], ['key', 'param2'], ['provider_short_name', 'cmrprovider']]);
+  t.deepEqual(actual, expected);
+});
+
+test('cmrSearchQueue provides correct initial params when SearchParams are a plain object.', (t) => {
+  const searchParams = { key: 'param' };
+  const defaultParams = { cmrSettings: { provider: 'cmrprovider' } };
+  const test1Params = { ...defaultParams, searchParams };
+  const actual = provideParams(test1Params);
+  const expected = { key: 'param', provider_short_name: 'cmrprovider' };
+  t.deepEqual(actual, expected);
 });


### PR DESCRIPTION
**Summary:** Adds granuleId input parameter to the reconciliationReport endpoint.

Addresses [CUMULUS-1963: Update reconciliation-report endpoint to take parameter: granule ID](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1963)

## Changes

* splits oneWay Report testing into one way for granules and one way for collections. When granuleIds are passed to reconcilationReport handler, collection comparisons become one way.
* CMR is searched for granuleIds using array of granuleIds each one passed to CMR on a `readable_granule_name[]` key
* Non-'Internal' reports now fail when both collectionId and granuleId are passed to the lambda.
* Adds a number of tests to describe the desired behavior of normalizeEvent
* Adds two tests for granuleId input to the lambda.
* updates CMRSearchConceptQueue to add provider_short_name to an input plain Object or an input URLSearchParams.
* updates cmr-client/searchConcept internally to use URLSearchParams rather than plan object so that multiple keyword params can be included to search CMR.

PR for API doc change https://github.com/nasa/cumulus-api/pull/289

## PR Checklist

- [X] Update CHANGELOG
- [X] Unit tests
- [X] Adhoc testing
- [ ] Integration tests


