### PR TITLE
Move event validation from lambda to endpoint.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     with those in CMR.
   - `/reconciliationReports` now validates any input json before starting the
     async operation and the lambda handler no longer validates input
-    parameters..
+    parameters.
 - **CUMULUS-1965**
   - Adds `collectionId` parameter to the `/reconcilationReports`
     endpoint. Setting this value will limit the scope of the reconcilation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     and will fail to create the report if both are provided.  Adding granuleId
     will find collections in Cumulus by granuleId and compare those one way
     with those in CMR.
+  - `/reconciliationReports` now validates any input json before starting the
+    async operation and the lambda handler no longer validates input
+    parameters..
 - **CUMULUS-1965**
   - Adds `collectionId` parameter to the `/reconcilationReports`
     endpoint. Setting this value will limit the scope of the reconcilation

--- a/packages/api/lambdas/create-reconciliation-report.js
+++ b/packages/api/lambdas/create-reconciliation-report.js
@@ -1,10 +1,7 @@
 'use strict';
 
-/*eslint prefer-const: ["error", {"destructuring": "all"}]*/
-
 const cloneDeep = require('lodash/cloneDeep');
 const keyBy = require('lodash/keyBy');
-const isString = require('lodash/isString');
 const camelCase = require('lodash/camelCase');
 const moment = require('moment');
 const DynamoDbSearchQueue = require('@cumulus/aws-client/DynamoDbSearchQueue');
@@ -20,8 +17,6 @@ const CMR = require('@cumulus/cmr-client/CMR');
 const CMRSearchConceptQueue = require('@cumulus/cmr-client/CMRSearchConceptQueue');
 const { constructOnlineAccessUrl, getCmrSettings } = require('@cumulus/cmrjs/cmr-utils');
 
-const { removeNilProperties } = require('@cumulus/common/util');
-const { InvalidArgument } = require('@cumulus/errors');
 const { createInternalReconciliationReport } = require('./internal-reconciliation-report');
 const GranuleFilesCache = require('../lib/GranuleFilesCache');
 const { ESCollectionGranuleQueue } = require('../es/esCollectionGranuleQueue');
@@ -300,7 +295,7 @@ async function reconciliationReportForGranuleFiles(params) {
   const relatedUrlPromises = granuleInCmr.RelatedUrls.map(async (relatedUrl) => {
     // only check URL types for downloading granule files and related data (such as documents)
     if (cmrGetDataTypes.includes(relatedUrl.Type)
-        || cmrRelatedDataTypes.includes(relatedUrl.Type)) {
+      || cmrRelatedDataTypes.includes(relatedUrl.Type)) {
       const urlFileName = relatedUrl.URL.split('/').pop();
 
       // filename in both Cumulus and CMR
@@ -354,7 +349,7 @@ async function reconciliationReportForGranuleFiles(params) {
   Object.keys(granuleFiles).forEach((fileName) => {
     // private file only in database, it's ok
     if (bucketsConfig.key(granuleFiles[fileName].bucket)
-        && bucketsConfig.type(granuleFiles[fileName].bucket) === 'private') {
+      && bucketsConfig.type(granuleFiles[fileName].bucket) === 'private') {
       okCount += 1;
     } else {
       let uri = granuleFiles[fileName].source;
@@ -718,123 +713,11 @@ async function processRequest(params) {
   return reconciliationReportModel.get({ name: reportRecord.name });
 }
 
-/**
- * Convert input to an ISO timestamp.
- * @param {any} dateable - any type convertable to JS Date
- * @returns {string} - date formated as ISO timestamp;
- */
-function isoTimestamp(dateable) {
-  if (dateable) {
-    const aDate = new Date(dateable);
-    if (Number.isNaN(aDate.valueOf())) {
-      throw new TypeError(`${dateable} is not a valid input for new Date().`);
-    }
-    return aDate.toISOString();
-  }
-  return undefined;
-}
-
-/**
- * Transforms input granuleId into correct parameters for use in the
- * Reconciliation Report lambda.
- * @param {Array<string>|string} granuleId - list of granule Ids
- * @param {string} reportType - report type
- * @param {Object} modifiedEvent - input event
- * @returns {Object} updated input even with correct granuleId and granuleIds values.
- */
-function updateGranuleIds(granuleId, reportType, modifiedEvent) {
-  let returnEvent = { ...modifiedEvent };
-  if (granuleId) {
-    // transform input granuleId into an array on granuleIds
-    const granuleIds = isString(granuleId) ? [granuleId] : granuleId;
-    if (reportType === 'Internal') {
-      if (!isString(granuleId)) {
-        throw new InvalidArgument(`granuleId: ${JSON.stringify(granuleId)} is not valid input for an 'Internal' report.`);
-      } else {
-        // include both granuleId and granuleIds for Internal Reports.
-        returnEvent = { ...modifiedEvent, granuleId, granuleIds: [granuleId] };
-      }
-    } else {
-      returnEvent = { ...modifiedEvent, granuleIds };
-    }
-  }
-  return returnEvent;
-}
-
-/**
- * Transforms input collectionId into correct parameters for use in the
- * Reconciliation Report lambda.
- * @param {Array<string>|string} collectionId - list of collection Ids
- * @param {string} reportType - report type
- * @param {Object} modifiedEvent - input event
- * @returns {Object} updated input even with correct collectionId and collectionIds values.
- */
-function updateCollectionIds(collectionId, reportType, modifiedEvent) {
-  let returnEvent = { ...modifiedEvent };
-  if (collectionId) {
-    const collectionIds = isString(collectionId) ? [collectionId] : collectionId;
-    if (reportType === 'Internal') {
-      if (!isString(collectionId)) {
-        throw new InvalidArgument(`collectionId: ${JSON.stringify(collectionId)} is not valid input for an 'Internal' report.`);
-      } else {
-        // include both collectionIds and collectionId for Internal Reports.
-        returnEvent = { ...modifiedEvent, collectionId, collectionIds: [collectionId] };
-      }
-    } else {
-      // add array of collectionIds
-      returnEvent = { ...modifiedEvent, collectionIds };
-    }
-  }
-  return returnEvent;
-}
-
-/**
- * Converts input parameters to normalized versions to pass on to the report
- * functions.  Ensures any input dates are formatted as ISO strings.
- *
- * @param {Object} event - input payload
- * @returns {Object} - Object with normalized parameters
- */
-function normalizeEvent(event) {
-  const systemBucket = event.systemBucket || process.env.system_bucket;
-  const stackName = event.stackName || process.env.stackName;
-  const startTimestamp = isoTimestamp(event.startTimestamp);
-  const endTimestamp = isoTimestamp(event.endTimestamp);
-
-  let reportType = event.reportType || 'Inventory';
-  if (reportType.toLowerCase() === 'granulenotfound') {
-    reportType = 'Granule Not Found';
-  }
-
-  // TODO [MHS, 09/08/2020] Clean this up when CUMULUS-2156 is worked/completed
-  // for now, move input collectionId to collectionIds as array
-  // internal reports will keep existing collectionId and copy it to collectionIds
-  let { collectionIds: anyCollectionIds, collectionId, granuleId, ...modifiedEvent } = { ...event };
-  if (anyCollectionIds) {
-    throw new InvalidArgument('`collectionIds` is not a valid input key for a reconciliation report, use `collectionId` instead.');
-  }
-  if (granuleId && collectionId && reportType !== 'Internal') {
-    throw new InvalidArgument(`${reportType} reports cannot be launched with both granuleId and collectionId input.`);
-  }
-  modifiedEvent = updateCollectionIds(collectionId, reportType, modifiedEvent);
-  modifiedEvent = updateGranuleIds(granuleId, reportType, modifiedEvent);
-
-  return removeNilProperties({
-    ...modifiedEvent,
-    systemBucket,
-    stackName,
-    startTimestamp,
-    endTimestamp,
-    reportType,
-  });
-}
-
 async function handler(event) {
   // increase the limit of search result from CMR.searchCollections/searchGranules
   process.env.CMR_LIMIT = process.env.CMR_LIMIT || 5000;
   process.env.CMR_PAGE_SIZE = process.env.CMR_PAGE_SIZE || 200;
 
-  const reportParams = normalizeEvent(event);
-  return processRequest(reportParams);
+  return processRequest(event);
 }
 exports.handler = handler;

--- a/packages/api/lib/reconciliationReport/normalizeEvent.js
+++ b/packages/api/lib/reconciliationReport/normalizeEvent.js
@@ -1,0 +1,117 @@
+'use strict';
+
+/*eslint prefer-const: ["error", {"destructuring": "all"}]*/
+const isString = require('lodash/isString');
+const { removeNilProperties } = require('@cumulus/common/util');
+const { InvalidArgument } = require('@cumulus/errors');
+/**
+ * Convert input to an ISO timestamp.
+ * @param {any} dateable - any type convertable to JS Date
+ * @returns {string} - date formated as ISO timestamp;
+ */
+function isoTimestamp(dateable) {
+  if (dateable) {
+    const aDate = new Date(dateable);
+    if (Number.isNaN(aDate.valueOf())) {
+      throw new TypeError(`${dateable} is not a valid input for new Date().`);
+    }
+    return aDate.toISOString();
+  }
+  return undefined;
+}
+
+/**
+ * Transforms input granuleId into correct parameters for use in the
+ * Reconciliation Report lambda.
+ * @param {Array<string>|string} granuleId - list of granule Ids
+ * @param {string} reportType - report type
+ * @param {Object} modifiedEvent - input event
+ * @returns {Object} updated input even with correct granuleId and granuleIds values.
+ */
+function updateGranuleIds(granuleId, reportType, modifiedEvent) {
+  let returnEvent = { ...modifiedEvent };
+  if (granuleId) {
+    // transform input granuleId into an array on granuleIds
+    const granuleIds = isString(granuleId) ? [granuleId] : granuleId;
+    if (reportType === 'Internal') {
+      if (!isString(granuleId)) {
+        throw new InvalidArgument(`granuleId: ${JSON.stringify(granuleId)} is not valid input for an 'Internal' report.`);
+      } else {
+        // include both granuleId and granuleIds for Internal Reports.
+        returnEvent = { ...modifiedEvent, granuleId, granuleIds: [granuleId] };
+      }
+    } else {
+      returnEvent = { ...modifiedEvent, granuleIds };
+    }
+  }
+  return returnEvent;
+}
+
+/**
+ * Transforms input collectionId into correct parameters for use in the
+ * Reconciliation Report lambda.
+ * @param {Array<string>|string} collectionId - list of collection Ids
+ * @param {string} reportType - report type
+ * @param {Object} modifiedEvent - input event
+ * @returns {Object} updated input even with correct collectionId and collectionIds values.
+ */
+function updateCollectionIds(collectionId, reportType, modifiedEvent) {
+  let returnEvent = { ...modifiedEvent };
+  if (collectionId) {
+    const collectionIds = isString(collectionId) ? [collectionId] : collectionId;
+    if (reportType === 'Internal') {
+      if (!isString(collectionId)) {
+        throw new InvalidArgument(`collectionId: ${JSON.stringify(collectionId)} is not valid input for an 'Internal' report.`);
+      } else {
+        // include both collectionIds and collectionId for Internal Reports.
+        returnEvent = { ...modifiedEvent, collectionId, collectionIds: [collectionId] };
+      }
+    } else {
+      // add array of collectionIds
+      returnEvent = { ...modifiedEvent, collectionIds };
+    }
+  }
+  return returnEvent;
+}
+
+/**
+ * Converts input parameters to normalized versions to pass on to the report
+ * functions.  Ensures any input dates are formatted as ISO strings.
+ *
+ * @param {Object} event - input payload
+ * @returns {Object} - Object with normalized parameters
+ */
+function normalizeEvent(event) {
+  const systemBucket = event.systemBucket || process.env.system_bucket;
+  const stackName = event.stackName || process.env.stackName;
+  const startTimestamp = isoTimestamp(event.startTimestamp);
+  const endTimestamp = isoTimestamp(event.endTimestamp);
+
+  let reportType = event.reportType || 'Inventory';
+  if (reportType.toLowerCase() === 'granulenotfound') {
+    reportType = 'Granule Not Found';
+  }
+
+  // TODO [MHS, 09/08/2020] Clean this up when CUMULUS-2156 is worked/completed
+  // for now, move input collectionId to collectionIds as array
+  // internal reports will keep existing collectionId and copy it to collectionIds
+  let { collectionIds: anyCollectionIds, collectionId, granuleId, ...modifiedEvent } = { ...event };
+  if (anyCollectionIds) {
+    throw new InvalidArgument('`collectionIds` is not a valid input key for a reconciliation report, use `collectionId` instead.');
+  }
+  if (granuleId && collectionId && reportType !== 'Internal') {
+    throw new InvalidArgument(`${reportType} reports cannot be launched with both granuleId and collectionId input.`);
+  }
+  modifiedEvent = updateCollectionIds(collectionId, reportType, modifiedEvent);
+  modifiedEvent = updateGranuleIds(granuleId, reportType, modifiedEvent);
+
+  return removeNilProperties({
+    ...modifiedEvent,
+    systemBucket,
+    stackName,
+    startTimestamp,
+    endTimestamp,
+    reportType,
+  });
+}
+exports.normalizeEvent = normalizeEvent;

--- a/packages/api/tests/lambdas/test-create-reconciliation-report-internals.js
+++ b/packages/api/tests/lambdas/test-create-reconciliation-report-internals.js
@@ -3,18 +3,16 @@
 const test = require('ava');
 const rewire = require('rewire');
 
-const { InvalidArgument } = require('@cumulus/errors');
 const { randomId } = require('@cumulus/common/test-utils');
 
 const CRP = rewire('../../lambdas/create-reconciliation-report');
 const isOneWayCollectionReport = CRP.__get__('isOneWayCollectionReport');
 const isOneWayGranuleReport = CRP.__get__('isOneWayGranuleReport');
 const shouldAggregateGranulesForCollections = CRP.__get__('shouldAggregateGranulesForCollections');
-const normalizeEvent = CRP.__get__('normalizeEvent');
 
 test(
   'isOneWayCollectionReport returns true only when one or more specific parameters '
-    + ' are present on the reconciliation report object.',
+  + ' are present on the reconciliation report object.',
   (t) => {
     const paramsThatShouldReturnTrue = [
       'startTimestamp',
@@ -52,7 +50,7 @@ test(
 
 test(
   'isOneWayGranuleReport returns true only when one or more specific parameters '
-    + ' are present on the reconciliation report object.',
+  + ' are present on the reconciliation report object.',
   (t) => {
     const paramsThatShouldReturnTrue = ['startTimestamp', 'endTimestamp'];
 
@@ -88,7 +86,7 @@ test(
 
 test(
   'shouldAggregateGranulesForCollections returns true only when one or more specific parameters '
-    + ' are present on the reconciliation report object.',
+  + ' are present on the reconciliation report object.',
   (t) => {
     const paramsThatShouldReturnTrue = ['updatedAt__to', 'updatedAt__from'];
     const paramsThatShouldReturnFalse = [
@@ -118,178 +116,3 @@ test(
     t.true(shouldAggregateGranulesForCollections({ ...allTrueKeys, ...allFalseKeys }));
   }
 );
-
-test('normalizeEvent throws error if array of collectionIds passed to Internal report', (t) => {
-  const inputEvent = {
-    systemBucket: 'systemBucket',
-    stackName: 'stackName',
-    startTimestamp: new Date().toISOString(),
-    endTimestamp: new Date().toISOString(),
-    reportType: 'Internal',
-    collectionId: ['someCollection___version'],
-  };
-  t.throws(() => normalizeEvent(inputEvent), {
-    message:
-      'collectionId: ["someCollection___version"] is not valid input for an \'Internal\' report.',
-  });
-});
-
-test('normalizeEvent converts input key collectionId string to length 1 array on collectionIds', (t) => {
-  const inputEvent = {
-    systemBucket: 'systemBucket',
-    stackName: 'stackName',
-    startTimestamp: new Date().toISOString(),
-    endTimestamp: new Date().toISOString(),
-    reportType: 'NotInternal',
-    collectionId: 'someCollection___version',
-  };
-  const expect = { ...inputEvent, collectionIds: ['someCollection___version'] };
-  delete expect.collectionId;
-
-  const actual = normalizeEvent(inputEvent);
-  t.deepEqual(actual, expect);
-});
-
-test('normalizeEvent moves input key collectionId array to array on collectionIds', (t) => {
-  const inputEvent = {
-    systemBucket: 'systemBucket',
-    stackName: 'stackName',
-    startTimestamp: new Date().toISOString(),
-    endTimestamp: new Date().toISOString(),
-    reportType: 'NotInternal',
-    collectionId: ['someCollection___version', 'secondcollection___version'],
-  };
-  const expect = {
-    ...inputEvent,
-    collectionIds: ['someCollection___version', 'secondcollection___version'],
-  };
-  delete expect.collectionId;
-
-  const actual = normalizeEvent(inputEvent);
-  t.deepEqual(actual, expect);
-});
-
-test('normalizeEvent adds new collectionIds key when collectionId passed to Internal report', (t) => {
-  const inputEvent = {
-    systemBucket: 'systemBucket',
-    stackName: 'stackName',
-    startTimestamp: new Date().toISOString(),
-    endTimestamp: new Date().toISOString(),
-    reportType: 'Internal',
-    collectionId: 'someCollection___version',
-  };
-  const expect = {
-    ...inputEvent,
-    collectionIds: ['someCollection___version'],
-  };
-
-  const actual = normalizeEvent(inputEvent);
-  t.deepEqual(actual, expect);
-});
-
-test('normalizeEvent throws error if original input event contains collectionIds key', (t) => {
-  const inputEvent = {
-    systemBucket: 'systemBucket',
-    stackName: 'stackName',
-    startTimestamp: new Date().toISOString(),
-    endTimestamp: new Date().toISOString(),
-    reportType: 'Internal',
-    collectionIds: ['someCollection___version'],
-  };
-  t.throws(() => normalizeEvent(inputEvent), {
-    message:
-      '`collectionIds` is not a valid input key for a reconciliation report, use `collectionId` instead.',
-  });
-});
-
-test('normalizeEvent moves string on granuleId to array on granuleIds', (t) => {
-  const inputEvent = {
-    systemBucket: 'systemBucket',
-    stackName: 'stackName',
-    startTimestamp: new Date().toISOString(),
-    endTimestamp: new Date().toISOString(),
-    reportType: 'Not Internal',
-    granuleId: 'someGranule',
-  };
-  const expect = {
-    ...inputEvent,
-    granuleIds: ['someGranule'],
-  };
-  delete expect.granuleId;
-
-  const actual = normalizeEvent(inputEvent);
-  t.deepEqual(actual, expect);
-});
-
-test('normalizeEvent moves array on granuleId to granuleIds', (t) => {
-  const inputEvent = {
-    systemBucket: 'systemBucket',
-    stackName: 'stackName',
-    startTimestamp: new Date().toISOString(),
-    endTimestamp: new Date().toISOString(),
-    reportType: 'Not Internal',
-    granuleId: ['someGranule', 'someGranule2'],
-  };
-
-  const expect = {
-    ...inputEvent,
-    granuleIds: ['someGranule', 'someGranule2'],
-  };
-  delete expect.granuleId;
-
-  const actual = normalizeEvent(inputEvent);
-  t.deepEqual(actual, expect);
-});
-
-test('normalizeEvent throws error if array of granuleIds is passed to Internal report', (t) => {
-  const inputEvent = {
-    systemBucket: 'systemBucket',
-    stackName: 'stackName',
-    startTimestamp: new Date().toISOString(),
-    endTimestamp: new Date().toISOString(),
-    reportType: 'Internal',
-    granuleId: ['someGranuleId'],
-  };
-  t.throws(() => normalizeEvent(inputEvent), {
-    message:
-      'granuleId: ["someGranuleId"] is not valid input for an \'Internal\' report.',
-  });
-});
-
-test('normalizeEvent throws error if granuleIds and collectionIds are passed to non-Internal report', (t) => {
-  const inputEvent = {
-    systemBucket: 'systemBucket',
-    stackName: 'stackName',
-    startTimestamp: new Date().toISOString(),
-    endTimestamp: new Date().toISOString(),
-    reportType: 'notInternal',
-    granuleId: ['someGranuleId'],
-    collectionId: ['someCollectionId1'],
-  };
-  t.throws(() => normalizeEvent(inputEvent), {
-    instanceOf: InvalidArgument,
-    message:
-      'notInternal reports cannot be launched with both granuleId and collectionId input.',
-  });
-});
-
-test('normalizeEvent correctly handles granuleIds and collectionIds if reportType is Internal', (t) => {
-  const inputEvent = {
-    systemBucket: 'systemBucket',
-    stackName: 'stackName',
-    startTimestamp: new Date().toISOString(),
-    endTimestamp: new Date().toISOString(),
-    reportType: 'Internal',
-    granuleId: 'someGranuleId',
-    collectionId: 'someCollectionId1',
-  };
-
-  const expected = {
-    ...inputEvent,
-    granuleIds: ['someGranuleId'],
-    collectionIds: ['someCollectionId1'],
-  };
-
-  const actual = normalizeEvent(inputEvent);
-  t.deepEqual(actual, expected);
-});

--- a/packages/api/tests/lambdas/test-create-reconciliation-report.js
+++ b/packages/api/tests/lambdas/test-create-reconciliation-report.js
@@ -26,10 +26,14 @@ const { fakeCollectionFactory, fakeGranuleFactoryV2 } = require('../../lib/testU
 const GranuleFilesCache = require('../../lib/GranuleFilesCache');
 const { Search } = require('../../es/search');
 const {
-  handler, reconciliationReportForGranules, reconciliationReportForGranuleFiles,
+  handler: unwrappedHandler, reconciliationReportForGranules, reconciliationReportForGranuleFiles,
 } = require('../../lambdas/create-reconciliation-report');
 const models = require('../../models');
 const indexer = require('../../es/indexer');
+const { normalizeEvent } = require('../../lib/reconciliationReport/normalizeEvent');
+
+// Call normalize event on all input events before calling the handler.
+const handler = (event) => unwrappedHandler(normalizeEvent(event));
 
 let esAlias;
 let esIndex;

--- a/packages/api/tests/lib/reconciliationReport/test-normalizeEvent.js
+++ b/packages/api/tests/lib/reconciliationReport/test-normalizeEvent.js
@@ -1,0 +1,165 @@
+const test = require('ava');
+const { InvalidArgument } = require('@cumulus/errors');
+const { normalizeEvent } = require('../../../lib/reconciliationReport/normalizeEvent');
+
+test('normalizeEvent throws error if array of collectionIds passed to Internal report', (t) => {
+  const inputEvent = {
+    systemBucket: 'systemBucket',
+    stackName: 'stackName',
+    startTimestamp: new Date().toISOString(),
+    endTimestamp: new Date().toISOString(),
+    reportType: 'Internal',
+    collectionId: ['someCollection___version'],
+  };
+  t.throws(() => normalizeEvent(inputEvent), {
+    message: 'collectionId: ["someCollection___version"] is not valid input for an \'Internal\' report.',
+  });
+});
+test('normalizeEvent converts input key collectionId string to length 1 array on collectionIds', (t) => {
+  const inputEvent = {
+    systemBucket: 'systemBucket',
+    stackName: 'stackName',
+    startTimestamp: new Date().toISOString(),
+    endTimestamp: new Date().toISOString(),
+    reportType: 'NotInternal',
+    collectionId: 'someCollection___version',
+  };
+  const expect = { ...inputEvent, collectionIds: ['someCollection___version'] };
+  delete expect.collectionId;
+
+  const actual = normalizeEvent(inputEvent);
+  t.deepEqual(actual, expect);
+});
+test('normalizeEvent moves input key collectionId array to array on collectionIds', (t) => {
+  const inputEvent = {
+    systemBucket: 'systemBucket',
+    stackName: 'stackName',
+    startTimestamp: new Date().toISOString(),
+    endTimestamp: new Date().toISOString(),
+    reportType: 'NotInternal',
+    collectionId: ['someCollection___version', 'secondcollection___version'],
+  };
+  const expect = {
+    ...inputEvent,
+    collectionIds: ['someCollection___version', 'secondcollection___version'],
+  };
+  delete expect.collectionId;
+
+  const actual = normalizeEvent(inputEvent);
+  t.deepEqual(actual, expect);
+});
+test('normalizeEvent adds new collectionIds key when collectionId passed to Internal report', (t) => {
+  const inputEvent = {
+    systemBucket: 'systemBucket',
+    stackName: 'stackName',
+    startTimestamp: new Date().toISOString(),
+    endTimestamp: new Date().toISOString(),
+    reportType: 'Internal',
+    collectionId: 'someCollection___version',
+  };
+  const expect = {
+    ...inputEvent,
+    collectionIds: ['someCollection___version'],
+  };
+
+  const actual = normalizeEvent(inputEvent);
+  t.deepEqual(actual, expect);
+});
+test('normalizeEvent throws error if original input event contains collectionIds key', (t) => {
+  const inputEvent = {
+    systemBucket: 'systemBucket',
+    stackName: 'stackName',
+    startTimestamp: new Date().toISOString(),
+    endTimestamp: new Date().toISOString(),
+    reportType: 'Internal',
+    collectionIds: ['someCollection___version'],
+  };
+  t.throws(() => normalizeEvent(inputEvent), {
+    message: '`collectionIds` is not a valid input key for a reconciliation report, use `collectionId` instead.',
+  });
+});
+test('normalizeEvent moves string on granuleId to array on granuleIds', (t) => {
+  const inputEvent = {
+    systemBucket: 'systemBucket',
+    stackName: 'stackName',
+    startTimestamp: new Date().toISOString(),
+    endTimestamp: new Date().toISOString(),
+    reportType: 'Not Internal',
+    granuleId: 'someGranule',
+  };
+  const expect = {
+    ...inputEvent,
+    granuleIds: ['someGranule'],
+  };
+  delete expect.granuleId;
+
+  const actual = normalizeEvent(inputEvent);
+  t.deepEqual(actual, expect);
+});
+test('normalizeEvent moves array on granuleId to granuleIds', (t) => {
+  const inputEvent = {
+    systemBucket: 'systemBucket',
+    stackName: 'stackName',
+    startTimestamp: new Date().toISOString(),
+    endTimestamp: new Date().toISOString(),
+    reportType: 'Not Internal',
+    granuleId: ['someGranule', 'someGranule2'],
+  };
+
+  const expect = {
+    ...inputEvent,
+    granuleIds: ['someGranule', 'someGranule2'],
+  };
+  delete expect.granuleId;
+
+  const actual = normalizeEvent(inputEvent);
+  t.deepEqual(actual, expect);
+});
+test('normalizeEvent throws error if array of granuleIds is passed to Internal report', (t) => {
+  const inputEvent = {
+    systemBucket: 'systemBucket',
+    stackName: 'stackName',
+    startTimestamp: new Date().toISOString(),
+    endTimestamp: new Date().toISOString(),
+    reportType: 'Internal',
+    granuleId: ['someGranuleId'],
+  };
+  t.throws(() => normalizeEvent(inputEvent), {
+    message: 'granuleId: ["someGranuleId"] is not valid input for an \'Internal\' report.',
+  });
+});
+test('normalizeEvent throws error if granuleIds and collectionIds are passed to non-Internal report', (t) => {
+  const inputEvent = {
+    systemBucket: 'systemBucket',
+    stackName: 'stackName',
+    startTimestamp: new Date().toISOString(),
+    endTimestamp: new Date().toISOString(),
+    reportType: 'notInternal',
+    granuleId: ['someGranuleId'],
+    collectionId: ['someCollectionId1'],
+  };
+  t.throws(() => normalizeEvent(inputEvent), {
+    instanceOf: InvalidArgument,
+    message: 'notInternal reports cannot be launched with both granuleId and collectionId input.',
+  });
+});
+test('normalizeEvent correctly handles granuleIds and collectionIds if reportType is Internal', (t) => {
+  const inputEvent = {
+    systemBucket: 'systemBucket',
+    stackName: 'stackName',
+    startTimestamp: new Date().toISOString(),
+    endTimestamp: new Date().toISOString(),
+    reportType: 'Internal',
+    granuleId: 'someGranuleId',
+    collectionId: 'someCollectionId1',
+  };
+
+  const expected = {
+    ...inputEvent,
+    granuleIds: ['someGranuleId'],
+    collectionIds: ['someCollectionId1'],
+  };
+
+  const actual = normalizeEvent(inputEvent);
+  t.deepEqual(actual, expected);
+});


### PR DESCRIPTION
**Summary:** moves event validation from lambda to endpoint for reconcilationReport

Addresses [CUMULUS-1963: add granuleIds to Reconcilation Reports](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1963)

## Changes

* Extracts normalizeEvent into lib function 
* Adds normalization to endpoint before async operation is called
* adds test to verify fast endpoint failures 
* deletes empty file packages/api/lib/RecordDoesNotExist.js  

## PR Checklist

- [X ] Update CHANGELOG
- [X ] Unit tests
- [X ] Adhoc testing
- [ ] Integration tests

