### PR TITLE
Fix doc titles

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -2,7 +2,6 @@
   "default": true,
   "line-length": false,
   "no-duplicate-header": false,
-  "single-h1": { "front_matter_title": "" },
   "ol-prefix": { "style": "ordered" },
   "no-inline-html": { "allowed_elements": ["code", "br", "ul", "li"] }
 }

--- a/bin/tasks-header.md
+++ b/bin/tasks-header.md
@@ -1,10 +1,8 @@
 ---
 id: tasks
 title: Cumulus Tasks
-hide_title: true
+hide_title: false
 ---
-
-# Cumulus Tasks
 
 A list of reusable Cumulus tasks. [Add your own.](adding-a-task.md)
 

--- a/docs/adding-a-task.md
+++ b/docs/adding-a-task.md
@@ -1,10 +1,8 @@
 ---
 id: adding-a-task
 title: Contributing a Task
-hide_title: true
+hide_title: false
 ---
-
-# Contributing a task
 
 We're tracking reusable Cumulus tasks [in this list](tasks.md) and, if you've got one you'd like to share with others, you can add it!
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,9 +1,7 @@
 ---
 id: api
 title: Cumulus API
-hide_title: true
+hide_title: false
 ---
-
-# Cumulus API
 
 Read the Cumulus API documentation at [https://nasa.github.io/cumulus-api](https://nasa.github.io/cumulus-api)

--- a/docs/configuration/cloudwatch-retention.md
+++ b/docs/configuration/cloudwatch-retention.md
@@ -1,10 +1,8 @@
 ---
 id: cloudwatch-retention
 title: Cloudwatch Retention
-hide_title: true
+hide_title: false
 ---
-
-# Cloudwatch Retention
 
 Our lambdas dump logs to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/). By default, these logs exist indefinitely. However, there are ways to specify a duration for log retention.
 

--- a/docs/configuration/collection-storage-best-practices.md
+++ b/docs/configuration/collection-storage-best-practices.md
@@ -1,10 +1,8 @@
 ---
 id: collection-storage-best-practices
-title: Collection Storage Best Practices
-hide_title: true
+title: Collection Cost Tracking and Storage Best Practices
+hide_title: false
 ---
-
-# Collection Cost Tracking and Storage Best Practices
 
 Organizing your data is important for metrics you may want to collect. AWS S3 storage and cost metrics are calculated at the bucket level, so it is easy to get metrics by bucket. You can get storage metrics at the key prefix level, but that is done through the CLI, which can be very slow for large buckets. It is very difficult to estimate costs at the prefix level.
 

--- a/docs/configuration/lifecycle-policies.md
+++ b/docs/configuration/lifecycle-policies.md
@@ -1,10 +1,8 @@
 ---
 id: lifecycle-policies
-title: Lifecycle Policies
-hide_title: true
+title: Setting S3 Lifecycle Policies
+hide_title: false
 ---
-
-# Setting S3 Lifecycle Policies
 
 This document will outline, in brief, how to set data lifecycle policies so that you are more easily able to control data storage costs while keeping your data accessible.   For more information on why you might want to do this, see the 'Additional Information' section at the end of the document.
 

--- a/docs/configuration/monitoring.md
+++ b/docs/configuration/monitoring.md
@@ -1,10 +1,8 @@
 ---
 id: monitoring-readme
 title: Monitoring Best Practices
-hide_title: true
+hide_title: false
 ---
-
-# Cumulus Monitoring Best Practices
 
 This document intends to provide a set of recommendations and best practices for monitoring the state of a deployed Cumulus and diagnosing any issues.
 

--- a/docs/configuration/server_access_logging.md
+++ b/docs/configuration/server_access_logging.md
@@ -1,10 +1,8 @@
 ---
 id: server_access_logging
 title: S3 Server Access Logging
-hide_title: true
+hide_title: false
 ---
-
-# S3 Server Access Logging
 
 **Note:** To support [EMS Reporting](../features/ems_reporting), you need to enable [Amazon S3 server access logging][awslogging] on all protected and public buckets.
 

--- a/docs/data-cookbooks/about-cookbooks.md
+++ b/docs/data-cookbooks/about-cookbooks.md
@@ -1,10 +1,8 @@
 ---
 id: about-cookbooks
 title: About Cookbooks
-hide_title: true
+hide_title: false
 ---
-
-# About
 
 ## Introduction
 

--- a/docs/data-cookbooks/browse-generation.md
+++ b/docs/data-cookbooks/browse-generation.md
@@ -1,10 +1,8 @@
 ---
 id: browse-generation
 title: Ingest Browse Generation
-hide_title: true
+hide_title: false
 ---
-
-# Browse Generation
 
 This entry documents how to setup a workflow that utilizes Cumulus's built-in granule file type configuration such that on ingest the browse data is exported to CMR.
 

--- a/docs/data-cookbooks/choice-states.md
+++ b/docs/data-cookbooks/choice-states.md
@@ -1,10 +1,8 @@
 ---
 id: choice-states
 title: Choice States
-hide_title: true
+hide_title: false
 ---
-
-# Choice States
 
 Cumulus supports AWS Step Function [`Choice`](https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-choice-state.html) states. A `Choice` state enables branching logic in Cumulus workflows.
 

--- a/docs/data-cookbooks/cnm-workflow.md
+++ b/docs/data-cookbooks/cnm-workflow.md
@@ -1,10 +1,8 @@
 ---
 id: cnm-workflow
 title: CNM Workflow
-hide_title: true
+hide_title: false
 ---
-
-# CNM Workflow
 
 This entry documents how to setup a workflow that utilizes the built-in CNM/Kinesis functionality in Cumulus.
 

--- a/docs/data-cookbooks/error-handling.md
+++ b/docs/data-cookbooks/error-handling.md
@@ -1,10 +1,8 @@
 ---
 id: error-handling
 title: Error Handling in Workflows
-hide_title: true
+hide_title: false
 ---
-
-# Error Handling in Workflows
 
 Cumulus Workflow error handling is configurable via AWS Step Function
 definitions, which enable users to configure what the state machine does next

--- a/docs/data-cookbooks/hello-world.md
+++ b/docs/data-cookbooks/hello-world.md
@@ -1,10 +1,8 @@
 ---
 id: hello-world
 title: HelloWorld Workflow
-hide_title: true
+hide_title: false
 ---
-
-# HelloWorld Workflow
 
 Example task meant to be a sanity check/introduction to the Cumulus workflows.
 

--- a/docs/data-cookbooks/ingest-notifications.md
+++ b/docs/data-cookbooks/ingest-notifications.md
@@ -1,10 +1,8 @@
 ---
 id: ingest-notifications
 title: Ingest Notification in Workflows
-hide_title: true
+hide_title: false
 ---
-
-# Ingest Notification in Workflows
 
 On deployment, an [SQS queue](https://aws.amazon.com/sqs/) and three [SNS topics](https://aws.amazon.com/sns/) are created and used for handling notification messages related to the workflow.
 

--- a/docs/data-cookbooks/run-tasks-in-lambda-or-docker.md
+++ b/docs/data-cookbooks/run-tasks-in-lambda-or-docker.md
@@ -1,10 +1,8 @@
 ---
 id: run-tasks-in-lambda-or-docker
-title: Run Step Function Tasks in Lambda or Docker
-hide_title: true
+title: Run Step Function Tasks in AWS Lambda or Docker
+hide_title: false
 ---
-
-# Running Step Function Tasks in AWS Lambda or Docker
 
 ## Overview
 

--- a/docs/data-cookbooks/setup.md
+++ b/docs/data-cookbooks/setup.md
@@ -1,10 +1,8 @@
 ---
 id: setup
 title: Data Cookbooks Introduction
-hide_title: true
+hide_title: false
 ---
-
-# Introduction
 
 ## Working with Data Cookbooks
 

--- a/docs/data-cookbooks/sips-workflow.md
+++ b/docs/data-cookbooks/sips-workflow.md
@@ -1,10 +1,8 @@
 ---
 id: sips-workflow
 title: Science Investigator-led Processing Systems (SIPS)
-hide_title: true
+hide_title: false
 ---
-
-# Science Investigator-led Processing Systems (SIPS)
 
 The Cumulus ingest workflow supports the SIPS workflow. In the following document, we'll discuss what a SIPS workflow is and how to set one up in a Cumulus instance.
 

--- a/docs/data-cookbooks/throttling-queued-executions.md
+++ b/docs/data-cookbooks/throttling-queued-executions.md
@@ -1,10 +1,8 @@
 ---
 id: throttling-queued-executions
 title: Throttling queued executions
-hide_title: true
+hide_title: false
 ---
-
-# Throttling queued executions
 
 In this entry, we will walkthrough how to create an SQS queue for scheduling executions which will be used to limit those executions to a maximum concurrency. And we will see how to configure our Cumulus workflows/rules to use this queue.
 

--- a/docs/data-cookbooks/tracking-files.md
+++ b/docs/data-cookbooks/tracking-files.md
@@ -1,18 +1,17 @@
 ---
 id: tracking-files
 title: Tracking Ancillary Files
-hide_title: true
+hide_title: false
 ---
-
-# Tracking Files
 
 ## Contents
 
-* [Introduction](#introduction)
-* [File Types](#file-types)
-* [File Type Configuration](#file-type-configuration)
-* [CMR Metadata](#cmr-metadata)
-* [Common Use Cases](#common-use-cases)
+- [Contents](#contents)
+  - [Introduction](#introduction)
+  - [File types](#file-types)
+  - [File Type Configuration](#file-type-configuration)
+  - [CMR Metadata](#cmr-metadata)
+  - [Common Use Cases](#common-use-cases)
 
 ### Introduction
 
@@ -66,7 +65,7 @@ Configuring browse imagery:
   "regex": "^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\_[\\d]{1}.jpg$",
   "sampleFileName": "MOD09GQ.A2017025.h21v00.006.2017034065104_1.jpg",
   "type": "browse"
-}  
+}
 ```
 
 Configuring a documentation entry:

--- a/docs/data-cookbooks/tracking-files.md
+++ b/docs/data-cookbooks/tracking-files.md
@@ -23,10 +23,10 @@ We will cover Cumulus file types, file type configuration, effects on CMR metada
 
 Cumulus follows the Cloud Notification Mechanism (CNM) file type conventions. Under this schema, there are four data types:
 
-* `data`
-* `browse`
-* `metadata`
-* `qa`
+- `data`
+- `browse`
+- `metadata`
+- `qa`
 
 In Cumulus, these data types are mapped to the `Type` attribute on `RelatedURL`s for UMM-G metadata, or used to map
 resources to one of `OnlineAccessURL`, `OnlineResource` or `AssociatedBrowseImages` for ECHO10 XML metadata.

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,10 +1,8 @@
 ---
 id: deployment-readme
 title: How to Deploy Cumulus
-hide_title: true
+hide_title: false
 ---
-
-# How to Deploy Cumulus
 
 ## Overview
 

--- a/docs/deployment/api_gateway_logging.md
+++ b/docs/deployment/api_gateway_logging.md
@@ -1,10 +1,8 @@
 ---
 id: api-gateway-logging
 title: API Gateway Logging
-hide_title: true
+hide_title: false
 ---
-
-# API Gateway Logging
 
 ## Enabling API Gateway logging
 

--- a/docs/deployment/components.md
+++ b/docs/deployment/components.md
@@ -1,10 +1,8 @@
 ---
 id: components
-title: Cumulus Components
-hide_title: true
+title: Component-based Cumulus Deployment
+hide_title: false
 ---
-
-# Component-based Cumulus Deployment
 
 Cumulus is now released in a modular architecture, which will allow users to
 pick and choose the individual components that they want to deploy. These
@@ -21,7 +19,7 @@ able to make use of the large number of publicly available modules on the [Terra
 * [ECS service](https://github.com/nasa/cumulus/tree/master/tf-modules/cumulus-ecs-service)
 * [Distribution](https://github.com/nasa/cumulus/tree/master/tf-modules/distribution)
 * [Thin Egress App](./thin_egress_app)
-* [Workflow](https://github.com/nasa/cumulus/tree/master/tf-modules/cumulus-ecs-service)
+* [Workflow](https://github.com/nasa/cumulus/tree/master/tf-modules/workflow)
 
 ## Adding components to your Terraform deployment
 

--- a/docs/deployment/configure_cloudwatch_logs_delivery.md
+++ b/docs/deployment/configure_cloudwatch_logs_delivery.md
@@ -1,10 +1,8 @@
 ---
 id: cloudwatch-logs-delivery
 title: Configure Cloudwatch Logs Delivery
-hide_title: true
+hide_title: false
 ---
-
-# Configure Cloudwatch Logs Delivery
 
 As an optional configuration step, it is possible to deliver CloudWatch logs to a cross-account shared AWS::Logs::Destination. An operator does this by configuring the `cumulus` module for [your deployment](../deployment/README.md#configure-and-deploy-the-cumulus-tf-root-module) as shown below. The value of the `log_destination_arn` variable is the ARN of a writeable log destination.
 

--- a/docs/deployment/create_bucket.md
+++ b/docs/deployment/create_bucket.md
@@ -1,10 +1,8 @@
 ---
 id: create_bucket
 title: Creating an S3 Bucket
-hide_title: true
+hide_title: false
 ---
-
-# Creating an S3 Bucket
 
 Buckets can be created on the command line with [AWS CLI][cli] or via the web interface on the [AWS console][web].
 

--- a/docs/deployment/share-s3-access-logs.md
+++ b/docs/deployment/share-s3-access-logs.md
@@ -1,10 +1,8 @@
 ---
 id: share-s3-access-logs
 title: Share S3 Access Logs
-hide_title: true
+hide_title: false
 ---
-
-# Sharing S3 Access Logs
 
 It is possible through Cumulus to share S3 access logs across multiple S3 packages using the S3 replicator package.
 

--- a/docs/deployment/terraform-best-practices.md
+++ b/docs/deployment/terraform-best-practices.md
@@ -1,10 +1,8 @@
 ---
 id: terraform-best-practices
 title: Terraform Best Practices
-hide_title: true
+hide_title: false
 ---
-
-# Terraform Best Practices
 
 ## How to Manage the Terraform State Bucket
 

--- a/docs/deployment/thin-egress-app.md
+++ b/docs/deployment/thin-egress-app.md
@@ -1,10 +1,8 @@
 ---
 id: thin_egress_app
-title: Thin Egress App
-hide_title: true
+title: Using the Thin Egress App for Cumulus distribution
+hide_title: false
 ---
-
-# Using the Thin Egress App for Cumulus distribution
 
 The [Thin Egress App (TEA)](https://github.com/asfadmin/thin-egress-app) is an app running in Lambda that allows retrieving data from S3 using temporary links and provides URS integration.
 

--- a/docs/deployment/upgrade.md
+++ b/docs/deployment/upgrade.md
@@ -1,10 +1,8 @@
 ---
 id: upgrade-readme
 title: Upgrading Cumulus
-hide_title: true
+hide_title: false
 ---
-
-# Upgrading Cumulus
 
 After the initial deployment, any future updates to the Cumulus deployment from configuration files, Terraform files (`*.tf`), or modules from a new version of Cumulus can be deployed and will update the appropriate portions of the stack as needed.
 

--- a/docs/docs-how-to.md
+++ b/docs/docs-how-to.md
@@ -1,12 +1,12 @@
 ---
 id: docs-how-to
 title: Cumulus Documentation: How To's
-hide_title: true
+hide_title: false
 ---
 
-# Cumulus Docs Installation
+## Cumulus Docs Installation
 
-## Run a Local Server
+### Run a Local Server
 
 Environment variables `DOCSEARCH_API_KEY` and `DOCSEARCH_INDEX_NAME` must be set for search to work. At the moment, search is only truly functional on prod because that is the only website we have registered to be indexed with DocSearch (see below on search).
 
@@ -19,13 +19,13 @@ npm run docs-serve
 
 **Note:** `docs-build` will build the documents into `website/build/Cumulus`.
 
-## Cumulus Documentation
+### Cumulus Documentation
 
 Our project documentation is hosted on [GitHub Pages](https://pages.github.com/). The resources published to this website are housed in `docs/` directory at the top of the Cumulus repository. Those resources primarily consist of markdown files and images.
 
 We use the open-source static website generator [Docusaurus](https://docusaurus.io) to build html files from our markdown documentation, add some organization and navigation, and provide some other niceties in the final website (search, easy templating, etc.).
 
-### Add a New Page and Sidebars
+#### Add a New Page and Sidebars
 
 Adding a new page should be as simple as writing some documentation in markdown, placing it under the correct directory in the `docs/` folder and adding some configuration values wrapped by `---` at the top of the file. There are many files that already have this header which can be used as reference.
 
@@ -33,36 +33,36 @@ Adding a new page should be as simple as writing some documentation in markdown,
 ---
 id: doc-unique-id    # unique id for this document. This must be unique accross ALL documentation under docs/
 title: Title Of Doc  # Whatever title you feel like adding. This will show up as the index to this page on the sidebar.
-hide_title: true     # So the title of the Doc doesn't show up at the top of the webpage (generally we already have the title written as h1 in the documentation).
+hide_title: false
 ---
 ```
 
 **Note:** To have the new page show up in a sidebar the designated `id` must be added to a sidebar in the `website/sidebars.json` file. Docusaurus has an in depth explanation of sidebars [here](https://docusaurus.io/docs/en/navigation).
 
-### Versioning Docs
+#### Versioning Docs
 
 We lean heavily on Docusaurus for versioning. Their suggestions and walkthrough can be found [here](https://docusaurus.io/docs/en/versioning). It is worth noting that we would like the Documentation versions to match up directly with release versions. Cumulus versioning is explained in the [Versioning Docs](https://github.com/nasa/cumulus/tree/master/docs/development/release.md).
 
-### Search
+#### Search
 
 Search on our documentation site is taken care of by [DocSearch](https://community.algolia.com/docsearch/). We have been provided with an `apiKey` and an `indexName` by DocSearch that we include in our `website/siteConfig.js` file. The rest, indexing and actual searching, we leave to DocSearch. Our builds expect environment variables for both these values to exist - `DOCSEARCH_API_KEY` and `DOCSEARCH_NAME_INDEX`.
 
-### Add a new task
+#### Add a new task
 
 The tasks list in docs/tasks.md is generated from the list of task package in the task folder. Do not edit the docs/tasks.md file directly.
 
 [Read more about adding a new task.](adding-a-task.md)
 
-### Editing the tasks.md header or template
+#### Editing the tasks.md header or template
 
 Look at the `bin/build-tasks-doc.js` and `bin/tasks-header.md` files to edit the output of the tasks build script.
 
-### Editing diagrams
+#### Editing diagrams
 
 For some diagrams included in the documentation, the raw source is included in the `docs/assets/raw` directory to allow for easy updating in the future:
 
 - `assets/interfaces.svg` -> `assets/raw/interfaces.drawio` (generated using [draw.io](https://www.draw.io/))
 
-## Deployment
+### Deployment
 
 The `master` branch is automatically built and deployed to `gh-pages` branch. The `gh-pages` branch is served by Github Pages. Do not make edits to the `gh-pages` branch.

--- a/docs/features/ancillary_metadata.md
+++ b/docs/features/ancillary_metadata.md
@@ -1,10 +1,8 @@
 ---
 id: ancillary_metadata
 title: Ancillary Metadata Export
-hide_title: true
+hide_title: false
 ---
-
-# Ancillary Metadata Export
 
 This feature utilizes the `type` key on a files object in a Cumulus [granule](https://github.com/nasa/cumulus/blob/master/packages/api/models/schemas.js).  It uses the key  to provide a mechanism where granule discovery, processing and other tasks can set and use this value to facilitate metadata export to CMR.
 

--- a/docs/features/backup_and_restore.md
+++ b/docs/features/backup_and_restore.md
@@ -1,10 +1,8 @@
 ---
 id: backup_and_restore
 title: Cumulus Backup and Restore
-hide_title: true
+hide_title: false
 ---
-
-# Cumulus Backup and Restore
 
 ## Deployment Backup and Restore
 

--- a/docs/features/data_in_dynamodb.md
+++ b/docs/features/data_in_dynamodb.md
@@ -1,10 +1,8 @@
 ---
 id: data_in_dynamodb
 title: Cumulus Metadata in DynamoDB
-hide_title: true
+hide_title: false
 ---
-
-# Cumulus Metadata in DynamoDB
 
 - [DynamoDB Auto Scaling](#dynamodb-auto-scaling)
 

--- a/docs/features/distribution-metrics.md
+++ b/docs/features/distribution-metrics.md
@@ -1,10 +1,8 @@
 ---
 id: distribution-metrics
 title: Cumulus Distribution Metrics
-hide_title: true
+hide_title: false
 ---
-
-# Cumulus Distribution Metrics
 
 It is possible to configure Cumulus and the Cumulus Dashboard to display information about the successes and failures of requests for data.  This requires the Cumulus instance to deliver Cloudwatch Logs and S3 Server Access logs to an ELK stack.
 

--- a/docs/features/ems_reporting.md
+++ b/docs/features/ems_reporting.md
@@ -1,10 +1,8 @@
 ---
 id: ems_reporting
 title: EMS Reporting
-hide_title: true
+hide_title: false
 ---
-
-# EMS Reporting
 
 Cumulus reports usage statistics to the [ESDIS Metrics System (EMS)](https://earthdata.nasa.gov/about/science-system-description/eosdis-components/esdis-metrics-system-ems).
 

--- a/docs/features/execution_payload_retention.md
+++ b/docs/features/execution_payload_retention.md
@@ -1,10 +1,8 @@
 ---
 id: execution_payload_retention
 title: Execution Payload Retention
-hide_title: true
+hide_title: false
 ---
-
-# Execution Payload Retention
 
 In addition to CloudWatch logs and AWS StepFunction API records, Cumulus automatically stores the initial and 'final' (the last update to the execution record) payload values as part of the Execution record in DynamoDB and Elasticsearch.
 

--- a/docs/features/inventory-reports.md
+++ b/docs/features/inventory-reports.md
@@ -1,10 +1,8 @@
 ---
 id: inventory_reports
 title: Inventory Reports
-hide_title: true
+hide_title: false
 ---
-
-# Inventory Reports
 
 This feature provides a detailed report of collections, granules and files in Cumulus and CMR.
 These reports show the following data:

--- a/docs/features/lambda_dead_letter_queue.md
+++ b/docs/features/lambda_dead_letter_queue.md
@@ -1,10 +1,8 @@
 ---
 id: dead_letter_queues
 title: Dead Letter Queues
-hide_title: true
+hide_title: false
 ---
-
-# Cumulus Dead Letter Queues
 
 ## startSF SQS queue
 

--- a/docs/features/logging-esdis-metrics.md
+++ b/docs/features/logging-esdis-metrics.md
@@ -1,10 +1,8 @@
 ---
 id: logging-esdis-metrics
 title: Writing logs for ESDIS Metrics
-hide_title: true
+hide_title: false
 ---
-
-# Writing logs for ESDIS Metrics
 
 > **Note:** This feature is only available for Cumulus deployments in NGAP environments.
 >

--- a/docs/features/replay-kinesis-messages.md
+++ b/docs/features/replay-kinesis-messages.md
@@ -1,10 +1,8 @@
 ---
 id: replay-kinesis-messages
-title: Replay Kinesis Messages
-hide_title: true
+title: How to replay Kinesis messages after an outage
+hide_title: false
 ---
-
-# How to replay Kinesis messages after an outage
 
 After a period of outage, it may be necessary for a Cumulus operator to reprocess or 'replay' messages that arrived on an AWS Kinesis Data Stream but did not trigger an ingest. This document serves as an outline on how to start a replay operation, and how to perform status tracking. Cumulus supports replay of all Kinesis messages on a stream (subject to the normal RetentionPeriod constraints), or all messages within a given time slice delimited by start and end timestamps.
 

--- a/docs/operator-docs/about-operator-docs.md
+++ b/docs/operator-docs/about-operator-docs.md
@@ -1,9 +1,7 @@
 ---
 id: about-operator-docs
 title: About Operator Docs
-hide_title: true
+hide_title: false
 ---
-
-# About Operator Docs
 
 Operator Docs are an augmentation to Cumulus documentation and Data Cookbooks. These documents will walk step-by-step through common Cumulus activities (that aren't necessarily as use-case directed as what you'd see in Data Cookbooks).

--- a/docs/operator-docs/bulk-operations.md
+++ b/docs/operator-docs/bulk-operations.md
@@ -1,10 +1,8 @@
 ---
 id: bulk-operations
 title: Bulk Operations
-hide_title: true
+hide_title: false
 ---
-
-# Bulk Operations
 
 Cumulus implements bulk operations through the use of `AsyncOperations`, which are long-running processes executed on an AWS ECS cluster.
 

--- a/docs/operator-docs/cmr-operations.md
+++ b/docs/operator-docs/cmr-operations.md
@@ -1,10 +1,8 @@
 ---
 id: cmr-operations
 title: CMR Operations
-hide_title: true
+hide_title: false
 ---
-
-# CMR Operations
 
 This document will outline basic procedures to interact with CMR on a per-granule basis.
 We rely on the Cumulus API's `ApplyWorkflow` functionality to accomplish these actions.

--- a/docs/operator-docs/common-use-cases.md
+++ b/docs/operator-docs/common-use-cases.md
@@ -1,10 +1,8 @@
 ---
 id: common-use-cases
 title: Common Use Cases
-hide_title: true
+hide_title: false
 ---
-
-# Common Use Cases
 
 Listed below are some example use cases that you may encounter during your onboarding process and daily activities.
 

--- a/docs/operator-docs/create-rule-in-cumulus.md
+++ b/docs/operator-docs/create-rule-in-cumulus.md
@@ -1,10 +1,8 @@
 ---
 id: create-rule-in-cumulus
 title: Create Rule In Cumulus
-hide_title: true
+hide_title: false
 ---
-
-# Create Rule In Cumulus
 
 Once the above files are in place and the entries created in CMR and Cumulus, we are ready to begin ingesting data. Depending on the type of ingestion (FTP/Kinesis, etc) the values below will change, but for the most part they are all similar. Rules tell Cumulus how to associate providers and collections, and when/how to start processing a workflow.
 

--- a/docs/operator-docs/discovery-filtering.md
+++ b/docs/operator-docs/discovery-filtering.md
@@ -1,10 +1,8 @@
 ---
 id: discovery-filtering
 title: Discovery Filtering
-hide_title: true
+hide_title: false
 ---
-
-# Discovery Filtering
 
 Discovery filtering is an advanced feature of the `discover-granules` and `discover-pdrs` tasks.
 It is a configurable option for discovery that allows an operator to manipulate which parts of a

--- a/docs/operator-docs/granule-workflows.md
+++ b/docs/operator-docs/granule-workflows.md
@@ -1,10 +1,8 @@
 ---
 id: granule-workflows
 title: Granule Workflows
-hide_title: true
+hide_title: false
 ---
-
-# Granule Workflows
 
 ## Failed Granule
 

--- a/docs/operator-docs/kinesis-stream-for-ingest.md
+++ b/docs/operator-docs/kinesis-stream-for-ingest.md
@@ -1,28 +1,26 @@
 ---
 id: kinesis-stream-for-ingest
-title: Kinesis Stream For Ingest
-hide_title: true
+title: Setup Kinesis Stream & CNM Message
+hide_title: false
 ---
 
-# Setup Kinesis Stream & CNM Message
-
 > **Note**: Keep in mind that you should only have to set this up once per ingest stream. Kinesis pricing is based on the shard value and not on amount of kinesis usage.
-<!-- markdownlint-disable MD029 -->
+
 1. Create a Kinesis Stream
 
-* In your AWS console, go to the `Kinesis` service and click `Create Data Stream`.
-* Assign a name to the stream.
-* Apply a `shard value` of `1`.
-* Click on `Create Kinesis Stream`.
-* A status page with stream details display. Once the status is `active` then the stream is ready to use. Keep in mind to record the streamName and StreamARN for later use.
-![Screenshot of AWS console page for creating a Kinesis stream](assets/cnm_create_kinesis_stream.jpg)
+    - In your AWS console, go to the `Kinesis` service and click `Create Data Stream`.
+    - Assign a name to the stream.
+    - Apply a `shard value` of `1`.
+    - Click on `Create Kinesis Stream`.
+    - A status page with stream details display. Once the status is `active` then the stream is ready to use. Keep in mind to record the streamName and StreamARN for later use.
+
+    ![Screenshot of AWS console page for creating a Kinesis stream](assets/cnm_create_kinesis_stream.jpg)
 
 2. Create a Rule
 
-* Refer to [Create Rule in Cumulus](../operator-docs/create-rule-in-cumulus).
+    - Refer to [Create Rule in Cumulus](../operator-docs/create-rule-in-cumulus).
 
 3. Send a message
 
-* Send a message that makes your schema using python or by your command line.
-* The `streamName` and `Collection` must match the `kinesisArn+collection` defined in the rule that you have created in [Step 2](../operator-docs/create-rule-in-cumulus).
-<!-- markdownlint-enable MD029 -->
+    - Send a message that makes your schema using python or by your command line.
+    - The `streamName` and `Collection` must match the `kinesisArn+collection` defined in the rule that you have created in [Step 2](../operator-docs/create-rule-in-cumulus).

--- a/docs/operator-docs/locating-access-logs.md
+++ b/docs/operator-docs/locating-access-logs.md
@@ -1,10 +1,8 @@
 ---
 id: locating-access-logs
 title: Locating S3 Access Logs
-hide_title: true
+hide_title: false
 ---
-
-# Locating S3 Access Logs
 
 When [enabling S3 Access Logs](../deployment/server_access_logging) for EMS Reporting you configured a `TargetBucket` and `TargetPrefix`.  Inside the `TargetBucket` at the `TargetPrefix` is where you will find the raw S3 access logs.
 

--- a/docs/operator-docs/provider.md
+++ b/docs/operator-docs/provider.md
@@ -1,10 +1,8 @@
 ---
 id: provider
 title: Provider Configuration
-hide_title: true
+hide_title: false
 ---
-
-# Provider Configuration
 
 In Cumulus, a Provider represents a endpoint from which data is ingested.   For example, a HTTP server serving data from a data provider, or an S3 bucket deployed within your organization with data staged for ingest into Cumulus.
 

--- a/docs/operator-docs/serve-dashboard-from-cloudfront.md
+++ b/docs/operator-docs/serve-dashboard-from-cloudfront.md
@@ -1,10 +1,8 @@
 ---
 id: serve-dashboard-from-cloudfront
-title: Serve Dashboard with CloudFront
-hide_title: true
+title: Serve Cumulus Dashboard with CloudFront
+hide_title: false
 ---
-
-# Serve Cumulus Dashboard behind CloudFront
 
 This document will briefly outline how to set up a [CloudFront](https://aws.amazon.com/cloudfront/) endpoint to serve the Cumulus Dashboard in an NASA/NGAP environment. Including, which [NASD](https://bugs.earthdata.nasa.gov/servicedesk/customer/portal/7) tickets are needed to request and configure a CloudFront endpoint.
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,10 +1,8 @@
 ---
 id: tasks
 title: Cumulus Tasks
-hide_title: true
+hide_title: false
 ---
-
-# Cumulus Tasks
 
 A list of reusable Cumulus tasks. [Add your own.](adding-a-task.md)
 

--- a/docs/team.md
+++ b/docs/team.md
@@ -1,7 +1,7 @@
 ---
 id: team
 title: Cumulus Team
-hide_title: true
+hide_title: false
 ---
 
 ### Cumulus Core Team

--- a/docs/troubleshooting/README.md
+++ b/docs/troubleshooting/README.md
@@ -1,10 +1,8 @@
 ---
 id: troubleshooting-readme
-title: Troubleshooting Cumulus
-hide_title: true
+title: How to Troubleshoot and Fix Issues
+hide_title: false
 ---
-
-# How to Troubleshoot and Fix Issues
 
 While Cumulus is a complex system, there is a focus on maintaining the integrity and availability of the system and data. Should you encounter errors or issues while using this system, this section will help troubleshoot and solve those issues.
 

--- a/docs/troubleshooting/rerunning-workflow-executions.md
+++ b/docs/troubleshooting/rerunning-workflow-executions.md
@@ -1,10 +1,8 @@
 ---
 id: rerunning-workflow-executions
 title: Re-running workflow executions
-hide_title: true
+hide_title: false
 ---
-
-# Re-running workflow executions
 
 To re-run a Cumulus workflow execution from the AWS console:
 

--- a/docs/troubleshooting/troubleshoot_deployment.md
+++ b/docs/troubleshooting/troubleshoot_deployment.md
@@ -1,10 +1,8 @@
 ---
 id: troubleshooting-deployment
 title: Troubleshooting Deployment
-hide_title: true
+hide_title: false
 ---
-
-# Troubleshooting Deployment
 
 This document provides 'notes' on frequently encountered deployment issues. The issues reported are organized by relevant subsection.
 

--- a/docs/workflow_tasks/discover_granules.md
+++ b/docs/workflow_tasks/discover_granules.md
@@ -1,10 +1,8 @@
 ---
 id: discover_granules
 title: Discover Granules
-hide_title: true
+hide_title: false
 ---
-
-# Discover Granules
 
 This task utilizes the Cumulus Message Adapter to interpret and construct incoming and outgoing messages.
 

--- a/docs/workflow_tasks/files_to_granules.md
+++ b/docs/workflow_tasks/files_to_granules.md
@@ -1,10 +1,8 @@
 ---
 id: files_to_granules
 title: Files To Granules
-hide_title: true
+hide_title: false
 ---
-
-# Files To Granules
 
 This task utilizes the Cumulus Message Adapter to interpret and construct incoming and outgoing messages.
 

--- a/docs/workflow_tasks/move_granules.md
+++ b/docs/workflow_tasks/move_granules.md
@@ -1,10 +1,8 @@
 ---
 id: move_granules
 title: Move Granules
-hide_title: true
+hide_title: false
 ---
-
-# Move Granules
 
 This task utilizes the Cumulus Message Adapter to interpret and construct incoming and outgoing messages.
 

--- a/docs/workflow_tasks/parse_pdr.md
+++ b/docs/workflow_tasks/parse_pdr.md
@@ -1,10 +1,8 @@
 ---
 id: parse_pdr
 title: Parse PDR
-hide_title: true
+hide_title: false
 ---
-
-# Parse PDR
 
 This task utilizes the Cumulus Message Adapter to interpret and construct incoming and outgoing messages.
 

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -1,10 +1,8 @@
 ---
 id: workflows-readme
 title: Workflows
-hide_title: true
+hide_title: false
 ---
-
-# Workflows
 
 Workflows are comprised of one or more AWS Lambda Functions and ECS Activities to discover, ingest, process, manage and archive data.
 

--- a/docs/workflows/cumulus-task-message-flow.md
+++ b/docs/workflows/cumulus-task-message-flow.md
@@ -1,10 +1,8 @@
 ---
 id: cumulus-task-message-flow
 title: Cumulus Tasks: Message Flow
-hide_title: true
+hide_title: false
 ---
-
-# Cumulus Tasks: Message Flow
 
 Cumulus Tasks comprise Cumulus Workflows and are either AWS Lambda tasks or AWS Elastic Container Service (ECS) activities. Cumulus Tasks permit a payload as input to the main task application code. The task payload is additionally wrapped by the [Cumulus Message Adapter](https://github.com/nasa/cumulus-message-adapter). The Cumulus Message Adapter supplies additional information supporting message templating and metadata management of these workflows.
 

--- a/docs/workflows/developing-a-cumulus-workflow.md
+++ b/docs/workflows/developing-a-cumulus-workflow.md
@@ -1,10 +1,8 @@
 ---
 id: developing-a-cumulus-workflow
-title: Developing A Cumulus Workflow
-hide_title: true
+title: Creating a Cumulus Workflow
+hide_title: false
 ---
-
-# Creating a Cumulus workflow
 
 ## The Cumulus workflow module
 

--- a/docs/workflows/developing-workflow-tasks.md
+++ b/docs/workflows/developing-workflow-tasks.md
@@ -1,10 +1,8 @@
 ---
 id: developing-workflow-tasks
 title: Developing Workflow Tasks
-hide_title: true
+hide_title: false
 ---
-
-# Developing Workflow Tasks
 
 Workflow tasks can be either AWS Lambda Functions or ECS Activities.
 

--- a/docs/workflows/docker.md
+++ b/docs/workflows/docker.md
@@ -1,10 +1,8 @@
 ---
 id: docker
 title: Dockerizing Data Processing
-hide_title: true
+hide_title: false
 ---
-
-# Dockerizing Data Processing
 
 The software used for processing data amongst DAAC's is developed in a variety of languages, and with different sets of dependencies and build environments. To standardize processing, Docker allows us to provide an environment (called an image) to meet the needs of any processing software, while running on the kernel of the host server (in this case, an EC2 instance). This lightweight virtualization does not carry the overhead of any additional VM, providing near-instant startup and the ability to run any dockerized process as a command-line call.
 

--- a/docs/workflows/input_output.md
+++ b/docs/workflows/input_output.md
@@ -1,10 +1,8 @@
 ---
 id: input_output
-title: Workflows Input & Output
-hide_title: true
+title: Workflow Inputs & Outputs
+hide_title: false
 ---
-
-# Workflow Inputs and Return Values
 
 ## General Structure
 

--- a/docs/workflows/lambda.md
+++ b/docs/workflows/lambda.md
@@ -1,10 +1,8 @@
 ---
 id: lambda
 title: Develop Lambda Functions
-hide_title: true
+hide_title: false
 ---
-
-# Develop Lambda Functions
 
 ## Develop a new Cumulus Lambda
 

--- a/docs/workflows/protocol.md
+++ b/docs/workflows/protocol.md
@@ -1,10 +1,10 @@
 ---
 id: protocol
 title: Workflow Protocol
-hide_title: true
+hide_title: false
 ---
 
-# Configuration and Message Use Diagram
+## Configuration and Message Use Diagram
 
 ![A diagram showing at which point in a workflow the Cumulus message is checked for conformity with the message schema and where the configuration is checked for conformity with the configuration schema](assets/cumulus_configuration_and_message_schema_diagram.png)
 

--- a/docs/workflows/workflow-configuration-how-to.md
+++ b/docs/workflows/workflow-configuration-how-to.md
@@ -1,10 +1,8 @@
 ---
 id: workflow-configuration-how-to
 title: Workflow Configuration How To's
-hide_title: true
+hide_title: false
 ---
-
-# Workflow Configuration How To's
 
 ## How to specify a bucket for granules
 

--- a/docs/workflows/workflow-triggers.md
+++ b/docs/workflows/workflow-triggers.md
@@ -1,10 +1,8 @@
 ---
 id: workflow-triggers
 title: Workflow Triggers
-hide_title: true
+hide_title: false
 ---
-
-# Workflow Triggers
 
 For a workflow to run, it needs to be associated with a rule (see [rule configuration](data-cookbooks/setup.md#rules)). The rule configuration determines how and when a workflow execution is triggered. Rules can be triggered one time, on a schedule, or by new data written to a kinesis stream.
 


### PR DESCRIPTION
This is a bit of personal preference. For some reason we decided to use `hide_title: true` as a setting in the front matter (most of the time) for our docs, which means it doesn't render the `title` from the front matter on the page and we have to add our own H1 tag to the doc. Not only is there no real reason to do this, it results in extra space being rendered above the header. See the before/after pictures with the changes to use `hide_title: false` below.

But we're also not being consistent, which doesn't make the docs look great. So we should standardize one way or the other, but I see no reason to hide the title by default and then have to add one to the doc manually. There were also some inconsistencies between the front matter title in the markdown and the H1 in the markdown, which is avoided by just using the title in the front matter.

Before

<img width="1104" alt="docs-before" src="https://user-images.githubusercontent.com/1001694/94313922-996f6300-ff4d-11ea-8898-8d1cbda93b15.png">

After

<img width="1016" alt="docs-after" src="https://user-images.githubusercontent.com/1001694/94313930-9eccad80-ff4d-11ea-855f-20e58861e389.png">

