### PR TITLE
CUMULUS-2201: Fix Reconciliation Report integration test failures

### DIFF
--- a/example/spec/helpers/granuleUtils.js
+++ b/example/spec/helpers/granuleUtils.js
@@ -179,8 +179,8 @@ const waitForGranuleRecordInOrNotInList = async (stackName, granuleId, granuleIs
     return granuleIsIncluded ? ids.includes(granuleId) : !ids.includes(granuleId);
   },
   {
-    interval: 3000,
-    timeout: 240 * 1000,
+    interval: 10000,
+    timeout: 480 * 1000,
   }
 );
 


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2201: Investigate Reconciliation Report integration test failures](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2201)

## Changes

* Increase timeout value for checking if a granule is deleted from elasticsearch

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

