### PR TITLE
Mhs/cumulus 2224/add extended metadata type to reconciliation report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - **CUMULUS-2111**
   - Changed `distribution_api_gateway_stage` variable for `cumulus` module to `tea_api_gateway_stage`
   - Changed `api_gateway_stage` variable for `distribution` module to `tea_api_gateway_stage`
+- **CUMULUS-2224**
+  - Updated `/reconciliationReport`'s file reconciliation to include `"EXTENDED METADATA"` as a valid CMR relatedUrls Type.
 
 ### Fixed
 

--- a/packages/api/lambdas/create-reconciliation-report.js
+++ b/packages/api/lambdas/create-reconciliation-report.js
@@ -285,7 +285,7 @@ async function reconciliationReportForGranuleFiles(params) {
   const granuleFiles = keyBy(granuleInDb.files, 'fileName');
 
   // URL types for downloading granule files
-  const cmrGetDataTypes = ['GET DATA', 'GET RELATED VISUALIZATION'];
+  const cmrGetDataTypes = ['GET DATA', 'GET RELATED VISUALIZATION', 'EXTENDED METADATA'];
   const cmrRelatedDataTypes = ['VIEW RELATED INFORMATION'];
 
   const bucketTypes = Object.values(bucketsConfig.buckets)

--- a/packages/api/tests/lambdas/test-create-reconciliation-report.js
+++ b/packages/api/tests/lambdas/test-create-reconciliation-report.js
@@ -1436,16 +1436,17 @@ test.serial('reconciliationReportForGranuleFiles reports discrepancy of granule 
     URL: `${process.env.DISTRIBUTION_ENDPOINT}testbucket-protected-2/MOD09GQ___006/MOD/MOD09GQ.A4675287.SWPE5_.006.7310007729190.cmr.xml`,
     Type: 'EXTENDED METADATA',
     Description: 'File to download',
-  },
-  {
-    URL: 'http://example.com/thisFileIsIgnoredBecauseOfTheRelatedUrlType.exe',
-    Type: 'DOWNLOAD SOFTWARE',
-    Description: 'File to download',
   }];
 
   const filesOnlyInCmr = [{
     URL: 'https://enjo7p7os7.execute-api.us-east-1.amazonaws.com/dev/MYD13Q1.A2017297.h19v10.006.2017313221202.hdf',
     Type: 'GET DATA',
+    Description: 'File to download',
+  }];
+
+  const urlsIgnoredInCmr = [{
+    URL: 'http://example.com/thisFileIsIgnoredBecauseOfTheRelatedUrlType.exe',
+    Type: 'DOWNLOAD SOFTWARE',
     Description: 'File to download',
   }];
 
@@ -1455,11 +1456,13 @@ test.serial('reconciliationReportForGranuleFiles reports discrepancy of granule 
     Description: 'api endpoint to retrieve temporary credentials valid for same-region direct s3 access',
   }];
 
+  const allCmrFiles = matchingFilesInCmr
+    .concat(filesOnlyInCmr).concat(urlsShouldOnlyInCmr).concat(urlsIgnoredInCmr);
   const granuleInCmr = {
     GranuleUR: 'MOD09GQ.A4675287.SWPE5_.006.7310007729190',
     ShortName: 'MOD09GQ',
     Version: '006',
-    RelatedUrls: matchingFilesInCmr.concat(filesOnlyInCmr).concat(urlsShouldOnlyInCmr),
+    RelatedUrls: allCmrFiles,
   };
 
   const report = await reconciliationReportForGranuleFiles({

--- a/packages/api/tests/lambdas/test-create-reconciliation-report.js
+++ b/packages/api/tests/lambdas/test-create-reconciliation-report.js
@@ -1434,7 +1434,12 @@ test.serial('reconciliationReportForGranuleFiles reports discrepancy of granule 
   },
   {
     URL: `${process.env.DISTRIBUTION_ENDPOINT}testbucket-protected-2/MOD09GQ___006/MOD/MOD09GQ.A4675287.SWPE5_.006.7310007729190.cmr.xml`,
-    Type: 'GET DATA',
+    Type: 'EXTENDED METADATA',
+    Description: 'File to download',
+  },
+  {
+    URL: 'http://example.com/thisFileIsIgnoredBecauseOfTheRelatedUrlType.exe',
+    Type: 'DOWNLOAD SOFTWARE',
     Description: 'File to download',
   }];
 


### PR DESCRIPTION
**Summary:** Adds "EXTENDED METADATA" type to granule files' comparisons

Addresses [CUMULUS-2224: Not all files are being found in CMR when they exist in cumulus during reconciliation reporting](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2224)

## Changes

* Adds test and code to include the relatedUrls Type 'EXTENDED METADATA' 

## PR Checklist

- [ x] Update CHANGELOG
- [ x] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

