### PR TITLE
Returns a signedS3Url to get the Granule Inventory report.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+
+- **CUMULUS-2200**
+  - Changes return from 303 redirect to 200 success for `Granule Inventory`'s
+    `/reconciliationReport` returns.  The user (dashboard) must read the value
+    of `url` from the return to get the s3SignedURL and then download the report.
+
 ### MIGRATION STEPS
 
 - **CUMULUS-2099**

--- a/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
+++ b/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
@@ -625,22 +625,22 @@ describe('When there are granule differences and granule reconciliation is run',
       reportRecord = JSON.parse(asyncOperation.output);
     });
 
-    it('Fetches a signed URL to the Granule Inventory report through the Cumulus API', async () => {
+    it('Fetches a object with a signedURL to the Granule Inventory report through the Cumulus API', async () => {
       redirectResponse = await reconciliationReportsApi.getReconciliationReport({
         prefix: config.stackName,
         name: reportRecord.name,
       });
 
-      expect(redirectResponse.statusCode).toBe(303);
-      expect(redirectResponse.headers.location).toMatch(`reconciliation-reports/${reportRecord.name}.csv?`);
-      expect(redirectResponse.headers.location).toMatch('AWSAccessKeyId');
-      expect(redirectResponse.headers.location).toMatch('Signature');
-      expect(redirectResponse.body).toMatch('See Other. Redirecting to');
+      expect(redirectResponse.statusCode).toBe(200);
+      const redirectUrl = JSON.parse(redirectResponse.body).url;
+      expect(redirectUrl).toMatch(`reconciliation-reports/${reportRecord.name}.csv?`);
+      expect(redirectUrl).toMatch('AWSAccessKeyId');
+      expect(redirectUrl).toMatch('Signature');
     });
 
     it('Wrote correct data to the S3 location.', async () => {
       const pieces = new RegExp('https://(.*)\.s3.amazonaws.com/(.*)\\?.*', 'm');
-      const [, Bucket, Key] = redirectResponse.headers.location.match(pieces);
+      const [, Bucket, Key] = JSON.parse(redirectResponse.body).url.match(pieces);
       let response;
       try {
         response = await s3().getObject({ Bucket, Key }).promise();

--- a/packages/api/endpoints/reconciliation-reports.js
+++ b/packages/api/endpoints/reconciliation-reports.js
@@ -62,7 +62,7 @@ async function getReport(req, res) {
       const downloadURL = s3().getSignedUrl('getObject', {
         Bucket, Key, ResponseContentDisposition: `attachment; filename="${downloadFile}"`,
       });
-      return res.redirect(303, downloadURL);
+      return res.json({ url: downloadURL });
     }
     logger.debug('reconciliation report getReport received an unhandled report type.');
   } catch (error) {


### PR DESCRIPTION

**Summary:** Instead of redirecting with a 303, return 200 and an object that holds the
signedS3Url.


Addresses [CUMULUS-2200:](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2200)

## Changes

* Changes the return from reconcilationReport/reportname.csv from 303 redirect to an object {url: signedS3URL}


## PR Checklist

- [x ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [x ] Integration tests

