### PR TITLE
Fix docs render

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/website",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "The Cumulus website",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-1](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1)

Fix documentation rendering - apparently the docs/package.json version is tied to the docs rendering.  

I've manually pushed the results of this change to the gh-pages branch. 
