### PR TITLE
protects the collection list endpoints from errors.

### DIFF
--- a/packages/api/lib/mmt.js
+++ b/packages/api/lib/mmt.js
@@ -5,6 +5,9 @@ const get = require('lodash/get');
 
 const { CMR } = require('@cumulus/cmr-client');
 const { getCmrSettings } = require('@cumulus/cmrjs/cmr-utils');
+const Logger = require('@cumulus/logger');
+
+const log = new Logger({ sender: 'api/lib/mmt' });
 
 let cmr;
 
@@ -70,11 +73,17 @@ const updateObjectWithMMT = async (responseObj) => {
  */
 const insertMMTLinks = async (inputResponse) => {
   const response = cloneDeep(inputResponse);
-  cmr = new CMR(await getCmrSettings());
+  try {
+    cmr = new CMR(await getCmrSettings());
 
-  response.results = await Promise.all(
-    inputResponse.results.map(updateObjectWithMMT)
-  );
+    response.results = await Promise.all(
+      inputResponse.results.map(updateObjectWithMMT)
+    );
+  } catch (error) {
+    log.error('Unable to update inputResponse with MMT Links');
+    log.error(error);
+    return inputResponse;
+  }
 
   return response;
 };

--- a/packages/api/tests/lib/test-mmt.js
+++ b/packages/api/tests/lib/test-mmt.js
@@ -10,6 +10,7 @@ const mmt = rewire('../../lib/mmt');
 
 const insertMMTLinks = mmt.__get__('insertMMTLinks');
 const buildMMTLink = mmt.__get__('buildMMTLink');
+const log = mmt.__get__('log');
 
 test.beforeEach(async (t) => {
   t.context.env = process.env.CMR_ENVIRONMENT;
@@ -110,12 +111,20 @@ test.serial(
         { thisData: 'Can be anything' },
       ],
     };
-
+    sinon.spy(log, 'error');
     const expected = cloneDeep(fakeESResponse);
+
     CMR.prototype.searchCollections.restore();
-    sinon.stub(CMR.prototype, 'searchCollections').throws(new Error('CMR is down today'));
+    const stubError = new Error('CMR is down today');
+    sinon.stub(CMR.prototype, 'searchCollections').throws(stubError);
+
     const actual = await insertMMTLinks(fakeESResponse);
+
     t.deepEqual(actual, expected);
+    t.true(log.error.calledWith('Unable to update inputResponse with MMT Links'));
+    t.true(log.error.calledWith(stubError));
+
+    log.error.restore();
   }
 );
 

--- a/packages/api/tests/lib/test-mmt.js
+++ b/packages/api/tests/lib/test-mmt.js
@@ -104,16 +104,16 @@ test.serial(
   async (t) => {
     const fakeESResponse = {
       meta: {
-        crazyNess: 'happens here',
+        irrelevant: 'information',
       },
       results: [
-        { thisIs: 'a bad result' },
+        { thisData: 'Can be anything' },
       ],
     };
 
     const expected = cloneDeep(fakeESResponse);
     CMR.prototype.searchCollections.restore();
-    sinon.stub(CMR.prototype, 'searchCollections').throws(new Error('CMR is hosed today'));
+    sinon.stub(CMR.prototype, 'searchCollections').throws(new Error('CMR is down today'));
     const actual = await insertMMTLinks(fakeESResponse);
     t.deepEqual(actual, expected);
   }

--- a/packages/api/tests/lib/test-mmt.js
+++ b/packages/api/tests/lib/test-mmt.js
@@ -99,7 +99,7 @@ test.serial(
   }
 );
 
-test.serial.only(
+test.serial(
   'insertMMTLinks returns the input unchanged if an error occurs with CMR.',
   async (t) => {
     const fakeESResponse = {

--- a/packages/api/tests/lib/test-mmt.js
+++ b/packages/api/tests/lib/test-mmt.js
@@ -5,6 +5,7 @@ const sinon = require('sinon');
 const rewire = require('rewire');
 const { CMR } = require('@cumulus/cmr-client');
 const { randomId } = require('@cumulus/common/test-utils');
+const { cloneDeep } = require('lodash');
 const mmt = rewire('../../lib/mmt');
 
 const insertMMTLinks = mmt.__get__('insertMMTLinks');
@@ -93,6 +94,26 @@ test.serial(
       ],
     };
 
+    const actual = await insertMMTLinks(fakeESResponse);
+    t.deepEqual(actual, expected);
+  }
+);
+
+test.serial(
+  'insertMMTLinks returns the input unchanged if an error occurs with CMR.',
+  async (t) => {
+    const fakeESResponse = {
+      meta: {
+        crazyNess: 'happens here',
+      },
+      results: [
+        { thisIs: 'a bad result' },
+      ],
+    };
+
+    const expected = cloneDeep(fakeESResponse);
+    CMR.prototype.searchCollections.restore();
+    sinon.stub(CMR.prototype, 'searchCollections').throws(new Error('CMR is hosed today'));
     const actual = await insertMMTLinks(fakeESResponse);
     t.deepEqual(actual, expected);
   }

--- a/packages/api/tests/lib/test-mmt.js
+++ b/packages/api/tests/lib/test-mmt.js
@@ -5,7 +5,7 @@ const sinon = require('sinon');
 const rewire = require('rewire');
 const { CMR } = require('@cumulus/cmr-client');
 const { randomId } = require('@cumulus/common/test-utils');
-const { cloneDeep } = require('lodash');
+const cloneDeep = require('lodash/cloneDeep');
 const mmt = rewire('../../lib/mmt');
 
 const insertMMTLinks = mmt.__get__('insertMMTLinks');
@@ -99,7 +99,7 @@ test.serial(
   }
 );
 
-test.serial(
+test.serial.only(
   'insertMMTLinks returns the input unchanged if an error occurs with CMR.',
   async (t) => {
     const fakeESResponse = {


### PR DESCRIPTION
**Summary:** prevent a CMR error from causing collection lists from returning. 

Addresses [CUMULUS-2063: Private CMR MMTLinks](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2063)

## Changes

* catch the error and return the original input.


## PR Checklist

- [no ] Update CHANGELOG
- [yes ] Unit tests
- [yes ] Adhoc testing
- [no ] Integration tests

