### PR TITLE
Mhs/cumulus 2216/2 make statistics inclusion optional with parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### BREAKING CHANGES
+
+- **CUMULUS-2216**
+  - `/collection` and `/collection/active` endpoints now return collections without granule aggregate statistics by default. The original behavior is preserved and can be found by including a query param of `includeStats=true` on the request to the endpoint.  This is likely to affect the dashboard only but included here for the change of behavior.
+
+### Fixed
 - **CUMULUS-2203**
   - Update Core tasks to use
     [cumulus-message-adapter-js](https://github.com/nasa/cumulus-message-adapter-js)
@@ -14,11 +20,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     prevented AWS from halting/restarting warmed instances when task code was
     throwing consistent errors under load.
 
-- **CUMULUS-2200**
-  - Changes return from 303 redirect to 200 success for `Granule Inventory`'s
-    `/reconciliationReport` returns.  The user (dashboard) must read the value
-    of `url` from the return to get the s3SignedURL and then download the report.
-    
 ### Added
 - **CUMULUS-2063**
   - Adds a new, optional query parameter to the `/collections[&getMMT=true]` and `/collections/active[&getMMT=true]` endpoints. When a user provides a value of `true` for `getMMT` in the query parameters, the endpoint will search CMR and update each collection's results with new key `MMTLink` containing a link to the MMT (Metadata Management Tool) if a CMR collection id is found.
@@ -30,6 +31,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Changes return from 303 redirect to 200 success for `Granule Inventory`'s `/reconciliationReport` returns.  The user (dashboard) must read the value of `url` from the return to get the s3SignedURL and then download the report.
 - **CUMULUS-2232**
   - Updated versions for `ajv`, `lodash`, `googleapis`, `archiver`, and `@cumulus/aws-client` to remediate vulnerabilities found in SNYK scan.
+- **CUMULUS-2216**
+  - `/collection` and `/collection/active` endpoints now return collections without granule aggregate statistics by default. The original behavior is preserved and can be found by including a query param of `includeStats=true` on the request to the endpoint.
+
 
 ## [v3.0.0] 2020-10-7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Updated versions for `ajv`, `lodash`, `googleapis`, `archiver`, and `@cumulus/aws-client` to remediate vulnerabilities found in SNYK scan.
 - **CUMULUS-2216**
   - `/collection` and `/collection/active` endpoints now return collections without granule aggregate statistics by default. The original behavior is preserved and can be found by including a query param of `includeStats=true` on the request to the endpoint.
+  - The `es/collections` Collection class takes a new parameter includeStats. It no longer appends granule aggregate statistics to the returned results by default. One must set the new parameter to any non-false value.
 
 
 ## [v3.0.0] 2020-10-7

--- a/packages/api/endpoints/collections.js
+++ b/packages/api/endpoints/collections.js
@@ -27,14 +27,15 @@ const log = new Logger({ sender: '@cumulus/api/collections' });
  * @returns {Promise<Object>} the promise of express response object
  */
 async function list(req, res) {
-  const { getMMT, ...queryStringParameters } = req.query;
+  const { getMMT, includeStats, ...queryStringParameters } = req.query;
   const collection = new Collection(
     { queryStringParameters },
     undefined,
-    process.env.ES_INDEX
+    process.env.ES_INDEX,
+    includeStats
   );
   let result = await collection.query();
-  if (getMMT && getMMT === 'true') {
+  if (getMMT === 'true') {
     result = await insertMMTLinks(result);
   }
   return res.send(result);
@@ -50,15 +51,16 @@ async function list(req, res) {
  * @returns {Promise<Object>} the promise of express response object
  */
 async function activeList(req, res) {
-  const { getMMT, ...queryStringParameters } = req.query;
+  const { getMMT, includeStats, ...queryStringParameters } = req.query;
 
   const collection = new Collection(
     { queryStringParameters },
     undefined,
-    process.env.ES_INDEX
+    process.env.ES_INDEX,
+    includeStats
   );
   let result = await collection.queryCollectionsWithActiveGranules();
-  if (getMMT && getMMT === 'true') {
+  if (getMMT === 'true') {
     result = await insertMMTLinks(result);
   }
   return res.send(result);

--- a/packages/api/endpoints/collections.js
+++ b/packages/api/endpoints/collections.js
@@ -32,7 +32,7 @@ async function list(req, res) {
     { queryStringParameters },
     undefined,
     process.env.ES_INDEX,
-    includeStats
+    includeStats === 'true'
   );
   let result = await collection.query();
   if (getMMT === 'true') {
@@ -57,7 +57,7 @@ async function activeList(req, res) {
     { queryStringParameters },
     undefined,
     process.env.ES_INDEX,
-    includeStats
+    includeStats === 'true'
   );
   let result = await collection.queryCollectionsWithActiveGranules();
   if (getMMT === 'true') {

--- a/packages/api/es/collections.js
+++ b/packages/api/es/collections.js
@@ -8,9 +8,9 @@ const { BaseSearch } = require('./search');
 const ES_MAX_AGG = 2147483647;
 
 class Collection extends BaseSearch {
-  constructor(event, type, index) {
+  constructor(event, type, index, includeStats = 'true') {
     super(event, type || 'collection', index);
-
+    this.includeStats = includeStats === 'true';
     // decrease the limit to 50
     this.size = this.size > 50 ? 50 : this.size;
   }
@@ -189,7 +189,7 @@ class Collection extends BaseSearch {
     const res = await super.query(searchParamsOverride);
 
     // get aggregations for results
-    if (res.results) {
+    if (res.results && this.includeStats) {
       res.results = await this.addStatsToCollectionResults(res.results);
     }
 

--- a/packages/api/es/collections.js
+++ b/packages/api/es/collections.js
@@ -8,9 +8,9 @@ const { BaseSearch } = require('./search');
 const ES_MAX_AGG = 2147483647;
 
 class Collection extends BaseSearch {
-  constructor(event, type, index, includeStats = 'true') {
+  constructor(event, type, index, includeStats = true) {
     super(event, type || 'collection', index);
-    this.includeStats = includeStats === 'true';
+    this.includeStats = includeStats === true;
     // decrease the limit to 50
     this.size = this.size > 50 ? 50 : this.size;
   }

--- a/packages/api/es/collections.js
+++ b/packages/api/es/collections.js
@@ -8,9 +8,9 @@ const { BaseSearch } = require('./search');
 const ES_MAX_AGG = 2147483647;
 
 class Collection extends BaseSearch {
-  constructor(event, type, index, includeStats = true) {
+  constructor(event, type, index, includeStats = false) {
     super(event, type || 'collection', index);
-    this.includeStats = includeStats === true;
+    this.includeStats = includeStats !== false;
     // decrease the limit to 50
     this.size = this.size > 50 ? 50 : this.size;
   }

--- a/packages/api/tests/es/test-collections.js
+++ b/packages/api/tests/es/test-collections.js
@@ -125,14 +125,14 @@ test.after.always(async () => {
 });
 
 test.serial('getStats returns an empty list if there are no records or ids', async (t) => {
-  const collectionSearch = new Collection({}, undefined, process.env.ES_INDEX);
+  const collectionSearch = new Collection({}, undefined, process.env.ES_INDEX, true);
   const stats = await collectionSearch.getStats([], []);
 
   t.deepEqual([], stats);
 });
 
 test.serial('getStats returns an empty list if there are no records', async (t) => {
-  const collectionSearch = new Collection({}, undefined, process.env.ES_INDEX);
+  const collectionSearch = new Collection({}, undefined, process.env.ES_INDEX, true);
   const stats = await collectionSearch.getStats([], ['coll1___1']);
 
   t.deepEqual(stats, []);
@@ -143,7 +143,7 @@ test.serial('getStats returns empty stats if there are no ids', async (t) => {
     { name: 'coll1', version: '1' },
     { name: 'coll1', version: '2' },
   ];
-  const collectionSearch = new Collection({}, undefined, process.env.ES_INDEX);
+  const collectionSearch = new Collection({}, undefined, process.env.ES_INDEX, true);
   const stats = await collectionSearch.getStats(records, []);
 
   t.deepEqual(stats,
@@ -159,7 +159,7 @@ test.serial('getStats returns empty stats if there are no ids', async (t) => {
 });
 
 test.serial('getStats correctly adds stats', async (t) => {
-  const collectionSearch = new Collection({}, undefined, process.env.ES_INDEX);
+  const collectionSearch = new Collection({}, undefined, process.env.ES_INDEX, true);
   const stats = await collectionSearch.getStats([{ name: 'coll1', version: '1' }], ['coll1___1']);
 
   t.is(stats.length, 1);
@@ -172,7 +172,7 @@ test.serial('getStats correctly adds stats', async (t) => {
 });
 
 test.serial('getStats correctly adds stats to different versions of collections', async (t) => {
-  const collectionSearch = new Collection({}, undefined, process.env.ES_INDEX);
+  const collectionSearch = new Collection({}, undefined, process.env.ES_INDEX, true);
   const stats = await collectionSearch.getStats([
     {
       name: 'coll1',
@@ -222,7 +222,7 @@ test.serial('addStatsToCollection add stats to ES collection results', async (t)
     },
   ];
 
-  const collectionSearch = new Collection({}, undefined, process.env.ES_INDEX);
+  const collectionSearch = new Collection({}, undefined, process.env.ES_INDEX, true);
   const resultsWithStats = await collectionSearch.addStatsToCollectionResults(esResults);
 
   t.deepEqual(resultsWithStats, [
@@ -250,17 +250,18 @@ test.serial('addStatsToCollection add stats to ES collection results', async (t)
 });
 
 test.serial('addStatsToCollection returns empty list for no collections', async (t) => {
-  const collectionSearch = new Collection({}, undefined, process.env.ES_INDEX);
+  const collectionSearch = new Collection({}, undefined, process.env.ES_INDEX, true);
   const resultsWithStats = await collectionSearch.addStatsToCollectionResults([]);
 
   t.deepEqual(resultsWithStats, []);
 });
 
-test.serial('query returns all collections with stats by default', async (t) => {
+test.serial('query returns all collections with stats when requested', async (t) => {
   const collectionSearch = new Collection(
     { queryStringParameters: { limit: 13 } },
     undefined,
-    process.env.ES_INDEX
+    process.env.ES_INDEX,
+    true
   );
   const queryResult = await collectionSearch.query();
 
@@ -336,12 +337,11 @@ test.serial('query returns all collections with stats by default', async (t) => 
   }))));
 });
 
-test.serial('Collection query returns all collections without stats', async (t) => {
+test.serial('Collection query returns all collections without stats by default', async (t) => {
   const collectionSearch = new Collection(
     { queryStringParameters: { limit: 13 } },
     undefined,
-    process.env.ES_INDEX,
-    false
+    process.env.ES_INDEX
   );
   const queryResult = await collectionSearch.query();
 
@@ -393,7 +393,7 @@ test.serial('query correctly queries collection by date', async (t) => {
       updatedAt__from: (new Date(2020, 0, 25)).getTime(),
       updatedAt__to: (new Date(2020, 0, 30)).getTime(),
     },
-  }, undefined, process.env.ES_INDEX);
+  }, undefined, process.env.ES_INDEX, true);
   const queryResult = await collectionSearch.query();
 
   t.is(queryResult.meta.count, 1);
@@ -401,7 +401,7 @@ test.serial('query correctly queries collection by date', async (t) => {
 });
 
 test.serial('aggregateGranuleCollections returns only collections with granules', async (t) => {
-  const collectionSearch = new Collection({}, undefined, process.env.ES_INDEX);
+  const collectionSearch = new Collection({}, undefined, process.env.ES_INDEX, true);
   const queryResult = await collectionSearch.aggregateGranuleCollections();
 
   const orderedResult = queryResult.sort();
@@ -419,7 +419,7 @@ test.serial('aggregateGranuleCollections respects date range for granules', asyn
       updatedAt__from: (new Date(2020, 1, 25)).getTime(),
       updatedAt__to: (new Date(2020, 1, 30)).getTime(),
     },
-  }, undefined, process.env.ES_INDEX);
+  }, undefined, process.env.ES_INDEX, true);
   const queryResult = await collectionSearch.aggregateGranuleCollections();
 
   t.deepEqual(queryResult, ['coll3___1']);
@@ -429,7 +429,8 @@ test.serial('queryCollectionsWithActiveGranules returns collection info and stat
   const collectionSearch = new Collection(
     { queryStringParameters: { limit: 11 } },
     undefined,
-    process.env.ES_INDEX
+    process.env.ES_INDEX,
+    true
   );
   const queryResult = await collectionSearch.queryCollectionsWithActiveGranules();
 
@@ -486,12 +487,11 @@ test.serial('queryCollectionsWithActiveGranules returns collection info and stat
   }))));
 });
 
-test.serial('Collection queryCollectionsWithActiveGranules returns collection info without statistics', async (t) => {
+test.serial('Collection queryCollectionsWithActiveGranules returns collection info without statistics by default', async (t) => {
   const collectionSearch = new Collection(
     { queryStringParameters: { limit: 11 } },
     undefined,
-    process.env.ES_INDEX,
-    false
+    process.env.ES_INDEX
   );
   const queryResult = await collectionSearch.queryCollectionsWithActiveGranules();
 
@@ -534,7 +534,7 @@ test.serial('queryCollectionsWithActiveGranules respects granule update times, b
       updatedAt__from: (new Date(2020, 1, 25)).getTime(),
       updatedAt__to: (new Date(2020, 1, 30)).getTime(),
     },
-  }, undefined, process.env.ES_INDEX);
+  }, undefined, process.env.ES_INDEX, true);
   const queryResult = await collectionSearch.queryCollectionsWithActiveGranules();
 
   t.is(queryResult.meta.count, 1);

--- a/packages/api/tests/es/test-collections.js
+++ b/packages/api/tests/es/test-collections.js
@@ -336,6 +336,57 @@ test.serial('query returns all collections with stats by default', async (t) => 
   }))));
 });
 
+test.serial('Collection query returns all collections without stats', async (t) => {
+  const collectionSearch = new Collection(
+    { queryStringParameters: { limit: 13 } },
+    undefined,
+    process.env.ES_INDEX,
+    false
+  );
+  const queryResult = await collectionSearch.query();
+
+  t.is(queryResult.meta.count, 13);
+
+  const collections = queryResult.results.map((c) => ({
+    name: c.name,
+    version: c.version,
+    stats: c.stats,
+  }));
+
+  const orderedCollections = sortBy(collections, ['name', 'version']);
+  t.deepEqual(orderedCollections, [
+    {
+      name: 'coll1',
+      version: '1',
+      stats: undefined,
+    },
+    {
+      name: 'coll1',
+      version: '2',
+      stats: undefined,
+    },
+    {
+      name: 'coll2',
+      version: '1',
+      stats: undefined,
+    },
+    {
+      name: 'coll3',
+      version: '1',
+      stats: undefined,
+    },
+    {
+      name: 'coll4',
+      version: '0',
+      stats: undefined,
+    },
+  ].concat(range(1, 9).map((i) => ({
+    name: 'coll4',
+    version: i.toString(),
+    stats: undefined,
+  }))));
+});
+
 test.serial('query correctly queries collection by date', async (t) => {
   const collectionSearch = new Collection({
     queryStringParameters: {
@@ -432,6 +483,48 @@ test.serial('queryCollectionsWithActiveGranules returns collection info and stat
       failed: 0,
       total: 1,
     },
+  }))));
+});
+
+test.serial('Collection queryCollectionsWithActiveGranules returns collection info without statistics', async (t) => {
+  const collectionSearch = new Collection(
+    { queryStringParameters: { limit: 11 } },
+    undefined,
+    process.env.ES_INDEX,
+    false
+  );
+  const queryResult = await collectionSearch.queryCollectionsWithActiveGranules();
+
+  t.is(queryResult.meta.count, 11);
+
+  const collections = queryResult.results.map((c) => ({
+    name: c.name,
+    version: c.version,
+    stats: c.stats,
+  }));
+
+  const orderedCollections = sortBy(collections, ['name', 'version']);
+
+  t.deepEqual(orderedCollections, [
+    {
+      name: 'coll1',
+      version: '1',
+      stats: undefined,
+    },
+    {
+      name: 'coll3',
+      version: '1',
+      stats: undefined,
+    },
+    {
+      name: 'coll4',
+      version: '0',
+      stats: undefined,
+    },
+  ].concat(range(1, 9).map((i) => ({
+    name: 'coll4',
+    version: i.toString(),
+    stats: undefined,
   }))));
 });
 


### PR DESCRIPTION
**Summary:**

Adds new parameter to es/Collection to toggle the appending of aggregate granule statistics to the returns.

/collection and /collection/active endpoints now OMIT aggregate statistics by default. To get the original behavior a query param of `includeStats=true` must be present on the request.


Addresses [CUMULUS-2226: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2216)

## Changes
* Collection endpoint looks for an `includeStats` query paramameter and passes that to the Collection constructor separately.


## PR Checklist

- [X] Update CHANGELOG
- [X] Unit tests
- [X] Adhoc testing
- [ ] Integration tests
