### PR TITLE
CMA module output = cumulus module expected input

### DIFF
--- a/bamboo/bootstrap-tf-deployment.sh
+++ b/bamboo/bootstrap-tf-deployment.sh
@@ -76,7 +76,7 @@ echo "Deploying Cumulus example to $DEPLOYMENT"
   -input=false \
   -var-file="../deployments/cumulus/$BASE_VAR_FILE" \
   -var-file="../deployments/cumulus/$DEPLOYMENT.tfvars" \
-  -var "cumulus_message_adapter_lambda_layer_arn=arn:aws:lambda:us-east-1:$AWS_ACCOUNT_ID:layer:Cumulus_Message_Adapter:$CMA_LAYER_VERSION" \
+  -var "cumulus_message_adapter_lambda_layer_version_arn=arn:aws:lambda:us-east-1:$AWS_ACCOUNT_ID:layer:Cumulus_Message_Adapter:$CMA_LAYER_VERSION" \
   -var "cmr_username=$CMR_USERNAME" \
   -var "cmr_password=$CMR_PASSWORD" \
   -var "cmr_client_id=cumulus-core-$DEPLOYMENT" \

--- a/docs/workflows/input_output.md
+++ b/docs/workflows/input_output.md
@@ -25,7 +25,7 @@ In order to make use of this configuration, a Lambda layer must be uploaded to y
 
 Once you've deployed the layer, integrate the CMA layer with your Lambdas:
 
-- If using the `cumulus` module, set the `cumulus_message_adapter_lambda_layer_arn` in your `.tfvars` file to integrate the CMA layer with all core Cumulus lambdas.
+- If using the `cumulus` module, set the `cumulus_message_adapter_lambda_layer_version_arn` in your `.tfvars` file to integrate the CMA layer with all core Cumulus lambdas.
 - If including your own Lambda or ECS task Terraform modules, specify the CMA layer ARN in the Terraform resource definitions.  Also, make sure to set the `CUMULUS_MESSAGE_ADAPTER_DIR` environment variable for the task to `/opt` for the CMA integration to work properly.
 
 In the future if you wish to update/change the CMA version you will need to update the deployed CMA, and update the layer configuration for the impacted Lambdas as needed.

--- a/example/cumulus-tf/cnm_response_task.tf
+++ b/example/cumulus-tf/cnm_response_task.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "cnm_response_task" {
   timeout       = 300
   memory_size   = 256
 
-  layers = [var.cumulus_message_adapter_lambda_layer_arn]
+  layers = [var.cumulus_message_adapter_lambda_layer_version_arn]
 
   environment {
     variables = {

--- a/example/cumulus-tf/cnm_to_cma_task.tf
+++ b/example/cumulus-tf/cnm_to_cma_task.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "cnm_to_cma_task" {
   timeout       = 300
   memory_size   = 128
 
-  layers = [var.cumulus_message_adapter_lambda_layer_arn]
+  layers = [var.cumulus_message_adapter_lambda_layer_version_arn]
 
   environment {
     variables = {

--- a/example/cumulus-tf/main.tf
+++ b/example/cumulus-tf/main.tf
@@ -54,7 +54,7 @@ data "aws_ssm_parameter" "ecs_image_id" {
 module "cumulus" {
   source = "../../tf-modules/cumulus"
 
-  cumulus_message_adapter_lambda_layer_arn = var.cumulus_message_adapter_lambda_layer_arn
+  cumulus_message_adapter_lambda_layer_version_arn = var.cumulus_message_adapter_lambda_layer_version_arn
 
   prefix = var.prefix
 

--- a/example/cumulus-tf/python-reference-task.tf
+++ b/example/cumulus-tf/python-reference-task.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "python_reference_task" {
   timeout          = 300
   memory_size      = 1556
 
-  layers = [var.cumulus_message_adapter_lambda_layer_arn]
+  layers = [var.cumulus_message_adapter_lambda_layer_version_arn]
 
   environment {
     variables = {

--- a/example/cumulus-tf/terraform.tfvars.example
+++ b/example/cumulus-tf/terraform.tfvars.example
@@ -1,7 +1,7 @@
 region = "us-east-1"
 
 # Replace 12345 with your actual AWS account ID
-cumulus_message_adapter_lambda_layer_arn = "arn:aws:lambda:us-east-1:12345:layer:Cumulus_Message_Adapter:4"
+cumulus_message_adapter_lambda_layer_version_arn = "arn:aws:lambda:us-east-1:12345:layer:Cumulus_Message_Adapter:4"
 permissions_boundary_arn = "arn:aws:iam::12345:policy/NGAPShRoleBoundary"
 
 prefix                   = "PREFIX"

--- a/example/cumulus-tf/variables.tf
+++ b/example/cumulus-tf/variables.tf
@@ -25,8 +25,9 @@ variable "bucket_map_key" {
   default = null
 }
 
-variable "cumulus_message_adapter_lambda_layer_arn" {
-  type = string
+variable "cumulus_message_adapter_lambda_layer_version_arn" {
+  type        = string
+  description = "Layer version ARN of the Lambda layer for the Cumulus Message Adapter"
 }
 
 variable "cmr_oauth_provider" {

--- a/tf-modules/cumulus-message-adapter/outputs.tf
+++ b/tf-modules/cumulus-message-adapter/outputs.tf
@@ -1,3 +1,7 @@
 output "cumulus_message_adapter_layer_arn" {
+  value = aws_lambda_layer_version.cumulus_message_adapter.arn
+}
+
+output "cumulus_message_adapter_layer_layer_arn" {
   value = aws_lambda_layer_version.cumulus_message_adapter.layer_arn
 }

--- a/tf-modules/cumulus-message-adapter/outputs.tf
+++ b/tf-modules/cumulus-message-adapter/outputs.tf
@@ -1,3 +1,3 @@
-output "cumulus_message_adapter_layer_arn" {
+output "cumulus_message_adapter_lambda_layer_version_arn" {
   value = aws_lambda_layer_version.cumulus_message_adapter.arn
 }

--- a/tf-modules/cumulus-message-adapter/outputs.tf
+++ b/tf-modules/cumulus-message-adapter/outputs.tf
@@ -1,7 +1,3 @@
 output "cumulus_message_adapter_layer_arn" {
   value = aws_lambda_layer_version.cumulus_message_adapter.arn
 }
-
-output "cumulus_message_adapter_layer_layer_arn" {
-  value = aws_lambda_layer_version.cumulus_message_adapter.layer_arn
-}

--- a/tf-modules/cumulus/README.md
+++ b/tf-modules/cumulus/README.md
@@ -31,7 +31,7 @@ This module's outputs are listed in [ouputs.tf](./outputs.tf). Notable values th
 module "cumulus" {
   source = "https://github.com/nasa/cumulus/releases/download/vx.x.x/terraform-aws-cumulus.zip//tf-modules/cumulus"
 
-  cumulus_message_adapter_lambda_layer_arn = "arn:aws:lambda:us-east-1:1234567890:layer:Cumulus_Message_Adapter:1"
+  cumulus_message_adapter_lambda_layer_version_arn = "arn:aws:lambda:us-east-1:1234567890:layer:Cumulus_Message_Adapter:1"
 
   prefix = "my-prefix"
 

--- a/tf-modules/cumulus/ingest.tf
+++ b/tf-modules/cumulus/ingest.tf
@@ -7,7 +7,7 @@ module "ingest" {
 
   distribution_url = var.tea_external_api_endpoint
 
-  cumulus_message_adapter_lambda_layer_arn = var.cumulus_message_adapter_lambda_layer_arn
+  cumulus_message_adapter_lambda_layer_version_arn = var.cumulus_message_adapter_lambda_layer_version_arn
 
   # Buckets config
   system_bucket = var.system_bucket

--- a/tf-modules/cumulus/variables.tf
+++ b/tf-modules/cumulus/variables.tf
@@ -25,7 +25,7 @@ variable "cmr_username" {
   type        = string
 }
 
-variable "cumulus_message_adapter_lambda_layer_arn" {
+variable "cumulus_message_adapter_lambda_layer_version_arn" {
   description = "Layer version ARN of the Lambda layer for the Cumulus Message Adapter"
   type        = string
   default     = null

--- a/tf-modules/ingest/add-missing-file-checksums.tf
+++ b/tf-modules/ingest/add-missing-file-checksums.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "add_missing_file_checksums_task" {
   timeout          = 300
   memory_size      = 256
 
-  layers = [var.cumulus_message_adapter_lambda_layer_arn]
+  layers = [var.cumulus_message_adapter_lambda_layer_version_arn]
 
   environment {
     variables = {

--- a/tf-modules/ingest/discover-granules-task.tf
+++ b/tf-modules/ingest/discover-granules-task.tf
@@ -9,7 +9,7 @@ resource "aws_lambda_function" "discover_granules_task" {
   timeout          = 300
   memory_size      = 512
 
-  layers = [var.cumulus_message_adapter_lambda_layer_arn]
+  layers = [var.cumulus_message_adapter_lambda_layer_version_arn]
 
   environment {
     variables = {

--- a/tf-modules/ingest/discover-pdrs-task.tf
+++ b/tf-modules/ingest/discover-pdrs-task.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "discover_pdrs_task" {
   timeout          = 300
   memory_size      = 1024
 
-  layers = [var.cumulus_message_adapter_lambda_layer_arn]
+  layers = [var.cumulus_message_adapter_lambda_layer_version_arn]
 
   environment {
     variables = {

--- a/tf-modules/ingest/fake-processing-task.tf
+++ b/tf-modules/ingest/fake-processing-task.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "fake_processing_task" {
   timeout          = 300
   memory_size      = 1024
 
-  layers = [var.cumulus_message_adapter_lambda_layer_arn]
+  layers = [var.cumulus_message_adapter_lambda_layer_version_arn]
 
   environment {
     variables = {

--- a/tf-modules/ingest/files-to-granules-task.tf
+++ b/tf-modules/ingest/files-to-granules-task.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "files_to_granules_task" {
   timeout          = 300
   memory_size      = 1024
 
-  layers = [var.cumulus_message_adapter_lambda_layer_arn]
+  layers = [var.cumulus_message_adapter_lambda_layer_version_arn]
 
   environment {
     variables = {

--- a/tf-modules/ingest/hello-world-task.tf
+++ b/tf-modules/ingest/hello-world-task.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "hello_world_task" {
   timeout          = 300
   memory_size      = 512
 
-  layers = [var.cumulus_message_adapter_lambda_layer_arn]
+  layers = [var.cumulus_message_adapter_lambda_layer_version_arn]
 
   environment {
     variables = {

--- a/tf-modules/ingest/hyrax-metadata-updates-task.tf
+++ b/tf-modules/ingest/hyrax-metadata-updates-task.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "hyrax_metadata_updates_task" {
   timeout          = 300
   memory_size      = 256
 
-  layers = [var.cumulus_message_adapter_lambda_layer_arn]
+  layers = [var.cumulus_message_adapter_lambda_layer_version_arn]
 
   environment {
     variables = {

--- a/tf-modules/ingest/lambda-functions.tf
+++ b/tf-modules/ingest/lambda-functions.tf
@@ -238,7 +238,7 @@ resource "aws_lambda_function" "sf_sqs_report_task" {
   timeout          = 300
   memory_size      = 1024
 
-  layers = [var.cumulus_message_adapter_lambda_layer_arn]
+  layers = [var.cumulus_message_adapter_lambda_layer_version_arn]
 
   environment {
     variables = {

--- a/tf-modules/ingest/move-granules-task.tf
+++ b/tf-modules/ingest/move-granules-task.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "move_granules_task" {
   timeout          = 300
   memory_size      = 1024
 
-  layers = [var.cumulus_message_adapter_lambda_layer_arn]
+  layers = [var.cumulus_message_adapter_lambda_layer_version_arn]
 
   environment {
     variables = {

--- a/tf-modules/ingest/parse-pdr-task.tf
+++ b/tf-modules/ingest/parse-pdr-task.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "parse_pdr_task" {
   timeout          = 300
   memory_size      = 1024
 
-  layers = [var.cumulus_message_adapter_lambda_layer_arn]
+  layers = [var.cumulus_message_adapter_lambda_layer_version_arn]
 
   environment {
     variables = {

--- a/tf-modules/ingest/pdr-status-check-task.tf
+++ b/tf-modules/ingest/pdr-status-check-task.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "pdr_status_check_task" {
   timeout          = 300
   memory_size      = 1024
 
-  layers = [var.cumulus_message_adapter_lambda_layer_arn]
+  layers = [var.cumulus_message_adapter_lambda_layer_version_arn]
 
   environment {
     variables = {

--- a/tf-modules/ingest/post-to-cmr-task.tf
+++ b/tf-modules/ingest/post-to-cmr-task.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "post_to_cmr_task" {
   timeout          = 300
   memory_size      = 256
 
-  layers = [var.cumulus_message_adapter_lambda_layer_arn]
+  layers = [var.cumulus_message_adapter_lambda_layer_version_arn]
 
   environment {
     variables = {

--- a/tf-modules/ingest/queue-granules-task.tf
+++ b/tf-modules/ingest/queue-granules-task.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "queue_granules_task" {
   timeout          = 300
   memory_size      = 1024
 
-  layers = [var.cumulus_message_adapter_lambda_layer_arn]
+  layers = [var.cumulus_message_adapter_lambda_layer_version_arn]
 
   environment {
     variables = {

--- a/tf-modules/ingest/queue-pdrs-task.tf
+++ b/tf-modules/ingest/queue-pdrs-task.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "queue_pdrs_task" {
   timeout          = 300
   memory_size      = 1024
 
-  layers = [var.cumulus_message_adapter_lambda_layer_arn]
+  layers = [var.cumulus_message_adapter_lambda_layer_version_arn]
 
   environment {
     variables = {

--- a/tf-modules/ingest/sync-granule-task.tf
+++ b/tf-modules/ingest/sync-granule-task.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "sync_granule_task" {
   timeout          = 300
   memory_size      = 1024
 
-  layers = [var.cumulus_message_adapter_lambda_layer_arn]
+  layers = [var.cumulus_message_adapter_lambda_layer_version_arn]
 
   environment {
     variables = {

--- a/tf-modules/ingest/update-cmr-access-constraints.tf
+++ b/tf-modules/ingest/update-cmr-access-constraints.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "update_cmr_access_constraints_task" {
   timeout          = 300
   memory_size      = 256
 
-  layers = [var.cumulus_message_adapter_lambda_layer_arn]
+  layers = [var.cumulus_message_adapter_lambda_layer_version_arn]
 
   environment {
     variables = {

--- a/tf-modules/ingest/variables.tf
+++ b/tf-modules/ingest/variables.tf
@@ -40,9 +40,10 @@ variable "cmr_username" {
   type = string
 }
 
-variable "cumulus_message_adapter_lambda_layer_arn" {
-  type    = string
-  default = null
+variable "cumulus_message_adapter_lambda_layer_version_arn" {
+  description = "Layer version ARN of the Lambda layer for the Cumulus Message Adapter"
+  type        = string
+  default     = null
 }
 
 variable "custom_queues" {


### PR DESCRIPTION
Modifies cumulus-message-adapter module output to match expected cumulus module input. Fixes #1956, fixes #1361 

**Summary:** Summary of changes

Addresses Issue #1956: Add cumulus-message-adapter module output to match cumulus-tf input
## Changes

* Changed existing cumulus_message_adapter_layer_arn output to the expected value of the cumulus-tf variable with the same name
* Added a new output, cumulus_message_adapter_layer_layer_arn to cover the original output value. (Follows naming convention of the [Terraform attributes for aws_lambda_layer_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_layer_version#arn))

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

