### PR TITLE
Update CHANGELOG to match backport commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Adds `granules/bulkReingest` endpoint to `@cumulus/api`
 
 ### Changed
-- **CUMULUS-2200**
-  - Changes return from 303 redirect to 200 success for `Granule Inventory`'s `/reconciliationReport` returns.  The user (dashboard) must read the value of `url` from the return to get the s3SignedURL and then download the report.
 - **CUMULUS-2232**
   - Updated versions for `ajv`, `lodash`, `googleapis`, `archiver`, and `@cumulus/aws-client` to remediate vulnerabilities found in SNYK scan.
 - **CUMULUS-2216**
@@ -66,6 +64,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### BREAKING CHANGES
 
+- **CUMULUS-2200**
+  - Changes return from 303 redirect to 200 success for `Granule Inventory`'s `/reconciliationReport` returns.  The user (dashboard) must read the value of `url` from the return to get the s3SignedURL and then download the report.
 - **CUMULUS-2099**
   - `meta.queues` has been removed from Cumulus core workflow messages.
   - `@cumulus/sf-sqs-report` workflow task no longer reads the reporting queue URL from `input.meta.queues.reporting` on the incoming event. Instead, it requires that the queue URL be set as the `reporting_queue_url` environment variable on the deployed Lambda.


### PR DESCRIPTION
**Summary:** Summary of changes

Bringing forward CHANGELOG entry fix from https://github.com/nasa/cumulus/blob/e1677176ab398ea38195032460097c680445eeb7/CHANGELOG.

Addresses [CUMULUS-1: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1)

