### PR TITLE
Update cleanup script to always use cache for stack unlock script

### DIFF
--- a/bamboo/cleanup-integration-tests.sh
+++ b/bamboo/cleanup-integration-tests.sh
@@ -18,5 +18,6 @@ fi
 npm install
 npm --version
 ## Bootstrapping is only required if updates to dynamodbDocClient relevant to lock-stack.js are made
+## Use the cached directory otherwise.
 # (npm run bootstrap-no-build || true) && npm run bootstrap-no-build && cd example && node ./scripts/lock-stack.js lock $GIT_SHA $DEPLOYMENT false
-cd example && npm install && node ./scripts/lock-stack.js lock "$GIT_SHA" "$DEPLOYMENT" false
+cd /cumulus/example && node ./scripts/lock-stack.js lock "$GIT_SHA" "$DEPLOYMENT" false


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2246: Fix cleanup script](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2246)

## Changes

* Updates the integration test cleanup script to use the cached layer instead of relying on npm install

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [x] Adhoc testing
- [x] Integration tests

