### PR TITLE
Fix integration test bootstrap

### DIFF
--- a/bamboo/bootstrap-integration-tests.sh
+++ b/bamboo/bootstrap-integration-tests.sh
@@ -28,9 +28,6 @@ if [[ $USE_TERRAFORM_ZIPS == true ]]; then
   ## Prepare repo lambdas
   cd ..
 
-  # Extract cache of compiled TS files
-  ./bamboo/extract-ts-build-cache.sh
-
   npm install && npm run package
   cd ..
 else


### PR DESCRIPTION
**Summary:** Summary of changes

Quick PR to fix the release CI - there was an unneeded call to extract-ts-build-cache.sh in the integration test bootstrap script, due to it being in the 'use release zips' setup. 

Addresses [CUMULUS-1: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1)

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

