### PR TITLE
Fix CI bootstrap script to not run TS compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "bootstrap-no-build-no-concurrency": "lerna bootstrap --no-ci --force-local --concurrency 1",
     "bootstrap-no-build-quiet": "lerna bootstrap --no-ci --force-local --loglevel=error",
     "ci:bootstrap-no-scripts": "lerna bootstrap --no-ci --force-local --ignore-scripts",
-    "ci:bootstrap-no-scripts-quiet": "lerna bootstrap --no-ci --force-local --loglevel=error",
+    "ci:bootstrap-no-scripts-quiet": "lerna bootstrap --no-ci --force-local --ignore-scripts --loglevel=error",
     "update": "lerna version --exact --force-publish --no-git-tag-version --no-push",
     "clean": "lerna run clean && lerna clean --yes && rm -rf ./node_modules",
     "build": "lerna run --ignore @cumulus/cumulus-integration-tests build",


### PR DESCRIPTION
The `ci:bootstrap-no-scripts-quiet` script did not have the `--ignore-scripts` flag for `lerna bootstrap` set, so it was needlessly running `prepare` scripts and the TS compilation, slowing down CI times. I noticed that our unit tests were back up to ~16 minutes, but with this change they should go back to ~10 minutes. 