### PR TITLE
[CUMULUS-2251] Add log_api_gateway_to_cloudwatch var to thin_egress_app module definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Adds `granules/bulkReingest` endpoint to `@cumulus/api`
 - **CUMULUS-2251**
   - Adds `log_api_gateway_to_cloudwatch` variable to `example/cumulus-tf/variables.tf`.
-  - Adds `log_api_gateway_to_cloudwatch` variable to `thin_egress_app` module defintion.
+  - Adds `log_api_gateway_to_cloudwatch` variable to `thin_egress_app` module definition.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - **CUMULUS-2211**
   - Adds `granules/bulkReingest` endpoint to `@cumulus/api`
 - **CUMULUS-2251**
-  - Adds `log_api_gateway_to_cloudwatch` variable to `example/cumulus-tf/variables.tf`
+  - Adds `log_api_gateway_to_cloudwatch` variable to `example/cumulus-tf/variables.tf`.
+  - Adds `log_api_gateway_to_cloudwatch` variable to `thin_egress_app` module defintion.
 
 ### Changed
 

--- a/example/cumulus-tf/main.tf
+++ b/example/cumulus-tf/main.tf
@@ -213,6 +213,7 @@ module "thin_egress_app" {
   stage_name                 = local.tea_stage_name
   urs_auth_creds_secret_name = aws_secretsmanager_secret.thin_egress_urs_creds.name
   vpc_subnet_ids             = var.lambda_subnet_ids
+  log_api_gateway_to_cloudwatch = var.log_api_gateway_to_cloudwatch
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "egress_api_gateway_log_subscription_filter" {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2251: Distribution module bug](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2251)

## Changes

* Added `log_api_gateway_to_cloudwatch` var to `thin_egress_app` module defintion so that it could return a non-null value for `module.thin_egress_app.egress_log_group`
https://github.com/asfadmin/thin-egress-app/blob/devel/terraform/outputs.tf#L20-L22
since `log_api_gateway_to_cloudwatch` defaults to false https://github.com/asfadmin/thin-egress-app/blob/devel/terraform/variables.tf#L101-L105
* Update changelog

## PR Checklist

- [X] Update CHANGELOG
- [ ] Unit tests
- [X] Adhoc testing
- [ ] Integration tests

