### PR TITLE
Hyrax 320

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- **HYRAX-320**
+  - **Task: hyrax-metadata-update** 
+    - Add component URI encoding for entry title id and granule ur to allow for values with special characters in them. For example, EntryTitleId 'Sentinel-6A MF/Jason-CS L2 Advanced Microwave Radiometer (AMR-C) NRT Geophysical Parameters' Now, URLs generated from such values will be encoded correctly and parsable by HyraxInTheCloud
 
 - **CUMULUS-2092**
   - Add documentation for Granule Not Found Reports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - **HYRAX-320**
-  - **Task: hyrax-metadata-update** 
-    - Add component URI encoding for entry title id and granule ur to allow for values with special characters in them. For example, EntryTitleId 'Sentinel-6A MF/Jason-CS L2 Advanced Microwave Radiometer (AMR-C) NRT Geophysical Parameters' Now, URLs generated from such values will be encoded correctly and parsable by HyraxInTheCloud
+  - **Task: hyrax-metadata-update** Add component URI encoding for entry title id and granule ur to allow for values with special characters in them. For example, EntryTitleId 'Sentinel-6A MF/Jason-CS L2 Advanced Microwave Radiometer (AMR-C) NRT Geophysical Parameters' Now, URLs generated from such values will be encoded correctly and parsable by HyraxInTheCloud
 
 - **CUMULUS-2092**
   - Add documentation for Granule Not Found Reports

--- a/tasks/hyrax-metadata-updates/index.js
+++ b/tasks/hyrax-metadata-updates/index.js
@@ -68,7 +68,7 @@ function generateAddress() {
  * @returns {string} - the native id
  */
 function getGranuleUr(metadata, isUmmG) {
-  return isUmmG ? metadata.GranuleUR : metadata.Granule.GranuleUR;
+  return encodeURIComponent(isUmmG ? metadata.GranuleUR : metadata.Granule.GranuleUR);
 }
 
 /**
@@ -115,7 +115,7 @@ async function getEntryTitle(config, metadata, isUmmG) {
     throw new RecordDoesNotExist(`Unable to query parent collection entry title using short name ${shortName} and version ${version}`);
   }
 
-  return datasetId;
+  return encodeURIComponent(datasetId);
 }
 
 /**

--- a/tasks/hyrax-metadata-updates/tests/data/cmr-results.json
+++ b/tasks/hyrax-metadata-updates/tests/data/cmr-results.json
@@ -15,7 +15,7 @@
                 ],
                 "version_id": "2.0",
                 "updated": "2017-12-01T00:00:00.000Z",
-                "dataset_id": "GLDAS Catchment Land Surface Model L4 daily 0.25 x 0.25 degree V2.0 (GLDAS_CLSM025_D) at GES DISC",
+                "dataset_id": "Sentinel-6A MF/Jason-CS L2 Advanced Microwave Radiometer (AMR-C) NRT Geophysical Parameters",
                 "has_spatial_subsetting": true,
                 "has_transforms": false,
                 "associations": {
@@ -64,7 +64,7 @@
                 "organizations": [
                     "NASA/GSFC/SED/ESD/GCDC/GESDISC"
                 ],
-                "title": "GLDAS Catchment Land Surface Model L4 daily 0.25 x 0.25 degree V2.0 (GLDAS_CLSM025_D) at GES DISC",
+                "title": "Sentinel-6A MF/Jason-CS L2 Advanced Microwave Radiometer (AMR-C) NRT Geophysical Parameters",
                 "coordinate_system": "CARTESIAN",
                 "summary": "Global Land Data Assimilation System Version 2 (hereafter, GLDAS-2) has two components: one forced entirely with the Princeton meteorological forcing data (hereafter, GLDAS-2.0), and the other forced with a combination of model and observation based forcing data sets (hereafter, GLDAS-2.1).\n\nThis data set, GLDAS-2.0 0.25 degree daily, contains a series of land surface parameters simulated from the Catchment Land Surface Model 3.3, and currently covers from January 1948 to December 2014.\n\nThe GLDAS-2.0 model simulations were initialized on January 1, 1948, using soil moisture and other state fields from the LSM climatology for that day of the year. The simulations were forced by the global meteorological forcing data set from Princeton University (Sheffield et al., 2006). Each simulation uses the common GLDAS data sets for land water mask (MOD44W: Carroll et al., 2009) and elevation (GTOPO30) along with the model default land cover and soils datasets. Catchment model uses the Mosaic land cover classification and soils, topographic, and other model-specific parameters were derived in a consistent manner as in the NASA/GMAO&#8217;s GEOS-5 climate modeling system. The MODIS based land surface parameters are used in the current GLDAS-2.0 and GLDAS-2.1 products. For more information, please see the README Document.",
                 "time_end": "2014-12-30T23:59:59.000Z",

--- a/tasks/hyrax-metadata-updates/tests/data/echo10out-1-online-resource-urls.xml
+++ b/tasks/hyrax-metadata-updates/tests/data/echo10out-1-online-resource-urls.xml
@@ -43,7 +43,7 @@
             <Type>Bar</Type>
         </OnlineResource>
         <OnlineResource>
-            <URL>https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/GLDAS%20Catchment%20Land%20Surface%20Model%20L4%20daily%200.25%20x%200.25%20degree%20V2.0%20(GLDAS_CLSM025_D)%20at%20GES%20DISC/granules/GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A20141230.020.nc4</URL>
+            <URL>https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/GLDAS%20Catchment%20Land%20Surface%20Model%20L4%20daily%200.25%20x%200.25%20degree%20V2.0%20(GLDAS_CLSM025_D)%20at%20GES%20DISC/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4</URL>
             <Description>OPeNDAP request URL</Description>
             <Type>GET DATA : OPENDAP DATA</Type>
         </OnlineResource>

--- a/tasks/hyrax-metadata-updates/tests/data/echo10out-2-online-resource-urls.xml
+++ b/tasks/hyrax-metadata-updates/tests/data/echo10out-2-online-resource-urls.xml
@@ -48,7 +48,7 @@
             <Type>Bar2</Type>
         </OnlineResource>
         <OnlineResource>
-            <URL>https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/GLDAS%20Catchment%20Land%20Surface%20Model%20L4%20daily%200.25%20x%200.25%20degree%20V2.0%20(GLDAS_CLSM025_D)%20at%20GES%20DISC/granules/GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A20141230.020.nc4</URL>
+            <URL>https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/GLDAS%20Catchment%20Land%20Surface%20Model%20L4%20daily%200.25%20x%200.25%20degree%20V2.0%20(GLDAS_CLSM025_D)%20at%20GES%20DISC/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4</URL>
             <Description>OPeNDAP request URL</Description>
             <Type>GET DATA : OPENDAP DATA</Type>
         </OnlineResource>

--- a/tasks/hyrax-metadata-updates/tests/data/echo10out-no-online-resource-urls.xml
+++ b/tasks/hyrax-metadata-updates/tests/data/echo10out-no-online-resource-urls.xml
@@ -38,7 +38,7 @@
     </OnlineAccessURLs>
     <OnlineResources>
         <OnlineResource>
-            <URL>https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/GLDAS%20Catchment%20Land%20Surface%20Model%20L4%20daily%200.25%20x%200.25%20degree%20V2.0%20(GLDAS_CLSM025_D)%20at%20GES%20DISC/granules/GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A20141230.020.nc4</URL>
+            <URL>https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/GLDAS%20Catchment%20Land%20Surface%20Model%20L4%20daily%200.25%20x%200.25%20degree%20V2.0%20(GLDAS_CLSM025_D)%20at%20GES%20DISC/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4</URL>
             <Description>OPeNDAP request URL</Description>
             <Type>GET DATA : OPENDAP DATA</Type>
         </OnlineResource>

--- a/tasks/hyrax-metadata-updates/tests/data/echo10out.xml
+++ b/tasks/hyrax-metadata-updates/tests/data/echo10out.xml
@@ -43,7 +43,7 @@
             <Type>Bar</Type>
         </OnlineResource>
         <OnlineResource>
-            <URL>https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/GLDAS%20Catchment%20Land%20Surface%20Model%20L4%20daily%200.25%20x%200.25%20degree%20V2.0%20(GLDAS_CLSM025_D)%20at%20GES%20DISC/granules/GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A20141230.020.nc4</URL>
+            <URL>https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/Sentinel-6A%20MF%2FJason-CS%20L2%20Advanced%20Microwave%20Radiometer%20(AMR-C)%20NRT%20Geophysical%20Parameters/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4</URL>
             <Description>OPeNDAP request URL</Description>
             <Type>GET DATA : OPENDAP DATA</Type>
         </OnlineResource>

--- a/tasks/hyrax-metadata-updates/tests/data/umm-gout-no-related-urls.json
+++ b/tasks/hyrax-metadata-updates/tests/data/umm-gout-no-related-urls.json
@@ -53,7 +53,7 @@
     "GranuleUR": "GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A20141230.020.nc4",
     "RelatedUrls": [
         {
-            "URL": "https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/GLDAS%20Catchment%20Land%20Surface%20Model%20L4%20daily%200.25%20x%200.25%20degree%20V2.0%20(GLDAS_CLSM025_D)%20at%20GES%20DISC/granules/GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A20141230.020.nc4",
+            "URL": "https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/GLDAS%20Catchment%20Land%20Surface%20Model%20L4%20daily%200.25%20x%200.25%20degree%20V2.0%20(GLDAS_CLSM025_D)%20at%20GES%20DISC/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4",
             "Type": "GET DATA",
             "Subtype": "OPENDAP DATA",
             "Description": "OPeNDAP request URL"

--- a/tasks/hyrax-metadata-updates/tests/data/umm-gout.json
+++ b/tasks/hyrax-metadata-updates/tests/data/umm-gout.json
@@ -5,7 +5,7 @@
             "Type": "GET DATA"
         },
         {
-            "URL": "https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/GLDAS%20Catchment%20Land%20Surface%20Model%20L4%20daily%200.25%20x%200.25%20degree%20V2.0%20(GLDAS_CLSM025_D)%20at%20GES%20DISC/granules/GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A20141230.020.nc4",
+            "URL": "https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/Sentinel-6A%20MF%2FJason-CS%20L2%20Advanced%20Microwave%20Radiometer%20(AMR-C)%20NRT%20Geophysical%20Parameters/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4",
             "Type": "GET DATA",
             "Subtype": "OPENDAP DATA",
             "Description": "OPeNDAP request URL"

--- a/tasks/hyrax-metadata-updates/tests/test-index.js
+++ b/tasks/hyrax-metadata-updates/tests/test-index.js
@@ -69,7 +69,7 @@ test('Test granule ur extraction from UMM-G', (t) => {
   const metadata = JSON.parse(data);
   const actual = getGranuleUr(metadata, true);
 
-  t.is(actual, 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A20141230.020.nc4');
+  t.is(actual, 'GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4');
 });
 
 test('Test granule ur extraction from ECHO10', async (t) => {
@@ -77,7 +77,7 @@ test('Test granule ur extraction from ECHO10', async (t) => {
   const metadata = await (promisify(xml2js.parseString))(data, xmlParseOptions);
   const actual = getGranuleUr(metadata, false);
 
-  t.is(actual, 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A20141230.020.nc4');
+  t.is(actual, 'GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4');
 });
 
 test('Test adding OPeNDAP URL to UMM-G file', (t) => {
@@ -85,7 +85,7 @@ test('Test adding OPeNDAP URL to UMM-G file', (t) => {
   const metadata = JSON.parse(data);
   const expected = fs.readFileSync('tests/data/umm-gout.json', 'utf8');
   const expectedObject = JSON.parse(expected);
-  const actual = addHyraxUrl(metadata, true, 'https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/GLDAS%20Catchment%20Land%20Surface%20Model%20L4%20daily%200.25%20x%200.25%20degree%20V2.0%20(GLDAS_CLSM025_D)%20at%20GES%20DISC/granules/GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A20141230.020.nc4');
+  const actual = addHyraxUrl(metadata, true, 'https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/Sentinel-6A%20MF%2FJason-CS%20L2%20Advanced%20Microwave%20Radiometer%20(AMR-C)%20NRT%20Geophysical%20Parameters/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4');
   t.is(actual, JSON.stringify(expectedObject, undefined, 2));
 });
 
@@ -94,7 +94,7 @@ test('Test adding OPeNDAP URL to UMM-G file with no related urls', (t) => {
   const metadata = JSON.parse(data);
   const expected = fs.readFileSync('tests/data/umm-gout-no-related-urls.json', 'utf8');
   const expectedObject = JSON.parse(expected);
-  const actual = addHyraxUrl(metadata, true, 'https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/GLDAS%20Catchment%20Land%20Surface%20Model%20L4%20daily%200.25%20x%200.25%20degree%20V2.0%20(GLDAS_CLSM025_D)%20at%20GES%20DISC/granules/GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A20141230.020.nc4');
+  const actual = addHyraxUrl(metadata, true, 'https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/GLDAS%20Catchment%20Land%20Surface%20Model%20L4%20daily%200.25%20x%200.25%20degree%20V2.0%20(GLDAS_CLSM025_D)%20at%20GES%20DISC/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4');
   t.is(actual, JSON.stringify(expectedObject, undefined, 2));
 });
 
@@ -102,7 +102,7 @@ test('Test adding OPeNDAP URL to ECHO10 file', async (t) => {
   const data = fs.readFileSync('tests/data/echo10in.xml', 'utf8');
   const metadata = await (promisify(xml2js.parseString))(data, xmlParseOptions);
   const expected = fs.readFileSync('tests/data/echo10out.xml', 'utf8');
-  const actual = addHyraxUrl(metadata, false, 'https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/GLDAS%20Catchment%20Land%20Surface%20Model%20L4%20daily%200.25%20x%200.25%20degree%20V2.0%20(GLDAS_CLSM025_D)%20at%20GES%20DISC/granules/GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A20141230.020.nc4');
+  const actual = addHyraxUrl(metadata, false, 'https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/Sentinel-6A%20MF%2FJason-CS%20L2%20Advanced%20Microwave%20Radiometer%20(AMR-C)%20NRT%20Geophysical%20Parameters/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4');
   t.is(actual, expected);
 });
 
@@ -110,7 +110,7 @@ test('Test adding OPeNDAP URL to ECHO10 file with no OnlineResources', async (t)
   const data = fs.readFileSync('tests/data/echo10in-no-online-resource-urls.xml', 'utf8');
   const metadata = await (promisify(xml2js.parseString))(data, xmlParseOptions);
   const expected = fs.readFileSync('tests/data/echo10out-no-online-resource-urls.xml', 'utf8');
-  const actual = addHyraxUrl(metadata, false, 'https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/GLDAS%20Catchment%20Land%20Surface%20Model%20L4%20daily%200.25%20x%200.25%20degree%20V2.0%20(GLDAS_CLSM025_D)%20at%20GES%20DISC/granules/GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A20141230.020.nc4');
+  const actual = addHyraxUrl(metadata, false, 'https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/GLDAS%20Catchment%20Land%20Surface%20Model%20L4%20daily%200.25%20x%200.25%20degree%20V2.0%20(GLDAS_CLSM025_D)%20at%20GES%20DISC/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4');
   t.is(actual, expected);
 });
 
@@ -118,7 +118,7 @@ test('Test adding OPeNDAP URL to ECHO10 file with one OnlineResources', async (t
   const data = fs.readFileSync('tests/data/echo10in-1-online-resource-urls.xml', 'utf8');
   const metadata = await (promisify(xml2js.parseString))(data, xmlParseOptions);
   const expected = fs.readFileSync('tests/data/echo10out-1-online-resource-urls.xml', 'utf8');
-  const actual = addHyraxUrl(metadata, false, 'https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/GLDAS%20Catchment%20Land%20Surface%20Model%20L4%20daily%200.25%20x%200.25%20degree%20V2.0%20(GLDAS_CLSM025_D)%20at%20GES%20DISC/granules/GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A20141230.020.nc4');
+  const actual = addHyraxUrl(metadata, false, 'https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/GLDAS%20Catchment%20Land%20Surface%20Model%20L4%20daily%200.25%20x%200.25%20degree%20V2.0%20(GLDAS_CLSM025_D)%20at%20GES%20DISC/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4');
   t.is(actual, expected.trim('\n'));
 });
 
@@ -126,6 +126,6 @@ test('Test adding OPeNDAP URL to ECHO10 file with two OnlineResources', async (t
   const data = fs.readFileSync('tests/data/echo10in-2-online-resource-urls.xml', 'utf8');
   const metadata = await (promisify(xml2js.parseString))(data, xmlParseOptions);
   const expected = fs.readFileSync('tests/data/echo10out-2-online-resource-urls.xml', 'utf8');
-  const actual = addHyraxUrl(metadata, false, 'https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/GLDAS%20Catchment%20Land%20Surface%20Model%20L4%20daily%200.25%20x%200.25%20degree%20V2.0%20(GLDAS_CLSM025_D)%20at%20GES%20DISC/granules/GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A20141230.020.nc4');
+  const actual = addHyraxUrl(metadata, false, 'https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/GLDAS%20Catchment%20Land%20Surface%20Model%20L4%20daily%200.25%20x%200.25%20degree%20V2.0%20(GLDAS_CLSM025_D)%20at%20GES%20DISC/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4');
   t.is(actual, expected);
 });

--- a/tasks/hyrax-metadata-updates/tests/test-integration-index.js
+++ b/tasks/hyrax-metadata-updates/tests/test-integration-index.js
@@ -503,14 +503,14 @@ test.serial('Test retrieving entry title from CMR using UMM-G', async (t) => {
   const data = fs.readFileSync('tests/data/umm-gin.json', 'utf8');
   const metadataObject = JSON.parse(data);
   const actual = await getEntryTitle(event.config, metadataObject, true);
-  t.is(actual, 'GLDAS Catchment Land Surface Model L4 daily 0.25 x 0.25 degree V2.0 (GLDAS_CLSM025_D) at GES DISC');
+  t.is(actual, 'Sentinel-6A%20MF%2FJason-CS%20L2%20Advanced%20Microwave%20Radiometer%20(AMR-C)%20NRT%20Geophysical%20Parameters');
 });
 
 test.serial('Test retrieving entry title from CMR using ECHO10', async (t) => {
   const data = fs.readFileSync('tests/data/echo10in.xml', 'utf8');
   const metadata = await (promisify(xml2js.parseString))(data, xmlParseOptions);
   const actual = await getEntryTitle(event.config, metadata, false);
-  t.is(actual, 'GLDAS Catchment Land Surface Model L4 daily 0.25 x 0.25 degree V2.0 (GLDAS_CLSM025_D) at GES DISC');
+  t.is(actual, 'Sentinel-6A%20MF%2FJason-CS%20L2%20Advanced%20Microwave%20Radiometer%20(AMR-C)%20NRT%20Geophysical%20Parameters');
 });
 
 test('Test generate path from UMM-G', async (t) => {
@@ -518,7 +518,7 @@ test('Test generate path from UMM-G', async (t) => {
   const metadataObject = JSON.parse(metadata);
   const actual = await generatePath(event.config, metadataObject, true);
 
-  t.is(actual, 'providers/GES_DISC/collections/GLDAS Catchment Land Surface Model L4 daily 0.25 x 0.25 degree V2.0 (GLDAS_CLSM025_D) at GES DISC/granules/GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A20141230.020.nc4');
+  t.is(actual, 'providers/GES_DISC/collections/Sentinel-6A%20MF%2FJason-CS%20L2%20Advanced%20Microwave%20Radiometer%20(AMR-C)%20NRT%20Geophysical%20Parameters/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4');
 });
 
 test('Test generate path from ECHO-10', async (t) => {
@@ -527,21 +527,21 @@ test('Test generate path from ECHO-10', async (t) => {
 
   const actual = await generatePath(event.config, metadataObject, false);
 
-  t.is(actual, 'providers/GES_DISC/collections/GLDAS Catchment Land Surface Model L4 daily 0.25 x 0.25 degree V2.0 (GLDAS_CLSM025_D) at GES DISC/granules/GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A20141230.020.nc4');
+  t.is(actual, 'providers/GES_DISC/collections/Sentinel-6A%20MF%2FJason-CS%20L2%20Advanced%20Microwave%20Radiometer%20(AMR-C)%20NRT%20Geophysical%20Parameters/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4');
 });
 
 test('Test generating OPeNDAP URL from ECHO10 file', async (t) => {
   const data = fs.readFileSync('tests/data/echo10in.xml', 'utf8');
   const metadata = await (promisify(xml2js.parseString))(data, xmlParseOptions);
   const actual = await generateHyraxUrl(event.config, metadata, false);
-  t.is(actual, 'https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/GLDAS%20Catchment%20Land%20Surface%20Model%20L4%20daily%200.25%20x%200.25%20degree%20V2.0%20(GLDAS_CLSM025_D)%20at%20GES%20DISC/granules/GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A20141230.020.nc4');
+  t.is(actual, 'https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/Sentinel-6A%20MF%2FJason-CS%20L2%20Advanced%20Microwave%20Radiometer%20(AMR-C)%20NRT%20Geophysical%20Parameters/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4');
 });
 
 test('Test generating OPeNDAP URL from UMM-G file', async (t) => {
   const data = fs.readFileSync('tests/data/umm-gin.json', 'utf8');
   const metadataObject = JSON.parse(data);
   const actual = await generateHyraxUrl(event.config, metadataObject, true);
-  t.is(actual, 'https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/GLDAS%20Catchment%20Land%20Surface%20Model%20L4%20daily%200.25%20x%200.25%20degree%20V2.0%20(GLDAS_CLSM025_D)%20at%20GES%20DISC/granules/GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A20141230.020.nc4');
+  t.is(actual, 'https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/Sentinel-6A%20MF%2FJason-CS%20L2%20Advanced%20Microwave%20Radiometer%20(AMR-C)%20NRT%20Geophysical%20Parameters/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4');
 });
 
 test('Test generate path from ECHO-10 throws exception with broken config', async (t) => {


### PR DESCRIPTION
**Summary:**

Addresses [Hyrax-320: As a Cumulus operator, I need to encode Hyrax URLs correctly where entry titles or granule URs have a slash in them](https://bugs.earthdata.nasa.gov/browse/Hyrax-320)

## Changes

* EntryTitleID URI components are now encoded
* GranuleUR URI components are now encoded

## PR Checklist

- [X] Update CHANGELOG
- [X] Unit tests
- [X] Adhoc testing
- [X] Integration tests

