### PR TITLE
Update cumulus-rds-tf to allow engine version as configurable value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - **CUMULUS-2092**
   - Add documentation for Getting Started section including FAQs
 
+### Changed
+
+ - **CUMULUS-2124**
+   - cumulus-rds-tf terraform module now takes engine_version as an input variable.
+
 ## [v4.0.0] 2020-11-20
 
 ### Migration notes

--- a/example/rds-cluster-tf/main.tf
+++ b/example/rds-cluster-tf/main.tf
@@ -16,6 +16,7 @@ module "rds_cluster" {
   region               = var.region
   vpc_id               = var.vpc_id
   subnets              = var.subnets
+  engine_version       = var.engine_version
   deletion_protection  = true
   cluster_identifier   = var.cluster_identifier
   tags                 = var.tags

--- a/example/rds-cluster-tf/variables.tf
+++ b/example/rds-cluster-tf/variables.tf
@@ -41,3 +41,10 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "engine_version" {
+  description = "Postgres engine version for Serverless cluster"
+  type        = string
+  default     = "10.12"
+}
+

--- a/tf-modules/cumulus-rds-tf/main.tf
+++ b/tf-modules/cumulus-rds-tf/main.tf
@@ -53,7 +53,7 @@ resource "aws_rds_cluster" "cumulus" {
   cluster_identifier      = var.cluster_identifier
   engine_mode             = "serverless"
   engine                  = "aurora-postgresql"
-  engine_version          = "10.7"
+  engine_version          = var.engine_version
   database_name           = "postgres"
   master_username         = var.db_admin_username
   master_password         = var.db_admin_password

--- a/tf-modules/cumulus-rds-tf/variables.tf
+++ b/tf-modules/cumulus-rds-tf/variables.tf
@@ -78,3 +78,9 @@ variable "vpc_id" {
   description = "VPC ID for the Cumulus Deployment"
   type        = string
 }
+
+variable "engine_version" {
+  description = "Postgres engine version for serverless cluster"
+  type        = string
+  default     = "10.12"
+}


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2124: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2124)

## Changes

* cumulus-rds-tf terraform module now takes engine_version as an input variable.

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Adhoc testing
- [ ] Integration tests

