### PR TITLE
Update Core ECS image targets to use terraform variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **CUMULUS-2318**
+  - Added`async_operation_image` as `cumulus` module variable to allow for override of the async_operation container image.  Users can optionally specify a non-default docker image for use with Core async operations.
 - **CUMULUS-2219**
   - Added `lzards-backup` Core task to facilitate making LZARDS backup requests in Cumulus ingest workflows
 - **CUMULUS-2092**
@@ -22,8 +24,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
- - **CUMULUS-2124**
-   - cumulus-rds-tf terraform module now takes engine_version as an input variable.
+- **CUMULUS-2124**
+  - cumulus-rds-tf terraform module now takes engine_version as an input variable.
 - **CUMULUS-2020**
   - Updated Elasticsearch mappings to support case-insensitive search
 

--- a/bamboo/bootstrap-tf-deployment.sh
+++ b/bamboo/bootstrap-tf-deployment.sh
@@ -91,4 +91,5 @@ echo "Deploying Cumulus example to $DEPLOYMENT"
   -var "urs_client_password=$EARTHDATA_CLIENT_PASSWORD" \
   -var "token_secret=$TOKEN_SECRET" \
   -var "permissions_boundary_arn=arn:aws:iam::$AWS_ACCOUNT_ID:policy/$ROLE_BOUNDARY" \
-  -var "pdr_node_name_provider_bucket=$PDR_NODE_NAME_PROVIDER_BUCKET"
+  -var "pdr_node_name_provider_bucket=$PDR_NODE_NAME_PROVIDER_BUCKET" \
+  -var "async_operation_image=$ASYNC_OPERATION_IMAGE"

--- a/bamboo/set-bamboo-env-variables.sh
+++ b/bamboo/set-bamboo-env-variables.sh
@@ -14,6 +14,7 @@ declare -a param_list=(
   "bamboo_PDR_NODE_NAME_PROVIDER_BUCKET"
   "bamboo_PUBLISH_FLAG"
   "bamboo_REPORT_BUILD_STATUS"
+  "bamboo_SECRET_ASYNC_OPERATION_IMAGE"
   "bamboo_SECRET_AWS_ACCESS_KEY_ID"
   "bamboo_SECRET_AWS_ACCOUNT_ID"
   "bamboo_SECRET_AWS_DEFAULT_REGION"

--- a/example/cumulus-tf/ecs_hello_world_workflow.tf
+++ b/example/cumulus-tf/ecs_hello_world_workflow.tf
@@ -12,7 +12,7 @@ module "hello_world_service" {
 
   cluster_arn                           = module.cumulus.ecs_cluster_arn
   desired_count                         = 1
-  image                                 = "cumuluss/cumulus-ecs-task:1.7.0"
+  image                                 = var.ecs_task_image
   log2elasticsearch_lambda_function_arn = module.cumulus.log2elasticsearch_lambda_function_arn
 
   cpu                = 400

--- a/example/cumulus-tf/main.tf
+++ b/example/cumulus-tf/main.tf
@@ -65,6 +65,7 @@ module "cumulus" {
   vpc_id            = var.vpc_id
   lambda_subnet_ids = var.lambda_subnet_ids
 
+  async_operation_image = var.async_operation_image
   ecs_cluster_instance_image_id   = data.aws_ssm_parameter.ecs_image_id.value
   ecs_cluster_instance_subnet_ids = (length(var.ecs_cluster_instance_subnet_ids) == 0
     ? var.lambda_subnet_ids

--- a/example/cumulus-tf/python_processing_workflow.tf
+++ b/example/cumulus-tf/python_processing_workflow.tf
@@ -12,7 +12,7 @@ module "python_test_ingest_processing_service" {
 
   cluster_arn                           = module.cumulus.ecs_cluster_arn
   desired_count                         = 1
-  image                                 = var.cumulus_test_ingest_process
+  image                                 = var.cumulus_test_ingest_process_image
   log2elasticsearch_lambda_function_arn = module.cumulus.log2elasticsearch_lambda_function_arn
 
   cpu                = 400

--- a/example/cumulus-tf/python_processing_workflow.tf
+++ b/example/cumulus-tf/python_processing_workflow.tf
@@ -12,7 +12,7 @@ module "python_test_ingest_processing_service" {
 
   cluster_arn                           = module.cumulus.ecs_cluster_arn
   desired_count                         = 1
-  image                                 = "jlkovarik/cumulus-test-ingest-process:12"
+  image                                 = var.cumulus_test_ingest_process
   log2elasticsearch_lambda_function_arn = module.cumulus.log2elasticsearch_lambda_function_arn
 
   cpu                = 400

--- a/example/cumulus-tf/python_reference_workflow.tf
+++ b/example/cumulus-tf/python_reference_workflow.tf
@@ -13,7 +13,7 @@ module "python_processing_service" {
 
   cluster_arn                           = module.cumulus.ecs_cluster_arn
   desired_count                         = 1
-  image                                 = var.cumulus_process_activity
+  image                                 = var.cumulus_process_activity_image
   log2elasticsearch_lambda_function_arn = module.cumulus.log2elasticsearch_lambda_function_arn
 
   cpu                = 400

--- a/example/cumulus-tf/python_reference_workflow.tf
+++ b/example/cumulus-tf/python_reference_workflow.tf
@@ -13,7 +13,7 @@ module "python_processing_service" {
 
   cluster_arn                           = module.cumulus.ecs_cluster_arn
   desired_count                         = 1
-  image                                 = "cumuluss/cumulus-process-activity:1"
+  image                                 = var.cumulus_process_activity
   log2elasticsearch_lambda_function_arn = module.cumulus.log2elasticsearch_lambda_function_arn
 
   cpu                = 400

--- a/example/cumulus-tf/variables.tf
+++ b/example/cumulus-tf/variables.tf
@@ -1,5 +1,29 @@
 # Required
 
+variable "async_operation_image" {
+  description = "docker image to use for Cumulus async operations tasks"
+  type = string
+  default = "cumuluss/async-operation:27"
+}
+
+variable "cumulus_process_activity" {
+  description = "docker image to use for python processing service"
+  type = string
+  default = "cumuluss/cumulus-process-activity:1"
+}
+
+variable "ecs_task_image" {
+  description = "docker image to use for Cumulus hello world task"
+  type = string
+  default = "cumuluss/cumulus-ecs-task:1.7.0"
+}
+
+variable "cumulus_test_ingest_process" {
+  description = "docker image to use for python test ingest processing service"
+  type = string
+  default = "jlkovarik/cumulus-test-ingest-process:12"
+}
+
 variable "cmr_client_id" {
   type = string
 }

--- a/example/cumulus-tf/variables.tf
+++ b/example/cumulus-tf/variables.tf
@@ -6,7 +6,7 @@ variable "async_operation_image" {
   default = "cumuluss/async-operation:27"
 }
 
-variable "cumulus_process_activity" {
+variable "cumulus_process_activity_image" {
   description = "docker image to use for python processing service"
   type = string
   default = "cumuluss/cumulus-process-activity:1"
@@ -18,7 +18,7 @@ variable "ecs_task_image" {
   default = "cumuluss/cumulus-ecs-task:1.7.0"
 }
 
-variable "cumulus_test_ingest_process" {
+variable "cumulus_test_ingest_process_image" {
   description = "docker image to use for python test ingest processing service"
   type = string
   default = "jlkovarik/cumulus-test-ingest-process:12"

--- a/tf-modules/archive/async_operation.tf
+++ b/tf-modules/archive/async_operation.tf
@@ -19,7 +19,7 @@ resource "aws_ecs_task_definition" "async_operation" {
         "value": "${data.aws_region.current.name}"
       }
     ],
-    "image": "cumuluss/async-operation:27",
+    "image": "${var.async_operation_image}",
     "memoryReservation": 700,
     "logConfiguration": {
       "logDriver": "awslogs",

--- a/tf-modules/archive/variables.tf
+++ b/tf-modules/archive/variables.tf
@@ -1,5 +1,10 @@
 # Required
 
+variable "async_operation_image" {
+  description = "docker image to use for Cumulus async operations tasks"
+  type = string
+}
+
 variable "background_queue_url" {
   description = "Queue URL to use for throttled background operations (e.g. granule reingest)"
   type = string

--- a/tf-modules/cumulus/archive.tf
+++ b/tf-modules/cumulus/archive.tf
@@ -11,7 +11,8 @@ module "archive" {
 
   lambda_processing_role_arn = aws_iam_role.lambda_processing.arn
 
-  ecs_cluster_name = aws_ecs_cluster.default.name
+  async_operation_image = var.async_operation_image
+  ecs_cluster_name      = aws_ecs_cluster.default.name
 
   elasticsearch_domain_arn        = var.elasticsearch_domain_arn
   elasticsearch_hostname          = var.elasticsearch_hostname

--- a/tf-modules/cumulus/variables.tf
+++ b/tf-modules/cumulus/variables.tf
@@ -1,5 +1,11 @@
 # Required
 
+variable "async_operation_image" {
+  description = "docker image to use for Cumulus async operations tasks"
+  type = string
+  default = "cumuluss/async-operation:27"
+}
+
 variable "cmr_client_id" {
   description = "Client ID that you want to use for requests to CMR (https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html)"
   type        = string


### PR DESCRIPTION
Update Core to utilize terraform variables for ECS images.   We've
added internal Amazon ECR images for use by the Core development
engineers so that we're not hitting the public dockerhub.

Addresses [CUMULUS-2318: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2318)

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

