### PR TITLE
Update terraform to use data resource for ECR URL

### DIFF
--- a/bamboo/bootstrap-tf-deployment.sh
+++ b/bamboo/bootstrap-tf-deployment.sh
@@ -92,4 +92,3 @@ echo "Deploying Cumulus example to $DEPLOYMENT"
   -var "token_secret=$TOKEN_SECRET" \
   -var "permissions_boundary_arn=arn:aws:iam::$AWS_ACCOUNT_ID:policy/$ROLE_BOUNDARY" \
   -var "pdr_node_name_provider_bucket=$PDR_NODE_NAME_PROVIDER_BUCKET" \
-  -var "async_operation_image=$ASYNC_OPERATION_IMAGE"

--- a/bamboo/set-bamboo-env-variables.sh
+++ b/bamboo/set-bamboo-env-variables.sh
@@ -1,4 +1,4 @@
-'#!/bin/bash
+#!/bin/bash
 set -ex
 
 # Bamboo envs are prefixed with bamboo_SECRET to avoid being printed

--- a/bamboo/set-bamboo-env-variables.sh
+++ b/bamboo/set-bamboo-env-variables.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+'#!/bin/bash
 set -ex
 
 # Bamboo envs are prefixed with bamboo_SECRET to avoid being printed
@@ -14,7 +14,6 @@ declare -a param_list=(
   "bamboo_PDR_NODE_NAME_PROVIDER_BUCKET"
   "bamboo_PUBLISH_FLAG"
   "bamboo_REPORT_BUILD_STATUS"
-  "bamboo_SECRET_ASYNC_OPERATION_IMAGE"
   "bamboo_SECRET_AWS_ACCESS_KEY_ID"
   "bamboo_SECRET_AWS_ACCOUNT_ID"
   "bamboo_SECRET_AWS_DEFAULT_REGION"

--- a/example/cumulus-tf/ecs_hello_world_workflow.tf
+++ b/example/cumulus-tf/ecs_hello_world_workflow.tf
@@ -3,6 +3,12 @@ resource "aws_sfn_activity" "ecs_task_hello_world" {
   tags = local.tags
 }
 
+
+
+data "aws_ecr_repository" "ecs_task_image" {
+  name = "cumulus-ecs-task"
+}
+
 module "hello_world_service" {
   source = "../../tf-modules/cumulus_ecs_service"
 
@@ -12,7 +18,7 @@ module "hello_world_service" {
 
   cluster_arn                           = module.cumulus.ecs_cluster_arn
   desired_count                         = 1
-  image                                 = var.ecs_task_image
+  image                                 = "${data.aws_ecr_repository.ecs_task_image.repository_url}:${var.ecs_task_image_version}"
   log2elasticsearch_lambda_function_arn = module.cumulus.log2elasticsearch_lambda_function_arn
 
   cpu                = 400

--- a/example/cumulus-tf/main.tf
+++ b/example/cumulus-tf/main.tf
@@ -51,6 +51,11 @@ data "aws_ssm_parameter" "ecs_image_id" {
   name = "image_id_ecs_amz2"
 }
 
+data "aws_ecr_repository" "async_operation" {
+  name = "async_operations"
+}
+
+
 module "cumulus" {
   source = "../../tf-modules/cumulus"
 
@@ -65,7 +70,7 @@ module "cumulus" {
   vpc_id            = var.vpc_id
   lambda_subnet_ids = var.lambda_subnet_ids
 
-  async_operation_image = var.async_operation_image
+  async_operation_image =  "${data.aws_ecr_repository.async_operation.repository_url}:${var.async_operation_image_version}"
   ecs_cluster_instance_image_id   = data.aws_ssm_parameter.ecs_image_id.value
   ecs_cluster_instance_subnet_ids = (length(var.ecs_cluster_instance_subnet_ids) == 0
     ? var.lambda_subnet_ids

--- a/example/cumulus-tf/python_processing_workflow.tf
+++ b/example/cumulus-tf/python_processing_workflow.tf
@@ -3,6 +3,11 @@ resource "aws_sfn_activity" "ecs_task_python_test_ingest_processing_service" {
   tags = local.tags
 }
 
+
+data "aws_ecr_repository" "cumulus_test_ingest_process" {
+  name = "cumulus-test-ingest-process"
+}
+
 module "python_test_ingest_processing_service" {
   source = "../../tf-modules/cumulus_ecs_service"
 
@@ -12,7 +17,7 @@ module "python_test_ingest_processing_service" {
 
   cluster_arn                           = module.cumulus.ecs_cluster_arn
   desired_count                         = 1
-  image                                 = var.cumulus_test_ingest_process_image
+  image                                 = "${data.aws_ecr_repository.cumulus_test_ingest_process.repository_url}:${var.cumulus_test_ingest_image_version}"
   log2elasticsearch_lambda_function_arn = module.cumulus.log2elasticsearch_lambda_function_arn
 
   cpu                = 400

--- a/example/cumulus-tf/python_reference_workflow.tf
+++ b/example/cumulus-tf/python_reference_workflow.tf
@@ -4,6 +4,10 @@ resource "aws_sfn_activity" "ecs_task_python_processing_service" {
   tags = local.tags
 }
 
+data "aws_ecr_repository" "cumulus_process_activity" {
+  name = "cumulus-process-activity"
+}
+
 module "python_processing_service" {
   source = "../../tf-modules/cumulus_ecs_service"
 
@@ -13,7 +17,7 @@ module "python_processing_service" {
 
   cluster_arn                           = module.cumulus.ecs_cluster_arn
   desired_count                         = 1
-  image                                 = var.cumulus_process_activity_image
+  image                                 = "${data.aws_ecr_repository.cumulus_process_activity.repository_url}:${var.cumulus_process_activity_version}"
   log2elasticsearch_lambda_function_arn = module.cumulus.log2elasticsearch_lambda_function_arn
 
   cpu                = 400

--- a/example/cumulus-tf/variables.tf
+++ b/example/cumulus-tf/variables.tf
@@ -3,7 +3,7 @@
 variable "async_operation_image_version" {
   description = "docker image version to use for Cumulus async operations tasks"
   type = string
-  default = "32"
+  default = "27"
 }
 
 variable "cumulus_process_activity_version" {

--- a/example/cumulus-tf/variables.tf
+++ b/example/cumulus-tf/variables.tf
@@ -1,27 +1,27 @@
 # Required
 
-variable "async_operation_image" {
-  description = "docker image to use for Cumulus async operations tasks"
+variable "async_operation_image_version" {
+  description = "docker image version to use for Cumulus async operations tasks"
   type = string
-  default = "cumuluss/async-operation:27"
+  default = "32"
 }
 
-variable "cumulus_process_activity_image" {
-  description = "docker image to use for python processing service"
-  type = string
-  default = "cumuluss/cumulus-process-activity:1"
+variable "cumulus_process_activity_version" {
+    description = "docker image version to use for python processing service"
+    type = string
+    default = "1"
 }
 
-variable "ecs_task_image" {
-  description = "docker image to use for Cumulus hello world task"
-  type = string
-  default = "cumuluss/cumulus-ecs-task:1.7.0"
+variable "ecs_task_image_version" {
+  description = "docker image version to use for Cumulus hello world task"
+    type = string
+    default = "1.7.0"
 }
 
-variable "cumulus_test_ingest_process_image" {
-  description = "docker image to use for python test ingest processing service"
-  type = string
-  default = "jlkovarik/cumulus-test-ingest-process:12"
+variable "cumulus_test_ingest_image_version" {
+    description = "docker image version to use for python test ingest processing service"
+    type = string
+    default = "12"
 }
 
 variable "cmr_client_id" {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2234](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2234)

## Changes

* Master port of https://github.com/nasa/cumulus/pull/2028

