### PR TITLE
[CUMULUS-2167] File PG Schema Change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     - The `async-operations` endpoint will now omit `output` instead
       of returning `none` when the operation did not return output.
   - **CUMULUS-2167**
-    - Change Postgres Schema definition for Files to remove `filename` and only support `file_name`.
+    - Change Postgres Schema definition for Files to remove `filename` and `name` and only support `file_name`.
     - Change Postgres Schema definition for Files to remove `size` to only support `file_size`.
 
 ## [v4.0.0] 2020-11-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - **CUMULUS-2187**
     - The `async-operations` endpoint will now omit `output` instead
       of returning `none` when the operation did not return output.
+  - **CUMULUS-2167**
+    - Change Postgres Schema definition for Files to remove `filename` and only support `file_name`.
+    - Change Postgres Schema definition for Files to remove `size` to only support `file_size`.
+    - Change Postgres Schema definition for Files to make `bucket` and `key` non-nullable.
 
 ## [v4.0.0] 2020-11-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - **CUMULUS-2167**
     - Change Postgres Schema definition for Files to remove `filename` and only support `file_name`.
     - Change Postgres Schema definition for Files to remove `size` to only support `file_size`.
-    - Change Postgres Schema definition for Files to make `bucket` and `key` non-nullable.
 
 ## [v4.0.0] 2020-11-20
 

--- a/lambdas/db-migration/src/migrations/20201014105102_create_files_table.ts
+++ b/lambdas/db-migration/src/migrations/20201014105102_create_files_table.ts
@@ -32,8 +32,6 @@ export const up = async (knex: Knex): Promise<void> =>
       .text('key')
       .comment('AWS S3 key file is archived at');
     table
-      .text('name');
-    table
       .text('path')
       .comment('Source file path');
     table

--- a/lambdas/db-migration/src/migrations/20201014105102_create_files_table.ts
+++ b/lambdas/db-migration/src/migrations/20201014105102_create_files_table.ts
@@ -18,8 +18,7 @@ export const up = async (knex: Knex): Promise<void> =>
       .comment('Size of file (bytes)');
     table
       .text('bucket')
-      .comment('AWS Bucket file is archived in')
-      .notNullable();
+      .comment('AWS Bucket file is archived in');
     table
       .text('checksum_type')
       .comment('Type of file checksum (e.g. md5');
@@ -31,8 +30,7 @@ export const up = async (knex: Knex): Promise<void> =>
       .comment('Source file name');
     table
       .text('key')
-      .comment('AWS S3 key file is archived at')
-      .notNullable();
+      .comment('AWS S3 key file is archived at');
     table
       .text('name');
     table

--- a/lambdas/db-migration/src/migrations/20201014105102_create_files_table.ts
+++ b/lambdas/db-migration/src/migrations/20201014105102_create_files_table.ts
@@ -15,13 +15,11 @@ export const up = async (knex: Knex): Promise<void> =>
       .timestamps(false, true);
     table
       .integer('file_size')
-      .comment('Deprecated - size of file');
-    table
-      .integer('size')
       .comment('Size of file (bytes)');
     table
       .text('bucket')
-      .comment('AWS Bucket file is archived in');
+      .comment('AWS Bucket file is archived in')
+      .notNullable();
     table
       .text('checksum_type')
       .comment('Type of file checksum (e.g. md5');
@@ -29,13 +27,12 @@ export const up = async (knex: Knex): Promise<void> =>
       .text('checksum_value')
       .comment('File checksum');
     table
-      .text('filename');
-    table
       .text('file_name')
       .comment('Source file name');
     table
       .text('key')
-      .comment('AWS S3 key file is archived at');
+      .comment('AWS S3 key file is archived at')
+      .notNullable();
     table
       .text('name');
     table


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2167: granules/files migration ](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2167)

## Changes

- Change Postgres Schema definition for Files to remove `filename` and only support `file_name`.
- Change Postgres Schema definition for Files to remove `size` to only support `file_size`.

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

