### PR TITLE
CUMULUS-2310: Use valid filename for reconciliation report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+
 - **CUMULUS-2291**
   - Add provider filter to Granule Inventory Report
+
+### Fixed
+
+- **CUMULUS-2310**
+  - Use valid filename for reconciliation report
 
 ## [v5.0.0] 2021-01-12
 

--- a/packages/api/lambdas/create-reconciliation-report.js
+++ b/packages/api/lambdas/create-reconciliation-report.js
@@ -681,8 +681,8 @@ async function createReconciliationReport(recReportParams) {
 async function processRequest(params) {
   const { reportType, reportName, systemBucket, stackName } = params;
   const createStartTime = moment.utc();
-  const reportRecordName = (reportName && filenamify(reportName))
-    || `${camelCase(reportType)}Report-${createStartTime.format('YYYYMMDDTHHmmssSSS')}`;
+  const reportRecordName = reportName ? filenamify(reportName)
+    : `${camelCase(reportType)}Report-${createStartTime.format('YYYYMMDDTHHmmssSSS')}`;
   let reportKey = `${stackName}/reconciliation-reports/${reportRecordName}.json`;
   if (reportType === 'Granule Inventory') reportKey = reportKey.replace('.json', '.csv');
 

--- a/packages/api/lambdas/create-reconciliation-report.js
+++ b/packages/api/lambdas/create-reconciliation-report.js
@@ -681,9 +681,9 @@ async function createReconciliationReport(recReportParams) {
 async function processRequest(params) {
   const { reportType, reportName, systemBucket, stackName } = params;
   const createStartTime = moment.utc();
-  const reportRecordName = reportName ? filenamify(reportName)
-    : `${camelCase(reportType)}Report-${createStartTime.format('YYYYMMDDTHHmmssSSS')}`;
-  let reportKey = `${stackName}/reconciliation-reports/${reportRecordName}.json`;
+  const reportRecordName = reportName
+    || `${camelCase(reportType)}Report-${createStartTime.format('YYYYMMDDTHHmmssSSS')}`;
+  let reportKey = `${stackName}/reconciliation-reports/${filenamify(reportRecordName)}.json`;
   if (reportType === 'Granule Inventory') reportKey = reportKey.replace('.json', '.csv');
 
   // add request to database

--- a/packages/api/lambdas/create-reconciliation-report.js
+++ b/packages/api/lambdas/create-reconciliation-report.js
@@ -21,7 +21,7 @@ const { createGranuleInventoryReport } = require('./reports/granule-inventory-re
 const GranuleFilesCache = require('../lib/GranuleFilesCache');
 const { ESCollectionGranuleQueue } = require('../es/esCollectionGranuleQueue');
 const { ReconciliationReport } = require('../models');
-const { deconstructCollectionId, errorify } = require('../lib/utils');
+const { deconstructCollectionId, errorify, filenamify } = require('../lib/utils');
 const {
   cmrGranuleSearchParams,
   convertToESCollectionSearchParams,
@@ -681,7 +681,7 @@ async function createReconciliationReport(recReportParams) {
 async function processRequest(params) {
   const { reportType, reportName, systemBucket, stackName } = params;
   const createStartTime = moment.utc();
-  const reportRecordName = reportName
+  const reportRecordName = filenamify(reportName)
     || `${camelCase(reportType)}Report-${createStartTime.format('YYYYMMDDTHHmmssSSS')}`;
   let reportKey = `${stackName}/reconciliation-reports/${reportRecordName}.json`;
   if (reportType === 'Granule Inventory') reportKey = reportKey.replace('.json', '.csv');

--- a/packages/api/lambdas/create-reconciliation-report.js
+++ b/packages/api/lambdas/create-reconciliation-report.js
@@ -681,7 +681,7 @@ async function createReconciliationReport(recReportParams) {
 async function processRequest(params) {
   const { reportType, reportName, systemBucket, stackName } = params;
   const createStartTime = moment.utc();
-  const reportRecordName = filenamify(reportName)
+  const reportRecordName = (reportName && filenamify(reportName))
     || `${camelCase(reportType)}Report-${createStartTime.format('YYYYMMDDTHHmmssSSS')}`;
   let reportKey = `${stackName}/reconciliation-reports/${reportRecordName}.json`;
   if (reportType === 'Granule Inventory') reportKey = reportKey.replace('.json', '.csv');

--- a/packages/api/lib/utils.js
+++ b/packages/api/lib/utils.js
@@ -9,6 +9,10 @@ function errorify(err) {
   return JSON.stringify(err, Object.getOwnPropertyNames(err));
 }
 
+function filenamify(fileName) {
+  return fileName.replace(/["%*/:<>?\\|]/g, '_');
+}
+
 /**
  * Ensures that the exception is returned as an object
  *
@@ -100,6 +104,7 @@ module.exports = {
   deconstructCollectionId,
   errorify,
   extractDate,
+  filenamify,
   findCaseInsensitiveKey,
   findCaseInsensitiveValue,
   getGranuleProductVolume,


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2310: certain inventory filenames make it impossible to retrieve from the api](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2310)

## Changes

* Use valid filename for reconciliation report

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

