### PR TITLE
Fix opendap url type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Updated `hyrax-metadata-updates` task so the opendap url has Type 'USE SERVICE API'
+
 ### MIGRATION NOTES
 
 - **CUMULUS-2255** - Cumulus has upgraded its supported version of Terraform from **0.12.12** to **0.13.6**. Please see the [instructions to upgrade your deployments](https://github.com/nasa/cumulus/blob/master/docs/upgrade-notes/upgrading-tf-version-0.13.6.md).

--- a/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
+++ b/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
@@ -492,10 +492,8 @@ describe('When there are granule differences and granule reconciliation is run',
       const urls = report.filesInCumulusCmr.onlyInCmr;
       expect(urls.find((url) => url.URL.endsWith(originalGranuleFile.fileName))).toBeTruthy();
       expect(urls.find((url) => url.URL.endsWith(updatedGranuleFile.fileName))).toBeFalsy();
-      // TBD update to 1 after the s3credentials url has type 'VIEW RELATED INFORMATION' (CUMULUS-1182)
-      // Cumulus 670 has a fix for the issue noted above from 1182.  Setting to 1.
       expect(report.filesInCumulusCmr.onlyInCmr.filter((file) => file.GranuleUR === publishedGranuleId).length)
-        .toBe(2);
+        .toBe(1);
     });
 
     it('deletes a reconciliation report through the Cumulus API', async () => {

--- a/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
@@ -544,7 +544,7 @@ describe('The S3 Ingest Granules workflow', () => {
         'GET DATA',
         'VIEW RELATED INFORMATION',
         'VIEW RELATED INFORMATION',
-        'GET DATA',
+        'USE SERVICE API',
         'GET RELATED VISUALIZATION',
       ];
       const cmrUrls = resource.map((r) => r.URL);

--- a/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
@@ -553,7 +553,7 @@ describe('The S3 Ingest Granules workflow', () => {
       expect(cmrUrls).toContain(s3BrowseImageUrl);
       expect(cmrUrls).toContain(s3CredsUrl);
       expect(cmrUrls).toContain(opendapFilePath);
-      expect(expectedTypes).toEqual(resource.map((r) => r.Type));
+      expect(expectedTypes.sort()).toEqual(resource.map((r) => r.Type).sort());
     });
 
     it('includes the Earthdata login ID for requests to protected science files', async () => {

--- a/example/spec/parallel/ingestGranule/IngestUMMGSuccessSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestUMMGSuccessSpec.js
@@ -358,7 +358,7 @@ describe('The S3 Ingest Granules workflow configured to ingest UMM-G', () => {
       const viewRelatedInfoResource = onlineResources.filter((resource) => resource.Type === 'VIEW RELATED INFORMATION');
       const s3CredsUrl = resolve(process.env.DISTRIBUTION_ENDPOINT, 's3credentials');
 
-      const ExpectedResources = ['GET DATA', 'GET DATA', 'GET DATA', 'GET RELATED VISUALIZATION',
+      const ExpectedResources = ['GET DATA', 'GET DATA', 'GET RELATED VISUALIZATION', 'USE SERVICE API',
         'EXTENDED METADATA', 'VIEW RELATED INFORMATION'].sort();
       expect(viewRelatedInfoResource.map(get('URL'))).toContain(s3CredsUrl);
       expect(onlineResources.map(get('Type')).sort()).toEqual(ExpectedResources);

--- a/tasks/hyrax-metadata-updates/README.md
+++ b/tasks/hyrax-metadata-updates/README.md
@@ -17,7 +17,7 @@ This url will be added to the Urls portion of the granule metadata as follows,
     ...
     {
         "URL": "https://opendap.earthdata.nasa.gov/providers/GHRC_CLOUD/datasets/ACES CONTINUOUS DATA V1/granules/aces1cont_2002.191_v2.50.nc",
-        "Type": "GET DATA",
+        "Type": "USE SERVICE API",
         "Subtype": "OPENDAP DATA",
         "Description": "OPeNDAP request URL"
     }

--- a/tasks/hyrax-metadata-updates/index.js
+++ b/tasks/hyrax-metadata-updates/index.js
@@ -166,7 +166,7 @@ function addHyraxUrlToUmmG(metadata, hyraxUrl) {
   }
   const url = {
     URL: hyraxUrl,
-    Type: 'GET DATA',
+    Type: 'USE SERVICE API',
     Subtype: 'OPENDAP DATA',
     Description: 'OPeNDAP request URL',
   };

--- a/tasks/hyrax-metadata-updates/tests/data/umm-gout-no-related-urls.json
+++ b/tasks/hyrax-metadata-updates/tests/data/umm-gout-no-related-urls.json
@@ -54,7 +54,7 @@
     "RelatedUrls": [
         {
             "URL": "https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/GLDAS%20Catchment%20Land%20Surface%20Model%20L4%20daily%200.25%20x%200.25%20degree%20V2.0%20(GLDAS_CLSM025_D)%20at%20GES%20DISC/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4",
-            "Type": "GET DATA",
+            "Type": "USE SERVICE API",
             "Subtype": "OPENDAP DATA",
             "Description": "OPeNDAP request URL"
         }

--- a/tasks/hyrax-metadata-updates/tests/data/umm-gout.json
+++ b/tasks/hyrax-metadata-updates/tests/data/umm-gout.json
@@ -6,7 +6,7 @@
         },
         {
             "URL": "https://opendap.earthdata.nasa.gov/providers/GES_DISC/collections/Sentinel-6A%20MF%2FJason-CS%20L2%20Advanced%20Microwave%20Radiometer%20(AMR-C)%20NRT%20Geophysical%20Parameters/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4",
-            "Type": "GET DATA",
+            "Type": "USE SERVICE API",
             "Subtype": "OPENDAP DATA",
             "Description": "OPeNDAP request URL"
         }


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-XX: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-XXX)

## Changes

* CMR has changed opendap url to have type USE SERVICE API instead of GET DATA in umm_json granule metadata. So update tasks `hyrax-metadata-updates`,  tests and test data accordingly.

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

