### PR TITLE
Change move-granules output to use evaluated urlPath rather than the template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - **CUMULUS-2351**
   - Inventory report no longer includes the File/Granule relation object in the okCountByGranules key of a report. The information is only included when a 'Granule Not Found' report is run.
 
+- Updated the output of the `move-granules` task so that `payload.granules.files.url_path`
+  values show the evaluated path, rather than the Collection's top-level `url_path`,
+  which may be an un-evaluted template string.
+
 ## [v5.0.1] 2021-01-27
 
 ### Changed

--- a/tasks/move-granules/index.js
+++ b/tasks/move-granules/index.js
@@ -108,7 +108,7 @@ async function updateGranuleMetadata(granulesObject, collection, cmrFiles, bucke
           bucket: bucketName,
           filepath,
           filename: `s3://${s3Join(bucketName, filepath)}`,
-          url_path: URLPathTemplate,
+          url_path: urlPath,
         },
       });
     });


### PR DESCRIPTION
**Summary:** in the output JSON, make `payload.granules.files.url_path` values show the evaluated path for that file, rather than using the Collection's top-level `url_path`, which may be an unevaluted template string.

Relates to [NDCUM-422: Implement new paradigm for collection sub-prefixes](https://bugs.earthdata.nasa.gov/browse/NDCUM-422). 

Updating our collection configuration with:
```
"url_path": "ATLAS/ATL03/003/{substring(file.name, 6, 10)}/{substring(file.name, 10,12)}/{substring(file.name, 12,14)}"
```
produced `payload.granules.files` like this in the output JSON:

```
{
  "name": "ATL03_20181016101230_02720101_003_01.h5",
  "path": "file-staging/ATL03/003/ff326bc3-4aff-464f-9932-b27771c2bcaf",
  "url_path": "ATLAS/ATL03/003/{substring(file.name, 6, 10)}/{substring(file.name, 10,12)}/{substring(file.name, 12,14)}",
  "bucket": "nsidc-cumulus-int-protected",
  "size": 2280316092,
  "checksumType": "SHA256",
  "checksum": "b5222fa90901aaa4d318bbe00293b2a57b911d8882369338b1b7f1ff1b447ac5",
  "type": "data",
  "filename": "s3://nsidc-cumulus-int-protected/ATLAS/ATL03/003/2018/10/16/ATL03_20181016101230_02720101_003_01.h5",
  "filepath": "ATLAS/ATL03/003/2018/10/16/ATL03_20181016101230_02720101_003_01.h5"
}
```

With the code change on this PR, the `payload.granules.files` in the output look like this:

```
{
  "name": "ATL03_20181016185101_02770108_003_01.h5",
  "path": "file-staging/ATL03/003/66779eb4-493a-41ee-b61c-883a1d0a6c98",
  "url_path": "ATLAS/ATL03/003/2018/10/16",
  "bucket": "nsidc-cumulus-int-protected",
  "size": 489301504,
  "checksumType": "SHA256",
  "checksum": "22033c8bc53a2338e07d25b71c8765ead43f3aa8c4d919d4253089ef43b71926",
  "type": "data",
  "filename": "s3://nsidc-cumulus-int-protected/ATLAS/ATL03/003/2018/10/16/ATL03_20181016185101_02770108_003_01.h5",
  "filepath": "ATLAS/ATL03/003/2018/10/16/ATL03_20181016185101_02770108_003_01.h5"
}
```

The files moved by the `move-granules` step did end up in the correct locations, however, `.dmrpp` files generated by later steps ([ghrcdaac/dmrpp-generator](https://github.com/ghrcdaac/dmrpp-generator), [ghrcdaac/dmrpp-file-generator-docker](https://github.com/ghrcdaac/dmrpp-file-generator-docker)) did end up in folders with `{substring(file.name, 6, 10)}` in their names. Fixing that requires some code changes to the dmrpp repos in addition to changing the JSON output here.

## Changes

* `move-granules`'s function `updateGranuleMetadata` now uses `urlPath` instead of `URLPathTemplate` for the object that is added to `updatedFiles`

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Adhoc testing
- [ ] Integration tests

