### PR TITLE
Improve spelling in documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ This documentation includes both guidelines, examples, and source code docs. It 
 * Cumulus Developer Documentation - [here](https://github.com/nasa/cumulus) - READMEs throughout the main repository.
 * Data Cookbooks - [here](data-cookbooks/about-cookbooks)
 
-### Auxillary Guides
+### Auxiliary Guides
 
 * Integrator Guide - [here](integrator-guide/about-int-guide)
 * Operator Docs - [here](operator-docs/about-operator-docs)

--- a/docs/data-cookbooks/choice-states.md
+++ b/docs/data-cookbooks/choice-states.md
@@ -6,7 +6,7 @@ hide_title: false
 
 Cumulus supports AWS Step Function [`Choice`](https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-choice-state.html) states. A `Choice` state enables branching logic in Cumulus workflows.
 
-`Choice` state definitions include a list of `Choice Rule`s. Each `Choice Rule` defines a logical operation which compares an input value against a value using a comparison operator. For available comparision operators, review [the AWS docs](https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-choice-state.html).
+`Choice` state definitions include a list of `Choice Rule`s. Each `Choice Rule` defines a logical operation which compares an input value against a value using a comparison operator. For available comparison operators, review [the AWS docs](https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-choice-state.html).
 
 If the comparison evaluates to `true`, the `Next` state is followed.
 

--- a/docs/data-cookbooks/cnm-workflow.md
+++ b/docs/data-cookbooks/cnm-workflow.md
@@ -449,7 +449,7 @@ This Lambda will take the files listed in the payload and move them to `s3://{de
 
 Assuming a successful execution of the workflow, this task will recover the `meta.cnm` key from the CMA output, and add a "SUCCESS" record to the notification Kinesis stream.
 
-If a prior step in the the workflow has failed, this will add a "FAILURE" record to the stream instead.
+If a prior step in the workflow has failed, this will add a "FAILURE" record to the stream instead.
 
 The data written to the `response-endpoint` should adhere to the [Response Message Fields](https://github.com/podaac/cloud-notification-message-schema#cumulus-sns-schema) schema.
 

--- a/docs/docs-how-to.md
+++ b/docs/docs-how-to.md
@@ -31,7 +31,7 @@ Adding a new page should be as simple as writing some documentation in markdown,
 
 ```markdown
 ---
-id: doc-unique-id    # unique id for this document. This must be unique accross ALL documentation under docs/
+id: doc-unique-id    # unique id for this document. This must be unique across ALL documentation under docs/
 title: Title Of Doc  # Whatever title you feel like adding. This will show up as the index to this page on the sidebar.
 hide_title: false
 ---

--- a/docs/features/logging-esdis-metrics.md
+++ b/docs/features/logging-esdis-metrics.md
@@ -28,7 +28,7 @@ The ESDIS metrics pipeline expects a log message to be a JSON string representat
 
 A log message can contain the following properties:
 
-- `executions`: The AWS Step Function exection name in which this task is executing, if any
+- `executions`: The AWS Step Function execution name in which this task is executing, if any
 - `granules`: A JSON string of the array of granule IDs being processed by this code, if any
 - `level`: A string identifier for the type of message being logged. Possible values:
   - `debug`

--- a/docs/operator-docs/trigger-workflow.md
+++ b/docs/operator-docs/trigger-workflow.md
@@ -89,7 +89,7 @@ The configuration below will store hdf files in the protected bucket and jpg fil
 
 [Create a rule](../configuration/data-management-types#create-a-rule) to trigger the workflow to discover your granule data and ingest your granule.
 
-Select the previously created provider and collection. See the [Cumulus Discover Granules workflow](https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/discover_granules_workflow.tf) for a workflow example of using Cumulus tasks to disover and queue data for ingest.
+Select the previously created provider and collection. See the [Cumulus Discover Granules workflow](https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/discover_granules_workflow.tf) for a workflow example of using Cumulus tasks to discover and queue data for ingest.
 
 In the rule meta, set the `provider_path` to `test-data`, so the `test-data` folder will be used to discover new granules.
 


### PR DESCRIPTION
**Summary:** This patch fixes the spelling of various words and removes some duplicate words within the docs directory.

I believe this change is small enough not to warrant an issue or an entry in the CHANGELOG. Please let me know if either assumption is incorrect. Thank you!