### PR TITLE
Changes waitForAsyncOperationStatus to fail if status not reached.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - `<prefix>-lambda-api-gateway` IAM role used by API Gateway Lambda now supports accessing all buckets defined in your `buckets` variable except "internal" buckets
 - **CUMULUS-2355**
   - Added logic to disable `/s3Credentials` endpoint based upon value for environment variable `DISABLE_S3_CREDENTIALS`. If set to "true",  the endpoint will not dispense S3 credentials and instead return a message indicating that the endpoint has been disabled.
+- **CUMULUS-2420**
+  - Updated test function `waitForAsyncOperationStatus` to take a retryObject and use exponential backoff.  Increased the total test duration for both AsycOperation specs and the ReconciliationReports tests.
 
 ### Removed
 

--- a/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
+++ b/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
@@ -430,7 +430,10 @@ describe('When there are granule differences and granule reconciliation is run',
           id: asyncOperationId,
           status: 'SUCCEEDED',
           stackName: config.stackName,
-          retries: 100,
+          retryOptions: {
+            retries: 70,
+            factor: 1.041,
+          },
         });
       } catch (error) {
         fail(error);
@@ -574,7 +577,10 @@ describe('When there are granule differences and granule reconciliation is run',
           id: asyncOperationId,
           status: 'SUCCEEDED',
           stackName: config.stackName,
-          retries: 100,
+          retryOptions: {
+            retries: 70,
+            factor: 1.041,
+          },
         });
       } catch (error) {
         fail(error);
@@ -656,7 +662,10 @@ describe('When there are granule differences and granule reconciliation is run',
           id: asyncOperationId,
           status: 'SUCCEEDED',
           stackName: config.stackName,
-          retries: 100,
+          retryOptions: {
+            retries: 70,
+            factor: 1.041,
+          },
         });
       } catch (error) {
         fail(error);

--- a/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
+++ b/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
@@ -424,13 +424,18 @@ describe('When there are granule differences and granule reconciliation is run',
     });
 
     it('generates reconciliation report through the Cumulus API', async () => {
-      const asyncOperation = await waitForAsyncOperationStatus({
-        id: asyncOperationId,
-        status: 'SUCCEEDED',
-        stackName: config.stackName,
-        retries: 100,
-      });
-
+      let asyncOperation;
+      try {
+        asyncOperation = await waitForAsyncOperationStatus({
+          id: asyncOperationId,
+          status: 'SUCCEEDED',
+          stackName: config.stackName,
+          retries: 100,
+        });
+      } catch (error) {
+        fail(error);
+      }
+      expect(asyncOperation.status).toEqual('SUCCEEDED');
       reportRecord = JSON.parse(asyncOperation.output);
     });
 
@@ -563,13 +568,17 @@ describe('When there are granule differences and granule reconciliation is run',
     });
 
     it('generates reconciliation report through the Cumulus API', async () => {
-      const asyncOperation = await waitForAsyncOperationStatus({
-        id: asyncOperationId,
-        status: 'SUCCEEDED',
-        stackName: config.stackName,
-        retries: 100,
-      });
-
+      let asyncOperation;
+      try {
+        asyncOperation = await waitForAsyncOperationStatus({
+          id: asyncOperationId,
+          status: 'SUCCEEDED',
+          stackName: config.stackName,
+          retries: 100,
+        });
+      } catch (error) {
+        fail(error);
+      }
       reportRecord = JSON.parse(asyncOperation.output);
     });
 
@@ -641,12 +650,17 @@ describe('When there are granule differences and granule reconciliation is run',
     });
 
     it('generates reconciliation report through the Cumulus API', async () => {
-      const asyncOperation = await waitForAsyncOperationStatus({
-        id: asyncOperationId,
-        status: 'SUCCEEDED',
-        stackName: config.stackName,
-        retries: 100,
-      });
+      let asyncOperation;
+      try {
+        asyncOperation = await waitForAsyncOperationStatus({
+          id: asyncOperationId,
+          status: 'SUCCEEDED',
+          stackName: config.stackName,
+          retries: 100,
+        });
+      } catch (error) {
+        fail(error);
+      }
 
       reportRecord = JSON.parse(asyncOperation.output);
     });

--- a/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
@@ -819,7 +819,10 @@ describe('The S3 Ingest Granules workflow', () => {
             id: asyncOperationId,
             status: 'SUCCEEDED',
             stackName: config.stackName,
-            retries: 100,
+            retryOptions: {
+              retries: 70,
+              factor: 1.041,
+            },
           });
 
           const reingestOutput = JSON.parse(asyncOperation.output);

--- a/packages/integration-tests/index.js
+++ b/packages/integration-tests/index.js
@@ -71,7 +71,7 @@ async function waitForAsyncOperationStatus({
   id,
   status,
   stackName,
-  retries = 10,
+  retries = 20,
 }) {
   const response = await asyncOperationsApi.getAsyncOperation({
     prefix: stackName,

--- a/packages/integration-tests/index.js
+++ b/packages/integration-tests/index.js
@@ -81,7 +81,7 @@ async function waitForAsyncOperationStatus({
   const operation = JSON.parse(response.body);
 
   if (operation.status === status) return operation;
-  if (retries <= 0) throw new Error(`Async Operation status ${operation.status} Never Reached desired state ${status}.`);
+  if (retries <= 0) throw new Error(`AsyncOperationStatus on ${JSON.stringify(operation)} Never Reached desired state ${status}.`);
 
   await delay(2000);
   return waitForAsyncOperationStatus({

--- a/packages/integration-tests/index.js
+++ b/packages/integration-tests/index.js
@@ -80,7 +80,8 @@ async function waitForAsyncOperationStatus({
 
   const operation = JSON.parse(response.body);
 
-  if (operation.status === status || retries <= 0) return operation;
+  if (operation.status === status) return operation;
+  if (retries <= 0) throw new Error(`Async Operation status ${operation.status} Never Reached desired state ${status}.`);
 
   await delay(2000);
   return waitForAsyncOperationStatus({


### PR DESCRIPTION
**Summary:** Increases test times for AsyncOperation and ReconciliationReports


Addresses [CUMULUS-2420 : Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2420)

## Changes

* waitForAsyncOperationStatus now throws an Error when the desired status is not reached during the specified wait period.
   - Before this change, this routine just returned the state of operation after the retries were expired. This led to lots of errors that were `Error: Expected 'RUNNING' to be 'SUCCESS'.`
* Changed the default values for waitForAsyncOperationStatus retries.
   - Originally this was set as 10 retries sampling every 2 seconds (20 sec total). Inspection shows that this isn't enough time for the AsyncOperation tests to complete every time. The defaults have been changed to use an exponential backoff and 15 retries.  This leads to 15 attempts over 60 Seconds.
   - This increase should help the tests pass. If they fail by not reaching the correct status, we get a better error message and we can tune the defaults.
* Changed the retry values in CreateReconciliationReportSpec and IngestGranuleSuccessSpec from retries: 100 (100 retries in 200 seconds [3.3 min] with no backoff) to use an exponential backoff and 70 retries which results in 70 attempts in ~6.3 min. This duration increase should fix the types of recReport errors that were occurring with errors like `Expected 'RUNNING' to be 'SUCCESS'.`
* Wraps the `waitForAsyncOperationStatus` in try/catch to fail with an explicit and more descriptive error.

## PR Checklist

- [X] Update CHANGELOG
- [n/a] Unit tests
- [X] Adhoc testing
- [X] Integration tests

