### PR TITLE
Fix Reconcilation test scroll id timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     AsycOperation specs and the ReconciliationReports tests.
   - Updated the default scroll duration used in ESScrollSearch and part of the
     reconcilation report functions as a result of testing and seeing timeouts
-    at it's current value of 2min.
+    at its current value of 2min.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Updated test function `waitForAsyncOperationStatus` to take a retryObject
     and use exponential backoff.  Increased the total test duration for both
     AsycOperation specs and the ReconciliationReports tests.
+  - Updated the default scroll duration used in ESScrollSearch and part of the
+    reconcilation report functions as a result of testing and seeing timeouts
+    at it's current value of 2min.
 
 ### Fixed
 

--- a/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
+++ b/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
@@ -440,6 +440,8 @@ describe('When there are granule differences and granule reconciliation is run',
       }
       expect(asyncOperation.status).toEqual('SUCCEEDED');
       reportRecord = JSON.parse(asyncOperation.output);
+      expect(reportRecord.status).toEqual('Generated');
+      console.log(`report Record: ${JSON.stringify(reportRecord)}`);
     });
 
     it('fetches a reconciliation report through the Cumulus API', async () => {

--- a/packages/api/es/esDefaults.js
+++ b/packages/api/es/esDefaults.js
@@ -1,5 +1,5 @@
 const defaultESScrollSize = 1000;
-const defaultESScrollDuration = '2m';
+const defaultESScrollDuration = '6m';
 
 module.exports = {
   defaultESScrollSize,


### PR DESCRIPTION
**Summary** increased the default scroll duration to 6min for esScrollSearch

After updating the waitForAsyncOperationStatus in my last PR I started printing the reportRecord from the AsyncOperation whether it passed or failed.

I began to see a number of unexpected errors from the reconcilationReport. Looking like this:

```
          "error": {
            "Error": "search_phase_execution_exception",
            "Cause": "{\"stack\":\"ResponseError: search_phase_execution_exception\\n    at IncomingMessage.response.on (/home/task/lambda-function/webpack:/node_modules/@elastic/elasticsearch/lib/Transport.js:289:1)\\n    at IncomingMessage.emit (events.js:203:15)\\n    at IncomingMessage.EventEmitter.emit (domain.js:448:20)\\n    at endReadableNT (_stream_readable.js:1145:12)\\n    at process._tickCallback (internal/process/next_tick.js:63:19)\",\"message\":\"search_phase_execution_exception\",\"name\":\"ResponseError\",\"meta\":{\"meta\":{\"name\":\"elasticsearch-js\"}}}"
          },
```

That's not a lot of information, but it's because log.error(ES-Error) gets eaten for some reason, I can't find the ticket for that, but it exists, there is an extra log added to the cloudwatch logs which shows that there is a response error. `"name": "ResponseError",` with a number of `root_cause` objects like `{ "type": "search_context_missing_exception", "reason": "No search context found for id [1611]"}` that are all happening on a request to `GET`  `"/_search/scroll/DnF1ZXJ.....`  so some googling leads me to believe that we are losing the search context by exceeding the 2min scroll duration.  

In order to prove this I added logging to my dev stack's esScrollSearch and verified that while generally the elapsed duration for a reconcilationReport scroll search doesn't exceed 1.5 min, they do occasionally exceed 2 min. I belive this causes the errors we often see.

I increased the scoll duration default to 6 min and ran our tests 170 times without any errors.


Addresses [CUMULUS-2420: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2420)

## Changes

* increase Scroll Duration
* Added expectation of report record status to be 'Generated' to help show more clearly.

## PR Checklist

- [X] Update CHANGELOG
- [n/a] Unit tests
- [X][X][X][X][X] Adhoc testing
- [X] Integration tests
