### PR TITLE
Remove dependence on process.env.GRANULES in logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Bulk granule operations endpoint now supports setting a custom queue for scheduling workflows via the `queueUrl` property in the request body. If provided, this value should be the full URL for an SQS queue.
 
+### Fixed
+
+- **CUMULUS-2281**
+  - Changed discover-granules task to write discovered granules directly to
+    logger, instead of via environment variable. This fixes a problem where a
+    large number of found granules prevents this lambda from running as an
+    activity with an E2BIG error.
+
 ## [v7.2.0] 2021-03-23
 
 ### Added

--- a/tasks/discover-granules/index.js
+++ b/tasks/discover-granules/index.js
@@ -10,13 +10,14 @@ const granules = require('@cumulus/api-client/granules');
 const { runCumulusTask } = require('@cumulus/cumulus-message-adapter-js');
 const { buildProviderClient } = require('@cumulus/ingest/providerClientUtils');
 
-const logger = () => new Logger({
+const logger = (logOptions) => new Logger({
   executions: process.env.EXECUTIONS,
   granules: process.env.GRANULES ? JSON.parse(process.env.GRANULES) : undefined,
   parentArn: process.env.PARENTARN,
-  sender: process.env.SENDER,
+  sender: process.env.SENDER || '@cumulus/discover-granules',
   stackName: process.env.STACKNAME,
   version: process.env.TASKVERSION,
+  ...logOptions,
 });
 
 /**
@@ -288,12 +289,7 @@ const discoverGranules = async ({ config }) => {
 
   const discoveredGranules = map(filesByGranuleId, buildGranule(config));
 
-  // Set the environment variable for the logger
-  if (discoveredGranules) {
-    process.env.GRANULES = JSON.stringify(discoveredGranules.map((g) => g.granuleId));
-  }
-
-  logger().info(`Discovered ${discoveredGranules.length} granules.`);
+  logger({ granules: discoveredGranules.map((g) => g.granuleId) }).info(`Discovered ${discoveredGranules.length} granules.`);
   return { granules: discoveredGranules };
 };
 


### PR DESCRIPTION
When the list of granules grows very large, the process.env.GRANULES cannot
handle the string, and the activity gets stuck in a bad state.

**Summary:**

Pass granule list directly to Logger constructor and bypass storing it in an environment variable. 


Addresses [CUMULUS-2281: Discover granules activity error out unless manually restarting the service.](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2281)

## Changes

* Allow passing in options to logs

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ XXXXXXXXXX ] Adhoc testing
- [ ] Integration tests

