### PR TITLE
[CUMULUS-2186]  Fix race condition in test teardown

### DIFF
--- a/lambdas/data-migration1/tests/test-index.js
+++ b/lambdas/data-migration1/tests/test-index.js
@@ -177,8 +177,7 @@ test('handler migrates async operations, collections, providers, rules', async (
     rulesModel.delete(fakeRule),
     providersModel.delete(fakeProvider),
     asyncOperationsModel.delete({ id: fakeAsyncOperation.id }),
-    collectionsModel.delete(fakeCollection),
-  ]));
+  ]).then(() => collectionsModel.delete(fakeCollection)));
 
   const call = await handler({});
   const expected = `


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2186: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2186)

## Changes

* Fixes race condition that results in this error:
```
  index › handler migrates async operations, collections, providers, rules
  AssociatedRulesError: Cannot delete a collection that has associated rules
```
because it tries `collectionsModel.delete()` before `rulesModel.delete()`. This ensures that the collection is deleted last.

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

