### PR TITLE
CUMULUS-2444: Disallow out-of-order execution writes

### DIFF
--- a/packages/api/models/executions.js
+++ b/packages/api/models/executions.js
@@ -169,7 +169,7 @@ class Execution extends Manager {
 
     // Do not allow out-of-order updates to set a completed or failed execution back to running
     if (executionItem.status === 'running') {
-      updateParams.ConditionExpression = '(attribute_not_exists(status) or :status = #status)';
+      updateParams.ConditionExpression = '(attribute_not_exists(#status) or :status = #status)';
     }
 
     try {

--- a/packages/api/models/executions.js
+++ b/packages/api/models/executions.js
@@ -2,7 +2,6 @@
 
 const pLimit = require('p-limit');
 
-const log = require('@cumulus/common/log');
 const {
   getMessageAsyncOperationId,
 } = require('@cumulus/message/AsyncOperations');
@@ -167,20 +166,7 @@ class Execution extends Manager {
       mutableFieldNames,
     });
 
-    // Do not allow out-of-order updates to set a completed or failed execution back to running
-    if (executionItem.status === 'running') {
-      updateParams.ConditionExpression = '(attribute_not_exists(#status) or :status = #status)';
-    }
-
-    try {
-      return await this.dynamodbDocClient.update(updateParams).promise();
-    } catch (error) {
-      if (error.name && error.name.includes('ConditionalCheckFailedException')) {
-        log.info(`Did not process delayed event for execution: ${executionItem.arn}`);
-        return undefined;
-      }
-      throw error;
-    }
+    await this.dynamodbDocClient.update(updateParams).promise();
   }
 }
 

--- a/packages/api/models/executions.js
+++ b/packages/api/models/executions.js
@@ -2,6 +2,7 @@
 
 const pLimit = require('p-limit');
 
+const log = require('@cumulus/common/log');
 const {
   getMessageAsyncOperationId,
 } = require('@cumulus/message/AsyncOperations');
@@ -166,7 +167,20 @@ class Execution extends Manager {
       mutableFieldNames,
     });
 
-    await this.dynamodbDocClient.update(updateParams).promise();
+    // Do not allow out-of-order updates to set a completed or failed execution back to running
+    if (executionItem.status === 'running') {
+      updateParams.ConditionExpression = '(attribute_not_exists(status) or :status = #status)';
+    }
+
+    try {
+      return await this.dynamodbDocClient.update(updateParams).promise();
+    } catch (error) {
+      if (error.name && error.name.includes('ConditionalCheckFailedException')) {
+        log.info(`Did not process delayed event for execution: ${executionItem.arn}`);
+        return undefined;
+      }
+      throw error;
+    }
   }
 }
 

--- a/packages/api/tests/lambdas/sf-event-sqs-to-db-records/test-index.js
+++ b/packages/api/tests/lambdas/sf-event-sqs-to-db-records/test-index.js
@@ -418,16 +418,13 @@ test('Lambda sends message to DLQ when writeRecords() throws an error', async (t
 test('writeRecords() discards an out of order message that is older than an existing message without error or write', async (t) => {
   const {
     cumulusMessage,
-    executionModel,
     granuleModel,
     pdrModel,
     knex,
-    executionArn,
     pdrName,
     granuleId,
   } = t.context;
 
-  const executionPgModel = new ExecutionPgModel();
   const pdrPgModel = new PdrPgModel();
   const granulePgModel = new GranulePgModel();
 
@@ -440,14 +437,9 @@ test('writeRecords() discards an out of order message that is older than an exis
   cumulusMessage.cumulus_meta.workflow_start_time = olderTimestamp;
   await t.notThrowsAsync(writeRecords({ cumulusMessage, knex, granuleModel }));
 
-  t.is(timestamp, (await executionModel.get({ arn: executionArn })).createdAt);
   t.is(timestamp, (await granuleModel.get({ granuleId })).createdAt);
   t.is(timestamp, (await pdrModel.get({ pdrName })).createdAt);
 
-  t.deepEqual(
-    new Date(timestamp),
-    (await executionPgModel.get(knex, { arn: executionArn })).created_at
-  );
   t.deepEqual(
     new Date(timestamp),
     (await granulePgModel.get(knex, { granule_id: granuleId })).created_at


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2444: disallow out-of-order updates that set a completed or failed execution back to running](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2444)

## Changes

* Disallow out-of-order execution writes.

## PR Checklist

- [ ] Update CHANGELOG
- [x] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

