### PR TITLE
[CUMULUS-2446] Remove schema validation on collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     - Add write-db-dlq-records-to-s3 lambda.
     - Add terraform config to automatically write db records DLQ messages to an s3 archive on the system bucket.
     - Add unit tests and a component spec test for the above.
+  - **CUMULUS-2446**
+    - Remove schema validation check against DynamoDB table for collections.
 
 ## [v7.1.0] 2021-03-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,7 +131,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     - Add terraform config to automatically write db records DLQ messages to an s3 archive on the system bucket.
     - Add unit tests and a component spec test for the above.
   - **CUMULUS-2446**
-    - Remove schema validation check against DynamoDB table for collections.
+    - Remove schema validation check against DynamoDB table for collections when migrating records from DynamoDB to core PostgreSQL database.
 
 ## [v7.1.0] 2021-03-12
 

--- a/lambdas/data-migration1/src/collections.ts
+++ b/lambdas/data-migration1/src/collections.ts
@@ -9,9 +9,6 @@ import { RecordAlreadyMigrated } from '@cumulus/errors';
 
 import { MigrationSummary } from './types';
 
-const Manager = require('@cumulus/api/models/base');
-const schemas = require('@cumulus/api/models/schemas');
-
 const logger = new Logger({ sender: '@cumulus/data-migration/collections' });
 
 /**
@@ -28,9 +25,6 @@ export const migrateCollectionRecord = async (
   dynamoRecord: AWS.DynamoDB.DocumentClient.AttributeMap,
   knex: Knex
 ): Promise<void> => {
-  // Use API model schema to validate record before processing
-  Manager.recordIsValid(dynamoRecord, schemas.collection);
-
   const existingRecord = await knex<PostgresCollectionRecord>('collections')
     .where({
       name: dynamoRecord.name,

--- a/lambdas/data-migration1/tests/test-collections.js
+++ b/lambdas/data-migration1/tests/test-collections.js
@@ -165,9 +165,8 @@ test.serial('migrateCollectionRecord handles nullable fields on source collectio
         tags: null,
         created_at: new Date(fakeCollection.createdAt),
         updated_at: new Date(fakeCollection.updatedAt),
-        // schema validation will add default values
-        duplicate_handling: 'error',
-        report_to_ems: true,
+        duplicate_handling: null,
+        report_to_ems: null,
       },
       collectionOmitList
     )


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2446: data-migration1 collection migration failure](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2446)

## Changes

* Removed `recordIsValid` check on collections.
* Ran updated lambda against PODAAC collections table where we were seeing failures. Verified that there are no failed migrations for a record collection.
## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Adhoc testing
- [ ] Integration tests

