### PR TITLE
CUMULUS-2406: Ensure that same updatedAt value is used for Dynamo/PG across all data types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
       of returning `none` when the operation did not return output.
   - **CUMULUS-2309**
     - Removed `@cumulus/api/models/granule.unpublishAndDeleteGranule` in favor of `@cumulus/api/lib/granule-remove-from-cmr.unpublishGranule` and `@cumulus/api/lib/granule-delete.deleteGranuleAndFiles`.
+
+### Added
+
 - **CUMULUS-2185** - RDS Migration Epic
   - **CUMULUS-2130**
     - Added postgres-migration-count-tool lambda/ECS task to allow for
@@ -124,6 +127,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     - Changed `Bulk operation BULK_GRANULE_DELETE` API behavior to also delete records from PostgreSQL database.
   - **CUMULUS-2367**
     - Updated `granule_cumulus_id` foreign key to granule in PostgreSQL `files` table to use a CASCADE delete, so records in the files table are automatically deleted by the database when the corresponding granule is deleted.
+  - **CUMULUS-2406**
+    - Updated parallel write logic to ensure that updatedAt/updated_at timestamps are the same in Dynamo/PG on record write for the following data types:
+      - async operations
+      - granules
+      - executions
+      - PDRs
 
 ## [v7.1.0] 2021-03-12
 

--- a/packages/api/ecs/async-operation/index.js
+++ b/packages/api/ecs/async-operation/index.js
@@ -161,7 +161,6 @@ const writeAsyncOperationToPostgres = async (params) => {
       {
         status,
         output: dbOutput,
-        // updated_at: trx.raw(`to_timestamp(${Number(updatedTime / 1000)})`),
         updated_at: new Date(Number(updatedTime)),
       }
     );

--- a/packages/api/ecs/async-operation/index.js
+++ b/packages/api/ecs/async-operation/index.js
@@ -13,7 +13,7 @@ const url = require('url');
 const Logger = require('@cumulus/logger');
 const { pipeline } = require('stream');
 const { promisify } = require('util');
-const { tableNames, getKnexClient } = require('@cumulus/db');
+const { getKnexClient, AsyncOperationPgModel } = require('@cumulus/db');
 const { dynamodb } = require('@cumulus/aws-client/services');
 
 const logger = new Logger({ sender: 'ecs/async-operation' });
@@ -150,17 +150,20 @@ function buildErrorOutput(error) {
   };
 }
 
-const writeAsyncOperationToRds = async (params) => {
+const writeAsyncOperationToPostgres = async (params) => {
   const { trx, env, dbOutput, status, updatedTime } = params;
   const id = env.asyncOperationId;
-  const knex = await getKnexClient({ env });
-  return trx(tableNames.asyncOperations)
-    .where({ id })
-    .update({
-      status,
-      output: dbOutput,
-      updated_at: knex.raw(`to_timestamp(${Number(updatedTime / 1000)})`),
-    });
+  const asyncOperationPgModel = new AsyncOperationPgModel();
+  return asyncOperationPgModel
+    .update(
+      trx,
+      { id },
+      {
+        status,
+        output: dbOutput,
+        updated_at: trx.raw(`to_timestamp(${Number(updatedTime / 1000)})`),
+      }
+    );
 };
 
 const writeAsyncOperationToDynamoDb = async (params) => {
@@ -201,7 +204,7 @@ const updateAsyncOperation = async (status, output, envOverride = {}) => {
   const env = { ...process.env, ...envOverride };
   const knex = await getKnexClient({ env });
   return knex.transaction(async (trx) => {
-    await writeAsyncOperationToRds({
+    await writeAsyncOperationToPostgres({
       dbOutput,
       env,
       status,

--- a/packages/api/ecs/async-operation/index.js
+++ b/packages/api/ecs/async-operation/index.js
@@ -161,7 +161,8 @@ const writeAsyncOperationToPostgres = async (params) => {
       {
         status,
         output: dbOutput,
-        updated_at: trx.raw(`to_timestamp(${Number(updatedTime / 1000)})`),
+        // updated_at: trx.raw(`to_timestamp(${Number(updatedTime / 1000)})`),
+        updated_at: new Date(Number(updatedTime)),
       }
     );
 };

--- a/packages/api/ecs/async-operation/tests/test-index.js
+++ b/packages/api/ecs/async-operation/tests/test-index.js
@@ -123,6 +123,38 @@ test('updateAsyncOperation updates databases as expected', async (t) => {
     output: JSON.stringify(output),
     updatedAt: Number(updateTime),
   });
+});
+
+test('updateAsyncOperation updates databases with correct timestamps', async (t) => {
+  const status = 'SUCCEEDED';
+  const output = { foo: 'bar' };
+  const updateTime = (Number(Date.now())).toString();
+  await updateAsyncOperation(
+    status,
+    output,
+    {
+      asyncOperationsTable: t.context.dynamoTableName,
+      asyncOperationId: t.context.asyncOperationId,
+      ...localStackConnectionEnv,
+      PG_DATABASE: testDbName,
+      updateTime,
+    }
+  );
+
+  const asyncOperationPgRecord = await t.context.asyncOperationPgModel
+    .get(
+      t.context.testKnex,
+      {
+        id: t.context.asyncOperationId,
+      }
+    );
+  const dynamoResponse = await DynamoDb.get({
+    tableName: t.context.dynamoTableName,
+    item: { id: t.context.asyncOperationId },
+    client: t.context.dynamodbDocClient,
+    getParams: { ConsistentRead: true },
+  });
+
   t.is(asyncOperationPgRecord.updated_at.getTime(), dynamoResponse.updatedAt);
   t.is(asyncOperationPgRecord.created_at.getTime(), dynamoResponse.createdAt);
 });

--- a/packages/api/endpoints/rules.js
+++ b/packages/api/endpoints/rules.js
@@ -135,14 +135,11 @@ async function put({ params: { name }, body }, res) {
       return models.Rule.invoke(oldRule).then(() => res.send(oldRule));
     }
 
-    const fieldsToDelete = Object.keys(oldRule).filter(
-      (key) => !(key in apiRule) && key !== 'createdAt'
-    );
     const postgresRule = await translateApiRuleToPostgresRule(apiRule, dbClient);
 
     await dbClient.transaction(async (trx) => {
       await rulePgModel.upsert(trx, postgresRule);
-      newRule = await model.update(oldRule, apiRule, fieldsToDelete);
+      newRule = await model.update(oldRule, apiRule);
     });
 
     if (inTestMode()) await addToLocalES(newRule, indexRule);

--- a/packages/api/endpoints/rules.js
+++ b/packages/api/endpoints/rules.js
@@ -135,11 +135,14 @@ async function put({ params: { name }, body }, res) {
       return models.Rule.invoke(oldRule).then(() => res.send(oldRule));
     }
 
+    const fieldsToDelete = Object.keys(oldRule).filter(
+      (key) => !(key in apiRule) && key !== 'createdAt'
+    );
     const postgresRule = await translateApiRuleToPostgresRule(apiRule, dbClient);
 
     await dbClient.transaction(async (trx) => {
       await rulePgModel.upsert(trx, postgresRule);
-      newRule = await model.update(oldRule, apiRule);
+      newRule = await model.update(oldRule, apiRule, fieldsToDelete);
     });
 
     if (inTestMode()) await addToLocalES(newRule, indexRule);

--- a/packages/api/endpoints/rules.js
+++ b/packages/api/endpoints/rules.js
@@ -87,7 +87,7 @@ async function post(req, res) {
 
     await dbClient.transaction(async (trx) => {
       await rulePgModel.create(trx, postgresRule);
-      record = await model.create(apiRule, apiRule.createdAt);
+      record = await model.create(apiRule);
     });
     if (inTestMode()) await addToLocalES(record, indexRule);
     return res.send({ message: 'Record saved', record });

--- a/packages/api/lambdas/sf-event-sqs-to-db-records/write-granules.js
+++ b/packages/api/lambdas/sf-event-sqs-to-db-records/write-granules.js
@@ -202,6 +202,7 @@ const writeGranuleAndFilesViaTransaction = async ({
   pdrCumulusId,
   fileUtils = FileUtils,
   trx,
+  updatedAt,
 }) => {
   const { files = [] } = granule;
   // This is necessary to set properties like
@@ -225,6 +226,7 @@ const writeGranuleAndFilesViaTransaction = async ({
     providerCumulusId,
     pdrCumulusId,
     processingTimeInfo,
+    updatedAt,
   });
 
   const upsertQueryResult = await upsertGranuleWithExecutionJoinRecord(
@@ -295,6 +297,7 @@ const writeGranule = async ({
   providerCumulusId,
   pdrCumulusId,
   granuleModel,
+  updatedAt = Date.now(),
 }) =>
   knex.transaction(async (trx) => {
     await writeGranuleAndFilesViaTransaction({
@@ -310,6 +313,7 @@ const writeGranule = async ({
       executionCumulusId,
       pdrCumulusId,
       trx,
+      updatedAt,
     });
     return granuleModel.storeGranuleFromCumulusMessage({
       granule,
@@ -322,6 +326,7 @@ const writeGranule = async ({
       workflowStatus,
       processingTimeInfo,
       queryFields,
+      updatedAt,
     });
   });
 

--- a/packages/api/lambdas/sf-event-sqs-to-db-records/write-pdr.js
+++ b/packages/api/lambdas/sf-event-sqs-to-db-records/write-pdr.js
@@ -25,6 +25,7 @@ const generatePdrRecord = ({
   providerCumulusId,
   executionCumulusId,
   now = Date.now(),
+  updatedAt = Date.now(),
 }) => {
   const stats = getMessagePdrStats(cumulusMessage);
   const progress = getPdrPercentCompletion(stats);
@@ -41,6 +42,7 @@ const generatePdrRecord = ({
     collection_cumulus_id: collectionCumulusId,
     provider_cumulus_id: providerCumulusId,
     created_at: new Date(workflowStartTime),
+    updated_at: new Date(updatedAt),
     timestamp: new Date(timestamp),
     duration: getWorkflowDuration(workflowStartTime, timestamp),
   };
@@ -82,12 +84,14 @@ const writePdrViaTransaction = async ({
   providerCumulusId,
   executionCumulusId,
   pdrPgModel = new PdrPgModel(),
+  updatedAt,
 }) => {
   const pdrRecord = generatePdrRecord({
     cumulusMessage,
     collectionCumulusId,
     providerCumulusId,
     executionCumulusId,
+    updatedAt,
   });
 
   const queryResult = await pdrPgModel.upsert(trx, pdrRecord);
@@ -111,6 +115,7 @@ const writePdr = async ({
   executionCumulusId,
   knex,
   pdrModel = new Pdr(),
+  updatedAt = Date.now(),
 }) => {
   // If there is no PDR in the message, then there's nothing to do here, which is fine
   if (!messageHasPdr(cumulusMessage)) {
@@ -130,8 +135,9 @@ const writePdr = async ({
       providerCumulusId,
       trx,
       executionCumulusId,
+      updatedAt,
     });
-    await pdrModel.storePdrFromCumulusMessage(cumulusMessage);
+    await pdrModel.storePdrFromCumulusMessage(cumulusMessage, updatedAt);
     // eslint-disable-next-line camelcase
     return cumulus_id;
   });

--- a/packages/api/lib/testUtils.js
+++ b/packages/api/lib/testUtils.js
@@ -104,6 +104,8 @@ function fakeRuleFactoryV2(params = {}) {
       type: 'onetime',
     },
     state: 'DISABLED',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
   };
 
   return { ...rule, ...params };

--- a/packages/api/models/base.js
+++ b/packages/api/models/base.js
@@ -354,7 +354,7 @@ class Manager {
   async update(itemKeys, updates = {}, fieldsToDelete = []) {
     const actualUpdates = {
       ...updates,
-      updatedAt: Date.now(),
+      updatedAt: updates.updatedAt || Date.now(),
     };
 
     // Make sure that we don't update the key fields

--- a/packages/api/models/executions.js
+++ b/packages/api/models/executions.js
@@ -43,9 +43,10 @@ class Execution extends Manager {
    * Generate an execution record from a Cumulus message.
    *
    * @param {Object} cumulusMessage - A Cumulus message
+   * @param {number} [updatedAt] - Optional updated timestamp for record
    * @returns {Object} An execution record
    */
-  static generateRecord(cumulusMessage) {
+  static generateRecord(cumulusMessage, updatedAt = Date.now()) {
     const arn = getMessageExecutionArn(cumulusMessage);
     if (isNil(arn)) throw new Error('Unable to determine execution ARN from Cumulus message');
 
@@ -72,7 +73,7 @@ class Execution extends Manager {
       status,
       createdAt: workflowStartTime,
       timestamp: now,
-      updatedAt: now,
+      updatedAt,
       originalPayload: getMessageExecutionOriginalPayload(cumulusMessage),
       finalPayload: getMessageExecutionFinalPayload(cumulusMessage),
       duration: getWorkflowDuration(workflowStartTime, workflowStopTime),
@@ -141,7 +142,7 @@ class Execution extends Manager {
    */
   _getMutableFieldNames(record) {
     if (record.status === 'running') {
-      return ['createdAt', 'updatedAt', 'timestamp', 'originalPayload'];
+      return ['updatedAt', 'timestamp', 'originalPayload'];
     }
     return Object.keys(record);
   }
@@ -150,10 +151,11 @@ class Execution extends Manager {
    * Generate and store an execution record from a Cumulus message.
    *
    * @param {Object} cumulusMessage - Cumulus workflow message
+   * @param {number} [updatedAt] - Optional updated timestamp for record
    * @returns {Promise}
    */
-  async storeExecutionFromCumulusMessage(cumulusMessage) {
-    const executionItem = Execution.generateRecord(cumulusMessage);
+  async storeExecutionFromCumulusMessage(cumulusMessage, updatedAt) {
+    const executionItem = Execution.generateRecord(cumulusMessage, updatedAt);
 
     // TODO: Refactor this all to use model.update() to avoid having to manually call
     // schema validation and the actual client.update() method.

--- a/packages/api/models/granules.js
+++ b/packages/api/models/granules.js
@@ -375,6 +375,7 @@ class Granule extends Manager {
     workflowStatus,
     queryFields,
     processingTimeInfo = {},
+    updatedAt,
   }) {
     if (!granule.granuleId) throw new CumulusModelError(`Could not create granule record, invalid granuleId: ${granule.granuleId}`);
 
@@ -412,7 +413,7 @@ class Granule extends Manager {
       createdAt: workflowStartTime,
       published,
       timestamp,
-      updatedAt: now,
+      updatedAt: updatedAt || now,
       // Duration is also used as timeToXfer for the EMS report
       duration: getWorkflowDuration(workflowStartTime, timestamp),
       productVolume: getGranuleProductVolume(granuleFiles),
@@ -696,6 +697,7 @@ class Granule extends Manager {
     pdrName,
     workflowStatus,
     queryFields,
+    updatedAt,
   }) {
     const granuleRecord = await this.generateGranuleRecord({
       s3: awsClients.s3(),
@@ -709,6 +711,7 @@ class Granule extends Manager {
       workflowStatus,
       processingTimeInfo,
       queryFields,
+      updatedAt,
     });
     return this._validateAndStoreGranuleRecord(granuleRecord);
   }

--- a/packages/api/models/pdrs.js
+++ b/packages/api/models/pdrs.js
@@ -67,10 +67,11 @@ class Pdr extends Manager {
    * Generate a PDR record.
    *
    * @param {Object} message - A workflow execution message
+   * @param {number} [updatedAt] - Optional updated timestamp for record
    * @returns {Object|undefined} - A PDR record, or null if `message.payload.pdr` is
    *   not set
    */
-  generatePdrRecord(message) {
+  generatePdrRecord(message, updatedAt = Date.now()) {
     const pdr = getMessagePdr(message);
 
     if (!pdr) { // We got a message with no PDR (OK)
@@ -108,6 +109,7 @@ class Pdr extends Manager {
       createdAt: getMessageWorkflowStartTime(message),
       timestamp,
       duration: getWorkflowDuration(workflowStartTime, timestamp),
+      updatedAt,
     };
 
     this.constructor.recordIsValid(record, this.schema);
@@ -119,9 +121,10 @@ class Pdr extends Manager {
    * If the record already exists, only update if the execution is different (re-run case).
    *
    * @param {Object} cumulusMessage - cumulus message object
+   * @param {number} [updatedAt] - Optional updated timestamp for record
    */
-  async storePdrFromCumulusMessage(cumulusMessage) {
-    const pdrRecord = this.generatePdrRecord(cumulusMessage);
+  async storePdrFromCumulusMessage(cumulusMessage, updatedAt) {
+    const pdrRecord = this.generatePdrRecord(cumulusMessage, updatedAt);
     if (!pdrRecord) return undefined;
     const updateParams = await this.generatePdrUpdateParamsFromRecord(pdrRecord);
 

--- a/packages/api/models/rules.js
+++ b/packages/api/models/rules.js
@@ -252,6 +252,9 @@ class Rule extends Manager {
       newRuleItem.state = 'ENABLED';
     }
 
+    newRuleItem.createdAt = item.createdAt || Date.now();
+    newRuleItem.updatedAt = item.updatedAt || Date.now();
+
     // Validate rule before kicking off workflows or adding event source mappings
     await this.constructor.recordIsValid(newRuleItem, this.schema, this.removeAdditional);
 

--- a/packages/api/models/rules.js
+++ b/packages/api/models/rules.js
@@ -2,7 +2,6 @@
 
 const cloneDeep = require('lodash/cloneDeep');
 const get = require('lodash/get');
-const merge = require('lodash/merge');
 const set = require('lodash/set');
 
 const awsServices = require('@cumulus/aws-client/services');

--- a/packages/api/models/rules.js
+++ b/packages/api/models/rules.js
@@ -242,7 +242,7 @@ class Rule extends Manager {
     await invoke(process.env.invoke, payload);
   }
 
-  async create(item, createdAt) {
+  async create(item) {
     // make sure the name only has word characters
     const re = /\W/;
     if (re.test(item.name)) {
@@ -257,8 +257,8 @@ class Rule extends Manager {
       newRuleItem.state = 'ENABLED';
     }
 
-    newRuleItem.createdAt = createdAt || Date.now();
-    newRuleItem.updatedAt = Date.now();
+    // newRuleItem.createdAt = createdAt || Date.now();
+    // newRuleItem.updatedAt = Date.now();
 
     // Validate rule before kicking off workflows or adding event source mappings
     await this.constructor.recordIsValid(newRuleItem, this.schema, this.removeAdditional);

--- a/packages/api/models/rules.js
+++ b/packages/api/models/rules.js
@@ -145,12 +145,9 @@ class Rule extends Manager {
    *    rule
    * @returns {Promise} the response from database updates
    */
-  async update(original, updates, fieldsToDelete = []) {
+  async update(original, updates) {
     // Make a copy of the existing rule to preserve existing values
-    let updatedRuleItem = cloneDeep(original);
-
-    // Apply updates to updated rule item to be saved
-    merge(updatedRuleItem, updates);
+    let updatedRuleItem = cloneDeep(updates);
 
     // Validate rule before kicking off workflows or adding event source mappings
     await this.constructor.recordIsValid(updatedRuleItem, this.schema, this.removeAdditional);
@@ -160,8 +157,7 @@ class Rule extends Manager {
 
     updatedRuleItem = await this.updateRuleTrigger(updatedRuleItem, stateChanged, valueUpdated);
 
-    return super.update({ name: original.name }, updatedRuleItem,
-      fieldsToDelete);
+    return super.create(updatedRuleItem);
   }
 
   async updateRuleTrigger(ruleItem, stateChanged, valueUpdated) {
@@ -256,9 +252,6 @@ class Rule extends Manager {
     if (!item.state) {
       newRuleItem.state = 'ENABLED';
     }
-
-    // newRuleItem.createdAt = createdAt || Date.now();
-    // newRuleItem.updatedAt = Date.now();
 
     // Validate rule before kicking off workflows or adding event source mappings
     await this.constructor.recordIsValid(newRuleItem, this.schema, this.removeAdditional);

--- a/packages/api/tests/endpoints/collections/create-collection.js
+++ b/packages/api/tests/endpoints/collections/create-collection.js
@@ -9,7 +9,14 @@ const {
   recursivelyDeleteS3Bucket,
 } = require('@cumulus/aws-client/S3');
 const { randomString } = require('@cumulus/common/test-utils');
-const { getKnexClient, localStackConnectionEnv } = require('@cumulus/db');
+const {
+  localStackConnectionEnv,
+  CollectionPgModel,
+  destroyLocalTestDb,
+  generateLocalTestDb,
+} = require('@cumulus/db');
+
+const { migrationDir } = require('../../../../../lambdas/db-migration');
 
 const AccessToken = require('../../../models/access-tokens');
 const Collection = require('../../../models/collections');
@@ -45,8 +52,10 @@ let collectionModel;
 let rulesModel;
 let publishStub;
 
+const testDbName = randomString(12);
+
 test.before(async (t) => {
-  process.env = { ...process.env, ...localStackConnectionEnv };
+  process.env = { ...process.env, ...localStackConnectionEnv, PG_DATABASE: testDbName };
 
   const esAlias = randomString();
   process.env.ES_INDEX = esAlias;
@@ -74,16 +83,24 @@ test.before(async (t) => {
     promise: async () => true,
   });
 
-  t.context.dbClient = await getKnexClient({ env: localStackConnectionEnv });
+  const { knex, knexAdmin } = await generateLocalTestDb(testDbName, migrationDir);
+  t.context.testKnex = knex;
+  t.context.testKnexAdmin = knexAdmin;
+  t.context.collectionPgModel = new CollectionPgModel();
 });
 
-test.after.always(async () => {
+test.after.always(async (t) => {
   await accessTokenModel.deleteTable();
   await collectionModel.deleteTable();
   await rulesModel.deleteTable();
   await recursivelyDeleteS3Bucket(process.env.system_bucket);
   await esClient.indices.delete({ index: esIndex });
   publishStub.restore();
+  await destroyLocalTestDb({
+    knex: t.context.testKnex,
+    knexAdmin: t.context.testKnexAdmin,
+    testDbName,
+  });
 });
 
 test('CUMULUS-911 POST without an Authorization header returns an Authorization Missing response', async (t) => {
@@ -138,16 +155,22 @@ test('POST creates a new collection', async (t) => {
   t.is(fetchedDynamoRecord.name, newCollection.name);
   t.is(fetchedDynamoRecord.version, newCollection.version);
 
-  const fetchedDbRecord = await t.context.dbClient.first()
-    .from('collections')
-    .where({
+  const collectionPgRecord = await t.context.collectionPgModel.get(
+    t.context.testKnex,
+    {
       name: newCollection.name,
       version: newCollection.version,
-    });
+    }
+  );
 
-  t.not(fetchedDbRecord, undefined);
-  t.is(fetchedDbRecord.created_at.getTime(), fetchedDynamoRecord.createdAt);
-  t.is(fetchedDbRecord.updated_at.getTime(), fetchedDynamoRecord.updatedAt);
+  t.not(collectionPgRecord, undefined);
+
+  t.true(fetchedDynamoRecord.createdAt > newCollection.createdAt);
+  t.true(fetchedDynamoRecord.updatedAt > newCollection.updatedAt);
+
+  // PG and Dynamo records have the same timestamps
+  t.is(collectionPgRecord.created_at.getTime(), fetchedDynamoRecord.createdAt);
+  t.is(collectionPgRecord.updated_at.getTime(), fetchedDynamoRecord.updatedAt);
 });
 
 test('POST without a name returns a 400 error', async (t) => {
@@ -323,8 +346,6 @@ test('POST with non-matching granuleId regex returns 400 bad request response', 
 });
 
 test('post() does not write to the database if writing to Dynamo fails', async (t) => {
-  const { dbClient } = t.context;
-
   const collection = fakeCollectionFactory();
 
   const fakeCollectionsModel = {
@@ -337,7 +358,7 @@ test('post() does not write to the database if writing to Dynamo fails', async (
   const expressRequest = {
     body: collection,
     testContext: {
-      dbClient,
+      dbClient: t.context.testKnex,
       collectionsModel: fakeCollectionsModel,
     },
   };
@@ -348,12 +369,14 @@ test('post() does not write to the database if writing to Dynamo fails', async (
 
   t.true(response.boom.badImplementation.calledWithMatch('something bad'));
 
-  const dbRecords = await dbClient.select('name', 'version')
-    .from('collections')
-    .where({
-      name: collection.name,
-      version: collection.version,
-    });
+  const dbRecords = await t.context.collectionPgModel
+    .search(
+      t.context.testKnex,
+      {
+        name: collection.name,
+        version: collection.version,
+      }
+    );
 
   t.is(dbRecords.length, 0);
 });

--- a/packages/api/tests/endpoints/collections/update-collection.js
+++ b/packages/api/tests/endpoints/collections/update-collection.js
@@ -148,16 +148,6 @@ test('PUT replaces an existing collection', async (t) => {
     version: originalCollection.version,
   });
 
-  // Endpoint logic will set an updated timestamp and ignore the value from the request
-  // body, so value on actual records should be different (greater) than the value
-  // sent in the request body
-  t.true(actualCollection.updatedAt > updatedCollection.updatedAt);
-  // createdAt timestamp from original record should have been preserved
-  t.is(actualCollection.createdAt, originalCollection.createdAt);
-  // PG and Dynamo records have the same timestamps
-  t.is(actualPgCollection.created_at.getTime(), actualCollection.createdAt);
-  t.is(actualPgCollection.updated_at.getTime(), actualCollection.updatedAt);
-
   t.like(actualCollection, {
     ...originalCollection,
     duplicateHandling: 'error',
@@ -173,6 +163,52 @@ test('PUT replaces an existing collection', async (t) => {
     created_at: originalPgRecord.created_at,
     updated_at: actualPgCollection.updated_at,
   });
+});
+
+test('PUT replaces an existing collection in Dynamo and PG with correct timestamps', async (t) => {
+  const knex = t.context.testKnex;
+  const originalCollection = fakeCollectionFactory({
+    duplicateHandling: 'replace',
+    process: randomString(),
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+
+  await collectionModel.create(originalCollection);
+
+  const updatedCollection = {
+    ...originalCollection,
+    updatedAt: Date.now(),
+    createdAt: Date.now(),
+    duplicateHandling: 'error',
+  };
+
+  await request(app)
+    .put(`/collections/${originalCollection.name}/${originalCollection.version}`)
+    .set('Accept', 'application/json')
+    .set('Authorization', `Bearer ${jwtAuthToken}`)
+    .send(updatedCollection)
+    .expect(200);
+
+  const actualCollection = await collectionModel.get({
+    name: originalCollection.name,
+    version: originalCollection.version,
+  });
+
+  const actualPgCollection = await t.context.collectionPgModel.get(knex, {
+    name: originalCollection.name,
+    version: originalCollection.version,
+  });
+
+  // Endpoint logic will set an updated timestamp and ignore the value from the request
+  // body, so value on actual records should be different (greater) than the value
+  // sent in the request body
+  t.true(actualCollection.updatedAt > updatedCollection.updatedAt);
+  // createdAt timestamp from original record should have been preserved
+  t.is(actualCollection.createdAt, originalCollection.createdAt);
+  // PG and Dynamo records have the same timestamps
+  t.is(actualPgCollection.created_at.getTime(), actualCollection.createdAt);
+  t.is(actualPgCollection.updated_at.getTime(), actualCollection.updatedAt);
 });
 
 test('PUT creates a new record in RDS if one does not exist', async (t) => {

--- a/packages/api/tests/endpoints/providers/create-provider.js
+++ b/packages/api/tests/endpoints/providers/create-provider.js
@@ -67,6 +67,8 @@ test.before(async (t) => {
   t.context.testKnexAdmin = knexAdmin;
   t.context.providerPgModel = new ProviderPgModel();
 
+  t.context.providerPgModel = new ProviderPgModel();
+
   await s3().createBucket({ Bucket: process.env.system_bucket }).promise();
 
   const esAlias = randomString();

--- a/packages/api/tests/endpoints/providers/create-provider.js
+++ b/packages/api/tests/endpoints/providers/create-provider.js
@@ -171,13 +171,12 @@ test('POST creates a new provider', async (t) => {
 
   const [providerPgRecord] = pgRecords;
 
-  // Endpoint logic will set an updated timestamp and ignore the value from the request
-  // body, so value on actual records should be different (greater) than the value
-  // sent in the request body
-  t.true(providerPgRecord.updated_at > postgresExpectedProvider.updated_at);
+  t.true(record.createdAt > newProvider.createdAt);
   t.true(record.updatedAt > newProvider.updatedAt);
-  // PG and Dynamo records have the same timestamp
-  t.deepEqual(providerPgRecord.updated_at, new Date(record.updatedAt));
+
+  // PG and Dynamo records have the same timestamps
+  t.is(providerPgRecord.created_at.getTime(), record.createdAt);
+  t.is(providerPgRecord.updated_at.getTime(), record.updatedAt);
 
   t.deepEqual(
     omit(providerPgRecord, postgresOmitList),

--- a/packages/api/tests/endpoints/providers/create-provider.js
+++ b/packages/api/tests/endpoints/providers/create-provider.js
@@ -207,7 +207,8 @@ test('POST returns a 409 error if the provider already exists', async (t) => {
 test('POST returns a 409 error if the provider already exists in RDS', async (t) => {
   const newProvider = fakeProviderFactory();
 
-  await t.context.testKnex(tableNames.providers).insert(
+  await t.context.providerPgModel.create(
+    t.context.testKnex,
     await translateApiProviderToPostgresProvider(newProvider)
   );
   const response = await request(app)

--- a/packages/api/tests/endpoints/providers/update-provider.js
+++ b/packages/api/tests/endpoints/providers/update-provider.js
@@ -146,13 +146,12 @@ test('PUT updates existing provider', async (t) => {
     { name: id }
   );
 
-  // Endpoint logic will set an updated timestamp and ignore the value from the request
-  // body, so value on actual records should be different (greater) than the value
-  // sent in the request body
-  t.true(actualPostgresProvider.updated_at > updatedPostgresProvider.updated_at);
   t.true(actualProvider.updatedAt > updatedProvider.updatedAt);
-  // PG and Dynamo records have the same timestamp
-  t.deepEqual(actualPostgresProvider.updated_at, new Date(actualProvider.updatedAt));
+  // createdAt timestamp from original record should have been preserved
+  t.is(actualProvider.createdAt, testProvider.createdAt);
+  // PG and Dynamo records have the same timestamps
+  t.is(actualPostgresProvider.created_at.getTime(), actualProvider.createdAt);
+  t.is(actualPostgresProvider.updated_at.getTime(), actualProvider.updatedAt);
 
   t.deepEqual(actualProvider, {
     ...expectedProvider,

--- a/packages/api/tests/endpoints/providers/update-provider.js
+++ b/packages/api/tests/endpoints/providers/update-provider.js
@@ -146,8 +146,13 @@ test('PUT updates existing provider', async (t) => {
     { name: id }
   );
 
+  // Endpoint logic will set an updated timestamp and ignore the value from the request
+  // body, so value on actual records should be different (greater) than the value
+  // sent in the request body
   t.true(actualPostgresProvider.updated_at > updatedPostgresProvider.updated_at);
   t.true(actualProvider.updatedAt > updatedProvider.updatedAt);
+  // PG and Dynamo records have the same timestamp
+  t.deepEqual(actualPostgresProvider.updated_at, new Date(actualProvider.updatedAt));
 
   t.deepEqual(actualProvider, {
     ...expectedProvider,

--- a/packages/api/tests/endpoints/providers/update-provider.js
+++ b/packages/api/tests/endpoints/providers/update-provider.js
@@ -131,8 +131,6 @@ test('PUT updates existing provider', async (t) => {
     updatedAt: Date.now(),
   };
 
-  const updatedPostgresProvider = await translateApiProviderToPostgresProvider(updatedProvider);
-
   await request(app)
     .put(`/providers/${id}`)
     .send(updatedProvider)
@@ -145,13 +143,6 @@ test('PUT updates existing provider', async (t) => {
     t.context.testKnex,
     { name: id }
   );
-
-  t.true(actualProvider.updatedAt > updatedProvider.updatedAt);
-  // createdAt timestamp from original record should have been preserved
-  t.is(actualProvider.createdAt, testProvider.createdAt);
-  // PG and Dynamo records have the same timestamps
-  t.is(actualPostgresProvider.created_at.getTime(), actualProvider.createdAt);
-  t.is(actualPostgresProvider.updated_at.getTime(), actualProvider.updatedAt);
 
   t.deepEqual(actualProvider, {
     ...expectedProvider,
@@ -175,6 +166,38 @@ test('PUT updates existing provider', async (t) => {
       postgresOmitList
     )
   );
+});
+
+test('PUT updates existing provider in Dynamo and PG with correct timestamps', async (t) => {
+  const { testProvider, testProvider: { id } } = t.context;
+  const expectedProvider = omit(testProvider,
+    ['globalConnectionLimit', 'protocol', 'cmKeyId']);
+
+  const updatedProvider = {
+    ...expectedProvider,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+
+  await request(app)
+    .put(`/providers/${id}`)
+    .send(updatedProvider)
+    .set('Accept', 'application/json')
+    .set('Authorization', `Bearer ${jwtAuthToken}`)
+    .expect(200);
+
+  const actualProvider = await providerModel.get({ id });
+  const actualPostgresProvider = await t.context.providerPgModel.get(
+    t.context.testKnex,
+    { name: id }
+  );
+
+  t.true(actualProvider.updatedAt > updatedProvider.updatedAt);
+  // createdAt timestamp from original record should have been preserved
+  t.is(actualProvider.createdAt, testProvider.createdAt);
+  // PG and Dynamo records have the same timestamps
+  t.is(actualPostgresProvider.created_at.getTime(), actualProvider.createdAt);
+  t.is(actualPostgresProvider.updated_at.getTime(), actualProvider.updatedAt);
 });
 
 test('PUT returns 404 for non-existent provider', async (t) => {

--- a/packages/api/tests/endpoints/test-rules.js
+++ b/packages/api/tests/endpoints/test-rules.js
@@ -7,26 +7,29 @@ const request = require('supertest');
 
 const { randomString, randomId } = require('@cumulus/common/test-utils');
 const {
-  getKnexClient,
+  CollectionPgModel,
+  ProviderPgModel,
   RulePgModel,
   localStackConnectionEnv,
-  tableNames,
+  destroyLocalTestDb,
+  generateLocalTestDb,
 } = require('@cumulus/db');
 const { translateApiRuleToPostgresRule } = require('@cumulus/db');
 const S3 = require('@cumulus/aws-client/S3');
 
 const { buildFakeExpressResponse } = require('./utils');
-const { fakeCollectionFactory, fakeProviderFactory } = require('../../lib/testUtils');
+const {
+  fakeCollectionFactory,
+  fakeProviderFactory,
+  fakeRuleFactoryV2,
+  createFakeJwtAuthToken,
+  setAuthorizedOAuthUsers,
+} = require('../../lib/testUtils');
 const { post } = require('../../endpoints/rules');
 const bootstrap = require('../../lambdas/bootstrap');
 const AccessToken = require('../../models/access-tokens');
 const Rule = require('../../models/rules');
 
-const {
-  createFakeJwtAuthToken,
-  setAuthorizedOAuthUsers,
-  fakeRuleFactoryV2,
-} = require('../../lib/testUtils');
 const { Search } = require('../../es/search');
 const indexer = require('../../es/indexer');
 const assertions = require('../../lib/assertions');
@@ -42,12 +45,16 @@ const assertions = require('../../lib/assertions');
   // eslint-disable-next-line no-return-assign
 ].forEach((varName) => process.env[varName] = randomString());
 
+const testDbName = randomString(12);
+
+const { migrationDir } = require('../../../../lambdas/db-migration');
+
 // import the express app after setting the env variables
 const { app } = require('../../app');
 
 const esIndex = randomString();
 const workflow = randomId('workflow-');
-const testRule = {
+const testRule = fakeRuleFactoryV2({
   name: randomId('testRule'),
   workflow: workflow,
   rule: {
@@ -57,9 +64,7 @@ const testRule = {
   },
   state: 'ENABLED',
   queueUrl: 'queue_url',
-  createdAt: Date.now(),
-  updatedAt: Date.now(),
-};
+});
 
 const dynamoRuleOmitList = ['createdAt', 'updatedAt', 'state', 'provider', 'collection', 'rule', 'queueUrl', 'executionNamePrefix'];
 
@@ -70,10 +75,12 @@ let jwtAuthToken;
 let accessTokenModel;
 let ruleModel;
 let buildPayloadStub;
-let pgRuleModel;
 
 test.before(async (t) => {
-  process.env = { ...process.env, ...localStackConnectionEnv };
+  process.env = { ...process.env, ...localStackConnectionEnv, PG_DATABASE: testDbName };
+  const { knex, knexAdmin } = await generateLocalTestDb(testDbName, migrationDir);
+  t.context.testKnex = knex;
+  t.context.testKnexAdmin = knexAdmin;
 
   const esAlias = randomString();
   process.env.ES_INDEX = esAlias;
@@ -84,13 +91,14 @@ test.before(async (t) => {
 
   buildPayloadStub = setBuildPayloadStub();
 
-  t.context.dbClient = await getKnexClient({ env: localStackConnectionEnv });
-  pgRuleModel = new RulePgModel();
+  t.context.collectionPgModel = new CollectionPgModel();
+  t.context.providerPgModel = new ProviderPgModel();
+  t.context.rulePgModel = new RulePgModel();
 
   ruleModel = new Rule();
   await ruleModel.createTable();
 
-  const ruleRecord = await ruleModel.create(testRule, testRule.createdAt);
+  const ruleRecord = await ruleModel.create(testRule);
   await indexer.indexRule(esClient, ruleRecord, esAlias);
 
   const username = randomString();
@@ -105,11 +113,8 @@ test.before(async (t) => {
 
 test.beforeEach(async (t) => {
   const newRule = fakeRuleFactoryV2();
-  newRule.createdAt = Date.now();
-  newRule.updatedAt = Date.now();
   delete newRule.collection;
   delete newRule.provider;
-
   t.context.newRule = newRule;
 });
 
@@ -118,8 +123,12 @@ test.after.always(async (t) => {
   await ruleModel.deleteTable();
   await S3.recursivelyDeleteS3Bucket(process.env.system_bucket);
   await esClient.indices.delete({ index: esIndex });
+  await destroyLocalTestDb({
+    knex: t.context.testKnex,
+    knexAdmin: t.context.testKnexAdmin,
+    testDbName,
+  });
 
-  await t.context.dbClient.destroy();
   buildPayloadStub.restore();
 });
 
@@ -265,16 +274,13 @@ test('When calling the API endpoint to delete an existing rule it does not retur
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .expect(200);
 
-  const fetchedPostgresRecord = await t.context.dbClient.queryBuilder()
-    .select()
-    .table(tableNames.rules)
-    .where({ name: newRule.name })
-    .first();
-
   const { message, record } = response.body;
   t.is(message, 'Record deleted');
   t.is(record, undefined);
-  t.is(fetchedPostgresRecord, undefined);
+  await t.throwsAsync(t.context.rulePgModel.get(
+    t.context.testKnex,
+    { name: newRule.name }
+  ), { name: 'RecordDoesNotExist' });
 });
 
 test('403 error when calling the API endpoint to delete an existing rule without a valid access token', async (t) => {
@@ -311,7 +317,7 @@ test('403 error when calling the API endpoint to delete an existing rule without
 });
 
 test('POST creates a rule', async (t) => {
-  const { dbClient, newRule } = t.context;
+  const { newRule } = t.context;
 
   const fakeCollection = fakeCollectionFactory();
   const fakeProvider = fakeProviderFactory({
@@ -352,8 +358,14 @@ test('POST creates a rule', async (t) => {
     port: fakeProvider.port,
   };
 
-  const [collectionCumulusId] = await dbClient(tableNames.collections).insert(collectionRecord).returning('cumulus_id');
-  const [providerCumulusId] = await dbClient(tableNames.providers).insert(providerRecord).returning('cumulus_id');
+  const [collectionCumulusId] = await t.context.collectionPgModel.create(
+    t.context.testKnex,
+    collectionRecord
+  );
+  const [providerCumulusId] = await t.context.providerPgModel.create(
+    t.context.testKnex,
+    providerRecord
+  );
 
   const response = await request(app)
     .post('/rules')
@@ -367,13 +379,13 @@ test('POST creates a rule', async (t) => {
     name: newRule.name,
   });
 
-  const fetchedPostgresRecord = await t.context.dbClient.queryBuilder()
-    .select()
-    .table(tableNames.rules)
-    .where({ name: newRule.name })
-    .first();
+  const fetchedPostgresRecord = await t.context.rulePgModel
+    .get(t.context.testKnex, { name: newRule.name });
 
   t.is(message, 'Record saved');
+
+  t.true(fetchedDynamoRecord.createdAt > newRule.createdAt);
+  t.true(fetchedDynamoRecord.updatedAt > newRule.updatedAt);
 
   t.deepEqual(
     omit(fetchedPostgresRecord, ['cumulus_id', 'created_at', 'updated_at']),
@@ -398,6 +410,7 @@ test('POST creates a rule', async (t) => {
   );
 
   t.is(fetchedPostgresRecord.created_at.getTime(), fetchedDynamoRecord.createdAt);
+  t.is(fetchedPostgresRecord.updated_at.getTime(), fetchedDynamoRecord.updatedAt);
 });
 
 test('POST creates a rule that is enabled by default', async (t) => {
@@ -411,11 +424,8 @@ test('POST creates a rule that is enabled by default', async (t) => {
     .send(newRule)
     .expect(200);
 
-  const fetchedPostgresRecord = await t.context.dbClient.queryBuilder()
-    .select()
-    .table(tableNames.rules)
-    .where({ name: newRule.name })
-    .first();
+  const fetchedPostgresRecord = await t.context.rulePgModel
+    .get(t.context.testKnex, { name: newRule.name });
 
   t.true(fetchedPostgresRecord.enabled);
   t.is(response.body.record.state, 'ENABLED');
@@ -518,7 +528,7 @@ test.serial('POST returns a 500 response if record creation throws unexpected er
 });
 
 test.serial('POST does not write to RDS or DynamoDB if writing to RDS fails', async (t) => {
-  const { newRule, dbClient } = t.context;
+  const { newRule, testKnex } = t.context;
 
   const failingTrx = (cb) => {
     const fakeTrx = sinon.stub().returns({
@@ -529,21 +539,20 @@ test.serial('POST does not write to RDS or DynamoDB if writing to RDS fails', as
     return cb(fakeTrx);
   };
 
-  const trxStub = sinon.stub(dbClient, 'transaction').callsFake(failingTrx);
+  const trxStub = sinon.stub(testKnex, 'transaction').callsFake(failingTrx);
   t.teardown(() => trxStub.restore());
 
   const expressRequest = {
     body: newRule,
     testContext: {
-      dbClient,
+      dbClient: testKnex,
     },
   };
   const response = buildFakeExpressResponse();
   await post(expressRequest, response);
 
-  const dbRecords = await dbClient.select()
-    .from(tableNames.rules)
-    .where({ name: newRule.name });
+  const dbRecords = await t.context.rulePgModel
+    .search(t.context.testKnex, { name: newRule.name });
 
   t.true(response.boom.badImplementation.calledWithMatch('Insert Rule Error'));
   t.false(await ruleModel.exists(newRule.name));
@@ -551,7 +560,7 @@ test.serial('POST does not write to RDS or DynamoDB if writing to RDS fails', as
 });
 
 test.serial('POST does not write to DynamoDB or RDS if writing to DynamoDB fails', async (t) => {
-  const { newRule, dbClient } = t.context;
+  const { newRule, testKnex } = t.context;
 
   const failingRulesModel = {
     exists: () => false,
@@ -563,7 +572,7 @@ test.serial('POST does not write to DynamoDB or RDS if writing to DynamoDB fails
   const expressRequest = {
     body: newRule,
     testContext: {
-      dbClient,
+      dbClient: testKnex,
       model: failingRulesModel,
     },
   };
@@ -574,32 +583,33 @@ test.serial('POST does not write to DynamoDB or RDS if writing to DynamoDB fails
 
   t.true(response.boom.badImplementation.calledWithMatch('Rule error'));
 
-  const dbRecords = await dbClient.select()
-    .from(tableNames.rules)
-    .where({ name: newRule.name });
+  const dbRecords = await t.context.rulePgModel
+    .search(t.context.testKnex, { name: newRule.name });
 
   t.is(dbRecords.length, 0);
   t.false(await ruleModel.exists(newRule.name));
 });
 
 test('PUT replaces a rule', async (t) => {
-  const { dbClient } = t.context;
-  const putTestRule = { ...testRule, name: randomId('testRule') };
+  const putTestRule = {
+    ...t.context.newRule,
+    queueUrl: 'fake-queue-url',
+  };
   t.truthy(putTestRule.queueUrl);
-  const postgresRule = await translateApiRuleToPostgresRule(putTestRule, t.context.dbClient);
+  const postgresRule = await translateApiRuleToPostgresRule(putTestRule, t.context.testKnex);
 
-  await dbClient.transaction(async (trx) => {
-    await pgRuleModel.create(trx, postgresRule);
+  await t.context.testKnex.transaction(async (trx) => {
+    await t.context.rulePgModel.create(trx, postgresRule);
     await ruleModel.create(putTestRule, putTestRule.createdAt);
   });
 
   const updateRule = {
     ...omit(putTestRule, ['queueUrl', 'provider', 'collection']),
     state: 'ENABLED',
+    // these timestamps should not get used
     createdAt: Date.now(),
     updatedAt: Date.now(),
   };
-  const updatePostgresRule = await translateApiRuleToPostgresRule(updateRule, t.context.dbClient);
 
   await request(app)
     .put(`/rules/${updateRule.name}`)
@@ -609,21 +619,26 @@ test('PUT replaces a rule', async (t) => {
     .expect(200);
 
   const actualRule = await ruleModel.get({ name: updateRule.name });
-  const actualPostgresRule = await dbClient.select()
-    .from(tableNames.rules)
-    .where({ name: updateRule.name })
-    .first();
-  const postgresExpectedRule = await translateApiRuleToPostgresRule({
-    ...updateRule, createdAt: actualRule.createdAt,
-  });
+
+  const actualPostgresRule = await t.context.rulePgModel
+    .get(t.context.testKnex, { name: updateRule.name });
+  const postgresExpectedRule = await translateApiRuleToPostgresRule(
+    {
+      ...updateRule,
+      createdAt: actualRule.createdAt,
+    },
+    t.context.testKnex
+  );
   Object.keys(postgresExpectedRule).forEach((key) => {
     if (postgresExpectedRule[key] === undefined) {
       postgresExpectedRule[key] = null;
     }
   });
 
-  t.true(actualPostgresRule.updated_at > updatePostgresRule.updated_at);
   t.true(actualRule.updatedAt > updateRule.updatedAt);
+  // PG and Dynamo records have the same timestamps
+  t.is(actualPostgresRule.created_at.getTime(), actualRule.createdAt);
+  t.is(actualPostgresRule.updated_at.getTime(), actualRule.updatedAt);
 
   t.like(actualPostgresRule, {
     ...postgresExpectedRule,
@@ -631,6 +646,7 @@ test('PUT replaces a rule', async (t) => {
     updated_at: actualPostgresRule.updated_at,
   });
   t.deepEqual(actualRule, {
+    // should not contain a queueUrl property
     ...updateRule,
     createdAt: putTestRule.createdAt,
     updatedAt: actualRule.updatedAt,
@@ -666,7 +682,7 @@ test('PUT returns 400 for name mismatch between params and payload',
   });
 
 test('DELETE deletes a rule', async (t) => {
-  const { dbClient, newRule } = t.context;
+  const { newRule } = t.context;
 
   await request(app)
     .post('/rules')
@@ -682,9 +698,8 @@ test('DELETE deletes a rule', async (t) => {
     .expect(200);
 
   const { message } = response.body;
-  const dbRecords = await dbClient.select()
-    .from(tableNames.rules)
-    .where({ name: newRule.name });
+  const dbRecords = await t.context.rulePgModel
+    .search(t.context.testKnex, { name: newRule.name });
 
   t.is(dbRecords.length, 0);
   t.is(message, 'Record deleted');

--- a/packages/api/tests/endpoints/test-rules.js
+++ b/packages/api/tests/endpoints/test-rules.js
@@ -15,8 +15,8 @@ const {
   ProviderPgModel,
   translateApiCollectionToPostgresCollection,
   translateApiProviderToPostgresProvider,
+  translateApiRuleToPostgresRule,
 } = require('@cumulus/db');
-const { translateApiRuleToPostgresRule } = require('@cumulus/db');
 const S3 = require('@cumulus/aws-client/S3');
 
 const { buildFakeExpressResponse } = require('./utils');

--- a/packages/api/tests/lambdas/sf-event-sqs-to-db-records/test-write-execution.js
+++ b/packages/api/tests/lambdas/sf-event-sqs-to-db-records/test-write-execution.js
@@ -231,8 +231,12 @@ test('writeExecution() saves execution to Dynamo and RDS and returns cumulus_id 
 
   await writeExecution({ cumulusMessage, knex });
 
-  t.true(await executionModel.exists({ arn: executionArn }));
-  t.true(await executionPgModel.exists(knex, { arn: executionArn }));
+  const dynamoRecord = await executionModel.get({ arn: executionArn });
+  const pgRecord = await executionPgModel.get(knex, { arn: executionArn });
+  t.true(dynamoRecord !== undefined);
+  t.true(pgRecord !== undefined);
+  t.is(pgRecord.created_at.getTime(), dynamoRecord.createdAt);
+  t.is(pgRecord.updated_at.getTime(), dynamoRecord.updatedAt);
 });
 
 test.serial('writeExecution() does not persist records to Dynamo or RDS if Dynamo write fails', async (t) => {

--- a/packages/api/tests/lambdas/sf-event-sqs-to-db-records/test-write-granules.js
+++ b/packages/api/tests/lambdas/sf-event-sqs-to-db-records/test-write-granules.js
@@ -333,10 +333,32 @@ test('writeGranules() saves granule records to Dynamo and RDS if RDS write is en
     granuleModel,
   });
 
+  t.true(await granuleModel.exists({ granuleId }));
+  t.true(await t.context.granulePgModel.exists(knex, { granule_id: granuleId }));
+});
+
+test('writeGranules() saves granule records to Dynamo and RDS with same timestamps', async (t) => {
+  const {
+    cumulusMessage,
+    granuleModel,
+    knex,
+    collectionCumulusId,
+    executionCumulusId,
+    providerCumulusId,
+    granuleId,
+  } = t.context;
+
+  await writeGranules({
+    cumulusMessage,
+    collectionCumulusId,
+    executionCumulusId,
+    providerCumulusId,
+    knex,
+    granuleModel,
+  });
+
   const dynamoRecord = await granuleModel.get({ granuleId });
   const pgRecord = await t.context.granulePgModel.get(knex, { granule_id: granuleId });
-  t.true(dynamoRecord !== undefined);
-  t.true(pgRecord !== undefined);
   t.is(pgRecord.created_at.getTime(), dynamoRecord.createdAt);
   t.is(pgRecord.updated_at.getTime(), dynamoRecord.updatedAt);
 });

--- a/packages/api/tests/lambdas/sf-event-sqs-to-db-records/test-write-granules.js
+++ b/packages/api/tests/lambdas/sf-event-sqs-to-db-records/test-write-granules.js
@@ -307,7 +307,7 @@ test('writeGranules() throws an error if collection is not provided', async (t) 
       collectionCumulusId: undefined,
       executionCumulusId,
       providerCumulusId,
-      knex: knex,
+      knex,
       granuleModel,
     })
   );
@@ -329,7 +329,7 @@ test('writeGranules() saves granule records to Dynamo and RDS if RDS write is en
     collectionCumulusId,
     executionCumulusId,
     providerCumulusId,
-    knex: knex,
+    knex,
     granuleModel,
   });
 
@@ -387,7 +387,7 @@ test('writeGranules() handles successful and failing writes independently', asyn
     collectionCumulusId,
     executionCumulusId,
     providerCumulusId,
-    knex: knex,
+    knex,
     granuleModel,
   }));
 
@@ -418,7 +418,7 @@ test('writeGranules() throws error if any granule writes fail', async (t) => {
     collectionCumulusId,
     executionCumulusId,
     providerCumulusId,
-    knex: knex,
+    knex,
     granuleModel,
   }));
 });
@@ -447,7 +447,7 @@ test.serial('writeGranules() does not persist records to Dynamo or RDS if Dynamo
       collectionCumulusId,
       executionCumulusId,
       providerCumulusId,
-      knex: knex,
+      knex,
       granuleModel: fakeGranuleModel,
     })
   );
@@ -486,7 +486,7 @@ test.serial('writeGranules() does not persist records to Dynamo or RDS if RDS wr
     collectionCumulusId,
     executionCumulusId,
     providerCumulusId,
-    knex: knex,
+    knex,
     granuleModel,
   }));
 

--- a/packages/api/tests/lambdas/sf-event-sqs-to-db-records/test-write-granules.js
+++ b/packages/api/tests/lambdas/sf-event-sqs-to-db-records/test-write-granules.js
@@ -307,7 +307,7 @@ test('writeGranules() throws an error if collection is not provided', async (t) 
       collectionCumulusId: undefined,
       executionCumulusId,
       providerCumulusId,
-      knex,
+      knex: knex,
       granuleModel,
     })
   );
@@ -329,7 +329,7 @@ test('writeGranules() saves granule records to Dynamo and RDS if RDS write is en
     collectionCumulusId,
     executionCumulusId,
     providerCumulusId,
-    knex,
+    knex: knex,
     granuleModel,
   });
 
@@ -387,7 +387,7 @@ test('writeGranules() handles successful and failing writes independently', asyn
     collectionCumulusId,
     executionCumulusId,
     providerCumulusId,
-    knex,
+    knex: knex,
     granuleModel,
   }));
 
@@ -418,7 +418,7 @@ test('writeGranules() throws error if any granule writes fail', async (t) => {
     collectionCumulusId,
     executionCumulusId,
     providerCumulusId,
-    knex,
+    knex: knex,
     granuleModel,
   }));
 });
@@ -447,7 +447,7 @@ test.serial('writeGranules() does not persist records to Dynamo or RDS if Dynamo
       collectionCumulusId,
       executionCumulusId,
       providerCumulusId,
-      knex,
+      knex: knex,
       granuleModel: fakeGranuleModel,
     })
   );
@@ -486,7 +486,7 @@ test.serial('writeGranules() does not persist records to Dynamo or RDS if RDS wr
     collectionCumulusId,
     executionCumulusId,
     providerCumulusId,
-    knex,
+    knex: knex,
     granuleModel,
   }));
 

--- a/packages/api/tests/lambdas/sf-event-sqs-to-db-records/test-write-pdr.js
+++ b/packages/api/tests/lambdas/sf-event-sqs-to-db-records/test-write-pdr.js
@@ -232,7 +232,31 @@ test('writePdr() throws an error if provider is not provided', async (t) => {
   );
 });
 
-test('writePdr() saves a PDR record to Dynamo and RDS and returns cumulus_id if RDS write is enabled', async (t) => {
+test('writePdr() saves a PDR record to Dynamo and RDS if RDS write is enabled', async (t) => {
+  const {
+    cumulusMessage,
+    pdrModel,
+    knex,
+    collectionCumulusId,
+    providerCumulusId,
+    executionCumulusId,
+    pdr,
+    pdrPgModel,
+  } = t.context;
+
+  await writePdr({
+    cumulusMessage,
+    collectionCumulusId,
+    providerCumulusId,
+    executionCumulusId: executionCumulusId,
+    knex,
+  });
+
+  t.true(await pdrModel.exists({ pdrName: pdr.name }));
+  t.true(await pdrPgModel.exists(knex, { name: pdr.name }));
+});
+
+test('writePdr() saves a PDR record to Dynamo and RDS with same timestamps', async (t) => {
   const {
     cumulusMessage,
     pdrModel,
@@ -254,8 +278,6 @@ test('writePdr() saves a PDR record to Dynamo and RDS and returns cumulus_id if 
 
   const dynamoRecord = await pdrModel.get({ pdrName: pdr.name });
   const pgRecord = await pdrPgModel.get(knex, { name: pdr.name });
-  t.true(dynamoRecord !== undefined);
-  t.true(pgRecord !== undefined);
   t.is(pgRecord.created_at.getTime(), dynamoRecord.createdAt);
   t.is(pgRecord.updated_at.getTime(), dynamoRecord.updatedAt);
 });

--- a/packages/api/tests/lambdas/sf-event-sqs-to-db-records/test-write-pdr.js
+++ b/packages/api/tests/lambdas/sf-event-sqs-to-db-records/test-write-pdr.js
@@ -252,8 +252,6 @@ test('writePdr() saves a PDR record to Dynamo and RDS and returns cumulus_id if 
     knex,
   });
 
-  // t.true(await pdrModel.exists({ pdrName: pdr.name }));
-  // t.true(await pdrPgModel.exists(knex, { name: pdr.name }));
   const dynamoRecord = await pdrModel.get({ pdrName: pdr.name });
   const pgRecord = await pdrPgModel.get(knex, { name: pdr.name });
   t.true(dynamoRecord !== undefined);

--- a/packages/api/tests/models/rules/test-query-rules.js
+++ b/packages/api/tests/models/rules/test-query-rules.js
@@ -198,13 +198,14 @@ test.serial('queryRules returns correct rules for given state and type', async (
 });
 
 test.serial('queryRules defaults to returning only ENABLED rules', async (t) => {
+  const enabledRule = fakeRuleFactoryV2({
+    rule: {
+      type: 'onetime',
+    },
+    state: 'ENABLED',
+  });
   const rules = [
-    fakeRuleFactoryV2({
-      rule: {
-        type: 'onetime',
-      },
-      state: 'ENABLED',
-    }),
+    enabledRule,
     fakeRuleFactoryV2({
       rule: {
         type: 'onetime',
@@ -217,10 +218,7 @@ test.serial('queryRules defaults to returning only ENABLED rules', async (t) => 
     type: 'onetime',
   });
   t.is(results.length, 1);
-  const expectedRule = results[0];
-  delete expectedRule.createdAt;
-  delete expectedRule.updatedAt;
-  t.deepEqual(rules[0], expectedRule);
+  t.deepEqual(rules[0], enabledRule);
 
   t.teardown(async () => {
     await Promise.all(rules.map((rule) => rulesModel.delete(rule)));

--- a/packages/api/tests/models/rules/test-rules-model.js
+++ b/packages/api/tests/models/rules/test-rules-model.js
@@ -75,7 +75,7 @@ test.before(async () => {
 });
 
 test.beforeEach(async (t) => {
-  t.context.onetimeRule = {
+  t.context.onetimeRule = fakeRuleFactoryV2({
     name: randomString(),
     workflow,
     provider: 'my-provider',
@@ -87,9 +87,9 @@ test.beforeEach(async (t) => {
       type: 'onetime',
     },
     state: 'ENABLED',
-  };
+  });
 
-  t.context.kinesisRule = {
+  t.context.kinesisRule = fakeRuleFactoryV2({
     name: randomString(),
     workflow,
     provider: 'my-provider',
@@ -102,7 +102,7 @@ test.beforeEach(async (t) => {
       value: 'my-kinesis-arn',
     },
     state: 'ENABLED',
-  };
+  });
 });
 
 test.after.always(async () => {

--- a/packages/api/tests/models/test-executions-model.js
+++ b/packages/api/tests/models/test-executions-model.js
@@ -164,7 +164,7 @@ test.serial('_getMutableFieldNames() returns correct fields for running status',
 
   // Fields are included even if not present in the item.
   t.deepEqual(updateFields, [
-    'createdAt', 'updatedAt', 'timestamp', 'originalPayload',
+    'updatedAt', 'timestamp', 'originalPayload',
   ]);
 });
 

--- a/packages/async-operations/tests/test-async_operations.js
+++ b/packages/async-operations/tests/test-async_operations.js
@@ -12,10 +12,10 @@ const { recursivelyDeleteS3Bucket } = require('@cumulus/aws-client/S3');
 const { randomString } = require('@cumulus/common/test-utils');
 const {
   localStackConnectionEnv,
-  createTestDatabase,
-  deleteTestDatabase,
-  getKnexClient,
   translateApiAsyncOperationToPostgresAsyncOperation,
+  generateLocalTestDb,
+  destroyLocalTestDb,
+  AsyncOperationPgModel,
 } = require('@cumulus/db');
 const { EcsStartTaskError } = require('@cumulus/errors');
 
@@ -38,18 +38,13 @@ const knexConfig = {
 };
 
 test.before(async (t) => {
-  t.context.knexAdmin = await getKnexClient({ env: localStackConnectionEnv });
-  t.context.knex = await getKnexClient({
-    env: {
-      ...localStackConnectionEnv,
-      PG_DATABASE: testDbName,
-      migrationDir,
-    },
-  });
+  process.env = { ...process.env, ...localStackConnectionEnv, PG_DATABASE: testDbName };
+  const { knex, knexAdmin } = await generateLocalTestDb(testDbName, migrationDir);
+  t.context.testKnex = knex;
+  t.context.testKnexAdmin = knexAdmin;
+
   systemBucket = randomString();
   await s3().createBucket({ Bucket: systemBucket }).promise();
-  await createTestDatabase(t.context.knexAdmin, testDbName, localStackConnectionEnv.PG_USER);
-  await t.context.knex.migrate.latest();
 
   // Set up the mock ECS client
   ecsClient = ecs();
@@ -73,14 +68,18 @@ test.before(async (t) => {
       },
     }),
   });
+
+  t.context.asyncOperationPgModel = new AsyncOperationPgModel();
 });
 
 test.after.always(async (t) => {
   sinon.restore();
-  await t.context.knex.destroy();
   await recursivelyDeleteS3Bucket(systemBucket);
-  await deleteTestDatabase(t.context.knexAdmin, testDbName);
-  await t.context.knexAdmin.destroy();
+  await destroyLocalTestDb({
+    knex: t.context.testKnex,
+    knexAdmin: t.context.testKnexAdmin,
+    testDbName,
+  });
 });
 
 test.serial('startAsyncOperation uploads the payload to S3', async (t) => {
@@ -229,12 +228,12 @@ test('startAsyncOperation calls Dynamo model create method', async (t) => {
   };
 
   t.true(result);
-  t.deepEqual(omit(spyCall, ['id']), expected);
+  t.deepEqual(omit(spyCall, ['id', 'createdAt', 'updatedAt']), expected);
   t.truthy(spyCall.id);
 });
 
 test.serial('The startAsyncOperation writes records to the databases', async (t) => {
-  const createSpy = sinon.spy((obj) => ({ id: obj.id }));
+  const createSpy = sinon.spy((createObject) => createObject);
   const stubbedAsyncOperationsModel = class {
     create = createSpy;
   };
@@ -261,11 +260,11 @@ test.serial('The startAsyncOperation writes records to the databases', async (t)
     systemBucket,
   }, stubbedAsyncOperationsModel);
 
-  const spyCall = createSpy.getCall(0).args[0];
-  const dbResults = await t.context.knex.select('*')
-    .from('async_operations')
-    .where('id', id)
-    .first();
+  const asyncOpDynamoSpyRecord = createSpy.getCall(0).args[0];
+  const asyncOperationPgRecord = await t.context.asyncOperationPgModel.get(
+    t.context.testKnex,
+    { id }
+  );
   const expected = {
     description,
     id,
@@ -275,10 +274,12 @@ test.serial('The startAsyncOperation writes records to the databases', async (t)
   };
   const omitList = ['created_at', 'updated_at', 'cumulus_id', 'output'];
   t.deepEqual(
-    omit(dbResults, omitList),
+    omit(asyncOperationPgRecord, omitList),
     translateApiAsyncOperationToPostgresAsyncOperation(omit(expected, omitList))
   );
-  t.deepEqual(omit(spyCall, omitList), omit(expected, omitList));
+  t.deepEqual(omit(asyncOpDynamoSpyRecord, ['createdAt', 'updatedAt']), omit(expected, ['createdAt', 'updatedAt']));
+  t.is(asyncOperationPgRecord.created_at.getTime(), asyncOpDynamoSpyRecord.createdAt);
+  t.is(asyncOperationPgRecord.updated_at.getTime(), asyncOpDynamoSpyRecord.updatedAt);
 });
 
 test.serial('The startAsyncOperation method returns the newly-generated record', async (t) => {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2406: Ensure that same updatedAt value is used for Dynamo/PG across all data types](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2406)

## Changes

* Update parallel write logic for granules, PDRs, executions to ensure that createdAt/updatedAt timestamps are the same in Dynamo/PG on write
  * Updated Dynamo models to ensure that updatedAt timestamp is properly handled
* Updated write logic for async operations to ensure that updatedAt timestamp is the same in Dynamo/PG on record update
* Added unit tests to prove that createdAt/updatedAt are the same on PUT/update for following data types: 
  * async operations 
  * rules
  * providers
  * collections 
* Various code cleanup & refactoring

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
