### PR TITLE
Move Dynamo table names for API lambdas into SSM parameter

### DIFF
--- a/bamboo/docker-compose.yml
+++ b/bamboo/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     image: maven.earthdata.nasa.gov/localstack/localstack:0.10.7
     network_mode: "service:build_env"
     environment:
-      SERVICES: "cloudformation,cloudwatch,cloudwatchlogs,dynamodb,kinesis,kms,lambda,s3,secretsmanager,sns,sqs,stepfunctions"
+      SERVICES: "cloudformation,cloudwatch,cloudwatchlogs,dynamodb,kinesis,kms,lambda,s3,secretsmanager,sns,sqs,stepfunctions,ssm"
   build_env:
     image: maven.earthdata.nasa.gov/cumulus:latest
     volumes:

--- a/packages/api/bin/serve.js
+++ b/packages/api/bin/serve.js
@@ -16,7 +16,6 @@ const {
   localUserName,
   getESClientAndIndex,
 } = require('./local-test-defaults');
-const { constructOnlineAccessUrl } = require('@cumulus/cmrjs/cmr-utils');
 
 const workflowList = testUtils.getWorkflowList();
 

--- a/packages/api/tests/app/test-app.js
+++ b/packages/api/tests/app/test-app.js
@@ -1,0 +1,41 @@
+const test = require('ava');
+
+const { MissingRequiredEnvVar } = require('@cumulus/errors');
+
+const { handler } = require('../../app');
+
+test.beforeEach(() => {
+  process.env.dynamoTableNamesParameterName = 'fake-param-name';
+});
+
+test.serial('handler throws error if environment variable for Dynamo tables parameter name is missing', async (t) => {
+  delete process.env.dynamoTableNamesParameterName;
+  await t.throwsAsync(
+    handler(),
+    { instanceOf: MissingRequiredEnvVar }
+  );
+});
+
+test('handler adds Dynamo table names from parameter to environment variables', async (t) => {
+  const dynamoTableNames = {
+    DynamoTableName: 'prefix-dynamoTableName',
+  };
+  const ssmClient = {
+    getParameter: () => ({
+      promise: async () => ({
+        Parameter: {
+          Value: JSON.stringify(dynamoTableNames),
+        },
+      }),
+    }),
+  };
+  t.falsy(process.env.DynamoTableName);
+  await handler(
+    {},
+    {
+      ssmClient,
+      succeed: () => true,
+    }
+  );
+  t.is(process.env.DynamoTableName, dynamoTableNames.DynamoTableName);
+});

--- a/packages/aws-client/src/services.ts
+++ b/packages/aws-client/src/services.ts
@@ -18,6 +18,7 @@ export const sfn = awsClient(AWS.StepFunctions, '2016-11-23');
 export const cf = awsClient(AWS.CloudFormation, '2010-05-15');
 export const sns = awsClient(AWS.SNS, '2010-03-31');
 export const secretsManager = awsClient(AWS.SecretsManager, '2017-10-17');
+export const systemsManager = awsClient(AWS.SSM, '2017-10-17');
 export const kms = awsClient(AWS.KMS, '2014-11-01');
 export const es = awsClient(AWS.ES, '2015-01-01');
 export const sts = awsClient(AWS.STS, '2011-06-15');

--- a/tf-modules/archive/api.tf
+++ b/tf-modules/archive/api.tf
@@ -1,13 +1,28 @@
+resource "aws_ssm_parameter" "dynamo_table_names" {
+  name = "${var.prefix}-dynamo-table-names"
+  type = "String"
+  value = jsonencode({
+    AccessTokensTable          = var.dynamo_tables.access_tokens.name
+    RulesTable                 = var.dynamo_tables.rules.name
+    AsyncOperationsTable       = var.dynamo_tables.async_operations.name
+    CollectionsTable           = var.dynamo_tables.collections.name
+    ExecutionsTable            = var.dynamo_tables.executions.name
+    GranulesTable              = var.dynamo_tables.granules.name
+    PdrsTable                  = var.dynamo_tables.pdrs.name
+    ProvidersTable             = var.dynamo_tables.providers.name
+    ReconciliationReportsTable = var.dynamo_tables.reconciliation_reports.name
+    RulesTable                 = var.dynamo_tables.rules.name
+  })
+}
+
 locals {
   api_port_substring        = var.api_port == null ? "" : ":${var.api_port}"
   api_id                    = var.deploy_to_ngap ? aws_api_gateway_rest_api.api[0].id : aws_api_gateway_rest_api.api_outside_ngap[0].id
   api_uri                   = var.api_url == null ? "https://${local.api_id}.execute-api.${data.aws_region.current.name}.amazonaws.com${local.api_port_substring}/${var.api_gateway_stage}/" : var.api_url
   api_redirect_uri          = "${local.api_uri}token"
   api_env_variables = {
-      AccessTokensTable                = var.dynamo_tables.access_tokens.name
       API_BASE_URL                     = local.api_uri
       ASSERT_ENDPOINT                  = var.saml_assertion_consumer_service
-      AsyncOperationsTable             = var.dynamo_tables.async_operations.name
       AsyncOperationTaskDefinition     = aws_ecs_task_definition.async_operation.arn
       auth_mode                        = "public"
       backgroundQueueUrl               = var.background_queue_url
@@ -19,11 +34,11 @@ locals {
       cmr_password_secret_name         = length(var.cmr_password) == 0 ? null : aws_secretsmanager_secret.api_cmr_password.name
       cmr_provider                     = var.cmr_provider
       cmr_username                     = var.cmr_username
-      CollectionsTable                 = var.dynamo_tables.collections.name
       databaseCredentialSecretArn      = var.rds_user_access_secret_arn
       dbHeartBeat                      = var.rds_connection_heartbeat
       DISTRIBUTION_ENDPOINT            = var.distribution_url
       distributionApiId                = var.distribution_api_id
+      dynamoTableNamesParameterName    = aws_ssm_parameter.dynamo_table_names.name
       EARTHDATA_BASE_URL               = replace(var.urs_url, "//*$/", "/") # Makes sure there's one and only one trailing slash
       EARTHDATA_CLIENT_ID              = var.urs_client_id
       EARTHDATA_CLIENT_PASSWORD        = var.urs_client_password
@@ -36,8 +51,6 @@ locals {
       ES_CONCURRENCY                   = var.es_request_concurrency
       ES_HOST                          = var.elasticsearch_hostname
       ES_INDEX_SHARDS                  = var.es_index_shards
-      ExecutionsTable                  = var.dynamo_tables.executions.name
-      GranulesTable                    = var.dynamo_tables.granules.name
       IDP_LOGIN                        = var.saml_idp_login
       IndexFromDatabaseLambda          = aws_lambda_function.index_from_database.arn
       invoke                           = var.schedule_sf_function_arn
@@ -59,13 +72,9 @@ locals {
       MigrationAsyncOperationLambda    = var.postgres_migration_async_operation_function_arn
       OAUTH_PROVIDER                   = var.oauth_provider
       oauth_user_group                 = var.oauth_user_group
-      PdrsTable                        = var.dynamo_tables.pdrs.name
       protected_buckets                = join(",", local.protected_buckets)
       provider_kms_key_id              = aws_kms_key.provider_kms_key.key_id
-      ProvidersTable                   = var.dynamo_tables.providers.name
       public_buckets                   = join(",", local.public_buckets)
-      ReconciliationReportsTable       = var.dynamo_tables.reconciliation_reports.name
-      RulesTable                       = var.dynamo_tables.rules.name
       stackName                        = var.prefix
       system_bucket                    = var.system_bucket
       TOKEN_REDIRECT_ENDPOINT          = local.api_redirect_uri

--- a/tf-modules/archive/iam.tf
+++ b/tf-modules/archive/iam.tf
@@ -179,6 +179,13 @@ data "aws_iam_policy_document" "lambda_api_gateway_policy" {
       var.rds_user_access_secret_arn
     ]
   }
+
+  statement {
+    actions = [
+      "ssm:GetParameter"
+    ]
+    resources = [aws_ssm_parameter.dynamo_table_names.arn]
+  }
 }
 
 resource "aws_iam_role_policy" "lambda_api_gateway" {


### PR DESCRIPTION
I started getting this error when trying to deploy the feature branch:

```
Error: Error modifying Lambda Function (mboyd-test-tf-ApiEndpoints) configuration : InvalidParameterValueException: Lambda was unable to configure your environment variables because the environment variables you have provided exceeded the 4KB limit.
```

The cause of the error is that the stringified version of all of our environment variables for the API lambdas are greater than 4096 bytes, which is not surprising since we've added a few environment variables to those Lambdas in this feature branch

The solution @Jkovarik  and I settled on as a temporary fix is to move some of the variables (right now only Dynamo table names) into a Systems Manager parameter, then read that parameter when starting up the API, and add the table names as environment variables.