### PR TITLE
[PRE-RDS release] Update env var for minimum RDS version

### DIFF
--- a/tf-modules/archive/sf_event_sqs_to_db_records.tf
+++ b/tf-modules/archive/sf_event_sqs_to_db_records.tf
@@ -177,7 +177,7 @@ resource "aws_lambda_function" "sf_event_sqs_to_db_records" {
       PdrsTable       = var.dynamo_tables.pdrs.name
       DeadLetterQueue = aws_sqs_queue.sf_event_sqs_to_db_records_dead_letter_queue.id
       databaseCredentialSecretArn = var.rds_user_access_secret_arn
-      RDS_DEPLOYMENT_CUMULUS_VERSION = "8.0.0"
+      RDS_DEPLOYMENT_CUMULUS_VERSION = "9.0.0"
     }
   }
 
@@ -230,5 +230,4 @@ resource "aws_lambda_function" "write_db_dlq_records_to_s3" {
 
   tags = var.tags
 }
-
 

--- a/tf-modules/archive/sf_event_sqs_to_db_records.tf
+++ b/tf-modules/archive/sf_event_sqs_to_db_records.tf
@@ -177,7 +177,7 @@ resource "aws_lambda_function" "sf_event_sqs_to_db_records" {
       PdrsTable       = var.dynamo_tables.pdrs.name
       DeadLetterQueue = aws_sqs_queue.sf_event_sqs_to_db_records_dead_letter_queue.id
       databaseCredentialSecretArn = var.rds_user_access_secret_arn
-      RDS_DEPLOYMENT_CUMULUS_VERSION = "5.0.0"
+      RDS_DEPLOYMENT_CUMULUS_VERSION = "8.0.0"
     }
   }
 


### PR DESCRIPTION
The `RDS_DEPLOYMENT_CUMULUS_VERSION` environment variable for the `sfEventSqsToDbRecords` Lambda will be used to determine if a workflow message came from a version of Cumulus before the RDS deployment or afterwards, which in turn is used to determine whether to write the data to RDS/PostgreSQL. 

Thus, it is critical that **the value of this environment variable match the actual version of Cumulus for phase 1 release of RDS.** Putting this PR up as a placeholder that should be updated and merged once we're ready to cut the RDS release and sure what the version number will be 