### PR TITLE
[Issue 2231] Adds .md extension to docs/README.md links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     defined on a payload that has no granules/an empty granule payload object
 - **[2231](https://github.com/nasa/cumulus/issues/2231)**
   - Fixes broken relative path links in `docs/README.md`
-
+  -
+## [v9.0.1] 2021-05-07
 ### Migration Steps
 
 Please review the migration steps for 9.0.0 as this release is only a patch to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,8 +71,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     defined on a payload that has no granules/an empty granule payload object
 - **[2231](https://github.com/nasa/cumulus/issues/2231)**
   - Fixes broken relative path links in `docs/README.md`
-  -
+
 ## [v9.0.1] 2021-05-07
+
 ### Migration Steps
 
 Please review the migration steps for 9.0.0 as this release is only a patch to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     - Updated `@cumulus/cmrjs/cmr-utils.isCmrFilename()` to include
       `isISOFile()`.
 
-
 ### Fixed
 
 - **CUMULUS-2519**
@@ -70,8 +69,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - **CUMULUS-2518**
   - Update sf-event-sqs-to-db-records to not throw if a collection is not
     defined on a payload that has no granules/an empty granule payload object
-
-## [v9.0.1] 2021-05-07
+- **[2231](https://github.com/nasa/cumulus/issues/2231)**
+  - Fixes broken relative path links in `docs/README.md`
 
 ### Migration Steps
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,19 +14,19 @@ This documentation includes both guidelines, examples, and source code docs. It 
 
 ### Get To Know Cumulus
 
-* Getting Started - [here](getting-started) - If you are new to Cumulus we suggest that you begin with this section to help you understand and work in the environment.
-* General Cumulus Documentation - [here](cumulus-docs-readme) <- you're here
+* Getting Started - [here](getting-started.md) - If you are new to Cumulus we suggest that you begin with this section to help you understand and work in the environment.
+* General Cumulus Documentation - [here](README.md) <- you're here
 
 ### Cumulus Reference Docs
 
 * Cumulus API Documentation - [here](https://nasa.github.io/cumulus-api)
 * Cumulus Developer Documentation - [here](https://github.com/nasa/cumulus) - READMEs throughout the main repository.
-* Data Cookbooks - [here](data-cookbooks/about-cookbooks)
+* Data Cookbooks - [here](data-cookbooks/about-cookbooks.md)
 
 ### Auxiliary Guides
 
-* Integrator Guide - [here](integrator-guide/about-int-guide)
-* Operator Docs - [here](operator-docs/about-operator-docs)
+* Integrator Guide - [here](integrator-guide/about-int-guide.md)
+* Operator Docs - [here](operator-docs/about-operator-docs.md)
 
 ---
 


### PR DESCRIPTION
* [CUMULUS-2231] Adds .md extension to docs/README.md links

A few of the relative links in the README did not contain the .md extension, which caused 404 Page not found errors when navigating in GitHub

* Use GH issue tag not CUMULUS tag

Co-authored-by: Nate Pauzenga <npauzenga@gmail.com>

Co-authored-by: Dan Stark <dstark@element84.com>
Co-authored-by: Nate Pauzenga <npauzenga@gmail.com>

**Summary:** Summary of changes

Addresses [CUMULUS-XX: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-XXX)

## Changes

* Detailed list or prose of changes
* ...

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
