### PR TITLE
add normalize-url to module whitelist

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -2,5 +2,5 @@
     "high": true,
     "pass-enoaudit": true,
     "retry-count": 20,
-    "whitelist": ["underscore", "trim-newlines"]
+    "whitelist": ["underscore", "trim-newlines", "normalize-url"]
 }


### PR DESCRIPTION
Our CI builds are now failing on this vulnerability:

https://www.npmjs.com/advisories/1755

In our case, it comes from this package lineage:

`latest-version>package-json>got>cacheable-request>normalize-url`, where `latest-version` is a devDependency in our root package.json 

`got` has already updated their dependency on `cacheable-request` to address the vulnerability:

https://github.com/sindresorhus/got/issues/1749

But there's no telling when they might do a release to fix the vulnerability, so we need to whitelist `normalize-url` in the meantime