### PR TITLE
CUMULUS-2558 -- Fix execution overwrite bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Removed all EMS reporting including lambdas, endpoints, params, etc as all
     reporting is now handled through Cloud Metrics
 - **CUMULUS-2472**
-  - Moved existing `EarthdataLoginClient` to `@cumulus/oauth-client/EarthdataLoginClient` and updated all references in Cumulus Core.
-  - Rename `EarthdataLoginClient` property from `earthdataLoginUrl` to `loginUrl` for consistency with new OAuth clients. See example in [oauth-client README](https://github.com/nasa/cumulus/blob/master/packages/oauth-client/README.md)
+  - Moved existing `EarthdataLoginClient` to
+    `@cumulus/oauth-client/EarthdataLoginClient` and updated all references in
+    Cumulus Core.
+  - Rename `EarthdataLoginClient` property from `earthdataLoginUrl` to
+    `loginUrl for consistency with new OAuth clients. See example in
+    [oauth-client
+    README](https://github.com/nasa/cumulus/blob/master/packages/oauth-client/README.md)
 
 ### Added
 
@@ -28,7 +33,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     same-region read-only tokens based on a user's CMR ACLs.
   - Configures the example deployment to enable this feature.
 - **CUMULUS-2442**
-  - Adds option to generate cloudfront URL to lzards-backup task. This will require a few new task config options that have been documented in the [task README](https://github.com/nasa/cumulus/blob/master/tasks/lzards-backup/README.md).
+  - Adds option to generate cloudfront URL to lzards-backup task. This will
+    require a few new task config options that have been documented in the
+    [task
+    README](https://github.com/nasa/cumulus/blob/master/tasks/lzards-backup/README.md).
 - **CUMULUS-2471**
   - Add `/s3credentialsREADME` endpoint to distribution API
 - **CUMULUS-2473**
@@ -36,7 +44,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Configured `example/cumulus-tf/cumulus_distribution.tf` to use CSDAP credentials
 - **CUMULUS-2474**
   - Add `S3ObjectStore` to `aws-client`. This class allows for interaction with the S3 object store.
-  - Add `object-store` package which contains abstracted object store functions for working with various cloud providers
+  - Add `object-store` package which contains abstracted object store functions
+    for working with various  cloud providers
 - **CUMULUS-2470**
   - Added `/s3credentials` endpoint for distribution API
 - **CUMULUS-2477**
@@ -49,10 +58,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - **[PR2224](https://github.com/nasa/cumulus/pull/2244)**
-  - Changed timeout on `sfEventSqsToDbRecords` Lambda to 60 seconds to match timeout for Knex library to acquire database connections
+  - Changed timeout on `sfEventSqsToDbRecords` Lambda to 60 seconds to match
+    timeout for Knex library to acquire dataase connections
 - **CUMULUS-2208**
   - Moved all `@cumulus/api/es/*` code to new `@cumulus/es-client` package
-- Changed timeout on `sfEventSqsToDbRecords` Lambda to 60 seconds to match timeout for Knex library to acquire database connections
+- Changed timeout on `sfEventSqsToDbRecords` Lambda to 60 seconds to match
+  timeout for Knex library to acquire database connections
 - **CUMULUS-2517**
   - Updated postgres-migration-count-tool default concurrency to '1'
 
@@ -70,7 +81,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     type 'GET DATA VIA DIRECT ACCESS' is not valid until UMM-G version
     [1.6.2](https://cdn.earthdata.nasa.gov/umm/granule/v1.6.2/umm-g-json-schema.json)
 - **CUMULUS-2472**
-  - Renamed `@cumulus/earthdata-login-client` to more generic `@cumulus/oauth-client` as a parent class for new OAuth clients.
+  - Renamed `@cumulus/earthdata-login-client` to more generic
+    `@cumulus/oauth-client` as a parnt  class for new OAuth clients.
   - Added `@cumulus/oauth-client/CognitoClient` to interface with AWS cognito login service.
 - **CUMULUS-2497**
   - Changed the `@cumulus/cmrjs` package:
@@ -81,6 +93,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **CUMULUS-2558**
+  - Fixed issue where executions original_payload would not be retained on successful execution
 - **CUMULUS-2519**
   - Update @cumulus/integration-tests.buildWorkflow to fail if provider/collection API response is not successful
 - **CUMULUS-2518**

--- a/packages/api/lambdas/sf-event-sqs-to-db-records/write-execution.js
+++ b/packages/api/lambdas/sf-event-sqs-to-db-records/write-execution.js
@@ -19,6 +19,8 @@ const {
   getWorkflowDuration,
 } = require('@cumulus/message/workflows');
 
+const { removeNilProperties } = require('@cumulus/common/util');
+
 const { parseException } = require('../../lib/utils');
 const Execution = require('../../models/executions');
 
@@ -54,7 +56,7 @@ const buildExecutionRecord = ({
   const workflowStartTime = getMessageWorkflowStartTime(cumulusMessage);
   const workflowStopTime = getMessageWorkflowStopTime(cumulusMessage);
 
-  return {
+  return removeNilProperties({
     arn,
     status: getMetaStatus(cumulusMessage),
     url: getExecutionUrlFromArn(arn),
@@ -71,7 +73,7 @@ const buildExecutionRecord = ({
     async_operation_cumulus_id: asyncOperationCumulusId,
     collection_cumulus_id: collectionCumulusId,
     parent_cumulus_id: parentExecutionCumulusId,
-  };
+  });
 };
 
 const writeExecutionViaTransaction = async ({

--- a/packages/api/tests/lambdas/sf-event-sqs-to-db-records/test-write-execution.js
+++ b/packages/api/tests/lambdas/sf-event-sqs-to-db-records/test-write-execution.js
@@ -4,6 +4,8 @@ const test = require('ava');
 const cryptoRandomString = require('crypto-random-string');
 const sinon = require('sinon');
 const uuidv4 = require('uuid/v4');
+const { removeNilProperties } = require('@cumulus/common/util');
+
 
 const {
   ExecutionPgModel,
@@ -37,6 +39,7 @@ test.before(async (t) => {
   t.context.knex = knex;
 
   t.context.executionPgModel = new ExecutionPgModel();
+  t.context.postRDSDeploymentVersion = '9.0.0';
 });
 
 test.beforeEach((t) => {
@@ -160,7 +163,6 @@ test('buildExecutionRecord builds correct record for "running" execution', (t) =
       url: `https://console.aws.amazon.com/states/home?region=us-east-1#/executions/details/${executionArn}`,
       workflow_name: workflowName,
       error: {},
-      final_payload: undefined,
       async_operation_cumulus_id: 1,
       collection_cumulus_id: 2,
       parent_cumulus_id: 3,

--- a/packages/api/tests/lambdas/sf-event-sqs-to-db-records/test-write-execution.js
+++ b/packages/api/tests/lambdas/sf-event-sqs-to-db-records/test-write-execution.js
@@ -4,8 +4,6 @@ const test = require('ava');
 const cryptoRandomString = require('crypto-random-string');
 const sinon = require('sinon');
 const uuidv4 = require('uuid/v4');
-const { removeNilProperties } = require('@cumulus/common/util');
-
 
 const {
   ExecutionPgModel,


### PR DESCRIPTION
Executions were not saving the originalPayload value as the
sf-even-sqs-to-db-records write-execution code was populating keys for
upsert with nil values -- this results in *overwriting* values from
the original record, which is inconsistent with the dynamo
implementation

Addresses [CUMULUS-2558](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2558)

## Changes

Bugfix: 

Executions were not saving the original_payload value in postgres as the
sf-even-sqs-to-db-records write-execution code was populating keys for
upsert with nil values -- this results in *overwriting* values from
the original record, which is inconsistent with the dynamo
implementation


Integration coverage will come from the 'read executions RDS' feature branch workk, as we will start reading these records from the API. 

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
