### PR TITLE
Remove unused pubkey endpoint

### DIFF
--- a/packages/api/app/distribution-routes.js
+++ b/packages/api/app/distribution-routes.js
@@ -70,14 +70,11 @@ const locate = (req, res) => res.status(501).end();
 
 const profile = (req, res) => res.send('Profile not available.');
 
-const pubkey = (req, res) => res.status(501).end();
-
 router.get('/', handleRootRequest);
 router.get('/locate', locate);
 router.get('/login', handleLoginRequest);
 router.get('/logout', handleLogoutRequest);
 router.get('/profile', profile);
-router.get('/pubkey', pubkey);
 router.get('/s3credentials', ensureAuthorizedOrRedirect, handleCredentialRequest);
 router.get('/s3credentialsREADME', displayS3CredentialInstructions);
 // Use router.use to leverage custom version middleware


### PR DESCRIPTION
**Summary:** Summary of changes

We won't be implementing the /pubkey endpoint at this time. This removes the route and stub function.

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
