### PR TITLE
Fix SyncGranuleDuplicateHandlingSpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### BREAKING CHANGES
 
+- `@cumulus/api-client/granules.getGranule` now returns the granule record from the GET `/granules/<granuleId>` endpoint, not the raw endpoint response
 - **CUMULUS-2434**
   - To use the updated `update-granules-cmr-metadata-file-links` task, the
     granule  UMM-G metadata should have version 1.6.2 or later, since CMR s3
@@ -27,6 +28,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- `@cumulus/api-client/granules.getGranuleResponse` to return the raw endpoint response from the GET `/granules/<granuleId>` endpoint
 - **HYRAX-439** - Corrected README.md according to a new Hyrax URL format.
 - **CUMULUS-2354**
   - Adds configuration options to allow `/s3credentials` endpoint to distribute

--- a/docs/deployment/README.md#cumulus-instance-sizing
+++ b/docs/deployment/README.md#cumulus-instance-sizing
@@ -552,7 +552,7 @@ You should be able to visit the dashboard website at `http://<prefix>-dashboard.
 
 ## Cumulus Instance Sizing
 
-The Cumulus deployment default sizing for Elasticsearch instances, EC2 instances, and Autoscaling Groups are small and designed for testing and cost savings. The default settings are likely not suitable for production workloads. Sizing his highly individual and dependent on expected load and archive size.
+The Cumulus deployment default sizing for Elasticsearch instances, EC2 instances, and Autoscaling Groups are small and designed for testing and cost savings. The default settings are likely not suitable for production workloads. Sizing is highly individual and dependent on expected load and archive size.
 
 > Please be cognizant of costs as any change in size will affect your AWS bill. AWS provides a [pricing calculator](https://calculator.aws/#/) for estimating costs.
 

--- a/example/spec/helpers/apiUtils.js
+++ b/example/spec/helpers/apiUtils.js
@@ -35,24 +35,6 @@ async function waitForApiRecord(getMethod, params, matchParams, retryConfig = {}
   );
 }
 
-// async function waitForApiStatus(getMethod, params, status, config) {
-//   return await pRetry(
-//     async () => {
-//       const record = await getMethod(params);
-
-//       const checkStatus = [status].flat();
-//       if (!checkStatus.includes(record.status)) {
-//         throw new Error(`Record status ${record.status}. Expect status ${status}`);
-//       }
-//       return record;
-//     },
-//     {
-//       maxTimeout: 60 * 1000,
-//       ...config,
-//     }
-//   );
-// }
-
 /**
  * Check a record for a particular set of statuses and retry until the record gets that status
  * This is to mitigate issues where a workflow completes, but there is a lag between
@@ -82,6 +64,5 @@ async function waitForModelStatus(model, params, status) {
 module.exports = {
   setDistributionApiEnvVars,
   waitForApiRecord,
-  // waitForApiStatus,
   waitForModelStatus,
 };

--- a/example/spec/helpers/apiUtils.js
+++ b/example/spec/helpers/apiUtils.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const isMatch = require('lodash/isMatch');
+const isNil = require('lodash/isNil');
 const pRetry = require('p-retry');
 
 function setDistributionApiEnvVars() {
@@ -11,6 +13,45 @@ function setDistributionApiEnvVars() {
     process.env.EARTHDATA_BASE_URL = 'https://uat.urs.earthdata.nasa.gov';
   }
 }
+
+async function waitForApiRecord(getMethod, params, matchParams, retryConfig = {}) {
+  return await pRetry(
+    async () => {
+      if (isNil(matchParams)) {
+        throw new pRetry.AbortError('matchParams are required');
+      }
+
+      const record = await getMethod(params);
+
+      if (!isMatch(record, matchParams)) {
+        throw new Error(`Record ${JSON.stringify(record)} did not match expected ${JSON.stringify(matchParams)}`);
+      }
+      return record;
+    },
+    {
+      maxTimeout: 60 * 1000,
+      ...retryConfig,
+    }
+  );
+}
+
+// async function waitForApiStatus(getMethod, params, status, config) {
+//   return await pRetry(
+//     async () => {
+//       const record = await getMethod(params);
+
+//       const checkStatus = [status].flat();
+//       if (!checkStatus.includes(record.status)) {
+//         throw new Error(`Record status ${record.status}. Expect status ${status}`);
+//       }
+//       return record;
+//     },
+//     {
+//       maxTimeout: 60 * 1000,
+//       ...config,
+//     }
+//   );
+// }
 
 /**
  * Check a record for a particular set of statuses and retry until the record gets that status
@@ -40,5 +81,7 @@ async function waitForModelStatus(model, params, status) {
 
 module.exports = {
   setDistributionApiEnvVars,
+  waitForApiRecord,
+  // waitForApiStatus,
   waitForModelStatus,
 };

--- a/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
+++ b/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
@@ -381,9 +381,9 @@ describe('When there are granule differences and granule reconciliation is run',
         granuleId: publishedGranuleId,
       });
       console.log('XXXXX Completed for getGranule()');
-      await waitForGranuleRecordUpdatedInList(config.stackName, JSON.parse(granuleBeforeUpdate.body));
+      await waitForGranuleRecordUpdatedInList(config.stackName, granuleBeforeUpdate);
       console.log('XXXXX Waiting for updateGranuleFile(publishedGranuleId, JSON.parse(granuleBeforeUpdate.body).files, /jpg$/, \'jpg2\'))');
-      ({ originalGranuleFile, updatedGranuleFile } = await updateGranuleFile(publishedGranuleId, JSON.parse(granuleBeforeUpdate.body).files, /jpg$/, 'jpg2'));
+      ({ originalGranuleFile, updatedGranuleFile } = await updateGranuleFile(publishedGranuleId, granuleBeforeUpdate.files, /jpg$/, 'jpg2'));
       console.log('XXXXX Completed for updateGranuleFile(publishedGranuleId, JSON.parse(granuleBeforeUpdate.body).files, /jpg$/, \'jpg2\'))');
 
       const [dbGranule, granuleAfterUpdate] = await Promise.all([
@@ -392,8 +392,8 @@ describe('When there are granule differences and granule reconciliation is run',
       ]);
       console.log('XXXX Waiting for granules updated in list');
       await Promise.all([
-        waitForGranuleRecordUpdatedInList(config.stackName, JSON.parse(dbGranule.body)),
-        waitForGranuleRecordUpdatedInList(config.stackName, JSON.parse(granuleAfterUpdate.body)),
+        waitForGranuleRecordUpdatedInList(config.stackName, dbGranule),
+        waitForGranuleRecordUpdatedInList(config.stackName, granuleAfterUpdate.body),
       ]);
     } catch (error) {
       console.log(error);

--- a/example/spec/parallel/ingestGranule/IngestGranuleFailureSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleFailureSpec.js
@@ -217,11 +217,10 @@ describe('The Ingest Granule failure workflow', () => {
         'failed'
       );
 
-      const granuleResponse = await getGranule({
+      const granule = await getGranule({
         prefix: config.stackName,
         granuleId: inputPayload.granules[0].granuleId,
       });
-      const granule = JSON.parse(granuleResponse.body);
 
       expect(granule.status).toBe('failed');
       expect(granule.error.Error).toBeDefined();

--- a/example/spec/parallel/ingestGranule/IngestGranuleFtpSuccessSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleFtpSuccessSpec.js
@@ -88,7 +88,6 @@ describe('The FTP Ingest Granules workflow', () => {
 
   describe('the execution', () => {
     let granule;
-    let granuleResponse;
 
     beforeAll(async () => {
       // Check that the granule has been updated in dynamo
@@ -99,11 +98,10 @@ describe('The FTP Ingest Granules workflow', () => {
         'completed'
       );
 
-      granuleResponse = await getGranule({
+      granule = await getGranule({
         prefix: config.stackName,
         granuleId: inputPayload.granules[0].granuleId,
       });
-      granule = JSON.parse(granuleResponse.body);
     });
 
     afterAll(async () => {

--- a/example/spec/parallel/ingestGranule/IngestGranulePythonProcessingSuccessSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranulePythonProcessingSuccessSpec.js
@@ -150,11 +150,10 @@ describe('The TestPythonProcessing workflow', () => {
       granuleId: inputPayload.granules[0].granuleId,
       status: 'completed',
     });
-    const granuleResponse = await getGranule({
+    granuleResult = await getGranule({
       prefix: config.stackName,
       granuleId: inputPayload.granules[0].granuleId,
     });
-    granuleResult = JSON.parse(granuleResponse.body);
     expect(granuleResult.granuleId).toEqual(inputPayload.granules[0].granuleId);
     expect(granuleResult.status).toEqual('completed');
   });

--- a/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
@@ -331,11 +331,10 @@ describe('The S3 Ingest Granules workflow', () => {
       ['running', 'completed']
     );
 
-    const granuleResponse = await getGranule({
+    const granule = await getGranule({
       prefix: config.stackName,
       granuleId: inputPayload.granules[0].granuleId,
     });
-    const granule = JSON.parse(granuleResponse.body);
 
     expect(granule.granuleId).toEqual(inputPayload.granules[0].granuleId);
     expect(['running', 'completed'].includes(granule.status)).toBeTrue();
@@ -837,11 +836,10 @@ describe('The S3 Ingest Granules workflow', () => {
         try {
           if (beforeAllError) throw SetupError;
 
-          const granuleResponse = await getGranule({
+          granule = await getGranule({
             prefix: config.stackName,
             granuleId: inputPayload.granules[0].granuleId,
           });
-          granule = JSON.parse(granuleResponse.body);
           cmrLink = granule.cmrLink;
         } catch (error) {
           subTestSetupError = error;
@@ -984,12 +982,11 @@ describe('The S3 Ingest Granules workflow', () => {
             'completed'
           );
 
-          const updatedGranuleResponse = await getGranule({
+          const updatedGranule = await getGranule({
             prefix: config.stackName,
             granuleId: reingestGranuleId,
           });
 
-          const updatedGranule = JSON.parse(updatedGranuleResponse.body);
           expect(updatedGranule.status).toEqual('completed');
           expect(updatedGranule.updatedAt).toBeGreaterThan(oldUpdatedAt);
           expect(updatedGranule.execution).not.toEqual(oldExecution);
@@ -1107,11 +1104,10 @@ describe('The S3 Ingest Granules workflow', () => {
           'completed'
         );
 
-        const granuleResponse = await getGranule({
+        const updatedGranuleRecord = await getGranule({
           prefix: config.stackName,
           granuleId: inputPayload.granules[0].granuleId,
         });
-        const updatedGranuleRecord = JSON.parse(granuleResponse.body);
         const updatedGranuleCmrFile = updatedGranuleRecord.files.find(isCMRFile);
 
         const granuleCmrMetadata = await metadataObjectFromCMRFile(`s3://${updatedGranuleCmrFile.bucket}/${updatedGranuleCmrFile.key}`);
@@ -1213,9 +1209,7 @@ describe('The S3 Ingest Granules workflow', () => {
           prefix: config.stackName,
           granuleId: inputPayload.granules[0].granuleId,
         });
-        const resp = JSON.parse(granuleResponse.body);
-
-        expect(resp.message).toEqual('Granule not found');
+        expect(granuleResponse.message).toEqual('Granule not found');
       });
     });
 

--- a/example/spec/parallel/ingestGranule/ingestGranuleQueueSpec.js
+++ b/example/spec/parallel/ingestGranule/ingestGranuleQueueSpec.js
@@ -286,12 +286,10 @@ describe('The S3 Ingest Granules workflow', () => {
       ['completed']
     );
 
-    const granuleResponse = await getGranule({
+    const granule = await getGranule({
       prefix: config.stackName,
       granuleId: inputPayload.granules[0].granuleId,
     });
-    const granule = JSON.parse(granuleResponse.body);
-
     expect(granule.granuleId).toEqual(inputPayload.granules[0].granuleId);
     expect((granule.status === 'running') || (granule.status === 'completed')).toBeTrue();
   });

--- a/example/spec/parallel/orca/OrcaBackupAndRecoverySpec.js
+++ b/example/spec/parallel/orca/OrcaBackupAndRecoverySpec.js
@@ -274,12 +274,11 @@ describe('The S3 Ingest Granules workflow', () => {
 
     it('returns granule information with recovery status', async () => {
       if (!isOrcaIncluded) pending();
-      const granuleResponse = await getGranule({
+      const granule = await getGranule({
         prefix: config.stackName,
         granuleId,
         query: { getRecoveryStatus: true },
       });
-      const granule = JSON.parse(granuleResponse.body);
 
       expect(granule.granuleId).toEqual(granuleId);
       expect((granule.recoveryStatus === 'running') || (granule.recoveryStatus === 'completed')).toBeTrue();

--- a/example/spec/parallel/syncGranule/SyncGranuleDuplicateHandlingSpec.js
+++ b/example/spec/parallel/syncGranule/SyncGranuleDuplicateHandlingSpec.js
@@ -6,7 +6,6 @@ const { s3Join } = require('@cumulus/aws-client/S3');
 const { constructCollectionId } = require('@cumulus/message/Collections');
 const { randomString } = require('@cumulus/common/test-utils');
 const { LambdaStep } = require('@cumulus/integration-tests/sfnStep');
-const { models: { Granule } } = require('@cumulus/api');
 const { deleteGranule, getGranule } = require('@cumulus/api-client/granules');
 const { deleteExecution } = require('@cumulus/api-client/executions');
 const {
@@ -17,6 +16,8 @@ const {
   cleanupCollections,
   cleanupProviders,
 } = require('@cumulus/integration-tests');
+const { getExecutionUrlFromArn } = require('@cumulus/message/Executions');
+
 const {
   deleteFolder,
   loadConfig,
@@ -31,7 +32,9 @@ const {
   loadFileWithUpdatedGranuleIdPathAndCollection,
   setupTestGranuleForIngest,
 } = require('../../helpers/granuleUtils');
-const { waitForModelStatus } = require('../../helpers/apiUtils');
+const {
+  waitForApiRecord,
+} = require('../../helpers/apiUtils');
 
 const workflowName = 'SyncGranule';
 
@@ -56,7 +59,6 @@ describe('When the Sync Granule workflow is configured', () => {
   let duplicateFilenameExecutionArn;
   let existingVersionedFileExecutionArn;
   let expectedPayload;
-  let granuleModel;
   let inputPayload;
   let lambdaStep;
   let newGranuleId;
@@ -78,9 +80,6 @@ describe('When the Sync Granule workflow is configured', () => {
     collection = { name: `MOD09GQ${testSuffix}`, version: '006' };
     provider = { id: `s3_provider${testSuffix}` };
     const newCollectionId = constructCollectionId(collection.name, collection.version);
-
-    process.env.GranulesTable = `${config.stackName}-GranulesTable`;
-    granuleModel = new Granule();
 
     process.env.PdrsTable = `${config.stackName}-PdrsTable`;
 
@@ -278,18 +277,18 @@ describe('When the Sync Granule workflow is configured', () => {
       it('captures both files', async () => {
         // This assertion is to check that the granule has been updated in dynamo
         // before performing further checks
-        const record = await waitForModelStatus(
-          granuleModel,
-          { granuleId: inputPayload.granules[0].granuleId },
-          'completed'
+        const granule = await waitForApiRecord(
+          getGranule,
+          {
+            prefix: config.stackName,
+            granuleId: inputPayload.granules[0].granuleId,
+          },
+          {
+            status: 'completed',
+            execution: getExecutionUrlFromArn(duplicateFilenameExecutionArn),
+          }
         );
-        expect(record.status).toEqual('completed');
-
-        const granuleResponse = await getGranule({
-          prefix: config.stackName,
-          granuleId: inputPayload.granules[0].granuleId,
-        });
-        const granule = JSON.parse(granuleResponse.body);
+        expect(granule.status).toEqual('completed');
         expect(granule.files.length).toEqual(3);
       });
     });
@@ -331,18 +330,18 @@ describe('When the Sync Granule workflow is configured', () => {
       });
 
       it('captures all files', async () => {
-        const record = await waitForModelStatus(
-          granuleModel,
-          { granuleId: inputPayload.granules[0].granuleId },
-          'completed'
+        const granule = await waitForApiRecord(
+          getGranule,
+          {
+            prefix: config.stackName,
+            granuleId: inputPayload.granules[0].granuleId,
+          },
+          {
+            status: 'completed',
+            execution: getExecutionUrlFromArn(existingVersionedFileExecutionArn),
+          }
         );
-        expect(record.status).toEqual('completed');
-
-        const granuleResponse = await getGranule({
-          prefix: config.stackName,
-          granuleId: inputPayload.granules[0].granuleId,
-        });
-        const granule = JSON.parse(granuleResponse.body);
+        expect(granule.status).toEqual('completed');
         expect(granule.files.length).toEqual(4);
       });
     });

--- a/example/spec/parallel/syncGranule/SyncGranuleDuplicateHandlingSpec.js
+++ b/example/spec/parallel/syncGranule/SyncGranuleDuplicateHandlingSpec.js
@@ -274,8 +274,8 @@ describe('When the Sync Granule workflow is configured', () => {
         expect(renamedFiles[0].size).toEqual(expectedRenamedFileSize);
       });
 
-      it('captures both files', async () => {
-        // This assertion is to check that the granule has been updated in dynamo
+      it('captures the additional file', async () => {
+        // This assertion is to check that the granule has been updated in the API
         // before performing further checks
         const granule = await waitForApiRecord(
           getGranule,

--- a/example/spec/parallel/syncGranule/SyncGranuleSuccessSpec.js
+++ b/example/spec/parallel/syncGranule/SyncGranuleSuccessSpec.js
@@ -276,11 +276,10 @@ describe('The Sync Granules workflow', () => {
     let granule;
 
     beforeAll(async () => {
-      const granuleResponse = await getGranule({
+      granule = await getGranule({
         prefix: config.stackName,
         granuleId: inputPayload.granules[0].granuleId,
       });
-      granule = JSON.parse(granuleResponse.body);
 
       oldUpdatedAt = granule.updatedAt;
       oldExecution = granule.execution;
@@ -345,12 +344,10 @@ describe('The Sync Granules workflow', () => {
         'completed'
       );
 
-      const updatedGranuleResponse = await getGranule({
+      const updatedGranule = await getGranule({
         prefix: config.stackName,
         granuleId: inputPayload.granules[0].granuleId,
       });
-
-      const updatedGranule = JSON.parse(updatedGranuleResponse.body);
       expect(updatedGranule.status).toEqual('completed');
       expect(updatedGranule.updatedAt).toBeGreaterThan(oldUpdatedAt);
       expect(updatedGranule.execution).not.toEqual(oldExecution);

--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -15,13 +15,13 @@ npm install @cumulus/api-client
 ```javascript
 const { granules } = require('@cumulus/api-client');
 
-const response = await granules.getGranule({
+const granule = await granules.getGranule({
   prefix: process.env.STACKNAME,
   granuleId
 });
 ```
 
-The above example call will return the full response from the API.  To get the body of the response, you will need to generally parse it: `JSON.parse(resopnse.body)`
+The above example call will return the parsed JSON body of the response from the API (e.g. `JSON.parse(response.body)`).
 
 ## About Cumulus
 

--- a/packages/api-client/src/granules.ts
+++ b/packages/api-client/src/granules.ts
@@ -1,13 +1,45 @@
 import pRetry from 'p-retry';
 import Logger from '@cumulus/logger';
-import { GranuleId, GranuleStatus } from '@cumulus/types/api/granules';
+import { ApiGranule, GranuleId, GranuleStatus } from '@cumulus/types/api/granules';
 import { invokeApi } from './cumulusApiClient';
 import { ApiGatewayLambdaHttpProxyResponse, InvokeApiFunction } from './types';
 
 const logger = new Logger({ sender: '@api-client/granules' });
 
 /**
- * GET /granules/{granuleName}
+ * GET raw response from /granules/{granuleName}
+ *
+ * @param {Object} params             - params
+ * @param {string} params.prefix      - the prefix configured for the stack
+ * @param {string} params.granuleId   - a granule ID
+ * @param {Object} [params.query]     - query to pass the API lambda
+ * @param {Function} params.callback  - async function to invoke the api lambda
+ *                                      that takes a prefix / user payload.  Defaults
+ *                                      to cumulusApiClient.invokeApifunction to invoke the
+ *                                      api lambda
+ * @returns {Promise<Object>}         - the granule fetched by the API
+ */
+export const getGranuleResponse = async (params: {
+  prefix: string,
+  granuleId: GranuleId,
+  query?: { [key: string]: string },
+  callback?: InvokeApiFunction
+}): Promise<ApiGatewayLambdaHttpProxyResponse> => {
+  const { prefix, granuleId, query, callback = invokeApi } = params;
+
+  return await callback({
+    prefix: prefix,
+    payload: {
+      httpMethod: 'GET',
+      resource: '/{proxy+}',
+      path: `/granules/${granuleId}`,
+      ...(query && { queryStringParameters: query }),
+    },
+  });
+};
+
+/**
+ * GET granule record from /granules/{granuleName}
  *
  * @param {Object} params             - params
  * @param {string} params.prefix      - the prefix configured for the stack
@@ -24,19 +56,8 @@ export const getGranule = async (params: {
   granuleId: GranuleId,
   query?: { [key: string]: string },
   callback?: InvokeApiFunction
-}): Promise<ApiGatewayLambdaHttpProxyResponse> => {
-  const { prefix, granuleId, query, callback = invokeApi } = params;
-
-  const response = await callback({
-    prefix: prefix,
-    payload: {
-      httpMethod: 'GET',
-      resource: '/{proxy+}',
-      path: `/granules/${granuleId}`,
-      ...(query && { queryStringParameters: query }),
-    },
-  });
-
+}): Promise<ApiGranule> => {
+  const response = await getGranuleResponse(params);
   return JSON.parse(response.body);
 };
 
@@ -70,7 +91,7 @@ export const waitForGranule = async (params: {
 
   await pRetry(
     async () => {
-      const apiResult = await getGranule({ prefix, granuleId, callback });
+      const apiResult = await getGranuleResponse({ prefix, granuleId, callback });
 
       if (apiResult.statusCode === 500) {
         throw new pRetry.AbortError('API misconfigured/down/etc, failing test');

--- a/packages/api-client/src/granules.ts
+++ b/packages/api-client/src/granules.ts
@@ -27,7 +27,7 @@ export const getGranule = async (params: {
 }): Promise<ApiGatewayLambdaHttpProxyResponse> => {
   const { prefix, granuleId, query, callback = invokeApi } = params;
 
-  return await callback({
+  const response = await callback({
     prefix: prefix,
     payload: {
       httpMethod: 'GET',
@@ -36,6 +36,8 @@ export const getGranule = async (params: {
       ...(query && { queryStringParameters: query }),
     },
   });
+
+  return JSON.parse(response.body);
 };
 
 /**

--- a/packages/api-client/tests/test-granules.js
+++ b/packages/api-client/tests/test-granules.js
@@ -20,6 +20,11 @@ test('getGranule calls the callback with the expected object', async (t) => {
 
   const callback = (configObject) => {
     t.deepEqual(configObject, expected);
+    return Promise.resolve({
+      body: JSON.stringify({
+        granuleId: t.context.granuleId,
+      }),
+    });
   };
 
   await t.notThrowsAsync(granulesApi.getGranule({
@@ -43,6 +48,11 @@ test('getGranule calls the callback with the expected object when there is query
 
   const callback = (configObject) => {
     t.deepEqual(configObject, expected);
+    return Promise.resolve({
+      body: JSON.stringify({
+        granuleId: t.context.granuleId,
+      }),
+    });
   };
 
   await t.notThrowsAsync(granulesApi.getGranule({

--- a/packages/integration-tests/Granules.js
+++ b/packages/integration-tests/Granules.js
@@ -21,7 +21,7 @@ class GranuleNotFoundError extends Error {
 }
 
 const getGranule = async (params) => {
-  const response = await granulesApi.getGranule(
+  const response = await granulesApi.getGranuleResponse(
     pick(params, ['prefix', 'granuleId', 'callback'])
   );
 

--- a/packages/integration-tests/api/collections.js
+++ b/packages/integration-tests/api/collections.js
@@ -16,7 +16,7 @@ const collectionsApi = require('@cumulus/api-client/collections');
  */
 const createCollection = (params) => {
   deprecate('@cumulus/integration-tests/collections.createCollection', '1.21.0', '@cumulus/api-client/collections.createCollection');
-  return collectionsApi.getGranule(params);
+  return collectionsApi.createCollection(params);
 };
 
 /*

--- a/tasks/discover-granules/index.js
+++ b/tasks/discover-granules/index.js
@@ -197,7 +197,7 @@ const buildGranule = curry(
  *
  */
 const checkGranuleHasNoDuplicate = async (granuleId, duplicateHandling) => {
-  const response = await granules.getGranule({
+  const response = await granules.getGranuleResponse({
     prefix: process.env.STACKNAME,
     granuleId,
   });


### PR DESCRIPTION
Primarily fixes a bug in `example/spec/parallel/syncGranule/SyncGranuleDuplicateHandlingSpec.js` where the returned `completed` granule may be for a previous execution instead of the most recent one, so assertions about that granule may intermittently fail. 

- Added `waitForApiRecord` to generically handle requesting a record from the API via GET and waiting until it matches the given object
- Updated `@cumulus/api-client/granules.getGranule` to return the parsed JSON body of the raw API response from GET /granules/<granuleId>
- Added `@cumulus/api-client/granules.getGranuleResponse` to return the raw API response from GET /granules/<granuleId>