### PR TITLE
re-add waiting to discover spec

### DIFF
--- a/example/spec/helpers/apiUtils.js
+++ b/example/spec/helpers/apiUtils.js
@@ -35,6 +35,24 @@ async function waitForApiRecord(getMethod, params, matchParams, retryConfig = {}
   );
 }
 
+async function waitForApiStatus(getMethod, params, status, retryConfig = {}) {
+  return await pRetry(
+    async () => {
+      const record = await getMethod(params);
+
+      const checkStatus = [status].flat();
+      if (!checkStatus.includes(record.status)) {
+        throw new Error(`Record status ${record.status}. Expect status ${status}`);
+      }
+      return record;
+    },
+    {
+      maxTimeout: 60 * 1000,
+      ...retryConfig,
+    }
+  );
+}
+
 /**
  * Check a record for a particular set of statuses and retry until the record gets that status
  * This is to mitigate issues where a workflow completes, but there is a lag between
@@ -64,5 +82,6 @@ async function waitForModelStatus(model, params, status) {
 module.exports = {
   setDistributionApiEnvVars,
   waitForApiRecord,
+  waitForApiStatus,
   waitForModelStatus,
 };

--- a/example/spec/parallel/discoverGranules/DiscoverGranulesDuplicateHandlingSkipSpec.js
+++ b/example/spec/parallel/discoverGranules/DiscoverGranulesDuplicateHandlingSkipSpec.js
@@ -24,7 +24,7 @@ const { deleteS3Object, s3PutObject } = require('@cumulus/aws-client/S3');
 const { loadConfig } = require('../../helpers/testUtils');
 
 describe('The DiscoverGranules workflow with one existing granule, one new granule, and duplicateHandling="skip"', () => {
-  let beforeAllFailed = false;
+  let beforeAllError = false;
   let collection;
   let discoverGranulesRule;
   let existingGranuleId;
@@ -156,18 +156,18 @@ describe('The DiscoverGranules workflow with one existing granule, one new granu
         status: 'completed',
       });
     } catch (error) {
-      beforeAllFailed = true;
+      beforeAllError = error;
       throw error;
     }
   });
 
   it('queues one granule for ingest', () => {
-    if (beforeAllFailed) fail('beforeAll() failed');
+    if (beforeAllError) fail(beforeAllError);
     else expect(finishedDiscoverGranulesExecution.finalPayload.running.length).toEqual(1);
   });
 
   it('queues the correct granule for ingest', async () => {
-    if (beforeAllFailed) fail('beforeAll() failed');
+    if (beforeAllError) fail(beforeAllError);
     else {
       // The execution ARN of the "IngestGranules" workflow that was
       // created as a result of the "DiscoverGranules" workflow.
@@ -181,7 +181,7 @@ describe('The DiscoverGranules workflow with one existing granule, one new granu
   });
 
   it('results in the new granule being ingested', async () => {
-    if (beforeAllFailed) fail('beforeAll() failed');
+    if (beforeAllError) fail(beforeAllError);
     else {
       await expectAsync(
         getGranuleWithStatus({ prefix, granuleId: newGranuleId, status: 'completed' })

--- a/example/spec/serial/DiscoverGranulesHttpSpec.js
+++ b/example/spec/serial/DiscoverGranulesHttpSpec.js
@@ -228,6 +228,13 @@ describe('The Discover Granules workflow with http Protocol', () => {
       noFilesIngestExecutionArns = noFilesConfigQueueGranulesOutput.payload.running;
     });
 
+    afterAll(async () => {
+      await Promise.all(
+        noFilesConfigQueueGranulesOutput.payload.running
+          .map((arn) => waitForCompletedExecution(arn))
+      );
+    });
+
     it('encounters a collection without a files configuration', async () => {
       const lambdaInput = await lambdaStep.getStepInput(
         noFilesConfigExecutionArn, 'DiscoverGranules'
@@ -283,6 +290,13 @@ describe('The Discover Granules workflow with http Protocol', () => {
       );
 
       partialFilesIngestExecutionArns = partialFilesQueueGranulesOutput.payload.running;
+    });
+
+    afterAll(async () => {
+      await Promise.all(
+        partialFilesQueueGranulesOutput.payload.running
+          .map((arn) => waitForCompletedExecution(arn))
+      );
     });
 
     it('encounters a collection with a files configuration that does not match all files', async () => {
@@ -343,6 +357,12 @@ describe('The Discover Granules workflow with http Protocol', () => {
       );
 
       ignoringFilesIngestExecutionArns = ignoringFilesQueueGranulesOutput.payload.running;
+    });
+
+    afterAll(async () => {
+      await Promise.all(
+        ignoringFilesIngestExecutionArns.map((arn) => waitForCompletedExecution(arn))
+      );
     });
 
     it('encounters a collection that has no files config, but should ignore files config', async () => {

--- a/example/spec/serial/DiscoverGranulesHttpSpec.js
+++ b/example/spec/serial/DiscoverGranulesHttpSpec.js
@@ -95,9 +95,9 @@ describe('The Discover Granules workflow with http Protocol', () => {
 
   afterAll(async () => {
     // clean up stack state added by test
-    await Promise.allSettled(queueGranulesOutput.payload.running
+    await Promise.all(queueGranulesOutput.payload.running
       .map((execution) => waitForCompletedExecution(execution)));
-    await Promise.allSettled(discoverGranulesLambdaOutput.payload.granules.map(
+    await Promise.all(discoverGranulesLambdaOutput.payload.granules.map(
       async (granule) => {
         await waitForApiStatus(
           getGranule,

--- a/packages/api-client/src/cumulusApiClient.ts
+++ b/packages/api-client/src/cumulusApiClient.ts
@@ -1,6 +1,8 @@
 import pRetry from 'p-retry';
-import Logger from '@cumulus/logger';
+
 import { lambda } from '@cumulus/aws-client/services';
+import Logger from '@cumulus/logger';
+
 import { CumulusApiClientError } from './CumulusApiClientError';
 import * as types from './types';
 
@@ -26,6 +28,7 @@ export async function invokeApi(
     payload,
     expectedStatusCode = 200,
     pRetryOptions = {},
+    throwOnApiFailure = true,
   } = params;
 
   return await pRetry(
@@ -47,7 +50,7 @@ export async function invokeApi(
         );
       }
 
-      if (parsedPayload?.statusCode !== expectedStatusCode) {
+      if (throwOnApiFailure && parsedPayload?.statusCode !== expectedStatusCode) {
         throw new CumulusApiClientError(
           `${payload.path} returned ${parsedPayload.statusCode}: ${parsedPayload.body}`
         );

--- a/packages/api-client/src/granules.ts
+++ b/packages/api-client/src/granules.ts
@@ -1,6 +1,8 @@
 import pRetry from 'p-retry';
-import Logger from '@cumulus/logger';
+
 import { ApiGranule, GranuleId, GranuleStatus } from '@cumulus/types/api/granules';
+import Logger from '@cumulus/logger';
+
 import { invokeApi } from './cumulusApiClient';
 import { ApiGatewayLambdaHttpProxyResponse, InvokeApiFunction } from './types';
 
@@ -23,9 +25,16 @@ export const getGranuleResponse = async (params: {
   prefix: string,
   granuleId: GranuleId,
   query?: { [key: string]: string },
-  callback?: InvokeApiFunction
+  callback?: InvokeApiFunction,
+  throwOnApiFailure?: boolean
 }): Promise<ApiGatewayLambdaHttpProxyResponse> => {
-  const { prefix, granuleId, query, callback = invokeApi } = params;
+  const {
+    prefix,
+    granuleId,
+    query,
+    callback = invokeApi,
+    throwOnApiFailure = false,
+  } = params;
 
   return await callback({
     prefix: prefix,
@@ -35,6 +44,7 @@ export const getGranuleResponse = async (params: {
       path: `/granules/${granuleId}`,
       ...(query && { queryStringParameters: query }),
     },
+    throwOnApiFailure,
   });
 };
 
@@ -57,7 +67,10 @@ export const getGranule = async (params: {
   query?: { [key: string]: string },
   callback?: InvokeApiFunction
 }): Promise<ApiGranule> => {
-  const response = await getGranuleResponse(params);
+  const response = await getGranuleResponse({
+    ...params,
+    throwOnApiFailure: true,
+  });
   return JSON.parse(response.body);
 };
 

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -30,6 +30,7 @@ export interface InvokeApiFunctionParams {
   payload: ApiGatewayLambdaProxyPayload,
   pRetryOptions?: pRetry.Options,
   expectedStatusCode?: number
+  throwOnApiFailure?: boolean
 }
 
 export type InvokeApiFunction = (

--- a/packages/api-client/tests/test-granules.js
+++ b/packages/api-client/tests/test-granules.js
@@ -8,6 +8,14 @@ test.before((t) => {
   t.context.granuleId = 'granule-1';
 });
 
+test('getGranuleResponse does not throw error on unexpected status code', async (t) => {
+  await t.notThrowsAsync(granulesApi.getGranuleResponse({
+    callback: () => Promise.resolve({ statusCode: 500 }),
+    prefix: t.context.testPrefix,
+    granuleId: t.context.granuleId,
+  }));
+});
+
 test('getGranule calls the callback with the expected object', async (t) => {
   const expected = {
     prefix: t.context.testPrefix,
@@ -16,6 +24,7 @@ test('getGranule calls the callback with the expected object', async (t) => {
       resource: '/{proxy+}',
       path: `/granules/${t.context.granuleId}`,
     },
+    throwOnApiFailure: true,
   };
 
   const callback = (configObject) => {
@@ -44,6 +53,7 @@ test('getGranule calls the callback with the expected object when there is query
       path: `/granules/${t.context.granuleId}`,
       queryStringParameters: query,
     },
+    throwOnApiFailure: true,
   };
 
   const callback = (configObject) => {
@@ -60,6 +70,14 @@ test('getGranule calls the callback with the expected object when there is query
     prefix: t.context.testPrefix,
     granuleId: t.context.granuleId,
     query,
+  }));
+});
+
+test('getGranule throws error on unexpected status code', async (t) => {
+  await t.throwsAsync(granulesApi.getGranule({
+    callback: () => Promise.resolve({ statusCode: 500 }),
+    prefix: t.context.testPrefix,
+    granuleId: t.context.granuleId,
   }));
 });
 


### PR DESCRIPTION
I was seeing 409 errors trying to delete the provider/collection in the cleanup and I think it's because we weren't waiting for the executions to complete (as a proxy for granules being completed) before trying to delete the provider/collection which is referred to from granules via a FK

See https://ci.earthdata.nasa.gov/browse/CUM-CBA2459-DIS-2