### PR TITLE
CUMULUS-2327: Set API reserved concurrency to 5.

### DIFF
--- a/tf-modules/archive/api.tf
+++ b/tf-modules/archive/api.tf
@@ -162,6 +162,8 @@ resource "aws_lambda_function" "api" {
   memory_size = 960
   tags        = var.tags
 
+  reserved_concurrent_executions = 5
+
   dynamic "vpc_config" {
     for_each = length(var.lambda_subnet_ids) == 0 ? [] : [1]
     content {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2327: As a cumulus integrator, I'd like to see reserved concurrency or some other mechanism in place to protect critical control of cumulus](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2327)

## Changes

* Set API reserved concurrency to 5.

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
