### PR TITLE
CUMULUS-2327: API Provisioned Concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **CUMULUS-2327**
+  - Added provisioned concurrency config to the API lambda function to ensure continuity of service
+    in the event of Lambda concurrency limitations being reached.
 - **CUMULUS-2475**
   - Adds `GET` endpoint to distribution API
 - **CUMULUS-2476**

--- a/tf-modules/archive/api.tf
+++ b/tf-modules/archive/api.tf
@@ -156,6 +156,7 @@ resource "aws_lambda_function" "api" {
   role             = aws_iam_role.lambda_api_gateway.arn
   runtime          = "nodejs12.x"
   timeout          = 100
+  publish          = true
   environment {
     variables = merge(local.api_env_variables, {"auth_mode"="public"})
   }
@@ -169,6 +170,14 @@ resource "aws_lambda_function" "api" {
       security_group_ids = concat(local.lambda_security_group_ids, [var.rds_security_group])
     }
   }
+}
+
+resource "aws_lambda_provisioned_concurrency_config" "api_provisioned_concurrency" {
+  function_name = aws_lambda_function.api.function_name
+  provisioned_concurrent_executions = 5
+  qualifier = aws_lambda_function.api.version
+
+  depends_on = [aws_lambda_function.api]
 }
 
 data "aws_iam_policy_document" "private_api_policy_document" {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2327: As a cumulus integrator, I'd like to see reserved concurrency or some other mechanism in place to protect critical control of cumulus](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2327)

## Changes

* Set API provisioned concurrency to 5. Reserved concurrency was not used as that setting caps the maximum concurrency, whereas provisioned concurrency does not.

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
