### PR TITLE
Jk/cumulus 2302 fix sf scheduler get provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - **CUMULUS-2302**
     - Update API collection GET endpoint to read individual provider records from
       PostgreSQL database instead of DynamoDB
-    - Update sf-scheduler lambda to utilize API endpoint to get provider record
+    - Update sf-scheduler lambda to utilize API endpoint to get provider and
+      collection records
       from database via Private API lambda
     - Update API granule `reingest` endpoint to read collection from PostgreSQL
       database instead of DynamoDB

--- a/packages/api/lambdas/sf-scheduler.js
+++ b/packages/api/lambdas/sf-scheduler.js
@@ -4,16 +4,19 @@ const get = require('lodash/get');
 const isNil = require('lodash/isNil');
 
 const { getCollection } = require('@cumulus/api-client/collections');
+const { getProvider } = require('@cumulus/api-client/providers');
 const SQS = require('@cumulus/aws-client/SQS');
 const { buildQueueMessageFromTemplate } = require('@cumulus/message/Build');
 const Logger = require('@cumulus/logger');
 
 const logger = new Logger({ sender: '@cumulus/api/lambdas/sf-scheduler' });
-const Provider = require('../models/providers');
 
-const getProvider = (id) => {
+const getApiProvider = (id) => {
   if (isNil(id)) return undefined;
-  return (new Provider()).get({ id });
+  return getProvider({
+    prefix: process.env.stackName,
+    providerId: id,
+  });
 };
 
 const getApiCollection = (collection) => {
@@ -37,7 +40,7 @@ const getApiCollection = (collection) => {
  */
 async function handleScheduleEvent(event) {
   const [provider, collection] = await Promise.all([
-    getProvider(event.provider),
+    getApiProvider(event.provider),
     getApiCollection(event.collection),
   ]);
 

--- a/packages/api/tests/lambdas/test-sf-scheduler.js
+++ b/packages/api/tests/lambdas/test-sf-scheduler.js
@@ -44,19 +44,17 @@ const fakeGetCollection = (item) => {
   return Promise.resolve(fakeCollection);
 };
 
-class FakeProvider {
-  get({ id }) {
-    if (id !== fakeProvider.id) {
-      return Promise.reject(new Error('Provider could not be found'));
-    }
-    return Promise.resolve(fakeProvider);
+const fakeGetProvider = ({ providerId }) => {
+  if (providerId !== fakeProvider.id) {
+    return Promise.reject(new Error('Provider could not be found'));
   }
-}
+  return Promise.resolve(fakeProvider);
+};
 
-const getProvider = schedule.__get__('getProvider');
+const getApiProvider = schedule.__get__('getApiProvider');
 const getApiCollection = schedule.__get__('getApiCollection');
 
-const resetProvider = schedule.__set__('Provider', FakeProvider);
+const resetProvider = schedule.__set__('getProvider', fakeGetProvider);
 const resetCollection = schedule.__set__('getCollection', fakeGetCollection);
 
 test.before(() => {
@@ -74,12 +72,12 @@ test.after.always(() => {
 });
 
 test.serial('getProvider returns undefined when input is falsey', async (t) => {
-  const response = await getProvider(undefined);
+  const response = await getApiProvider(undefined);
   t.is(response, undefined);
 });
 
 test.serial('getProvider returns provider when input is a valid provider ID', async (t) => {
-  const response = await getProvider(fakeProvider.id);
+  const response = await getApiProvider(fakeProvider.id);
   t.deepEqual(response, fakeProvider);
 });
 

--- a/packages/db/src/translate/collections.ts
+++ b/packages/db/src/translate/collections.ts
@@ -23,7 +23,7 @@ export const translatePostgresCollectionToApiCollection = (
   reportToEms: collectionRecord.report_to_ems,
   sampleFileName: collectionRecord.sample_file_name,
   ignoreFilesConfigForDiscovery: collectionRecord.ignore_files_config_for_discovery,
-  meta: collectionRecord.meta ? JSON.parse(collectionRecord.meta) : undefined,
+  meta: collectionRecord.meta ?? undefined,
   tags: collectionRecord.tags ?? undefined,
 }));
 

--- a/packages/db/tests/translate/test-collections.js
+++ b/packages/db/tests/translate/test-collections.js
@@ -24,7 +24,7 @@ test('translatePostgresCollectionToApiCollection converts Postgres collection to
     files: collectionRecord.files,
     granuleId: collectionRecord.granule_id_validation_regex,
     granuleIdExtraction: collectionRecord.granule_id_validation_regex,
-    meta: JSON.parse(collectionRecord.meta),
+    meta: collectionRecord.meta,
     name: collectionRecord.name,
     sampleFileName: collectionRecord.sample_file_name,
     tags: collectionRecord.tags,


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2302](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2302)

## Changes

Follow-on to #2305, updating sf-scheduler to read from the Provider postgres table was missed

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
