### PR TITLE
Fix sqsRuleSpec/ IngestFailureSpec -- fix-API-error-test-failures

### DIFF
--- a/example/spec/parallel/ingestGranule/IngestGranuleFailureSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleFailureSpec.js
@@ -106,16 +106,19 @@ describe('The Ingest Granule failure workflow', () => {
   afterAll(async () => {
     // The granule provided cannot clean up the
     // fake S3 objects, so we expect it to fail
-    const granuleResponse = await deleteGranule({
-      prefix: config.stackName,
-      granuleId: inputPayload.granules[0].granuleId,
-      pRetryOptions: {
-        retries: 0,
-      },
-      expectedStatusCode: 400,
-    });
-    if (JSON.parse(granuleResponse.body).code !== 'NoSuchBucket') {
-      throw new Error(`Could not complete test cleanup ${granuleResponse.body}`);
+    try {
+      await deleteGranule({
+        prefix: config.stackName,
+        granuleId: inputPayload.granules[0].granuleId,
+        pRetryOptions: {
+          retries: 0,
+        },
+      });
+    } catch (error) {
+      const apiMessage = JSON.parse(error.apiMessage);
+      if (apiMessage.code !== 'NoSuchBucket') {
+        throw new Error(`Could not complete test cleanup ${error.apiMessage}`);
+      }
     }
 
     await apiTestUtils.deletePdr({

--- a/example/spec/parallel/ingestGranule/IngestGranuleFailureSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleFailureSpec.js
@@ -104,11 +104,19 @@ describe('The Ingest Granule failure workflow', () => {
   });
 
   afterAll(async () => {
-    // clean up stack state added by test
-    await deleteGranule({
+    // The granule provided cannot clean up the
+    // fake S3 objects, so we expect it to fail
+    const granuleResponse = await deleteGranule({
       prefix: config.stackName,
       granuleId: inputPayload.granules[0].granuleId,
+      pRetryOptions: {
+        retries: 0,
+      },
+      expectedStatusCode: 400,
     });
+    if (JSON.parse(granuleResponse.body).code !== 'NoSuchBucket') {
+      throw new Error(`Could not complete test cleanup ${granuleResponse.body}`);
+    }
 
     await apiTestUtils.deletePdr({
       prefix: config.stackName,

--- a/example/spec/parallel/testAPI/sqsRuleSpec.js
+++ b/example/spec/parallel/testAPI/sqsRuleSpec.js
@@ -34,6 +34,9 @@ const {
 const { getS3KeyForArchivedMessage } = require('@cumulus/ingest/sqs');
 const { randomId } = require('@cumulus/common/test-utils');
 
+const { constructCollectionId } = require('@cumulus/message/Collections');
+const { getExecutions } = require('@cumulus/api-client/executions');
+
 const { waitForModelStatus } = require('../../helpers/apiUtils');
 const { setupTestGranuleForIngest } = require('../../helpers/granuleUtils');
 
@@ -65,6 +68,7 @@ const granuleRegex = '^MOD09GQ\\.A[\\d]{7}\\.[\\w]{6}\\.006\\.[\\d]{13}$';
 const ruleDirectory = './spec/parallel/testAPI/data/rules/sqs';
 
 let queues = {};
+let collectionResult;
 
 async function setupCollectionAndTestData() {
   const s3data = [
@@ -74,7 +78,7 @@ async function setupCollectionAndTestData() {
   ];
 
   // populate collections, providers and test data
-  await Promise.all([
+  [, collectionResult] = await Promise.all([
     uploadTestDataToBucket(config.bucket, s3data, testDataFolder),
     addCollections(config.stackName, config.bucket, collectionsDir, testSuffix),
     addProviders(config.stackName, config.bucket, providersDir, config.bucket, testSuffix),
@@ -92,9 +96,20 @@ async function cleanUp() {
     pdr: pdrFilename,
   });
 
-  // TODO there may be another execution to delete here
-  await waitForCompletedExecution(executionArn);
-  await deleteExecution({ prefix: config.stackName, executionArn });
+  const collection = collectionResult[0];
+  // Delete successful execution and 2 failed executions
+  const executions = JSON.parse((await getExecutions({
+    prefix: config.stackName,
+    query: {
+      fields: ['arn'],
+      collectionId: constructCollectionId(collection.name, collection.version),
+    },
+  })).body).results;
+  await Promise.all(executions.map(
+    (execution) => waitForCompletedExecution(execution.arn)
+      .then(deleteExecution({ prefix: config.stackName, executionArn: execution.arn }))
+  ));
+
   await Promise.all(inputPayload.granules.map(
     (granule) => deleteGranule({ prefix: config.stackName, granuleId: granule.granuleId })
   ));

--- a/packages/api-client/src/granules.ts
+++ b/packages/api-client/src/granules.ts
@@ -245,7 +245,6 @@ export const applyWorkflow = async (params: {
  *
  * @param {Object} params                      - params
  * @param {pRetry.Options} params.pRetryObject - pRetry options object
- * @param {number} params.expectedStatusCode   - expected API status code
  * @param {string} params.prefix               - the prefix configured for the stack
  * @param {string} params.granuleId            - a granule ID
  * @param {Function} params.callback           - async function to invoke the api lambda

--- a/packages/api-client/src/granules.ts
+++ b/packages/api-client/src/granules.ts
@@ -243,22 +243,31 @@ export const applyWorkflow = async (params: {
  * Delete a granule from Cumulus via the API lambda
  * DELETE /granules/${granuleId}
  *
- * @param {Object} params             - params
- * @param {string} params.prefix      - the prefix configured for the stack
- * @param {string} params.granuleId   - a granule ID
- * @param {Function} params.callback  - async function to invoke the api lambda
- *                                      that takes a prefix / user payload.  Defaults
- *                                      to cumulusApiClient.invokeApifunction to invoke the
- *                                      api lambda
- * @returns {Promise<Object>}         - the delete confirmation from the API
+ * @param {Object} params                      - params
+ * @param {pRetry.Options} params.pRetryObject - pRetry options object
+ * @param {number} params.expectedStatusCode   - expected API status code
+ * @param {string} params.prefix               - the prefix configured for the stack
+ * @param {string} params.granuleId            - a granule ID
+ * @param {Function} params.callback           - async function to invoke the api lambda
+ *                                               that takes a prefix / user payload.  Defaults
+ *                                               to cumulusApiClient.invokeApifunction to invoke the
+ *                                               api lambda
+ * @returns {Promise<Object>}                  - the delete confirmation from the API
  */
 export const deleteGranule = async (params: {
   prefix: string,
   granuleId: GranuleId,
+  expectedStatusCode?: number,
+  pRetryOptions?: pRetry.Options,
   callback?: InvokeApiFunction
 }): Promise<ApiGatewayLambdaHttpProxyResponse> => {
-  const { prefix, granuleId, callback = invokeApi } = params;
-
+  const {
+    expectedStatusCode = 200,
+    pRetryOptions,
+    prefix,
+    granuleId,
+    callback = invokeApi,
+  } = params;
   return await callback({
     prefix: prefix,
     payload: {
@@ -266,6 +275,8 @@ export const deleteGranule = async (params: {
       resource: '/{proxy+}',
       path: `/granules/${granuleId}`,
     },
+    pRetryOptions,
+    expectedStatusCode,
   });
 };
 

--- a/packages/api-client/src/granules.ts
+++ b/packages/api-client/src/granules.ts
@@ -257,12 +257,10 @@ export const applyWorkflow = async (params: {
 export const deleteGranule = async (params: {
   prefix: string,
   granuleId: GranuleId,
-  expectedStatusCode?: number,
   pRetryOptions?: pRetry.Options,
   callback?: InvokeApiFunction
 }): Promise<ApiGatewayLambdaHttpProxyResponse> => {
   const {
-    expectedStatusCode = 200,
     pRetryOptions,
     prefix,
     granuleId,
@@ -276,7 +274,6 @@ export const deleteGranule = async (params: {
       path: `/granules/${granuleId}`,
     },
     pRetryOptions,
-    expectedStatusCode,
   });
 };
 


### PR DESCRIPTION
**Summary:** Summary of changes

## Changes

* Fixes sqsRuleSpec on the integration test fix branch.

Failed execution (and the redrive retry) was preventing the cleanup from occurring, this PR adds an execution search query against the unique collectionId. 

* Fixes IngestFailureSpec - the integration test was failing as the granule deletion endpoint was (rightly) failing as it cannot delete fake S3 objects.    This updates the test to expect the failure (which *does* remove the granule record) and continue to delete the other records without a refactor to the endpoint logic. 

