### PR TITLE
Update PDR spec tests to use unique granule IDs

### DIFF
--- a/example/spec/helpers/testUtils.js
+++ b/example/spec/helpers/testUtils.js
@@ -50,26 +50,46 @@ function templateFile({ inputTemplateFilename, config }) {
  * Upload a file from the test-data package to the S3 test data
  * and update contents with replacements
  *
- * @param {string} file - filename of data to upload
- * @param {string} bucket - bucket to upload to
- * @param {string} prefix - S3 folder prefix
- * @param {Array<StringReplacement>} [replacements] - array of replacements in file content e.g. [{old: 'test', new: 'newTest' }]
+ * @param {Object} params                         - parameters
+ * @param {string} params.file                    - filename of data to upload
+ * @param {string} params.bucket                  - bucket to upload to
+ * @param {string} params.prefix                  - S3 folder prefix
+ * @param {string} params.targetReplacementRegex  - regexp to allow file copy target to target
+ *                                                  a different s3 key from the original file
+ *                                                  if specified will replace matches with
+ *                                                  targetReplacementString
+ * @param {string} params.targetReplacementString - replacement value for targetReplacementRegex match
+ * @param {Array<StringReplacement>} params.replacements - array of replacements in file content e.g. [{old: 'test', new: 'newTest' }]
  * @returns {Promise<Object>} - promise returned from S3 PUT
  */
-async function updateAndUploadTestFileToBucket(file, bucket, prefix = 'cumulus-test-data/pdrs', replacements = []) {
+async function updateAndUploadTestFileToBucket(params) {
+  const {
+    file,
+    bucket,
+    prefix,
+    replacements = [],
+    targetReplacementRegex,
+    targetReplacementString,
+  } = params;
   let data;
   if (replacements.length > 0) {
     data = fs.readFileSync(require.resolve(file), 'utf8');
     replacements.forEach((replacement) => {
       data = replace(data, new RegExp(replacement.old, 'g'), replacement.new);
     });
-  } else data = fs.readFileSync(require.resolve(file));
-  const key = path.basename(file);
+  } else {
+    data = fs.readFileSync(require.resolve(file));
+  }
+  let key = path.basename(file);
+  if (targetReplacementRegex) {
+    key = key.replace(targetReplacementRegex, targetReplacementString);
+  }
+
   return await s3().putObject({
     Bucket: bucket,
     Key: `${prefix}/${key}`,
     Body: data,
-    ContentType: mime.lookup(key) || null,
+    ContentType: mime.lookup(key) || undefined,
   }).promise();
 }
 
@@ -84,7 +104,7 @@ async function updateAndUploadTestFileToBucket(file, bucket, prefix = 'cumulus-t
  * @returns {Array<Promise>} - responses from S3 upload
  */
 async function updateAndUploadTestDataToBucket(bucket, data, prefix, replacements) {
-  return await Promise.all(data.map((file) => updateAndUploadTestFileToBucket(file, bucket, prefix, replacements)));
+  return await Promise.all(data.map((file) => updateAndUploadTestFileToBucket({ file, bucket, prefix, replacements })));
 }
 
 /**
@@ -186,6 +206,7 @@ module.exports = {
   templateFile,
   timestampedName,
   updateAndUploadTestDataToBucket,
+  updateAndUploadTestFileToBucket,
   uploadTestDataToBucket,
   isValidAsyncOperationId,
 };

--- a/example/spec/parallel/ingest/ingestFromPdrSpec.js
+++ b/example/spec/parallel/ingest/ingestFromPdrSpec.js
@@ -14,7 +14,7 @@
  * pdr status check
  * This will kick off the ingest workflow
  *
- * Ingest worklow:
+ * Ingest workflow:
  * runs sync granule - saves file to file staging location
  * performs the fake processing step - generates CMR metadata
  * Moves the file to the final location
@@ -89,7 +89,7 @@ describe('Ingesting from PDR', () => {
   let testDataFolder;
   let testSuffix;
   let workflowExecution;
-  let addedCollection;
+  let addedCollections;
   let ingestGranuleExecution;
 
   beforeAll(async () => {
@@ -110,7 +110,7 @@ describe('Ingesting from PDR', () => {
       provider = { id: `s3_provider${testSuffix}` };
 
       // populate collections, providers and test data
-      [addedCollection] = await Promise.all(
+      [addedCollections] = await Promise.all(
         flatten([
           addCollections(config.stackName, config.bucket, collectionsDir, testSuffix, testId),
           updateAndUploadTestDataToBucket(
@@ -176,7 +176,7 @@ describe('Ingesting from PDR', () => {
           config.stackName,
           config.bucket,
           workflowName,
-          { name: addedCollection.name, version: addedCollection.version },
+          { name: addedCollections[0].name, version: addedCollections[0].version },
           provider,
           undefined,
           { provider_path: testDataFolder }

--- a/example/spec/parallel/ingest/ingestFromPdrWithChildWorkflowMetaSpec.js
+++ b/example/spec/parallel/ingest/ingestFromPdrWithChildWorkflowMetaSpec.js
@@ -70,7 +70,7 @@ describe('The DiscoverAndQueuePdrsChildWorkflowMeta workflow', () => {
   const providersDir = './data/providers/s3/';
   const collectionsDir = './data/collections/s3_MOD09GQ_006';
 
-  let addedCollection;
+  let addedCollections;
   let beforeAllFailed;
   let config;
   let executionNamePrefix;
@@ -99,7 +99,7 @@ describe('The DiscoverAndQueuePdrsChildWorkflowMeta workflow', () => {
       provider = { id: `s3_provider${testSuffix}` };
 
       // populate collections, providers and test data
-      [addedCollection] = await Promise.all([
+      [addedCollections] = await Promise.all([
         addCollections(
           config.stackName,
           config.bucket,
@@ -143,7 +143,7 @@ describe('The DiscoverAndQueuePdrsChildWorkflowMeta workflow', () => {
         config.stackName,
         config.bucket,
         workflowName,
-        { name: addedCollection[0].name, version: addedCollection[0].version },
+        { name: addedCollections[0].name, version: addedCollections[0].version },
         provider,
         undefined,
         {

--- a/example/spec/parallel/ingest/ingestFromPdrWithExecutionNamePrefixSpec.js
+++ b/example/spec/parallel/ingest/ingestFromPdrWithExecutionNamePrefixSpec.js
@@ -69,7 +69,7 @@ describe('The DiscoverAndQueuePdrsExecutionPrefix workflow', () => {
   const providersDir = './data/providers/s3/';
   const collectionsDir = './data/collections/s3_MOD09GQ_006';
 
-  let addedCollection;
+  let addedCollections;
   let beforeAllFailed;
   let config;
   let executionNamePrefix;
@@ -99,7 +99,7 @@ describe('The DiscoverAndQueuePdrsExecutionPrefix workflow', () => {
       provider = { id: `s3_provider${testSuffix}` };
 
       // populate collections, providers and test data
-      [addedCollection] = await Promise.all(
+      [addedCollections] = await Promise.all(
         flatten([
           addCollections(
             config.stackName,
@@ -156,7 +156,7 @@ describe('The DiscoverAndQueuePdrsExecutionPrefix workflow', () => {
         config.stackName,
         config.bucket,
         workflowName,
-        { name: addedCollection.name, version: addedCollection.version },
+        { name: addedCollections[0].name, version: addedCollections[0].version },
         provider,
         undefined,
         {


### PR DESCRIPTION
Updates integration tests to use unique granuleIds for all PDR tests
