### PR TITLE
Update buildAndExecuteWorkflow to use API, update spec to use new helper

### DIFF
--- a/example/spec/helpers/workflowUtils.js
+++ b/example/spec/helpers/workflowUtils.js
@@ -196,7 +196,7 @@ async function testWorkflow(stackName, bucketName, workflowName, inputFile) {
     const parsedInput = JSON.parse(rawInput);
     const workflowStatus = await executeWorkflow(stackName, bucketName, workflowName, parsedInput);
 
-    if (workflowStatus.status === 'SUCCEEDED') {
+    if (workflowStatus.status === 'completed') {
       console.log(`Workflow ${workflowName} execution succeeded.`);
     } else {
       console.log(`Workflow ${workflowName} execution failed with state: ${workflowStatus.status}`);

--- a/example/spec/helpers/workflowUtils.js
+++ b/example/spec/helpers/workflowUtils.js
@@ -1,6 +1,22 @@
 'use strict';
 
 const get = require('lodash/get');
+const merge = require('lodash/merge');
+const uuidv4 = require('uuid/v4');
+
+const {
+  templateKey,
+  getWorkflowFileKey,
+} = require('@cumulus/common/workflows');
+const { getJsonS3Object } = require('@cumulus/aws-client/S3');
+const collectionsApi = require('@cumulus/api-client/collections');
+const providersApi = require('@cumulus/api-client/providers');
+const { getExecution } = require('@cumulus/api-client/executions');
+const {
+  sfn,
+} = require('@cumulus/aws-client/services');
+
+const { waitForApiStatus } = require('./apiUtils');
 
 function isReingestExecution(taskInput) {
   return get(
@@ -31,6 +47,178 @@ function isReingestExecutionForGranuleId(taskInput, { granuleId }) {
     isExecutionForGranuleId(taskInput, granuleId);
 }
 
+/**
+ * Kick off a workflow execution
+ *
+ * @param {string} workflowArn - ARN for the workflow
+ * @param {Object} workflowMsg - workflow message
+ * @returns {Promise.<Object>} execution details: {executionArn, startDate}
+ */
+
+async function startWorkflowExecution(workflowArn, workflowMsg) {
+  // Give this execution a unique name
+  workflowMsg.cumulus_meta.execution_name = uuidv4();
+  workflowMsg.cumulus_meta.workflow_start_time = Date.now();
+  workflowMsg.cumulus_meta.state_machine = workflowArn;
+
+  const workflowParams = {
+    stateMachineArn: workflowArn,
+    input: JSON.stringify(workflowMsg),
+    name: workflowMsg.cumulus_meta.execution_name,
+  };
+
+  return await sfn().startExecution(workflowParams).promise();
+}
+
+/**
+ * Start the workflow and return the execution Arn. Does not wait
+ * for workflow completion.
+ *
+ * @param {string} stackName - Cloud formation stack name
+ * @param {string} bucketName - S3 internal bucket name
+ * @param {string} workflowName - workflow name
+ * @param {Object} workflowMsg - workflow message
+ * @returns {string} - executionArn
+ */
+async function startWorkflow(stackName, bucketName, workflowName, workflowMsg) {
+  const { arn: workflowArn } = await getJsonS3Object(
+    bucketName,
+    getWorkflowFileKey(stackName, workflowName)
+  );
+  const { executionArn } = await startWorkflowExecution(workflowArn, workflowMsg);
+
+  console.log(`Starting workflow: ${workflowName}. Execution ARN ${executionArn}`);
+
+  return executionArn;
+}
+
+/**
+ * Execute the given workflow.
+ * Wait for workflow to complete to get the status
+ * Return the execution arn and the workflow status.
+ *
+ * @param {string} stackName - Cloud formation stack name
+ * @param {string} bucketName - S3 internal bucket name
+ * @param {string} workflowName - workflow name
+ * @param {Object} workflowMsg - workflow message
+ * @param {number} [timeout=600] - number of seconds to wait for execution to complete
+ * @returns {Object} - {executionArn: <arn>, status: <status>}
+ */
+async function executeWorkflow(stackName, bucketName, workflowName, workflowMsg, timeout = 600) {
+  const executionArn = await startWorkflow(stackName, bucketName, workflowName, workflowMsg);
+  // Wait for the execution to complete to get the status
+  const record = await waitForApiStatus(
+    getExecution,
+    { prefix: stackName, arn: executionArn },
+    ['completed', 'failed'],
+    { maxTimeout: timeout * 1000 }
+  );
+
+  return { status: record.status, executionArn };
+}
+
+/**
+ * build workflow message
+ *
+ * @param {string} stackName - Cloud formation stack name
+ * @param {string} bucketName - S3 internal bucket name
+ * @param {string} workflowName - workflow name
+ * @param {Object} collection - collection information
+ * @param {Object} collection.name - collection name
+ * @param {Object} collection.version - collection version
+ * @param {Object} provider - provider information
+ * @param {Object} provider.id - provider id
+ * @param {Object} payload - payload information
+ * @param {Object} meta - additional keys to add to meta field
+ * @returns {Object} workflow message
+ */
+async function buildWorkflow(
+  stackName,
+  bucketName,
+  workflowName,
+  collection,
+  provider,
+  payload,
+  meta
+) {
+  const template = await getJsonS3Object(bucketName, templateKey(stackName));
+
+  if (collection) {
+    const collectionsApiResponse = await collectionsApi.getCollection({
+      prefix: stackName,
+      collectionName: collection.name,
+      collectionVersion: collection.version,
+    });
+    if (collectionsApiResponse.statusCode) {
+      throw new Error(`Collections API responded with error on buildWorkflow ${JSON.stringify(collectionsApiResponse)}`);
+    }
+    template.meta.collection = collectionsApiResponse;
+  } else {
+    template.meta.collection = {};
+  }
+
+  if (provider) {
+    const providersApiResponse = await providersApi.getProvider(
+      {
+        prefix: stackName,
+        providerId: provider.id,
+      }
+    );
+    if (providersApiResponse.statusCode !== 200) {
+      throw new Error(`Providers API responded with error on buildWorkflow ${JSON.stringify(providersApiResponse)}`);
+    }
+    template.meta.provider = JSON.parse(providersApiResponse.body);
+    template.meta.provider.password = provider.password;
+  } else {
+    template.meta.provider = {};
+  }
+
+  template.meta.workflow_name = workflowName;
+  template.meta = merge(template.meta, meta);
+  template.payload = payload || {};
+
+  return template;
+}
+
+/**
+ * build workflow message and execute the workflow
+ *
+ * @param {string} stackName - Cloud formation stack name
+ * @param {string} bucketName - S3 internal bucket name
+ * @param {string} workflowName - workflow name
+ * @param {Object} collection - collection information
+ * @param {Object} collection.name - collection name
+ * @param {Object} collection.version - collection version
+ * @param {Object} provider - provider information
+ * @param {Object} provider.id - provider id
+ * @param {Object} payload - payload information
+ * @param {Object} meta - additional keys to add to meta field
+ * @param {number} [timeout=600] - number of seconds to wait for execution to complete
+ * @returns {Object} - {executionArn: <arn>, status: <status>}
+ */
+async function buildAndExecuteWorkflow(
+  stackName,
+  bucketName,
+  workflowName,
+  collection,
+  provider,
+  payload,
+  meta = {},
+  timeout = 600
+) {
+  const workflowMsg = await buildWorkflow(
+    stackName,
+    bucketName,
+    workflowName,
+    collection,
+    provider,
+    payload,
+    meta
+  );
+  return executeWorkflow(stackName, bucketName, workflowName, workflowMsg, timeout);
+}
+
 module.exports = {
+  buildAndExecuteWorkflow,
   isReingestExecutionForGranuleId,
 };

--- a/example/spec/loadTest/runScaledTest.js
+++ b/example/spec/loadTest/runScaledTest.js
@@ -13,10 +13,8 @@ const { listS3ObjectsV2 } = require('@cumulus/aws-client/S3');
 const { collections, granules, providers } = require('@cumulus/api-client');
 const { randomString } = require('@cumulus/common/test-utils');
 
-const {
-  api: apiTestUtils,
-  buildAndExecuteWorkflow,
-} = require('@cumulus/integration-tests');
+const { api: apiTestUtils } = require('@cumulus/integration-tests');
+const { buildAndExecuteWorkflow } = require('../helpers/workflowUtils');
 
 const {
   createTestSuffix,

--- a/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
+++ b/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
@@ -26,7 +26,6 @@ const { Granule } = require('@cumulus/api/models');
 const {
   addCollections,
   addProviders,
-  buildAndExecuteWorkflow,
   cleanupProviders,
   generateCmrXml,
   waitForAsyncOperationStatus,
@@ -39,6 +38,7 @@ const { getCollections } = require('@cumulus/api-client/collections');
 const { getGranule } = require('@cumulus/api-client/granules');
 const { getCmrSettings } = require('@cumulus/cmrjs/cmr-utils');
 
+const { buildAndExecuteWorkflow } = require('../../helpers/workflowUtils');
 const {
   loadConfig,
   uploadTestDataToBucket,

--- a/example/spec/parallel/discoverGranules/DiscoverGranulesHttpsSpec.js
+++ b/example/spec/parallel/discoverGranules/DiscoverGranulesHttpsSpec.js
@@ -4,11 +4,11 @@ const { deleteProvider } = require('@cumulus/api-client/providers');
 const { LambdaStep } = require('@cumulus/integration-tests/sfnStep');
 const {
   addCollections,
-  buildAndExecuteWorkflow,
   cleanupCollections,
   waitForCompletedExecution,
 } = require('@cumulus/integration-tests');
 
+const { buildAndExecuteWorkflow } = require('../../helpers/workflowUtils');
 const { loadConfig, createTimestampedTestId, createTestSuffix } = require('../../helpers/testUtils');
 const { buildHttpOrHttpsProvider, createProvider } = require('../../helpers/Providers');
 const { waitForApiStatus } = require('../../helpers/apiUtils');

--- a/example/spec/parallel/discoverGranules/DiscoverGranulesS3FailureSpec.js
+++ b/example/spec/parallel/discoverGranules/DiscoverGranulesS3FailureSpec.js
@@ -3,7 +3,6 @@
 const get = require('lodash/get');
 const { randomString } = require('@cumulus/common/test-utils');
 const {
-  buildAndExecuteWorkflow,
   loadCollection,
   loadProvider,
 } = require('@cumulus/integration-tests');
@@ -17,6 +16,8 @@ const { deleteExecution } = require('@cumulus/api-client/executions');
 const {
   createProvider, deleteProvider,
 } = require('@cumulus/api-client/providers');
+
+const { buildAndExecuteWorkflow } = require('../../helpers/workflowUtils');
 const {
   loadConfig,
   createTimestampedTestId,

--- a/example/spec/parallel/discoverGranules/DiscoverGranulesS3FailureSpec.js
+++ b/example/spec/parallel/discoverGranules/DiscoverGranulesS3FailureSpec.js
@@ -84,7 +84,7 @@ describe('The DiscoverGranules workflow with a non-existent bucket', () => {
 
   it('fails', () => {
     if (!beforeAllCompleted) fail('beforeAll() failed');
-    else expect(workflowExecution.status).toEqual('FAILED');
+    else expect(workflowExecution.status).toEqual('failed');
   });
 
   it('records the correct execution failure reason in the API', async () => {

--- a/example/spec/parallel/discoverGranules/DiscoverGranulesS3SuccessSpec.js
+++ b/example/spec/parallel/discoverGranules/DiscoverGranulesS3SuccessSpec.js
@@ -173,7 +173,7 @@ describe('The DiscoverGranules workflow', () => {
       const ingestGranuleExecutionStatus = await waitForCompletedExecution(
         queueGranulesOutput.payload.running[0]
       );
-      expect(ingestGranuleExecutionStatus).toEqual('completed');
+      expect(ingestGranuleExecutionStatus).toEqual('SUCCEEDED');
     }
   });
 

--- a/example/spec/parallel/discoverGranules/DiscoverGranulesS3SuccessSpec.js
+++ b/example/spec/parallel/discoverGranules/DiscoverGranulesS3SuccessSpec.js
@@ -2,7 +2,6 @@
 
 const pWaitFor = require('p-wait-for');
 const {
-  buildAndExecuteWorkflow,
   getExecutionInputObject,
   loadCollection,
   loadProvider,
@@ -20,6 +19,7 @@ const { getGranule, deleteGranule } = require('@cumulus/api-client/granules');
 const {
   waitForApiStatus,
 } = require('../../helpers/apiUtils');
+const { buildAndExecuteWorkflow } = require('../../helpers/workflowUtils');
 const {
   createTimestampedTestId,
   deleteFolder,

--- a/example/spec/parallel/discoverGranules/DiscoverGranulesS3SuccessSpec.js
+++ b/example/spec/parallel/discoverGranules/DiscoverGranulesS3SuccessSpec.js
@@ -145,7 +145,7 @@ describe('The DiscoverGranules workflow', () => {
 
   it('executes successfully', () => {
     if (!beforeAllCompleted) fail('beforeAll() failed');
-    else expect(workflowExecution.status).toEqual('SUCCEEDED');
+    else expect(workflowExecution.status).toEqual('completed');
   });
 
   it('can be fetched from the API', async () => {
@@ -173,7 +173,7 @@ describe('The DiscoverGranules workflow', () => {
       const ingestGranuleExecutionStatus = await waitForCompletedExecution(
         queueGranulesOutput.payload.running[0]
       );
-      expect(ingestGranuleExecutionStatus).toEqual('SUCCEEDED');
+      expect(ingestGranuleExecutionStatus).toEqual('completed');
     }
   });
 

--- a/example/spec/parallel/discoverGranules/DiscoverGranulesWithExecutionNamePrefixSpec.js
+++ b/example/spec/parallel/discoverGranules/DiscoverGranulesWithExecutionNamePrefixSpec.js
@@ -7,7 +7,6 @@ const { LambdaStep } = require('@cumulus/integration-tests/sfnStep');
 const { deleteExecution } = require('@cumulus/api-client/executions');
 const { deleteGranule } = require('@cumulus/api-client/granules');
 const {
-  buildAndExecuteWorkflow,
   loadCollection,
   loadProvider,
   waitForStartedExecution,
@@ -21,6 +20,8 @@ const {
   createProvider,
   deleteProvider,
 } = require('@cumulus/api-client/providers');
+
+const { buildAndExecuteWorkflow } = require('../../helpers/workflowUtils');
 const {
   createTimestampedTestId,
   deleteFolder,

--- a/example/spec/parallel/discoverGranules/DiscoverGranulesWithExecutionNamePrefixSpec.js
+++ b/example/spec/parallel/discoverGranules/DiscoverGranulesWithExecutionNamePrefixSpec.js
@@ -138,7 +138,7 @@ describe('The DiscoverGranules workflow', () => {
 
   it('executes successfully', () => {
     if (!beforeAllCompleted) fail('beforeAll() failed');
-    else expect(workflowExecution.status).toEqual('SUCCEEDED');
+    else expect(workflowExecution.status).toEqual('completed');
   });
 
   it('properly sets the name of the queued execution', () => {

--- a/example/spec/parallel/helloWorld/HelloWorldEcsSpec.js
+++ b/example/spec/parallel/helloWorld/HelloWorldEcsSpec.js
@@ -1,7 +1,7 @@
 const { Execution } = require('@cumulus/api/models');
 const { deleteExecution } = require('@cumulus/api-client/executions');
-const { buildAndExecuteWorkflow } = require('@cumulus/integration-tests');
 const { ActivityStep } = require('@cumulus/integration-tests/sfnStep');
+const { buildAndExecuteWorkflow } = require('../../helpers/workflowUtils');
 const { loadConfig } = require('../../helpers/testUtils');
 const { waitForModelStatus } = require('../../helpers/apiUtils');
 

--- a/example/spec/parallel/helloWorld/HelloWorldEcsSpec.js
+++ b/example/spec/parallel/helloWorld/HelloWorldEcsSpec.js
@@ -29,7 +29,7 @@ describe('The Hello World workflow using ECS and CMA Layers', () => {
   });
 
   it('executes successfully', () => {
-    expect(workflowExecution.status).toEqual('SUCCEEDED');
+    expect(workflowExecution.status).toEqual('completed');
   });
 
   describe('the HelloWorld ECS', () => {

--- a/example/spec/parallel/ingest/ingestFromPdrSpec.js
+++ b/example/spec/parallel/ingest/ingestFromPdrSpec.js
@@ -37,7 +37,6 @@ const {
   addProviders,
   api: apiTestUtils,
   executionsApi: executionsApiTestUtils,
-  buildAndExecuteWorkflow,
   cleanupProviders,
   cleanupCollections,
   waitForCompletedExecution,
@@ -53,7 +52,7 @@ const {
   updateAndUploadTestFileToBucket,
   updateAndUploadTestDataToBucket,
 } = require('../../helpers/testUtils');
-
+const { buildAndExecuteWorkflow } = require('../../helpers/workflowUtils');
 const {
   loadFileWithUpdatedGranuleIdPathAndCollection,
 } = require('../../helpers/granuleUtils');

--- a/example/spec/parallel/ingest/ingestFromPdrWithChildWorkflowMetaSpec.js
+++ b/example/spec/parallel/ingest/ingestFromPdrWithChildWorkflowMetaSpec.js
@@ -32,7 +32,6 @@ const {
   addCollections,
   addProviders,
   api: apiTestUtils,
-  buildAndExecuteWorkflow,
   cleanupProviders,
   cleanupCollections,
   getExecutionInputObject,
@@ -40,6 +39,7 @@ const {
   waitForCompletedExecution,
 } = require('@cumulus/integration-tests');
 
+const { buildAndExecuteWorkflow } = require('../../helpers/workflowUtils');
 const {
   createTestDataPath,
   createTestSuffix,

--- a/example/spec/parallel/ingest/ingestFromPdrWithChildWorkflowMetaSpec.js
+++ b/example/spec/parallel/ingest/ingestFromPdrWithChildWorkflowMetaSpec.js
@@ -198,7 +198,7 @@ describe('The DiscoverAndQueuePdrsChildWorkflowMeta workflow', () => {
   it('executes successfully', () => {
     if (beforeAllFailed) fail(beforeAllFailed);
     else {
-      expect(workflowExecution.status).toEqual('SUCCEEDED');
+      expect(workflowExecution.status).toEqual('completed');
     }
   });
 

--- a/example/spec/parallel/ingest/ingestFromPdrWithExecutionNamePrefixSpec.js
+++ b/example/spec/parallel/ingest/ingestFromPdrWithExecutionNamePrefixSpec.js
@@ -32,13 +32,14 @@ const {
   addCollections,
   addProviders,
   api: apiTestUtils,
-  buildAndExecuteWorkflow,
   cleanupProviders,
   cleanupCollections,
   waitForCompletedExecution,
   waitForStartedExecution,
 } = require('@cumulus/integration-tests');
 
+
+const { buildAndExecuteWorkflow } = require('../../helpers/workflowUtils');
 const {
   createTestDataPath,
   createTestSuffix,

--- a/example/spec/parallel/ingest/ingestFromPdrWithExecutionNamePrefixSpec.js
+++ b/example/spec/parallel/ingest/ingestFromPdrWithExecutionNamePrefixSpec.js
@@ -214,7 +214,7 @@ describe('The DiscoverAndQueuePdrsExecutionPrefix workflow', () => {
   it('executes successfully', () => {
     if (beforeAllFailed) fail(beforeAllFailed);
     else {
-      expect(workflowExecution.status).toEqual('SUCCEEDED');
+      expect(workflowExecution.status).toEqual('completed');
     }
   });
 

--- a/example/spec/parallel/ingest/ingestPdrWithNodeNameSpec.js
+++ b/example/spec/parallel/ingest/ingestPdrWithNodeNameSpec.js
@@ -226,7 +226,7 @@ describe('Ingesting from PDR', () => {
     it('executes successfully', () => {
       if (beforeAllFailed) fail('beforeAll() failed');
       else {
-        expect(workflowExecution.status).toEqual('SUCCEEDED');
+        expect(workflowExecution.status).toEqual('completed');
       }
     });
 

--- a/example/spec/parallel/ingest/ingestPdrWithNodeNameSpec.js
+++ b/example/spec/parallel/ingest/ingestPdrWithNodeNameSpec.js
@@ -36,12 +36,12 @@ const {
   addProviders,
   api: apiTestUtils,
   executionsApi: executionsApiTestUtils,
-  buildAndExecuteWorkflow,
   cleanupProviders,
   cleanupCollections,
   waitForCompletedExecution,
 } = require('@cumulus/integration-tests');
 
+const { buildAndExecuteWorkflow } = require('../../helpers/workflowUtils');
 const {
   createTestDataPath,
   createTestSuffix,

--- a/example/spec/parallel/ingestGranule/IngestGranuleFailureSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleFailureSpec.js
@@ -7,7 +7,6 @@ const {
   addCollections,
   addProviders,
   api: apiTestUtils,
-  buildAndExecuteWorkflow,
   cleanupCollections,
   cleanupProviders,
   executionsApi: executionsApiTestUtils,
@@ -15,6 +14,7 @@ const {
 
 const { deleteExecution } = require('@cumulus/api-client/executions');
 
+const { buildAndExecuteWorkflow } = require('../../helpers/workflowUtils');
 const {
   waitForModelStatus,
 } = require('../../helpers/apiUtils');

--- a/example/spec/parallel/ingestGranule/IngestGranuleFailureSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleFailureSpec.js
@@ -137,7 +137,7 @@ describe('The Ingest Granule failure workflow', () => {
   it('completes execution with failure status', () => {
     if (beforeAllFailed) fail('beforeAll() failed');
     else {
-      expect(workflowExecution.status).toEqual('FAILED');
+      expect(workflowExecution.status).toEqual('failed');
     }
   });
 

--- a/example/spec/parallel/ingestGranule/IngestGranuleFtpSuccessSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleFtpSuccessSpec.js
@@ -115,7 +115,7 @@ describe('The FTP Ingest Granules workflow', () => {
     });
 
     it('completes execution with success status', () => {
-      expect(workflowExecution.status).toEqual('SUCCEEDED');
+      expect(workflowExecution.status).toEqual('completed');
     });
 
     it('makes the granule available through the Cumulus API', () => {

--- a/example/spec/parallel/ingestGranule/IngestGranuleFtpSuccessSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleFtpSuccessSpec.js
@@ -2,19 +2,21 @@
 
 const fs = require('fs-extra');
 const pMap = require('p-map');
+const mime = require('mime-types');
+
 const { models: { Granule } } = require('@cumulus/api');
 const { headObject } = require('@cumulus/aws-client/S3');
 const { randomStringFromRegex } = require('@cumulus/common/test-utils');
 const {
   addCollections,
   api: apiTestUtils,
-  buildAndExecuteWorkflow,
   cleanupCollections,
 } = require('@cumulus/integration-tests');
 const { deleteExecution } = require('@cumulus/api-client/executions');
 const { getGranule, deleteGranule } = require('@cumulus/api-client/granules');
 const { deleteProvider } = require('@cumulus/api-client/providers');
-const mime = require('mime-types');
+
+const { buildAndExecuteWorkflow } = require('../../helpers/workflowUtils');
 const { loadConfig, createTimestampedTestId, createTestSuffix } = require('../../helpers/testUtils');
 const { waitForModelStatus } = require('../../helpers/apiUtils');
 const { buildFtpProvider, createProvider } = require('../../helpers/Providers');

--- a/example/spec/parallel/ingestGranule/IngestGranulePythonProcessingSuccessSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranulePythonProcessingSuccessSpec.js
@@ -11,7 +11,6 @@ const { s3 } = require('@cumulus/aws-client/services');
 const {
   addCollections,
   api: apiTestUtils,
-  buildAndStartWorkflow,
   getExecutionOutput,
   waitForCompletedExecution,
 } = require('@cumulus/integration-tests');
@@ -23,6 +22,7 @@ const {
 } = require('@cumulus/api-client/providers');
 
 const { ActivityStep } = require('@cumulus/integration-tests/sfnStep');
+const { buildAndStartWorkflow } = require('../../helpers/workflowUtils');
 
 const {
   loadConfig,

--- a/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
@@ -34,8 +34,6 @@ const { isCMRFile, metadataObjectFromCMRFile } = require('@cumulus/cmrjs/cmr-uti
 const { constructCollectionId } = require('@cumulus/message/Collections');
 const {
   addCollections,
-  buildAndExecuteWorkflow,
-  buildAndStartWorkflow,
   conceptExists,
   getExecutionOutput,
   getOnlineResources,
@@ -65,6 +63,10 @@ const {
 } = require('@cumulus/integration-tests/api/distribution');
 const { LambdaStep } = require('@cumulus/integration-tests/sfnStep');
 
+const {
+  buildAndExecuteWorkflow,
+  buildAndStartWorkflow,
+} = require('../../helpers/workflowUtils');
 const {
   loadConfig,
   templateFile,

--- a/example/spec/parallel/ingestGranule/IngestUMMGSuccessSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestUMMGSuccessSpec.js
@@ -20,7 +20,6 @@ const { generateChecksumFromStream } = require('@cumulus/checksum');
 const { constructCollectionId } = require('@cumulus/message/Collections');
 const {
   addCollections,
-  buildAndExecuteWorkflow,
   conceptExists,
   getOnlineResources,
 } = require('@cumulus/integration-tests');
@@ -46,6 +45,7 @@ const {
   createTestSuffix,
   templateFile,
 } = require('../../helpers/testUtils');
+const { buildAndExecuteWorkflow } = require('../../helpers/workflowUtils');
 const {
   setDistributionApiEnvVars,
 } = require('../../helpers/apiUtils');
@@ -238,7 +238,7 @@ describe('The S3 Ingest Granules workflow configured to ingest UMM-G', () => {
 
   it('completes execution with success status', () => {
     if (beforeAllError) throw beforeAllError;
-    expect(workflowExecution.status).toEqual('SUCCEEDED');
+    expect(workflowExecution.status).toEqual('completed');
   });
 
   // This is a sanity check to make sure we actually generated UMM and also

--- a/example/spec/parallel/ingestGranule/ingestGranuleQueueSpec.js
+++ b/example/spec/parallel/ingestGranule/ingestGranuleQueueSpec.js
@@ -23,7 +23,6 @@ const { generateChecksumFromStream } = require('@cumulus/checksum');
 const { constructCollectionId } = require('@cumulus/message/Collections');
 const {
   addCollections,
-  buildAndStartWorkflow,
   conceptExists,
   getOnlineResources,
   waitForCompletedExecution,
@@ -40,6 +39,7 @@ const {
 } = require('@cumulus/integration-tests/api/distribution');
 const { LambdaStep } = require('@cumulus/integration-tests/sfnStep');
 
+const { buildAndStartWorkflow } = require('../../helpers/workflowUtils');
 const {
   loadConfig,
   templateFile,

--- a/example/spec/parallel/orca/OrcaBackupAndRecoverySpec.js
+++ b/example/spec/parallel/orca/OrcaBackupAndRecoverySpec.js
@@ -19,12 +19,12 @@ const { deleteProvider } = require('@cumulus/api-client/providers');
 const {
   addCollections,
   addProviders,
-  buildAndStartWorkflow,
   waitForAsyncOperationStatus,
   waitForCompletedExecution,
 } = require('@cumulus/integration-tests');
 const { LambdaStep } = require('@cumulus/integration-tests/sfnStep');
 
+const { buildAndStartWorkflow } = require('../../helpers/workflowUtils');
 const { waitForModelStatus } = require('../../helpers/apiUtils');
 const {
   setupTestGranuleForIngest,

--- a/example/spec/parallel/pythonReferenceTests/PythonReferenceSpec.js
+++ b/example/spec/parallel/pythonReferenceTests/PythonReferenceSpec.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const { ActivityStep, LambdaStep } = require('@cumulus/integration-tests/sfnStep');
-const { buildAndExecuteWorkflow } = require('@cumulus/integration-tests');
 
+const { buildAndExecuteWorkflow } = require('../../helpers/workflowUtils');
 const { loadConfig } = require('../../helpers/testUtils');
 
 const workflowName = 'PythonReferenceWorkflow';

--- a/example/spec/parallel/pythonReferenceTests/PythonReferenceSpec.js
+++ b/example/spec/parallel/pythonReferenceTests/PythonReferenceSpec.js
@@ -37,7 +37,7 @@ describe('The Python Reference workflow', () => {
   });
 
   it('executes successfully', () => {
-    expect(workflowExecution.status).toEqual('SUCCEEDED');
+    expect(workflowExecution.status).toEqual('completed');
   });
 
   it('contains the expected output from the PythonReferenceTask', async () => {

--- a/example/spec/parallel/retryConfiguration/retryConfigurationSpec.js
+++ b/example/spec/parallel/retryConfiguration/retryConfigurationSpec.js
@@ -1,6 +1,7 @@
 const { LambdaStep } = require('@cumulus/integration-tests/sfnStep');
-const { buildAndExecuteWorkflow } = require('@cumulus/integration-tests');
 const { deleteExecution } = require('@cumulus/api-client/executions');
+
+const { buildAndExecuteWorkflow } = require('../../helpers/workflowUtils');
 const { loadConfig } = require('../../helpers/testUtils');
 
 const lambdaStep = new LambdaStep();

--- a/example/spec/parallel/retryConfiguration/retryConfigurationSpec.js
+++ b/example/spec/parallel/retryConfiguration/retryConfigurationSpec.js
@@ -29,13 +29,12 @@ function getRetryIntervals(executions) {
 }
 
 describe('When a task is configured', () => {
-  let retryPassWorkflowExecution = null;
-  let noRetryWorkflowExecution = null;
-  let retryFailWorkflowExecution = null;
+  let retryPassWorkflowExecution;
+  let noRetryWorkflowExecution;
+  let retryFailWorkflowExecution;
 
-  let retryPassLambdaExecutions = null;
-  let retryFailLambdaExecutions = null;
-
+  let retryPassLambdaExecutions;
+  let retryFailLambdaExecutions;
   beforeAll(async () => {
     config = await loadConfig();
 
@@ -98,20 +97,20 @@ describe('When a task is configured', () => {
 
     describe('and it succeeds', () => {
       it('Cumulus continues the workflow', () => {
-        expect(retryPassWorkflowExecution.status).toEqual('SUCCEEDED');
+        expect(retryPassWorkflowExecution.status).toEqual('completed');
       });
     });
   });
 
   describe('not to retry', () => {
     it('Cumulus fails the workflow', () => {
-      expect(noRetryWorkflowExecution.status).toEqual('FAILED');
+      expect(noRetryWorkflowExecution.status).toEqual('failed');
     });
   });
 
   describe('a specific number of times', () => {
     it('and it fails that number of times, Cumulus stops retrying it and fails the workflow', () => {
-      expect(retryFailWorkflowExecution.status).toEqual('FAILED');
+      expect(retryFailWorkflowExecution.status).toEqual('failed');
       expect(retryFailLambdaExecutions.length).toEqual(4);
     });
   });

--- a/example/spec/parallel/syncGranule/SyncGranuleDuplicateHandlingSpec.js
+++ b/example/spec/parallel/syncGranule/SyncGranuleDuplicateHandlingSpec.js
@@ -162,7 +162,7 @@ describe('When the Sync Granule workflow is configured', () => {
 
   describe('to keep both files when encountering duplicate filenames\n', () => {
     it('the initial workflow completes execution with success status', () => {
-      expect(workflowExecution.status).toEqual('SUCCEEDED');
+      expect(workflowExecution.status).toEqual('completed');
     });
 
     describe('and it encounters data with a duplicated filename with duplicate checksum', () => {
@@ -198,7 +198,7 @@ describe('When the Sync Granule workflow is configured', () => {
       });
 
       it('does not raise a workflow error', () => {
-        expect(workflowExecution.status).toEqual('SUCCEEDED');
+        expect(workflowExecution.status).toEqual('completed');
       });
 
       it('does not create a copy of the file', async () => {
@@ -250,7 +250,7 @@ describe('When the Sync Granule workflow is configured', () => {
       });
 
       it('does not raise a workflow error', () => {
-        expect(workflowExecution.status).toEqual('SUCCEEDED');
+        expect(workflowExecution.status).toEqual('completed');
       });
 
       it('moves the existing data to a file with a suffix to distinguish it from the new file', async () => {
@@ -308,7 +308,7 @@ describe('When the Sync Granule workflow is configured', () => {
       });
 
       it('does not raise a workflow error', () => {
-        expect(workflowExecution.status).toEqual('SUCCEEDED');
+        expect(workflowExecution.status).toEqual('completed');
       });
 
       it('moves the existing data to a file with a suffix to distinguish it from the new file and existing versioned file', async () => {
@@ -371,7 +371,7 @@ describe('When the Sync Granule workflow is configured', () => {
       });
 
       it('fails the workflow', () => {
-        expect(workflowExecution.status).toEqual('FAILED');
+        expect(workflowExecution.status).toEqual('failed');
       });
     });
 
@@ -404,7 +404,7 @@ describe('When the Sync Granule workflow is configured', () => {
       });
 
       it('completes execution with success status', () => {
-        expect(workflowExecution.status).toEqual('SUCCEEDED');
+        expect(workflowExecution.status).toEqual('completed');
       });
     });
   });

--- a/example/spec/parallel/syncGranule/SyncGranuleDuplicateHandlingSpec.js
+++ b/example/spec/parallel/syncGranule/SyncGranuleDuplicateHandlingSpec.js
@@ -12,12 +12,13 @@ const {
   addCollections,
   addProviders,
   api: apiTestUtils,
-  buildAndExecuteWorkflow,
   cleanupCollections,
   cleanupProviders,
 } = require('@cumulus/integration-tests');
 const { getExecutionUrlFromArn } = require('@cumulus/message/Executions');
 
+
+const { buildAndExecuteWorkflow } = require('../../helpers/workflowUtils');
 const {
   deleteFolder,
   loadConfig,

--- a/example/spec/parallel/syncGranule/SyncGranuleSuccessSpec.js
+++ b/example/spec/parallel/syncGranule/SyncGranuleSuccessSpec.js
@@ -4,7 +4,6 @@ const {
   addCollections,
   addProviders,
   api: apiTestUtils,
-  buildAndExecuteWorkflow,
   cleanupCollections,
   cleanupProviders,
   waitForCompletedExecution,
@@ -23,6 +22,8 @@ const {
 } = require('@cumulus/aws-client/S3');
 const { constructCollectionId } = require('@cumulus/message/Collections');
 const { LambdaStep } = require('@cumulus/integration-tests/sfnStep');
+
+const { buildAndExecuteWorkflow } = require('../../helpers/workflowUtils');
 const {
   loadConfig,
   templateFile,

--- a/example/spec/parallel/syncGranule/SyncGranuleSuccessSpec.js
+++ b/example/spec/parallel/syncGranule/SyncGranuleSuccessSpec.js
@@ -182,7 +182,7 @@ describe('The Sync Granules workflow', () => {
   });
 
   it('completes execution with success status', () => {
-    expect(workflowExecution.status).toEqual('SUCCEEDED');
+    expect(workflowExecution.status).toEqual('completed');
   });
 
   describe('the SyncGranule Lambda function', () => {
@@ -366,7 +366,7 @@ describe('The Sync Granules workflow', () => {
     });
 
     it('completes execution with failure status', () => {
-      expect(failingExecution.status).toEqual('FAILED');
+      expect(failingExecution.status).toEqual('failed');
     });
 
     it('raises an error', () => {

--- a/example/spec/parallel/testAPI/bulkOperationsSuccessSpec.js
+++ b/example/spec/parallel/testAPI/bulkOperationsSuccessSpec.js
@@ -312,8 +312,9 @@ describe('POST /granules/bulk', () => {
           },
           {
             timestamp__from: bulkRequestTime,
+            asyncOperationId: postBulkOperationsBody.id,
           },
-          { timeout: 120 }
+          { timeout: 60 }
         );
         console.log('bulkOperationExecutionArn', bulkOperationExecutionArn);
 

--- a/example/spec/parallel/testAPI/bulkOperationsSuccessSpec.js
+++ b/example/spec/parallel/testAPI/bulkOperationsSuccessSpec.js
@@ -312,9 +312,8 @@ describe('POST /granules/bulk', () => {
           },
           {
             timestamp__from: bulkRequestTime,
-            asyncOperationId: postBulkOperationsBody.id,
           },
-          { timeout: 60 }
+          { timeout: 120 }
         );
         console.log('bulkOperationExecutionArn', bulkOperationExecutionArn);
 

--- a/example/spec/serial/DiscoverGranulesHttpSpec.js
+++ b/example/spec/serial/DiscoverGranulesHttpSpec.js
@@ -7,11 +7,11 @@ const { deleteProvider } = require('@cumulus/api-client/providers');
 const {
   api: apiTestUtils,
   addCollections,
-  buildAndExecuteWorkflow,
   cleanupCollections,
   waitForCompletedExecution,
 } = require('@cumulus/integration-tests');
 
+const { buildAndExecuteWorkflow } = require('../helpers/workflowUtils');
 const {
   loadConfig,
   createTimestampedTestId,

--- a/example/spec/serial/DiscoverGranulesHttpSpec.js
+++ b/example/spec/serial/DiscoverGranulesHttpSpec.js
@@ -96,7 +96,14 @@ describe('The Discover Granules workflow with http Protocol', () => {
   afterAll(async () => {
     // clean up stack state added by test
     await Promise.all(queueGranulesOutput.payload.running
-      .map((execution) => waitForCompletedExecution(execution)));
+      .map((arn) => waitForApiStatus(
+        getExecution,
+        {
+          prefix: config.stackName,
+          arn,
+        },
+        'completed'
+      )));
     await Promise.all(discoverGranulesLambdaOutput.payload.granules.map(
       async (granule) => {
         await waitForApiStatus(
@@ -113,6 +120,7 @@ describe('The Discover Granules workflow with http Protocol', () => {
         });
       }
     ));
+
     // Order matters. Child executions must be deleted before parents.
     await deleteExecution({ prefix: config.stackName, executionArn: ingestGranuleWorkflowArn1 });
     await deleteExecution({ prefix: config.stackName, executionArn: ingestGranuleWorkflowArn2 });

--- a/example/spec/serial/DiscoverGranulesHttpSpec.js
+++ b/example/spec/serial/DiscoverGranulesHttpSpec.js
@@ -144,7 +144,7 @@ describe('The Discover Granules workflow with http Protocol', () => {
   it('executes successfully', () => {
     if (beforeAllFailed) fail('beforeAll() failed');
 
-    expect(discoverGranulesExecution.status).toEqual('SUCCEEDED');
+    expect(discoverGranulesExecution.status).toEqual('completed');
   });
 
   describe('the DiscoverGranules Lambda', () => {
@@ -262,7 +262,7 @@ describe('The Discover Granules workflow with http Protocol', () => {
     });
 
     it('executes successfully', () => {
-      expect(noFilesConfigExecution.status).toEqual('SUCCEEDED');
+      expect(noFilesConfigExecution.status).toEqual('completed');
     });
 
     it('discovers granules, but output has no files', async () => {
@@ -326,7 +326,7 @@ describe('The Discover Granules workflow with http Protocol', () => {
     });
 
     it('executes successfully', () => {
-      expect(partialFilesConfigExecution.status).toEqual('SUCCEEDED');
+      expect(partialFilesConfigExecution.status).toEqual('completed');
     });
 
     it('discovers granules, but output does not include all files', async () => {
@@ -392,7 +392,7 @@ describe('The Discover Granules workflow with http Protocol', () => {
     });
 
     it('executes successfully', () => {
-      expect(ignoringFilesConfigExecution.status).toEqual('SUCCEEDED');
+      expect(ignoringFilesConfigExecution.status).toEqual('completed');
     });
 
     it('discovers granules, but output includes all files', async () => {

--- a/example/spec/standalone/redeployment/LambdaRedeploySpec.js
+++ b/example/spec/standalone/redeployment/LambdaRedeploySpec.js
@@ -2,13 +2,13 @@
 
 const { LambdaStep } = require('@cumulus/integration-tests/sfnStep');
 const {
-  buildAndStartWorkflow,
   getLambdaAliases,
   getLambdaVersions,
   waitForCompletedExecution,
 } = require('@cumulus/integration-tests');
 
 const fs = require('fs-extra');
+const { buildAndStartWorkflow } = require('../../helpers/workflowUtils');
 const {
   loadConfig,
   protectFile,

--- a/example/spec/standalone/redeployment/WorkflowRedeploySpec.js
+++ b/example/spec/standalone/redeployment/WorkflowRedeploySpec.js
@@ -3,11 +3,11 @@
 const pRetry = require('p-retry');
 
 const {
-  buildAndStartWorkflow,
   waitForCompletedExecution,
   executionsApi: executionsApiTestUtils,
 } = require('@cumulus/integration-tests');
 
+const { buildAndStartWorkflow } = require('../../helpers/workflowUtils');
 const {
   loadConfig,
   protectFile,

--- a/packages/integration-tests/index.js
+++ b/packages/integration-tests/index.js
@@ -7,10 +7,7 @@ const replace = require('lodash/replace');
 const orderBy = require('lodash/orderBy');
 const cloneDeep = require('lodash/cloneDeep');
 const isEqual = require('lodash/isEqual');
-const merge = require('lodash/merge');
 const Handlebars = require('handlebars');
-const uuidv4 = require('uuid/v4');
-const fs = require('fs-extra');
 const pRetry = require('p-retry');
 const pWaitFor = require('p-wait-for');
 const pMap = require('p-map');
@@ -18,12 +15,10 @@ const moment = require('moment');
 
 const {
   ecs,
-  sfn,
 } = require('@cumulus/aws-client/services');
 const { getJsonS3Object, listS3ObjectsV2 } = require('@cumulus/aws-client/S3');
 const StepFunctions = require('@cumulus/aws-client/StepFunctions');
 const {
-  templateKey,
   getWorkflowFileKey,
 } = require('@cumulus/common/workflows');
 const { readJsonFile } = require('@cumulus/common/FileUtils');
@@ -199,96 +194,6 @@ async function waitForCompletedExecution(executionArn, timeout = 600) {
   );
 
   return status;
-}
-
-/**
- * Kick off a workflow execution
- *
- * @param {string} workflowArn - ARN for the workflow
- * @param {Object} workflowMsg - workflow message
- * @returns {Promise.<Object>} execution details: {executionArn, startDate}
- */
-async function startWorkflowExecution(workflowArn, workflowMsg) {
-  // Give this execution a unique name
-  workflowMsg.cumulus_meta.execution_name = uuidv4();
-  workflowMsg.cumulus_meta.workflow_start_time = Date.now();
-  workflowMsg.cumulus_meta.state_machine = workflowArn;
-
-  const workflowParams = {
-    stateMachineArn: workflowArn,
-    input: JSON.stringify(workflowMsg),
-    name: workflowMsg.cumulus_meta.execution_name,
-  };
-
-  return await sfn().startExecution(workflowParams).promise();
-}
-
-/**
- * Start the workflow and return the execution Arn. Does not wait
- * for workflow completion.
- *
- * @param {string} stackName - Cloud formation stack name
- * @param {string} bucketName - S3 internal bucket name
- * @param {string} workflowName - workflow name
- * @param {Object} workflowMsg - workflow message
- * @returns {string} - executionArn
- */
-async function startWorkflow(stackName, bucketName, workflowName, workflowMsg) {
-  const { arn: workflowArn } = await getJsonS3Object(
-    bucketName,
-    getWorkflowFileKey(stackName, workflowName)
-  );
-  const { executionArn } = await startWorkflowExecution(workflowArn, workflowMsg);
-
-  console.log(`Starting workflow: ${workflowName}. Execution ARN ${executionArn}`);
-
-  return executionArn;
-}
-
-/**
- * Execute the given workflow.
- * Wait for workflow to complete to get the status
- * Return the execution arn and the workflow status.
- *
- * @param {string} stackName - Cloud formation stack name
- * @param {string} bucketName - S3 internal bucket name
- * @param {string} workflowName - workflow name
- * @param {Object} workflowMsg - workflow message
- * @param {number} [timeout=600] - number of seconds to wait for execution to complete
- * @returns {Object} - {executionArn: <arn>, status: <status>}
- */
-async function executeWorkflow(stackName, bucketName, workflowName, workflowMsg, timeout = 600) {
-  const executionArn = await startWorkflow(stackName, bucketName, workflowName, workflowMsg);
-
-  // Wait for the execution to complete to get the status
-  const status = await waitForCompletedExecution(executionArn, timeout);
-
-  return { status, executionArn };
-}
-
-/**
- * Test the given workflow and report whether the workflow failed or succeeded
- *
- * @param {string} stackName - Cloud formation stack name
- * @param {string} bucketName - S3 internal bucket name
- * @param {string} workflowName - workflow name
- * @param {string} inputFile - path to input JSON file
- * @returns {*} undefined
- */
-async function testWorkflow(stackName, bucketName, workflowName, inputFile) {
-  try {
-    const rawInput = await fs.readFile(inputFile, 'utf8');
-    const parsedInput = JSON.parse(rawInput);
-    const workflowStatus = await executeWorkflow(stackName, bucketName, workflowName, parsedInput);
-
-    if (workflowStatus.status === 'SUCCEEDED') {
-      console.log(`Workflow ${workflowName} execution succeeded.`);
-    } else {
-      console.log(`Workflow ${workflowName} execution failed with state: ${workflowStatus.status}`);
-    }
-  } catch (error) {
-    console.log(`Error executing workflow ${workflowName}. Error: ${error}`);
-  }
 }
 
 /**
@@ -628,137 +533,6 @@ async function deleteRules(stackName, bucketName, rules, postfix) {
 }
 
 /**
- * build workflow message
- *
- * @param {string} stackName - Cloud formation stack name
- * @param {string} bucketName - S3 internal bucket name
- * @param {string} workflowName - workflow name
- * @param {Object} collection - collection information
- * @param {Object} collection.name - collection name
- * @param {Object} collection.version - collection version
- * @param {Object} provider - provider information
- * @param {Object} provider.id - provider id
- * @param {Object} payload - payload information
- * @param {Object} meta - additional keys to add to meta field
- * @returns {Object} workflow message
- */
-async function buildWorkflow(
-  stackName,
-  bucketName,
-  workflowName,
-  collection,
-  provider,
-  payload,
-  meta
-) {
-  const template = await getJsonS3Object(bucketName, templateKey(stackName));
-
-  if (collection) {
-    const collectionsApiResponse = await collectionsApi.getCollection({
-      prefix: stackName,
-      collectionName: collection.name,
-      collectionVersion: collection.version,
-    });
-    if (collectionsApiResponse.statusCode) {
-      throw new Error(`Collections API responded with error on buildWorkflow ${JSON.stringify(collectionsApiResponse)}`);
-    }
-    template.meta.collection = collectionsApiResponse;
-  } else {
-    template.meta.collection = {};
-  }
-
-  if (provider) {
-    const providersApiResponse = await providersApi.getProvider(
-      {
-        prefix: stackName,
-        providerId: provider.id,
-      }
-    );
-    if (providersApiResponse.statusCode !== 200) {
-      throw new Error(`Providers API responded with error on buildWorkflow ${JSON.stringify(providersApiResponse)}`);
-    }
-    template.meta.provider = JSON.parse(providersApiResponse.body);
-    template.meta.provider.password = provider.password;
-  } else {
-    template.meta.provider = {};
-  }
-
-  template.meta.workflow_name = workflowName;
-  template.meta = merge(template.meta, meta);
-  template.payload = payload || {};
-
-  return template;
-}
-
-/**
- * build workflow message and execute the workflow
- *
- * @param {string} stackName - Cloud formation stack name
- * @param {string} bucketName - S3 internal bucket name
- * @param {string} workflowName - workflow name
- * @param {Object} collection - collection information
- * @param {Object} collection.name - collection name
- * @param {Object} collection.version - collection version
- * @param {Object} provider - provider information
- * @param {Object} provider.id - provider id
- * @param {Object} payload - payload information
- * @param {Object} meta - additional keys to add to meta field
- * @param {number} [timeout=600] - number of seconds to wait for execution to complete
- * @returns {Object} - {executionArn: <arn>, status: <status>}
- */
-async function buildAndExecuteWorkflow(
-  stackName,
-  bucketName,
-  workflowName,
-  collection,
-  provider,
-  payload,
-  meta = {},
-  timeout = 600
-) {
-  const workflowMsg = await buildWorkflow(
-    stackName,
-    bucketName,
-    workflowName,
-    collection,
-    provider,
-    payload,
-    meta
-  );
-  return executeWorkflow(stackName, bucketName, workflowName, workflowMsg, timeout);
-}
-
-/**
- * build workflow message and start the workflow. Does not wait
- * for workflow completion.
- *
- * @param {string} stackName - Cloud formation stack name
- * @param {string} bucketName - S3 internal bucket name
- * @param {string} workflowName - workflow name
- * @param {Object} collection - collection information
- * @param {Object} collection.name - collection name
- * @param {Object} collection.version - collection version
- * @param {Object} provider - provider information
- * @param {Object} provider.id - provider id
- * @param {Object} payload - payload information
- * @param {Object} meta - additional keys to add to meta field
- * @returns {string} - executionArn
- */
-async function buildAndStartWorkflow(
-  stackName,
-  bucketName,
-  workflowName,
-  collection,
-  provider,
-  payload,
-  meta = {}
-) {
-  const workflowMsg = await
-  buildWorkflow(stackName, bucketName, workflowName, collection, provider, payload, meta);
-  return startWorkflow(stackName, bucketName, workflowName, workflowMsg);
-}
-
-/**
  * returns the most recently executed workflows for the specified state machine.
  *
  * @param {string} workflowArn - name of the workflow to get executions for
@@ -929,10 +703,7 @@ module.exports = {
   addRules,
   addRulesWithPostfix,
   api,
-  buildAndExecuteWorkflow,
-  buildAndStartWorkflow,
   buildCollection,
-  buildWorkflow,
   cleanupCollections,
   cleanupProviders,
   conceptExists: cmr.conceptExists,
@@ -941,7 +712,6 @@ module.exports = {
   deleteRules,
   distributionApi,
   EarthdataLogin,
-  executeWorkflow,
   executionsApi,
   generateCmrFilesForGranules: cmr.generateCmrFilesForGranules,
   generateCmrXml: cmr.generateCmrXml,
@@ -964,7 +734,6 @@ module.exports = {
   removeRuleAddedParams,
   rulesApi,
   setProcessEnvironment,
-  testWorkflow,
   waitForAllTestSf,
   waitForAsyncOperationStatus,
   waitForCompletedExecution,


### PR DESCRIPTION
**Summary:** Summary of changes

This PR:

- Addresses an issue where the UMMG spec was not waiting for granules to be in a completed state before attempting to move them, this resulted in a cmr-js failure where the test would attempt to move the granule object from the start of a workflow. 

- Updates buildAndExecuteWorkflow to wait for the workflow to complete in the *API* not the step function API 
- Moves all 'workflow' helpers from the integration-tests package to example/spec/helpers 

All tests passed with at least one manual run as of bbfeff3

  

