### PR TITLE
Update es-client index error output

### DIFF
--- a/packages/es-client/indexer.js
+++ b/packages/es-client/indexer.js
@@ -74,7 +74,13 @@ async function genericRecordUpdate(esClient, id, doc, index, type, parent) {
 
   // adding or replacing record to ES
   const actualEsClient = esClient || (await Search.es());
-  const indexResponse = await actualEsClient.index(params);
+  let indexResponse;
+  try {
+    indexResponse = await actualEsClient.index(params);
+  } catch (error) {
+    logger.error(`Error thrown on index ${JSON.stringify(error)}`);
+    throw error;
+  }
   return indexResponse.body;
 }
 

--- a/packages/es-client/indexer.js
+++ b/packages/es-client/indexer.js
@@ -74,13 +74,7 @@ async function genericRecordUpdate(esClient, id, doc, index, type, parent) {
 
   // adding or replacing record to ES
   const actualEsClient = esClient || (await Search.es());
-  let indexResponse;
-  try {
-    indexResponse = await actualEsClient.index(params);
-  } catch (error) {
-    logger.error(`Error thrown on index ${JSON.stringify(error)}`);
-    throw error;
-  }
+  const indexResponse = await actualEsClient.index(params);
   return indexResponse.body;
 }
 


### PR DESCRIPTION
**Summary:** Summary of changes

es-client was not properly logging index errors - as such the *reason*
for index failures was not present in the logs

## Changes

* Updated es-client/indexer.genericRecordUpdate such that any error thrown on .index is JSON.stringifed in the logs