### PR TITLE
CUMULUS-2620: Update remove from cmr logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,11 @@ behavior
     collection deletion in test cleanup.
 - **CUMULUS-2558**
   - Fixed issue where executions original_payload would not be retained on successful execution
+- **CUMULUS-2620**
+  - Fixed a bug where a granule could be removed from CMR but still be set as
+  `published: true` and with a CMR link in the Dynamo/PostgreSQL databases. Now,
+  the CMR deletion and the Dynamo/PostgreSQL record updates will all succeed or fail
+  together, preventing the database records from being out of sync with CMR.
 - Fixed `@cumulus/api-client/pdrs.getPdr` to request correct
 endpoint for returning a PDR from the API
 

--- a/packages/api/tests/lib/test-granule-remove-from-cmr.js
+++ b/packages/api/tests/lib/test-granule-remove-from-cmr.js
@@ -233,7 +233,7 @@ test.serial('unpublishGranule() succeeds with Dynamo and PG granule', async (t) 
   );
 });
 
-test.serial('unpublishGranule() does not update granule or delete from CMR if PG write fails', async (t) => {
+test.serial('unpublishGranule() does not update granule CMR status or delete from CMR if PG write fails', async (t) => {
   const {
     originalDynamoGranule,
     originalPgGranule,
@@ -303,7 +303,7 @@ test.serial('unpublishGranule() does not update granule or delete from CMR if PG
   );
 });
 
-test.serial('unpublishGranule() does not update granule or delete from CMR if Dynamo write fails', async (t) => {
+test.serial('unpublishGranule() does not update granule CMR status or delete from CMR if Dynamo write fails', async (t) => {
   const {
     originalDynamoGranule,
     originalPgGranule,
@@ -373,7 +373,7 @@ test.serial('unpublishGranule() does not update granule or delete from CMR if Dy
   );
 });
 
-test.serial('unpublishGranule() does not update granule if CMR removal fails', async (t) => {
+test.serial('unpublishGranule() does not update granule CMR status if CMR removal fails', async (t) => {
   const {
     originalDynamoGranule,
     originalPgGranule,

--- a/packages/api/tests/lib/test-granule-remove-from-cmr.js
+++ b/packages/api/tests/lib/test-granule-remove-from-cmr.js
@@ -28,6 +28,30 @@ const { migrationDir } = require('../../../../lambdas/db-migration');
 
 const testDbName = `granule_remove_cmr_${cryptoRandomString({ length: 10 })}`;
 
+const createGranuleInDynamoAndPG = async (t, params) => {
+  const granule = fakeGranuleFactoryV2({
+    collectionId: constructCollectionId(
+      t.context.fakeCollection.name,
+      t.context.fakeCollection.version
+    ),
+    ...params,
+  });
+  const originalDynamoGranule = await t.context.granulesModel.create(granule);
+  const originalPgGranule = await translateApiGranuleToPostgresGranule(
+    granule,
+    t.context.knex
+  );
+  const [pgGranuleCumulusId] = await t.context.granulePgModel.create(
+    t.context.knex,
+    originalPgGranule
+  );
+  return {
+    originalDynamoGranule,
+    originalPgGranule,
+    pgGranuleCumulusId,
+  };
+};
+
 test.before(async (t) => {
   process.env = {
     ...process.env,
@@ -59,6 +83,9 @@ test.before(async (t) => {
   const { knex, knexAdmin } = await generateLocalTestDb(testDbName, migrationDir);
   t.context.knex = knex;
   t.context.knexAdmin = knexAdmin;
+
+  t.context.fakeCollection = fakeCollectionRecordFactory();
+  await t.context.collectionPgModel.create(t.context.knex, t.context.fakeCollection);
 });
 
 test.after.always(async (t) => {
@@ -78,15 +105,35 @@ test.after.always(async (t) => {
 });
 
 test('unpublishGranule() removing a granule from CMR fails if the granule is not in CMR', async (t) => {
-  const granule = fakeGranuleFactoryV2({ published: false });
-
-  await t.context.granulesModel.create(granule);
+  const {
+    originalDynamoGranule,
+    pgGranuleCumulusId,
+  } = await createGranuleInDynamoAndPG(t, {
+    published: false,
+    cmrLink: undefined,
+  });
 
   try {
-    await unpublishGranule(t.context.knex, granule);
+    await unpublishGranule(t.context.knex, originalDynamoGranule);
   } catch (error) {
-    t.is(error.message, `Granule ${granule.granuleId} is not published to CMR, so cannot be removed from CMR`);
+    t.is(error.message, `Granule ${originalDynamoGranule.granuleId} is not published to CMR, so cannot be removed from CMR`);
   }
+
+  t.like(
+    await t.context.granulesModel.get({ granuleId: originalDynamoGranule.granuleId }),
+    {
+      published: false,
+      cmrLink: undefined,
+    }
+  );
+
+  t.like(
+    await t.context.granulePgModel.get(t.context.knex, { cumulus_id: pgGranuleCumulusId }),
+    {
+      published: false,
+      cmr_link: null,
+    }
+  );
 });
 
 test.serial('unpublishGranule() succeeds with Dynamo granule only', async (t) => {
@@ -120,30 +167,23 @@ test.serial('unpublishGranule() succeeds with Dynamo granule only', async (t) =>
 });
 
 test.serial('unpublishGranule() succeeds with Dynamo and PG granule', async (t) => {
-  const fakeCollection = fakeCollectionRecordFactory();
+  const { fakeCollection } = t.context;
 
-  const granule = fakeGranuleFactoryV2({
+  const {
+    originalDynamoGranule,
+    originalPgGranule,
+    pgGranuleCumulusId,
+  } = await createGranuleInDynamoAndPG(t, {
     published: true,
     collectionId: constructCollectionId(fakeCollection.name, fakeCollection.version),
   });
-  await t.context.granulesModel.create(granule);
 
   t.like(
-    await t.context.granulesModel.get({ granuleId: granule.granuleId }),
+    await t.context.granulesModel.get({ granuleId: originalDynamoGranule.granuleId }),
     {
       published: true,
-      cmrLink: granule.cmrLink,
+      cmrLink: originalDynamoGranule.cmrLink,
     }
-  );
-
-  await t.context.collectionPgModel.create(t.context.knex, fakeCollection);
-  const originalPgGranule = await translateApiGranuleToPostgresGranule(
-    granule,
-    t.context.knex
-  );
-  const [pgGranuleCumulusId] = await t.context.granulePgModel.create(
-    t.context.knex,
-    originalPgGranule
   );
 
   t.like(
@@ -165,13 +205,16 @@ test.serial('unpublishGranule() succeeds with Dynamo and PG granule', async (t) 
     cmrDeleteStub.restore();
   });
 
-  const { dynamoGranule, pgGranule } = await unpublishGranule(t.context.knex, granule);
+  const {
+    dynamoGranule,
+    pgGranule,
+  } = await unpublishGranule(t.context.knex, originalDynamoGranule);
 
   t.deepEqual(
     dynamoGranule,
     omit(
       {
-        ...granule,
+        ...originalDynamoGranule,
         published: false,
         updatedAt: dynamoGranule.updatedAt,
       },
@@ -189,30 +232,20 @@ test.serial('unpublishGranule() succeeds with Dynamo and PG granule', async (t) 
 });
 
 test.serial('unpublishGranule() does not update granule if PG write fails', async (t) => {
-  const fakeCollection = fakeCollectionRecordFactory();
-
-  const granule = fakeGranuleFactoryV2({
+  const {
+    originalDynamoGranule,
+    originalPgGranule,
+    pgGranuleCumulusId,
+  } = await createGranuleInDynamoAndPG(t, {
     published: true,
-    collectionId: constructCollectionId(fakeCollection.name, fakeCollection.version),
   });
-  await t.context.granulesModel.create(granule);
 
   t.like(
-    await t.context.granulesModel.get({ granuleId: granule.granuleId }),
+    await t.context.granulesModel.get({ granuleId: originalDynamoGranule.granuleId }),
     {
       published: true,
-      cmrLink: granule.cmrLink,
+      cmrLink: originalDynamoGranule.cmrLink,
     }
-  );
-
-  await t.context.collectionPgModel.create(t.context.knex, fakeCollection);
-  const originalPgGranule = await translateApiGranuleToPostgresGranule(
-    granule,
-    t.context.knex
-  );
-  const [pgGranuleCumulusId] = await t.context.granulePgModel.create(
-    t.context.knex,
-    originalPgGranule
   );
 
   t.like(
@@ -244,16 +277,16 @@ test.serial('unpublishGranule() does not update granule if PG write fails', asyn
   await t.throwsAsync(
     unpublishGranule(
       t.context.knex,
-      granule,
+      originalDynamoGranule,
       fakeGranulePgModel
     )
   );
 
   t.like(
-    await t.context.granulesModel.get({ granuleId: granule.granuleId }),
+    await t.context.granulesModel.get({ granuleId: originalDynamoGranule.granuleId }),
     {
       published: true,
-      cmrLink: granule.cmrLink,
+      cmrLink: originalDynamoGranule.cmrLink,
     }
   );
   t.like(
@@ -268,30 +301,20 @@ test.serial('unpublishGranule() does not update granule if PG write fails', asyn
 });
 
 test.serial('unpublishGranule() does not update granule if Dynamo write fails', async (t) => {
-  const fakeCollection = fakeCollectionRecordFactory();
-
-  const granule = fakeGranuleFactoryV2({
+  const {
+    originalDynamoGranule,
+    originalPgGranule,
+    pgGranuleCumulusId,
+  } = await createGranuleInDynamoAndPG(t, {
     published: true,
-    collectionId: constructCollectionId(fakeCollection.name, fakeCollection.version),
   });
-  await t.context.granulesModel.create(granule);
 
   t.like(
-    await t.context.granulesModel.get({ granuleId: granule.granuleId }),
+    await t.context.granulesModel.get({ granuleId: originalDynamoGranule.granuleId }),
     {
       published: true,
-      cmrLink: granule.cmrLink,
+      cmrLink: originalDynamoGranule.cmrLink,
     }
-  );
-
-  await t.context.collectionPgModel.create(t.context.knex, fakeCollection);
-  const originalPgGranule = await translateApiGranuleToPostgresGranule(
-    granule,
-    t.context.knex
-  );
-  const [pgGranuleCumulusId] = await t.context.granulePgModel.create(
-    t.context.knex,
-    originalPgGranule
   );
 
   t.like(
@@ -322,17 +345,17 @@ test.serial('unpublishGranule() does not update granule if Dynamo write fails', 
   await t.throwsAsync(
     unpublishGranule(
       t.context.knex,
-      granule,
+      originalDynamoGranule,
       t.context.granulePgModel,
       fakeGranuleDynamoModel
     )
   );
 
   t.like(
-    await t.context.granulesModel.get({ granuleId: granule.granuleId }),
+    await t.context.granulesModel.get({ granuleId: originalDynamoGranule.granuleId }),
     {
       published: true,
-      cmrLink: granule.cmrLink,
+      cmrLink: originalDynamoGranule.cmrLink,
     }
   );
   t.like(


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2620: Update remove granule from CMR logic to ensure consistency](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2620)

## Changes

* Moved logic to remove granule from CMR into transaction with database updates so that they all either fail or succeed together, preventing the situation where the granule is removed from CMR but still referenced in the databases

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
