### PR TITLE
Update scheduledRuleWithExecutionPrefixSpec Rule name to conform to AWS length limits

### DIFF
--- a/example/spec/parallel/testAPI/scheduledRuleWithExecutionPrefixSpec.js
+++ b/example/spec/parallel/testAPI/scheduledRuleWithExecutionPrefixSpec.js
@@ -43,7 +43,7 @@ describe('When I create a scheduled rule with an executionNamePrefix via the Cum
 
       const testId = createTimestampedTestId(config.stackName, 'Rule');
       testSuffix = createTestSuffix(testId);
-      scheduledRuleName = timestampedName('SchedRuleWithExecutionPrefix');
+      scheduledRuleName = timestampedName('SRWEP');
       scheduledHelloWorldRule = {
         name: scheduledRuleName,
         collection: { name: `MOD09GQ${testSuffix}`, version: '006' },


### PR DESCRIPTION
**Summary:** 

Addresses [CUMULUS-1: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1)

## Changes

* Updates generated test rule to be a less verbose, yet serachable text string that still retains timestamp information. 
*  
## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [x] Integration tests
