### PR TITLE
Allow custom cmr protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ period. Reserved concurrency can be configured with the `archive_api_reserved_co
 terraform variable on the Cumulus module and increased if you are seeing throttling erorrs.
 The default reserved concurrency value is 8.
 
+### Notable changes
+
+- `cmr_custom_host` variable for `cumulus` module can now be used to configure Cumulus to
+integrate with a custom CMR host name and protocol (e.g. `http://custom-cmr-host.com`)
+
 ### Added
 
 - Added user doc describing new features related to the Cumulus dead letter archive.
@@ -100,6 +105,8 @@ the error object:
 - Added `params.pRetryOptions` parameter to
 `@cumulus/api-client/granules.deleteGranule` to control the retry
 behavior
+- Updated `cmr_custom_host` variable to accept a full protocol and host name
+(e.g. `http://cmr-custom-host.com`), whereas it previously only accepted a host name
 - **CUMULUS-2463**
   - Increases the duration of allowed backoff times for a successful test from 0.5 sec to 1 sec.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ The default reserved concurrency value is 8.
 ### Notable changes
 
 - `cmr_custom_host` variable for `cumulus` module can now be used to configure Cumulus to
-integrate with a custom CMR host name and protocol (e.g. `http://custom-cmr-host.com`)
+integrate with a custom CMR host name and protocol (e.g. `http://custom-cmr-host.com`). Note
+that you **must** include a protocol (`http://` or `https://`) if specifying a value for this
+variable.
 
 ### Added
 

--- a/example/cumulus-tf/variables.tf
+++ b/example/cumulus-tf/variables.tf
@@ -420,7 +420,7 @@ variable "optional_dynamo_tables" {
 }
 
 variable "cmr_custom_host" {
-  description = "Custom host to use for CMR requests"
+  description = "Custom protocol/host to use for CMR requests (e.g. http://cmr-host.com)"
   type        = string
   default     = null
 }

--- a/example/cumulus-tf/variables.tf
+++ b/example/cumulus-tf/variables.tf
@@ -420,7 +420,7 @@ variable "optional_dynamo_tables" {
 }
 
 variable "cmr_custom_host" {
-  description = "Custom protocol/host to use for CMR requests (e.g. http://cmr-host.com)"
+  description = "Custom protocol and host to use for CMR requests (e.g. http://cmr-host.com)"
   type        = string
   default     = null
 }

--- a/lambdas/sqs-message-remover/variables.tf
+++ b/lambdas/sqs-message-remover/variables.tf
@@ -23,7 +23,7 @@ variable "lambda_processing_role_arn" {
 # Optional
 
 variable "cmr_custom_host" {
-  description = "Custom host to use for CMR requests"
+  description = "Custom protocol/host to use for CMR requests (e.g. http://cmr-host.com)"
   type        = string
   default     = null
 }

--- a/lambdas/sqs-message-remover/variables.tf
+++ b/lambdas/sqs-message-remover/variables.tf
@@ -23,7 +23,7 @@ variable "lambda_processing_role_arn" {
 # Optional
 
 variable "cmr_custom_host" {
-  description = "Custom protocol/host to use for CMR requests (e.g. http://cmr-host.com)"
+  description = "Custom protocol and host to use for CMR requests (e.g. http://cmr-host.com)"
   type        = string
   default     = null
 }

--- a/packages/cmr-client/src/getUrl.ts
+++ b/packages/cmr-client/src/getUrl.ts
@@ -23,11 +23,11 @@ export function getCmrHost({
   }
   switch (cmrEnvironment) {
     case 'OPS':
-      return 'cmr.earthdata.nasa.gov';
+      return 'https://cmr.earthdata.nasa.gov';
     case 'UAT':
-      return 'cmr.uat.earthdata.nasa.gov';
+      return 'https://cmr.uat.earthdata.nasa.gov';
     case 'SIT':
-      return 'cmr.sit.earthdata.nasa.gov';
+      return 'https://cmr.sit.earthdata.nasa.gov';
     default:
       throw new TypeError(`Invalid CMR environment: ${cmrEnvironment}`);
   }
@@ -40,7 +40,7 @@ export function getBucketAccessUrl({
   host?: string,
   cmrEnv?: string,
 }): string {
-  return `https://${getCmrHost({ cmrEnvironment: cmrEnv, cmrHost: host })}/access-control/s3-buckets/`;
+  return `${getCmrHost({ cmrEnvironment: cmrEnv, cmrHost: host })}/access-control/s3-buckets/`;
 }
 
 export function getIngestUrl({
@@ -52,7 +52,7 @@ export function getIngestUrl({
   cmrEnv?: string,
   provider: string,
 }): string {
-  return `https://${getCmrHost({ cmrEnvironment: cmrEnv, cmrHost: host })}/ingest/providers/${provider}/`;
+  return `${getCmrHost({ cmrEnvironment: cmrEnv, cmrHost: host })}/ingest/providers/${provider}/`;
 }
 
 export function getSearchUrl({
@@ -62,7 +62,7 @@ export function getSearchUrl({
   host?: string,
   cmrEnv?: string,
 } = {}): string {
-  return `https://${getCmrHost({ cmrEnvironment: cmrEnv, cmrHost: host })}/search/`;
+  return `${getCmrHost({ cmrEnvironment: cmrEnv, cmrHost: host })}/search/`;
 }
 
 export function getTokenUrl({
@@ -72,7 +72,7 @@ export function getTokenUrl({
   host?: string,
   cmrEnv?: string,
 } = {}): string {
-  return `https://${getCmrHost({ cmrEnvironment: cmrEnv, cmrHost: host })}/legacy-services/rest/tokens`;
+  return `${getCmrHost({ cmrEnvironment: cmrEnv, cmrHost: host })}/legacy-services/rest/tokens`;
 }
 
 export function getValidateUrl({
@@ -84,5 +84,5 @@ export function getValidateUrl({
   cmrEnv?: string,
   provider: string,
 }): string {
-  return `https://${getCmrHost({ cmrEnvironment: cmrEnv, cmrHost: host })}/ingest/providers/${provider}/validate/`;
+  return `${getCmrHost({ cmrEnvironment: cmrEnv, cmrHost: host })}/ingest/providers/${provider}/validate/`;
 }

--- a/packages/cmr-client/tests/test-getUrl.js
+++ b/packages/cmr-client/tests/test-getUrl.js
@@ -5,13 +5,13 @@ const test = require('ava');
 const { getCmrHost, getSearchUrl, getBucketAccessUrl } = require('../getUrl');
 
 test('getCmrHost uses provided logical CMR environment', (t) => {
-  t.is(getCmrHost({ cmrEnvironment: 'OPS' }), 'cmr.earthdata.nasa.gov');
-  t.is(getCmrHost({ cmrEnvironment: 'UAT' }), 'cmr.uat.earthdata.nasa.gov');
-  t.is(getCmrHost({ cmrEnvironment: 'SIT' }), 'cmr.sit.earthdata.nasa.gov');
+  t.is(getCmrHost({ cmrEnvironment: 'OPS' }), 'https://cmr.earthdata.nasa.gov');
+  t.is(getCmrHost({ cmrEnvironment: 'UAT' }), 'https://cmr.uat.earthdata.nasa.gov');
+  t.is(getCmrHost({ cmrEnvironment: 'SIT' }), 'https://cmr.sit.earthdata.nasa.gov');
 });
 
 test('getCmrHost uses custom CMR host', (t) => {
-  t.is(getCmrHost({ cmrHost: 'custom-host' }), 'custom-host');
+  t.is(getCmrHost({ cmrHost: 'http://custom-host' }), 'http://custom-host');
 });
 
 test('getCmrHost throws error if provided environment is incorrect', (t) => {
@@ -22,13 +22,13 @@ test('getCmrHost throws error if provided environment is incorrect', (t) => {
 test.serial('getCmrHost uses process.env.CMR_ENVIRONMENT logical name, if provided', (t) => {
   process.env.CMR_ENVIRONMENT = 'OPS';
   t.teardown(() => delete process.env.CMR_ENVIRONMENT);
-  t.is(getCmrHost(), 'cmr.earthdata.nasa.gov');
+  t.is(getCmrHost(), 'https://cmr.earthdata.nasa.gov');
 });
 
 test.serial('getCmrHost uses process.env.CMR_HOST custom host, if provided', (t) => {
-  process.env.CMR_HOST = 'cmr-host';
+  process.env.CMR_HOST = 'http://cmr-host';
   t.teardown(() => delete process.env.CMR_HOST);
-  t.is(getCmrHost(), 'cmr-host');
+  t.is(getCmrHost(), 'http://cmr-host');
 });
 
 test.serial('getSearchUrl returns value according to cmrEnvironment param', (t) => {

--- a/tf-modules/archive/variables.tf
+++ b/tf-modules/archive/variables.tf
@@ -164,7 +164,7 @@ variable "buckets" {
 }
 
 variable "cmr_custom_host" {
-  description = "Custom host to use for CMR requests"
+  description = "Custom protocol/host to use for CMR requests (e.g. http://cmr-host.com)"
   type        = string
   default     = null
 }

--- a/tf-modules/archive/variables.tf
+++ b/tf-modules/archive/variables.tf
@@ -164,7 +164,7 @@ variable "buckets" {
 }
 
 variable "cmr_custom_host" {
-  description = "Custom protocol/host to use for CMR requests (e.g. http://cmr-host.com)"
+  description = "Custom protocol and host to use for CMR requests (e.g. http://cmr-host.com)"
   type        = string
   default     = null
 }

--- a/tf-modules/cumulus/variables.tf
+++ b/tf-modules/cumulus/variables.tf
@@ -186,7 +186,7 @@ variable "bucket_map_key" {
 }
 
 variable "cmr_custom_host" {
-  description = "Custom host to use for CMR requests"
+  description = "Custom protocol/host to use for CMR requests (e.g. http://cmr-host.com)"
   type        = string
   default     = null
 }

--- a/tf-modules/cumulus/variables.tf
+++ b/tf-modules/cumulus/variables.tf
@@ -186,7 +186,7 @@ variable "bucket_map_key" {
 }
 
 variable "cmr_custom_host" {
-  description = "Custom protocol/host to use for CMR requests (e.g. http://cmr-host.com)"
+  description = "Custom protocol and host to use for CMR requests (e.g. http://cmr-host.com)"
   type        = string
   default     = null
 }

--- a/tf-modules/ingest/variables.tf
+++ b/tf-modules/ingest/variables.tf
@@ -17,7 +17,7 @@ variable "cmr_environment" {
 }
 
 variable "cmr_custom_host" {
-  description = "Custom host to use for CMR requests"
+  description = "Custom protocol/host to use for CMR requests (e.g. http://cmr-host.com)"
   type        = string
   default     = null
 }

--- a/tf-modules/ingest/variables.tf
+++ b/tf-modules/ingest/variables.tf
@@ -17,7 +17,7 @@ variable "cmr_environment" {
 }
 
 variable "cmr_custom_host" {
-  description = "Custom protocol/host to use for CMR requests (e.g. http://cmr-host.com)"
+  description = "Custom protocol and host to use for CMR requests (e.g. http://cmr-host.com)"
   type        = string
   default     = null
 }


### PR DESCRIPTION
Currently, our `cmr-client` code is hardcoded to assume that all CMR hosts will be accessed via `https`. 

But there are non-NASA projects using Cumulus and CMR (such as the NASA/NOAA collab project that I work on) and these CMR deployments initially only create a load balancer DNS name for accessing the CMR API that is served via `http`. And for testing environments on these other projects, we may use the load balancer directly for accessing CMR and not set up Cloudront or Route 53 to handle `https` traffic to minimize costs and complexity. 

So this PR updates our `cmr-client` to be configurable with a custom CMR host and protocol.

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
