### PR TITLE
CUMULUS-2460 Added knex to call of translatePostgresExecutionToApiExecution()

### DIFF
--- a/packages/api/endpoints/executions.js
+++ b/packages/api/endpoints/executions.js
@@ -108,7 +108,7 @@ async function searchByGranules(req, res) {
     .searchByCumulusIds(knex, executionCumulusIds, { limit, offset });
 
   const apiExecutions = await Promise.all(executions
-    .map((execution) => translatePostgresExecutionToApiExecution(execution)));
+    .map((execution) => translatePostgresExecutionToApiExecution(execution, knex)));
 
   return res.send(apiExecutions);
 }


### PR DESCRIPTION
**Summary:** Added knex to call of translatePostgresExecutionToApiExecution()

Addresses [CUMULUS-2460: executions endpoint should be able to return a list of workflowNames](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2460)

## Changes

* Added knex instance to call of translatePostgresExecutionToApiExecution

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
