### PR TITLE
move kinesis replays endpoint to explicit subpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ behavior
 - **CUMULUS-2373**
   - Updated `getS3KeyForArchivedMessage` in `ingest/sqs` to store SQS messages
     by `queueName`.
+  - Moved kinesis replay functionality from `/replays` to `/replays/kinesis`. Due to the use of explicit pathing to infer the type of the replay request, the `type` parameter is no longer required in the payload of a POST request.
 
 ### Fixed
 

--- a/docs/features/replay-kinesis-messages.md
+++ b/docs/features/replay-kinesis-messages.md
@@ -16,7 +16,7 @@ Cumulus has added a new endpoint to its API, `/replays`. This endpoint will allo
 
 ## Start a replay
 
-In order to start a replay, you must perform a `POST` request to the `replays` endpoint.
+In order to start a Kinesis replay, you must perform a `POST` request to the `/replays/kinesis` endpoint.
 
 The required and optional fields that should be part of the body of this request are documented below.
 
@@ -25,7 +25,6 @@ If tolerable, the same is recommended for the `startTimestamp` although it is us
 
 | Field | Type | Required | Description |
 | ------ | ------ | ------ | ------ |
-| `type` | string | required | Currently only accepts `kinesis`. |
 | `kinesisStream` | string | for type `kinesis` | Any valid kinesis stream name (*not* ARN) |
 | `kinesisStreamCreationTimestamp` | * | optional | Any input valid for a JS Date constructor. For reasons to use this field see [AWS documentation on StreamCreationTimestamp](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_ListShards.html#API_ListShards_RequestSyntax). |
 | `endTimestamp` | * | optional | Any input valid for a JS Date constructor. Messages newer than this timestamp will be skipped.
@@ -33,5 +32,5 @@ If tolerable, the same is recommended for the `startTimestamp` although it is us
 
 ## Status tracking
 
-A successful response from the `/replays` endpoint will contain an `asyncOperationId` field.
+A successful response from the `/replays/kinesis` endpoint will contain an `asyncOperationId` field.
 Use this ID with the `/asyncOperations` endpoint to track the status.

--- a/example/spec/parallel/kinesisTests/KinesisReplaySpec.js
+++ b/example/spec/parallel/kinesisTests/KinesisReplaySpec.js
@@ -146,7 +146,6 @@ describe('The Kinesis Replay API', () => {
       await Promise.all(newRecordsToSkip.map((r) => putRecordOnStream(streamName, r)));
 
       const apiRequestBody = {
-        type: 'kinesis',
         kinesisStream: streamName,
         endTimestamp,
         startTimestamp,

--- a/packages/api-client/src/replays.ts
+++ b/packages/api-client/src/replays.ts
@@ -29,7 +29,7 @@ export const postKinesisReplays = async (params: {
       headers: {
         'Content-Type': 'application/json',
       },
-      path: '/replays',
+      path: '/replays/kinesis',
       body: JSON.stringify(payload),
     },
     expectedStatusCode: 202,

--- a/packages/api-client/tests/test-replays.js
+++ b/packages/api-client/tests/test-replays.js
@@ -6,7 +6,6 @@ const replaysApi = require('../replays');
 
 test('postKinesisReplays calls the callback with the expected object', async (t) => {
   const payload = {
-    type: 'kinesis',
     kinesisStream: 'fake-stream',
     endTimestamp: Date.now(),
     startTimestamp: Date.now(),

--- a/packages/api-client/tests/test-replays.js
+++ b/packages/api-client/tests/test-replays.js
@@ -18,7 +18,7 @@ test('postKinesisReplays calls the callback with the expected object', async (t)
       headers: {
         'Content-Type': 'application/json',
       },
-      path: '/replays',
+      path: '/replays/kinesis',
       body: JSON.stringify(payload),
     },
     expectedStatusCode: 202,

--- a/packages/api/endpoints/replays.js
+++ b/packages/api/endpoints/replays.js
@@ -5,6 +5,7 @@ const asyncOperations = require('@cumulus/async-operations');
 
 const { asyncOperationEndpointErrorHandler } = require('../app/middleware');
 const AsyncOperation = require('../models/async-operation');
+
 /**
  * Start an AsyncOperation that will perform kinesis message replay
  *
@@ -20,13 +21,10 @@ async function startKinesisReplayAsyncOperation(req, res) {
 
   const payload = req.body;
 
-  if (!payload.type) {
-    return res.boom.badRequest('replay type is required');
-  }
-
-  if (payload.type === 'kinesis' && !payload.kinesisStream) {
+  if (!payload.kinesisStream) {
     return res.boom.badRequest('kinesisStream is required for kinesis-type replay');
   }
+
   const asyncOperation = await asyncOperations.startAsyncOperation({
     asyncOperationTaskDefinition: process.env.AsyncOperationTaskDefinition,
     cluster: process.env.EcsCluster,
@@ -43,6 +41,6 @@ async function startKinesisReplayAsyncOperation(req, res) {
   return res.status(202).send({ asyncOperationId: asyncOperation.id });
 }
 
-router.post('/', startKinesisReplayAsyncOperation, asyncOperationEndpointErrorHandler);
+router.post('/kinesis', startKinesisReplayAsyncOperation, asyncOperationEndpointErrorHandler);
 
 module.exports = router;

--- a/packages/api/tests/endpoints/test-replays.js
+++ b/packages/api/tests/endpoints/test-replays.js
@@ -59,33 +59,15 @@ test.after.always(async () => {
   });
 });
 
-test.serial('request to replays endpoint returns 400 when no type is specified', async (t) => {
+test.serial('request to kinesis replays endpoint returns 400 if no kinesisStream is specified', async (t) => {
   const asyncOperationStartStub = sinon.stub(asyncOperations, 'startAsyncOperation').resolves(
     { id: '1234' }
   );
 
-  await request(app)
-    .post('/replays')
-    .set('Accept', 'application/json')
-    .set('Authorization', `Bearer ${jwtAuthToken}`)
-    .send({})
-    .expect(400, /replay type is required/);
-
-  asyncOperationStartStub.restore();
-  t.false(asyncOperationStartStub.called);
-});
-
-test.serial('request to replays endpoint returns 400 if type is kinesis but no kinesisStream is specified', async (t) => {
-  const asyncOperationStartStub = sinon.stub(asyncOperations, 'startAsyncOperation').resolves(
-    { id: '1234' }
-  );
-
-  const body = {
-    type: 'kinesis',
-  };
+  const body = {};
 
   await request(app)
-    .post('/replays')
+    .post('/replays/kinesis')
     .set('Accept', 'application/json')
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .send(body)
@@ -95,20 +77,19 @@ test.serial('request to replays endpoint returns 400 if type is kinesis but no k
   t.false(asyncOperationStartStub.called);
 });
 
-test.serial('request to replays endpoint with valid kinesis parameters starts an AsyncOperation and returns its id', async (t) => {
+test.serial('request to kinesis replays endpoint with valid kinesis parameters starts an AsyncOperation and returns its id', async (t) => {
   const asyncOperationStartStub = sinon.stub(asyncOperations, 'startAsyncOperation').resolves(
     { id: '1234' }
   );
 
   const body = {
-    type: 'kinesis',
     kinesisStream: 'fakestream',
     endTimestamp: 12345678,
     startTimestamp: 12356789,
   };
 
   await request(app)
-    .post('/replays')
+    .post('/replays/kinesis')
     .set('Accept', 'application/json')
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .send(body)
@@ -123,13 +104,12 @@ test.serial('request to replays endpoint with valid kinesis parameters starts an
   asyncOperationStartStub.restore();
 });
 
-test.serial('request to /replays endpoint returns 500 if starting ECS task throws unexpected error', async (t) => {
+test.serial('request to /replays/kinesis endpoint returns 500 if starting ECS task throws unexpected error', async (t) => {
   const asyncOperationStartStub = sinon.stub(asyncOperations, 'startAsyncOperation').throws(
     new Error('failed to start')
   );
 
   const body = {
-    type: 'kinesis',
     kinesisStream: 'fakestream',
     endTimestamp: 12345678,
     startTimestamp: 12356789,
@@ -137,7 +117,7 @@ test.serial('request to /replays endpoint returns 500 if starting ECS task throw
 
   try {
     const response = await request(app)
-      .post('/replays')
+      .post('/replays/kinesis')
       .set('Accept', 'application/json')
       .set('Authorization', `Bearer ${jwtAuthToken}`)
       .send(body);
@@ -147,13 +127,12 @@ test.serial('request to /replays endpoint returns 500 if starting ECS task throw
   }
 });
 
-test.serial('request to /replays endpoint returns 503 if starting ECS task throws unexpected error', async (t) => {
+test.serial('request to /replays/kinesis endpoint returns 503 if starting ECS task throws unexpected error', async (t) => {
   const asyncOperationStartStub = sinon.stub(asyncOperations, 'startAsyncOperation').throws(
     new EcsStartTaskError('failed to start')
   );
 
   const body = {
-    type: 'kinesis',
     kinesisStream: 'fakestream',
     endTimestamp: 12345678,
     startTimestamp: 12356789,
@@ -161,7 +140,7 @@ test.serial('request to /replays endpoint returns 503 if starting ECS task throw
 
   try {
     const response = await request(app)
-      .post('/replays')
+      .post('/replays/kinesis')
       .set('Accept', 'application/json')
       .set('Authorization', `Bearer ${jwtAuthToken}`)
       .send(body);


### PR DESCRIPTION
**Summary:** Summary of changes

## Changes

*   - Moved kinesis replay functionality from `/replays` to `/replays/kinesis`. Due to the use of explicit pathing to infer the type of the replay request, the `type` parameter is no longer required in the payload of a POST request.

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
