### PR TITLE
Updates to CUMULUS-2388

### DIFF
--- a/packages/aws-client/src/S3.ts
+++ b/packages/aws-client/src/S3.ts
@@ -196,7 +196,7 @@ export const waitForObjectToExist = async (params: {
     timeout = 30 * 1000,
   } = params;
 
-  await pWaitFor(
+  return await pWaitFor(
     () => s3ObjectExists({ Bucket: bucket, Key: key }),
     { interval, timeout }
   );
@@ -499,8 +499,7 @@ export const getObjectReadStream = (params: {
 **/
 export const fileExists = async (bucket: string, key: string) => {
   try {
-    const r = await s3().headObject({ Key: key, Bucket: bucket }).promise();
-    return r;
+    return await s3().headObject({ Key: key, Bucket: bucket }).promise();
   } catch (error) {
     // if file is not return false
     if (error.stack.match(/(NotFound)/) || error.stack.match(/(NoSuchBucket)/)) {
@@ -575,7 +574,7 @@ export const recursivelyDeleteS3Bucket = improveStackTrace(
     });
 
     await deleteS3Files(s3Objects);
-    await s3().deleteBucket({ Bucket: bucket }).promise();
+    return await s3().deleteBucket({ Bucket: bucket }).promise();
   }
 );
 
@@ -1039,5 +1038,5 @@ export const moveObject = async (
     ACL: params.ACL,
     copyTags: isBoolean(params.copyTags) ? params.copyTags : true,
   });
-  await deleteS3Object(params.sourceBucket, params.sourceKey);
+  return await deleteS3Object(params.sourceBucket, params.sourceKey);
 };

--- a/packages/cmrjs/src/cmr-utils.js
+++ b/packages/cmrjs/src/cmr-utils.js
@@ -99,8 +99,8 @@ function granuleToCmrFileObject({ granuleId, files = [] }) {
     .map((file) => ({
       // Include etag only if file has one
       ...pick(file, 'etag'),
-      // handle both new-style and old-style files model
-      filename: file.key ? buildS3Uri(file.bucket, file.key) : file.filename, // TODO - is this still valid in postgres land?   Consider removing phase 2
+      bucket: file.bucket,
+      key: file.key,
       granuleId,
     }));
 }

--- a/tasks/move-granules/tests/data/payload.json
+++ b/tasks/move-granules/tests/data/payload.json
@@ -70,32 +70,24 @@
         "granuleId": "MOD11A1.A2017200.h19v04.006.2017201090724",
         "files": [
           {
-            "name": "MOD11A1.A2017200.h19v04.006.2017201090724.hdf",
+            "key": "file-staging/subdir/MOD11A1.A2017200.h19v04.006.2017201090724.hdf",
             "bucket": "cumulus-internal",
-            "filename": "s3://cumulus-internal/file-staging/subdir/MOD11A1.A2017200.h19v04.006.2017201090724.hdf",
-            "type": "data",
-            "fileStagingDir": "file-staging/subdir"
+            "type": "data"
           },
           {
-            "name": "MOD11A1.A2017200.h19v04.006.2017201090724_1.jpg",
+            "key": "file-staging/subdir/MOD11A1.A2017200.h19v04.006.2017201090724_1.jpg",
             "bucket": "cumulus-internal",
-            "filename": "s3://cumulus-internal/file-staging/subdir/MOD11A1.A2017200.h19v04.006.2017201090724_1.jpg",
-            "type": "browse",
-            "fileStagingDir": "file-staging/subdir"
+            "type": "browse"
           },
           {
-            "name": "MOD11A1.A2017200.h19v04.006.2017201090724_2.jpg",
+            "key": "file-staging/subdir/MOD11A1.A2017200.h19v04.006.2017201090724_2.jpg",
             "bucket": "cumulus-internal",
-            "filename": "s3://cumulus-internal/file-staging/subdir/MOD11A1.A2017200.h19v04.006.2017201090724_2.jpg",
-            "type": "browse",
-            "fileStagingDir": "file-staging/subdir"
+            "type": "browse"
           },
           {
-            "name": "MOD11A1.A2017200.h19v04.006.2017201090724.cmr.xml",
+            "key": "file-staging/subdir/MOD11A1.A2017200.h19v04.006.2017201090724.cmr.xml",
             "bucket": "cumulus-internal",
-            "filename": "s3://cumulus-internal/file-staging/subdir/MOD11A1.A2017200.h19v04.006.2017201090724.cmr.xml",
-            "type": "metadata",
-            "fileStagingDir": "file-staging/subdir"
+            "type": "metadata"
           }
         ]
       }


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2388: Consistent granules-files](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2388)

## Changes

* Update move-granules to use bucket/key inputs.

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
