### PR TITLE
CUMULUS-2577: Adds `POST /executions` endpoint to create an execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ but technically it is a breaking change to the Elasticsearch mappings.
 - **CUMULUS-2592**
   - Adds logging when messages fail to be added to queue
 
+- **CUMULUS-2577**
+  - Adds `POST` to `executions` endpoint to create an execution
+
 ## [v9.4.0] 2021-08-16
 
 ### Notable changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ but technically it is a breaking change to the Elasticsearch mappings.
   - Adds logging when messages fail to be added to queue
 
 - **CUMULUS-2577**
-  - Adds `POST` to `executions` endpoint to create an execution
+  - Adds `POST /executions` endpoint to create an execution
 
 ## [v9.4.0] 2021-08-16
 

--- a/packages/api/endpoints/executions.js
+++ b/packages/api/endpoints/executions.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const router = require('express-promise-router')();
+const { inTestMode } = require('@cumulus/common/test-utils');
 const { RecordDoesNotExist } = require('@cumulus/errors');
+const Logger = require('@cumulus/logger');
 const {
   getKnexClient,
   getApiGranuleExecutionCumulusIds,
@@ -11,10 +13,63 @@ const {
   translatePostgresExecutionToApiExecution,
 } = require('@cumulus/db');
 const Search = require('@cumulus/es-client/search').Search;
+const {
+  addToLocalES,
+  indexExecution,
+} = require('@cumulus/es-client/indexer');
 const models = require('../models');
+const { isBadRequestError } = require('../lib/errors');
 const { getGranulesForPayload } = require('../lib/granules');
+const { writeExecutionApiRecord } = require('../lib/writeRecords/write-execution');
 const { validateGranuleExecutionRequest } = require('../lib/request');
 
+const log = new Logger({ sender: '@cumulus/api/collections' });
+/**
+ * create an execution
+ *
+ * @param {Object} req - express request object
+ * @param {Object} res - express response object
+ * @returns {Promise<Object>} the promise of express response object
+ */
+async function create(req, res) {
+  const {
+    executionModel = new models.Execution(),
+    knex = await getKnexClient(),
+  } = req.testContext || {};
+
+  const execution = req.body || {};
+  const { arn } = execution;
+
+  if (!arn) {
+    return res.boom.badRequest('Field arn is missing');
+  }
+
+  if (await executionModel.exists({ arn })) {
+    return res.boom.conflict(`A record already exists for ${arn}`);
+  }
+
+  execution.updatedAt = Date.now();
+  execution.createdAt = Date.now();
+
+  try {
+    await writeExecutionApiRecord({ record: execution, knex });
+
+    if (inTestMode()) {
+      await addToLocalES(execution, indexExecution);
+    }
+
+    return res.send({
+      message: 'Record saved',
+      record: execution,
+    });
+  } catch (error) {
+    if (isBadRequestError(error) || error instanceof RecordDoesNotExist) {
+      return res.boom.badRequest(error.message);
+    }
+    log.error('Error occurred while trying to create execution:', error);
+    return res.boom.badImplementation(error.message);
+  }
+}
 /**
  * List and search executions
  *
@@ -144,6 +199,7 @@ async function workflowsByGranules(req, res) {
 
 router.post('/search-by-granules', validateGranuleExecutionRequest, searchByGranules);
 router.post('/workflows-by-granules', validateGranuleExecutionRequest, workflowsByGranules);
+router.post('/', create);
 router.get('/:arn', get);
 router.get('/', list);
 router.delete('/:arn', del);

--- a/packages/api/endpoints/executions.js
+++ b/packages/api/endpoints/executions.js
@@ -20,10 +20,11 @@ const {
 const models = require('../models');
 const { isBadRequestError } = require('../lib/errors');
 const { getGranulesForPayload } = require('../lib/granules');
-const { writeExecutionApiRecord } = require('../lib/writeRecords/write-execution');
+const { writeExecutionRecordsFromApi } = require('../lib/writeRecords/write-execution');
 const { validateGranuleExecutionRequest } = require('../lib/request');
 
-const log = new Logger({ sender: '@cumulus/api/collections' });
+const log = new Logger({ sender: '@cumulus/api/executions' });
+
 /**
  * create an execution
  *
@@ -52,7 +53,7 @@ async function create(req, res) {
   execution.createdAt = Date.now();
 
   try {
-    await writeExecutionApiRecord({ record: execution, knex });
+    await writeExecutionRecordsFromApi({ record: execution, knex });
 
     if (inTestMode()) {
       await addToLocalES(execution, indexExecution);

--- a/packages/api/endpoints/executions.js
+++ b/packages/api/endpoints/executions.js
@@ -20,7 +20,7 @@ const {
 const models = require('../models');
 const { isBadRequestError } = require('../lib/errors');
 const { getGranulesForPayload } = require('../lib/granules');
-const { writeExecutionRecordsFromApi } = require('../lib/writeRecords/write-execution');
+const { writeExecutionRecordFromApi } = require('../lib/writeRecords/write-execution');
 const { validateGranuleExecutionRequest } = require('../lib/request');
 
 const log = new Logger({ sender: '@cumulus/api/executions' });
@@ -53,7 +53,7 @@ async function create(req, res) {
   execution.createdAt = Date.now();
 
   try {
-    await writeExecutionRecordsFromApi({ record: execution, knex });
+    await writeExecutionRecordFromApi({ record: execution, knex });
 
     if (inTestMode()) {
       await addToLocalES(execution, indexExecution);

--- a/packages/api/lambdas/sf-event-sqs-to-db-records/index.js
+++ b/packages/api/lambdas/sf-event-sqs-to-db-records/index.js
@@ -34,7 +34,7 @@ const {
 
 const {
   shouldWriteExecutionToPostgres,
-  writeExecutionRecordsFromMessage,
+  writeExecutionRecordFromMessage,
 } = require('../../lib/writeRecords/write-execution');
 
 const {
@@ -142,7 +142,7 @@ const writeRecords = async ({
     });
   }
 
-  const executionCumulusId = await writeExecutionRecordsFromMessage({
+  const executionCumulusId = await writeExecutionRecordFromMessage({
     cumulusMessage,
     collectionCumulusId,
     asyncOperationCumulusId,

--- a/packages/api/lambdas/sf-event-sqs-to-db-records/index.js
+++ b/packages/api/lambdas/sf-event-sqs-to-db-records/index.js
@@ -34,7 +34,7 @@ const {
 
 const {
   shouldWriteExecutionToPostgres,
-  writeExecution,
+  writeExecutionRecordsFromMessage,
 } = require('../../lib/writeRecords/write-execution');
 
 const {
@@ -142,7 +142,7 @@ const writeRecords = async ({
     });
   }
 
-  const executionCumulusId = await writeExecution({
+  const executionCumulusId = await writeExecutionRecordsFromMessage({
     cumulusMessage,
     collectionCumulusId,
     asyncOperationCumulusId,

--- a/packages/api/lambdas/sf-event-sqs-to-db-records/index.js
+++ b/packages/api/lambdas/sf-event-sqs-to-db-records/index.js
@@ -35,7 +35,7 @@ const {
 const {
   shouldWriteExecutionToPostgres,
   writeExecution,
-} = require('./write-execution');
+} = require('../../lib/writeRecords/write-execution');
 
 const {
   writePdr,

--- a/packages/api/lib/writeRecords/write-execution.js
+++ b/packages/api/lib/writeRecords/write-execution.js
@@ -26,7 +26,7 @@ const Logger = require('@cumulus/logger');
 const { parseException } = require('../utils');
 const Execution = require('../../models/executions');
 
-const logger = new Logger({ sender: '@cumulus/sfEventSqsToDbRecords/write-execution' });
+const logger = new Logger({ sender: '@cumulus/api/lib/writeRecords/write-execution' });
 
 const shouldWriteExecutionToPostgres = ({
   messageCollectionNameVersion,

--- a/packages/api/lib/writeRecords/write-execution.js
+++ b/packages/api/lib/writeRecords/write-execution.js
@@ -95,7 +95,7 @@ const _writeExecutionRecord = ({
   return executionCumulusId;
 });
 
-const writeExecutionRecordsFromMessage = ({
+const writeExecutionRecordFromMessage = ({
   cumulusMessage,
   knex,
   collectionCumulusId,
@@ -115,7 +115,7 @@ const writeExecutionRecordsFromMessage = ({
   return _writeExecutionRecord({ dynamoRecord, postgresRecord, knex, executionModel });
 };
 
-const writeExecutionRecordsFromApi = async ({
+const writeExecutionRecordFromApi = async ({
   record: dynamoRecord,
   knex,
   executionModel = new Execution(),
@@ -127,6 +127,6 @@ const writeExecutionRecordsFromApi = async ({
 module.exports = {
   buildExecutionRecord,
   shouldWriteExecutionToPostgres,
-  writeExecutionRecordsFromMessage,
-  writeExecutionRecordsFromApi,
+  writeExecutionRecordFromMessage,
+  writeExecutionRecordFromApi,
 };

--- a/packages/api/lib/writeRecords/write-execution.js
+++ b/packages/api/lib/writeRecords/write-execution.js
@@ -2,6 +2,7 @@ const isNil = require('lodash/isNil');
 
 const {
   ExecutionPgModel,
+  translateApiExecutionToPostgresExecution,
 } = require('@cumulus/db');
 const {
   getMessageExecutionArn,
@@ -22,7 +23,7 @@ const {
 const { removeNilProperties } = require('@cumulus/common/util');
 const Logger = require('@cumulus/logger');
 
-const { parseException } = require('../../lib/utils');
+const { parseException } = require('../utils');
 const Execution = require('../../models/executions');
 
 const logger = new Logger({ sender: '@cumulus/sfEventSqsToDbRecords/write-execution' });
@@ -79,29 +80,22 @@ const buildExecutionRecord = ({
   });
 };
 
-const writeExecutionViaTransaction = async ({
-  cumulusMessage,
-  collectionCumulusId,
-  asyncOperationCumulusId,
-  parentExecutionCumulusId,
-  trx,
+const _writeExecutionRecord = ({
+  dynamoRecord,
+  postgresRecord,
+  knex,
+  executionModel = new Execution(),
   executionPgModel = new ExecutionPgModel(),
-  updatedAt,
-}) => {
-  const executionRecord = buildExecutionRecord({
-    cumulusMessage,
-    collectionCumulusId,
-    asyncOperationCumulusId,
-    parentExecutionCumulusId,
-    updatedAt,
-  });
-  logger.info(`About to write execution ${executionRecord.arn} to PostgreSQL`);
-  const upsertResponse = await executionPgModel.upsert(trx, executionRecord);
-  logger.info(`Successfully wrote execution ${executionRecord.arn} to PostgreSQL with cumulus_id ${upsertResponse[0]}`);
-  return upsertResponse;
-};
+}) => knex.transaction(async (trx) => {
+  logger.info(`About to write execution ${postgresRecord.arn} to PostgreSQL`);
+  const [executionCumulusId] = await executionPgModel.upsert(trx, postgresRecord);
+  logger.info(`Successfully wrote execution ${postgresRecord.arn} to PostgreSQL with cumulus_id ${executionCumulusId}`);
 
-const writeExecution = async ({
+  await executionModel.storeExecutionRecord(dynamoRecord);
+  return executionCumulusId;
+});
+
+const writeExecution = ({
   cumulusMessage,
   knex,
   collectionCumulusId,
@@ -109,23 +103,30 @@ const writeExecution = async ({
   parentExecutionCumulusId,
   executionModel = new Execution(),
   updatedAt = Date.now(),
-}) =>
-  await knex.transaction(async (trx) => {
-    const [executionCumulusId] = await writeExecutionViaTransaction({
-      cumulusMessage,
-      collectionCumulusId,
-      asyncOperationCumulusId,
-      parentExecutionCumulusId,
-      trx,
-      updatedAt,
-    });
-    await executionModel.storeExecutionFromCumulusMessage(cumulusMessage, updatedAt);
-    return executionCumulusId;
+}) => {
+  const postgresRecord = buildExecutionRecord({
+    cumulusMessage,
+    collectionCumulusId,
+    asyncOperationCumulusId,
+    parentExecutionCumulusId,
+    updatedAt,
   });
+  const dynamoRecord = Execution.generateRecord(cumulusMessage, updatedAt);
+  return _writeExecutionRecord({ dynamoRecord, postgresRecord, knex, executionModel });
+};
+
+const writeExecutionApiRecord = async ({
+  record: dynamoRecord,
+  knex,
+  executionModel = new Execution(),
+}) => {
+  const postgresRecord = await translateApiExecutionToPostgresExecution(dynamoRecord, knex);
+  return _writeExecutionRecord({ dynamoRecord, postgresRecord, knex, executionModel });
+};
 
 module.exports = {
   buildExecutionRecord,
   shouldWriteExecutionToPostgres,
-  writeExecutionViaTransaction,
   writeExecution,
+  writeExecutionApiRecord,
 };

--- a/packages/api/lib/writeRecords/write-execution.js
+++ b/packages/api/lib/writeRecords/write-execution.js
@@ -95,7 +95,7 @@ const _writeExecutionRecord = ({
   return executionCumulusId;
 });
 
-const writeExecution = ({
+const writeExecutionRecordsFromMessage = ({
   cumulusMessage,
   knex,
   collectionCumulusId,
@@ -115,7 +115,7 @@ const writeExecution = ({
   return _writeExecutionRecord({ dynamoRecord, postgresRecord, knex, executionModel });
 };
 
-const writeExecutionApiRecord = async ({
+const writeExecutionRecordsFromApi = async ({
   record: dynamoRecord,
   knex,
   executionModel = new Execution(),
@@ -127,6 +127,6 @@ const writeExecutionApiRecord = async ({
 module.exports = {
   buildExecutionRecord,
   shouldWriteExecutionToPostgres,
-  writeExecution,
-  writeExecutionApiRecord,
+  writeExecutionRecordsFromMessage,
+  writeExecutionRecordsFromApi,
 };

--- a/packages/api/tests/lib/writeRecords/test-write-execution.js
+++ b/packages/api/tests/lib/writeRecords/test-write-execution.js
@@ -18,7 +18,7 @@ const {
   buildExecutionRecord,
   shouldWriteExecutionToPostgres,
   writeExecution,
-} = require('../../../lambdas/sf-event-sqs-to-db-records/write-execution');
+} = require('../../../lib/writeRecords/write-execution');
 
 test.before(async (t) => {
   process.env.ExecutionsTable = cryptoRandomString({ length: 10 });

--- a/packages/api/tests/models/test-executions-model.js
+++ b/packages/api/tests/models/test-executions-model.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const test = require('ava');
+const pick = require('lodash/pick');
 const { randomId, randomString } = require('@cumulus/common/test-utils');
 
 const Execution = require('../../models/executions');
@@ -202,6 +203,10 @@ test('storeExecutionRecord() can be used to update an execution', async (t) => {
 
   await executionModel.storeExecutionRecord(execution);
 
+  const checkList = ['asyncOperationId', 'status', 'originalPayload'];
+  const fetchedItem = await executionModel.get({ arn: execution.arn });
+  t.deepEqual(pick(fetchedItem, checkList), pick(execution, checkList));
+
   const newPayload = { foo: 'bar' };
   const updatedExecution = {
     ...execution,
@@ -212,9 +217,9 @@ test('storeExecutionRecord() can be used to update an execution', async (t) => {
 
   await executionModel.storeExecutionRecord(updatedExecution);
 
-  const fetchedItem = await executionModel.get({ arn: execution.arn });
-  t.deepEqual(fetchedItem.originalPayload, newPayload);
-  t.is(fetchedItem.asyncOperationId, '2');
+  const fetchedUpdatedItem = await executionModel.get({ arn: execution.arn });
+  t.deepEqual(pick(fetchedUpdatedItem, checkList), pick(updatedExecution, checkList));
+  t.notDeepEqual(pick(fetchedUpdatedItem, checkList), pick(fetchedItem, checkList));
 });
 
 test.serial('storeExecutionFromCumulusMessage() can be used to create a new running execution', async (t) => {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -3,6 +3,7 @@ export {
   createTestDatabase,
   deleteTestDatabase,
   destroyLocalTestDb,
+  fakeAsyncOperationRecordFactory,
   fakeCollectionRecordFactory,
   fakeExecutionRecordFactory,
   fakeFileRecordFactory,


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2577: As a user I want to create an execution](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2577)

## Changes

* Adds POST to executions endpoint to create an execution

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
