### PR TITLE
Update bootstrap script to set explicit data volume permissions 

### DIFF
--- a/bamboo/bootstrap-sftp.sh
+++ b/bamboo/bootstrap-sftp.sh
@@ -8,4 +8,6 @@ if [[ $CI = true ]]; then
   rm -Rf /data/*
   cp -Rp /data_volume/* /data/ || true
 fi
+chgrp user /data/granules
+chmod 775 /data/granules
 /usr/sbin/sshd -D -f /etc/ssh/sshd_config


### PR DESCRIPTION

**Summary:** Summary of changes

Addresses [CUMULUS-2562](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2562)

## Changes

* Explicitly set user group/write for the sftp container data volume.   This should resolve the local errors noted in the ticket. 
