### PR TITLE
Cumulus-2644 Update serve.js erasePostgresTables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,9 @@ but technically it is a breaking change to the Elasticsearch mappings.
   - **CUMULUS-2634**
     - Changed `sfEventSqsToDbRecords` Lambda to use new upsert helpers for executions, granules, and PDRs
     to ensure out-of-order writes are handled correctly when writing to Elasticsearch
+  - **CUMULUS-2644**
+    - Changed `erasePostgresTables` in serve.js to ensure granules_executions, granules, pdrs, are
+    deleted before executions
 
 ## [v9.4.0] 2021-08-16
 

--- a/packages/api/bin/serve.js
+++ b/packages/api/bin/serve.js
@@ -385,20 +385,16 @@ async function erasePostgresTables(knex) {
   const providerPgModel = new ProviderPgModel();
   const rulePgModel = new RulePgModel();
 
+  await granulesExecutionsPgModel.delete(knex, {});
+  await granulePgModel.delete(knex, {});
+  await pdrPgModel.delete(knex, {});
   await executionPgModel.delete(knex, {});
   await asyncOperationPgModel.delete(knex, {});
   await filePgModel.delete(knex, {});
   await granulePgModel.delete(knex, {});
   await rulePgModel.delete(knex, {});
-
-  const delPromises = [
-    collectionPgModel.delete(knex, {}),
-    granulePgModel.delete(knex, {}),
-    granulesExecutionsPgModel.delete(knex, {}),
-    pdrPgModel.delete(knex, {}),
-    providerPgModel.delete(knex, {}),
-  ];
-  await Promise.all(delPromises);
+  await collectionPgModel.delete(knex, {});
+  await providerPgModel.delete(knex, {});
 }
 
 /**


### PR DESCRIPTION
**Summary:** Updated servejs. -> erasePostgresTables() to order the deletes to support foreign key constraints.

Addresses [CUMULUS-2644: Update LocalAPI to support Postgres seeding for development and testing](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2644)

## Changes

* Reordered delete calls so granule_executions records, pdrs, and granules are deleted before executions so prevent foreign key constraint errors
* That left only collections and providers in the promise.all() so I went ahead and moved them out for consistency

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests

