### PR TITLE
Changes return from badRequest to notFound when granuleId doesn't exist in DBs for update.

### DIFF
--- a/packages/api/endpoints/granules.js
+++ b/packages/api/endpoints/granules.js
@@ -114,7 +114,7 @@ const update = async (req, res) => {
     existingGranule = await granuleModel.get({ granuleId: body.granuleId });
   } catch (error) {
     if (error instanceof RecordDoesNotExist) {
-      return res.boom.badRequest(`No granule found to update for ${body.granuleId}`);
+      return res.boom.notFound(`No granule found to update for ${body.granuleId}`);
     }
     return res.boom.badRequest(errorify(error));
   }

--- a/packages/api/models/granules.js
+++ b/packages/api/models/granules.js
@@ -299,7 +299,8 @@ class Granule extends Manager {
    * @param {string} params.collectionId - Cumulus collection id
    * @param {string} params.provider - Provider id
    * @param {number} params.timeToArchive - seconds to post to cmr.
-   * @param {number} [params.timeToPreprocess] -  seconds
+   * @param {number } [params.timeToPreprocess] -  seconds
+   * @param {number } [params.timestamp = Date.now()] - a timestamp
    * @param {integer} [params.productVolume] - sum of the files sizes in bytes
    * @param {number} [params.duration] - seconds
    * @param {GranuleStatus} params.status - ['running','failed','completed']

--- a/packages/api/models/granules.js
+++ b/packages/api/models/granules.js
@@ -299,8 +299,8 @@ class Granule extends Manager {
    * @param {string} params.collectionId - Cumulus collection id
    * @param {string} params.provider - Provider id
    * @param {number} params.timeToArchive - seconds to post to cmr.
-   * @param {number } [params.timeToPreprocess] -  seconds
-   * @param {number } [params.timestamp = Date.now()] - a timestamp
+   * @param {number} [params.timeToPreprocess] -  seconds
+   * @param {number} [params.timestamp = Date.now()] - a timestamp
    * @param {integer} [params.productVolume] - sum of the files sizes in bytes
    * @param {number} [params.duration] - seconds
    * @param {GranuleStatus} params.status - ['running','failed','completed']

--- a/packages/api/tests/endpoints/test-granules.js
+++ b/packages/api/tests/endpoints/test-granules.js
@@ -1659,9 +1659,9 @@ test.serial('update (PUT) returns bad request if granule does not exist', async 
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .set('Accept', 'application/json')
     .send(newGranule)
-    .expect(400);
+    .expect(404);
 
-  t.is(response.body.error, 'Bad Request');
+  t.is(response.body.error, 'Not Found');
   t.is(response.body.message, `No granule found to update for ${newGranule.granuleId}`);
 });
 

--- a/packages/api/tests/endpoints/test-granules.js
+++ b/packages/api/tests/endpoints/test-granules.js
@@ -1648,7 +1648,7 @@ test.serial('create (POST) return bad request if a granule is submitted with a b
   t.is(response.error.message, 'cannot POST /granules (400)');
 });
 
-test.serial('update (PUT) returns bad request if granule does not exist', async (t) => {
+test.serial('update (PUT) returns Not Found if granule does not exist', async (t) => {
   const newGranule = fakeGranuleFactoryV2({
     collectionId: t.context.collectionId,
     execution: undefined,

--- a/packages/db/src/migrations/20201014105058_create_granules_table.ts
+++ b/packages/db/src/migrations/20201014105058_create_granules_table.ts
@@ -57,7 +57,7 @@ export const up = async (knex: Knex): Promise<void> =>
       .comment('Date granule completed');
     table
       .timestamp('last_update_date_time')
-      .comment('Timestap for last update');
+      .comment('Timestamp for last update');
     table
       .timestamp('processing_end_date_time')
       .comment('Date granule finished processing');


### PR DESCRIPTION
-------

**Summary:** return notFound instead of badRequest

Addresses [CUMULUS-2576: update Granule via API](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2576)

## Changes

* updates return to notFound when trying to update a granule that doesn't exist in the database.
* updates tests to reflect.

## PR Checklist

- [ NO ] Update CHANGELOG  (not released, just a small update to existing changelog entry)
- [X] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests