### PR TITLE
Add KMS decrypt permissions for ECS cluster instance role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Adds `PUT /granules/{granuleId}/execution` API endpoint to associate an execution with a granule
   - Adds helper `associateExecutionWithGranule` to `@cumulus/api-client/granules`
 
+### Fixed
+
+- Added missing permission for `<prefix>_ecs_cluster_instance_role` IAM role (used when running ECS services/tasks)
+to allow `kms:Decrypt` on the KMS key used to encrypt provider credentials. Adding this permission fixes the `sync-granule` task when run as an ECS activity in a Step Function, which previously failed trying to decrypt credentials for providers.
+
 ## [v9.5.0] 2021-09-07
 
 ### BREAKING CHANGES

--- a/example/spec/helpers/kinesisHelpers.js
+++ b/example/spec/helpers/kinesisHelpers.js
@@ -3,16 +3,15 @@
 const delay = require('delay');
 const pRetry = require('p-retry');
 
-const { Kinesis } = require('aws-sdk');
 const { receiveSQSMessages } = require('@cumulus/aws-client/SQS');
+const { describeStream } = require('@cumulus/aws-client/Kinesis');
+const { kinesis } = require('@cumulus/aws-client/services');
 
 const {
   waitForAllTestSf,
 } = require('@cumulus/integration-tests');
 
 const waitPeriodMs = 1000;
-
-const getRegion = () => process.env.AWS_REGION;
 
 /**
  * Helper to simplify common setup code.  wraps function in try catch block
@@ -46,8 +45,7 @@ async function tryCatchExit(cleanupCallback, wrappedFunction, ...args) { // esli
  * @returns {string} stream status
  */
 async function getStreamStatus(StreamName) {
-  const kinesis = new Kinesis({ apiVersion: '2013-12-02', region: getRegion() });
-  const stream = await kinesis.describeStream({ StreamName }).promise();
+  const stream = await describeStream({ StreamName });
   return stream.StreamDescription.StreamStatus;
 }
 
@@ -63,8 +61,6 @@ async function getStreamStatus(StreamName) {
  * @throws {Error} - Error describing current stream status
  */
 async function waitForActiveStream(streamName, initialDelaySecs = 10, maxRetries = 10) {
-  const kinesis = new Kinesis({ apiVersion: '2013-12-02', region: getRegion() });
-
   let streamStatus = 'UNDEFINED';
   let stream;
   const displayName = streamName.split('-').pop();
@@ -73,7 +69,7 @@ async function waitForActiveStream(streamName, initialDelaySecs = 10, maxRetries
 
   return await pRetry(
     async () => {
-      stream = await kinesis.describeStream({ StreamName: streamName }).promise();
+      stream = await describeStream({ StreamName: streamName });
       streamStatus = stream.StreamDescription.StreamStatus;
       if (streamStatus === 'ACTIVE') return streamStatus;
       throw new Error(`Stream never became active:  status: ${streamStatus}: ${streamName}`);
@@ -96,8 +92,7 @@ async function waitForActiveStream(streamName, initialDelaySecs = 10, maxRetries
  * @returns {Promise<Object>} - a kinesis delete stream proxy object.
  */
 async function deleteTestStream(streamName) {
-  const kinesis = new Kinesis({ apiVersion: '2013-12-02', region: getRegion() });
-  return await kinesis.deleteStream({ StreamName: streamName }).promise();
+  return await kinesis().deleteStream({ StreamName: streamName }).promise();
 }
 
 /**
@@ -107,11 +102,10 @@ async function deleteTestStream(streamName) {
  * @returns {Promise<Object>} - kinesis create stream promise if stream to be created.
  */
 async function createKinesisStream(streamName) {
-  const kinesis = new Kinesis({ apiVersion: '2013-12-02', region: getRegion() });
   return await pRetry(
     async () => {
       try {
-        return await kinesis.createStream({ StreamName: streamName, ShardCount: 1 }).promise();
+        return await kinesis().createStream({ StreamName: streamName, ShardCount: 1 }).promise();
       } catch (error) {
         if (error.code === 'LimitExceededException') throw error;
         throw new pRetry.AbortError(error);
@@ -133,11 +127,10 @@ async function createKinesisStream(streamName) {
  * @throws {Error} Kinesis error if stream cannot be created.
  */
 async function createOrUseTestStream(streamName) {
-  const kinesis = new Kinesis({ apiVersion: '2013-12-02', region: getRegion() });
   let stream;
 
   try {
-    stream = await kinesis.describeStream({ StreamName: streamName }).promise();
+    stream = await describeStream({ StreamName: streamName });
   } catch (error) {
     if (error.code === 'ResourceNotFoundException') {
       console.log('Creating a new stream:', streamName);
@@ -160,13 +153,11 @@ async function createOrUseTestStream(streamName) {
  * @returns {string}            - Shard iterator
  */
 async function getShardIterator(streamName) {
-  const kinesis = new Kinesis({ apiVersion: '2013-12-02', region: getRegion() });
-
   const describeStreamParams = {
     StreamName: streamName,
   };
 
-  const streamDetails = await kinesis.describeStream(describeStreamParams).promise();
+  const streamDetails = await describeStream(describeStreamParams);
   const shardId = streamDetails.StreamDescription.Shards[0].ShardId;
   const startingSequenceNumber = streamDetails.StreamDescription.Shards[0].SequenceNumberRange.StartingSequenceNumber;
 
@@ -177,7 +168,7 @@ async function getShardIterator(streamName) {
     StreamName: streamName,
   };
 
-  const shardIterator = await kinesis.getShardIterator(shardIteratorParams).promise();
+  const shardIterator = await kinesis().getShardIterator(shardIteratorParams).promise();
   return shardIterator.ShardIterator;
 }
 
@@ -190,8 +181,7 @@ async function getShardIterator(streamName) {
  * @returns {Array} Array of records from kinesis stream.
  */
 async function getRecords(shardIterator, records = []) {
-  const kinesis = new Kinesis({ apiVersion: '2013-12-02', region: getRegion() });
-  const data = await kinesis.getRecords({ ShardIterator: shardIterator }).promise();
+  const data = await kinesis().getRecords({ ShardIterator: shardIterator }).promise();
   records.push(...data.Records);
   if ((data.NextShardIterator !== null) && (data.MillisBehindLatest > 0)) {
     await delay(waitPeriodMs);
@@ -208,8 +198,7 @@ async function getRecords(shardIterator, records = []) {
  * @returns {Promise<Object>} - Kinesis putRecord response proxy object.
  */
 async function putRecordOnStream(streamName, record) {
-  const kinesis = new Kinesis({ apiVersion: '2013-12-02', region: getRegion() });
-  return await kinesis.putRecord({
+  return await kinesis().putRecord({
     Data: JSON.stringify(record),
     PartitionKey: '1',
     StreamName: streamName,

--- a/packages/api/lib/writeRecords/write-granules.js
+++ b/packages/api/lib/writeRecords/write-granules.js
@@ -154,8 +154,6 @@ const _writePostgresGranuleViaTransaction = async ({
   trx,
   granulePgModel,
 }) => {
-  log.info(`About to write granule with granuleId ${granuleRecord.granule_id}, collection_cumulus_id ${granuleRecord.collection_cumulus_id} to PostgreSQL`);
-
   const upsertQueryResult = await upsertGranuleWithExecutionJoinRecord(
     trx,
     granuleRecord,
@@ -170,10 +168,6 @@ const _writePostgresGranuleViaTransaction = async ({
     granuleRecord,
   });
 
-  log.info(`
-    Successfully wrote granule with granuleId ${granuleRecord.granule_id}, collection_cumulus_id ${granuleRecord.collection_cumulus_id}
-    to granule record with cumulus_id ${granuleCumulusId} in PostgreSQL
-  `);
   return granuleCumulusId;
 };
 
@@ -296,6 +290,10 @@ const _writeGranule = async ({
   granulePgModel,
 }) => {
   let granuleCumulusId;
+
+  log.info('About to write granule record %j to PostgreSQL', postgresGranuleRecord);
+  log.info('About to write granule record %j to DynamoDB', dynamoGranuleRecord);
+
   await knex.transaction(async (trx) => {
     granuleCumulusId = await _writePostgresGranuleViaTransaction({
       granuleRecord: postgresGranuleRecord,
@@ -305,6 +303,14 @@ const _writeGranule = async ({
     });
     return granuleModel.storeGranule(dynamoGranuleRecord);
   });
+
+  log.info(
+    `
+    Successfully wrote granule %j to PostgreSQL. Record cumulus_id in PostgreSQL: ${granuleCumulusId}.
+    `,
+    postgresGranuleRecord
+  );
+  log.info('Successfully wrote granule %j to DynamoDB', dynamoGranuleRecord);
 
   const { files, granuleId, status, error } = dynamoGranuleRecord;
 

--- a/packages/aws-client/src/client.ts
+++ b/packages/aws-client/src/client.ts
@@ -3,7 +3,7 @@ import { inTestMode, testAwsClient } from './test-utils';
 
 const noop = () => {}; // eslint-disable-line lodash/prefer-noop
 
-const getRegion = () => process.env.AWS_REGION || 'us-east-1';
+const getRegion = () => process.env.AWS_DEFAULT_REGION || process.env.AWS_REGION || 'us-east-1';
 
 // Workaround upload hangs. See: https://github.com/andrewrk/node-s3-client/issues/74
 // @ts-ignore - AWS.util is not part of the public API and may break

--- a/packages/aws-client/tests/test-client.js
+++ b/packages/aws-client/tests/test-client.js
@@ -11,7 +11,22 @@ test.beforeEach(() => {
 
 test.afterEach.always(() => {
   delete process.env.AWS_REGION;
+  delete process.env.AWS_DEFAULT_REGION;
   process.env.NODE_ENV = 'test';
+});
+
+test.serial('client respects AWS_DEFAULT_REGION when creating service clients', (t) => {
+  process.env.AWS_DEFAULT_REGION = 'us-west-2';
+
+  const s3client = client(AWS.S3)();
+  t.is(s3client.config.region, 'us-west-2');
+});
+
+test.serial('client defaults region to us-east-1 if AWS_DEFAULT_REGION env var is an empty string', (t) => {
+  process.env.AWS_DEFAULT_REGION = '';
+
+  const s3client = client(AWS.S3)();
+  t.is(s3client.config.region, 'us-east-1');
 });
 
 test.serial('client respects AWS_REGION when creating service clients', (t) => {
@@ -21,7 +36,7 @@ test.serial('client respects AWS_REGION when creating service clients', (t) => {
   t.is(s3client.config.region, 'us-west-2');
 });
 
-test.serial('client defaults region to us-east-1 if AWS_REGION env var is not set', (t) => {
+test.serial('client defaults region to us-east-1 if no env var is not set', (t) => {
   const s3client = client(AWS.S3)();
   t.is(s3client.config.region, 'us-east-1');
 });

--- a/packages/ingest/package.json
+++ b/packages/ingest/package.json
@@ -42,6 +42,7 @@
     "@cumulus/common": "9.5.0",
     "@cumulus/db": "9.5.0",
     "@cumulus/errors": "9.5.0",
+    "@cumulus/logger": "9.5.0",
     "@cumulus/message": "9.5.0",
     "@cumulus/sftp-client": "9.5.0",
     "aws-sdk": "^2.585.0",

--- a/packages/ingest/src/util.ts
+++ b/packages/ingest/src/util.ts
@@ -4,7 +4,7 @@ import { S3KeyPairProvider } from '@cumulus/common/key-pair-provider';
 
 import Logger from '@cumulus/logger';
 
-const logger = new Logger({ sender: '@cumulus/ingest/utils' });
+const logger = new Logger({ sender: '@cumulus/ingest/util' });
 
 export const decrypt = async (
   ciphertext: string

--- a/packages/ingest/src/util.ts
+++ b/packages/ingest/src/util.ts
@@ -2,12 +2,17 @@ import mime from 'mime-types';
 import * as KMS from '@cumulus/aws-client/KMS';
 import { S3KeyPairProvider } from '@cumulus/common/key-pair-provider';
 
+import Logger from '@cumulus/logger';
+
+const logger = new Logger({ sender: '@cumulus/ingest/utils' });
+
 export const decrypt = async (
   ciphertext: string
 ): Promise<string | undefined> => {
   try {
     return await KMS.decryptBase64String(ciphertext);
-  } catch (_) {
+  } catch (error) {
+    logger.error('Could not decrypt secret with KMS', error);
     return S3KeyPairProvider.decrypt(ciphertext);
   }
 };

--- a/tf-modules/cumulus/ecs_cluster.tf
+++ b/tf-modules/cumulus/ecs_cluster.tf
@@ -138,6 +138,11 @@ data "aws_iam_policy_document" "ecs_cluster_instance_policy" {
       var.rds_user_access_secret_arn
     ]
   }
+
+  statement {
+    actions   = ["kms:Decrypt"]
+    resources = [module.archive.provider_kms_key_arn]
+  }
 }
 
 resource "aws_iam_role_policy" "ecs_cluster_instance" {

--- a/tf-modules/ingest/lzards-backup-task.tf
+++ b/tf-modules/ingest/lzards-backup-task.tf
@@ -13,6 +13,7 @@ resource "aws_lambda_function" "lzards_backup_task" {
 
   environment {
     variables = {
+      AWS_REGION                       = data.aws_region.current.name
       CMR_ENVIRONMENT                  = var.cmr_environment
       CMR_HOST                         = var.cmr_custom_host
       stackName                        = var.prefix

--- a/tf-modules/ingest/lzards-backup-task.tf
+++ b/tf-modules/ingest/lzards-backup-task.tf
@@ -13,7 +13,6 @@ resource "aws_lambda_function" "lzards_backup_task" {
 
   environment {
     variables = {
-      AWS_REGION                       = data.aws_region.current.name
       CMR_ENVIRONMENT                  = var.cmr_environment
       CMR_HOST                         = var.cmr_custom_host
       stackName                        = var.prefix


### PR DESCRIPTION
We ran into an issue on MAAP when running `sync-granule` as an ECS activity in a Step Function where it was failing to decrypt provider credentials around here in the code:

https://github.com/nasa/cumulus/blob/master/packages/ingest/src/util.ts#L9

Because that code swallows the error encountered from KMS.decrypt, it was difficult to identify the cause. 

However, I noticed that the `lambda-processing` role used by `sync-granule` when run **as a Lambda** has permissions to decrypt the KMS key.

https://github.com/nasa/cumulus/blob/master/tf-modules/cumulus/iam.tf#L142

But the ECS cluster instance role, which is used when `sync-granule` is run as an ECS activity, doesn't have permissions to decrypt the KMS key:

https://github.com/nasa/cumulus/blob/master/tf-modules/cumulus/ecs_cluster.tf#L9

So this PR adds that KMS decrypt permissions for the ECS cluster instance role and updates the code to log the error if/when this happens.