### PR TITLE
Cumulus-2594 Making CMR Oauth information available over API

### DIFF
--- a/packages/api/endpoints/instance-meta.js
+++ b/packages/api/endpoints/instance-meta.js
@@ -14,6 +14,7 @@ function instanceMetadata(req, res) {
     cmr: {
       provider: process.env.cmr_provider,
       environment: process.env.CMR_ENVIRONMENT || 'UAT',
+      oauth_provider: process.env.cmr_oauth_provider || '',
     },
     cumulus: {
       stackName: process.env.stackName,

--- a/packages/api/tests/endpoints/test-instance-meta.js
+++ b/packages/api/tests/endpoints/test-instance-meta.js
@@ -20,9 +20,11 @@ const {
 
 const CMR_ENVIRONMENT = randomString();
 const CMR_PROVIDER = randomString();
+const CMR_OAUTH_PROVIDER = randomString();
 const STACKNAME = randomId('stack');
 process.env.CMR_ENVIRONMENT = CMR_ENVIRONMENT;
 process.env.cmr_provider = CMR_PROVIDER;
+process.env.cmr_oauth_provider = CMR_OAUTH_PROVIDER;
 process.env.TOKEN_SECRET = randomString();
 process.env.stackName = STACKNAME;
 let accessTokenModel;
@@ -61,6 +63,7 @@ test('GET returns expected metadata', async (t) => {
     cmr: {
       provider: CMR_PROVIDER,
       environment: CMR_ENVIRONMENT,
+      oauth_provider: CMR_OAUTH_PROVIDER,
     },
     cumulus: {
       stackName: STACKNAME,


### PR DESCRIPTION

Addresses [CUMULUS-2594: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2594)

Added cmr_oauth_provider info to /instanceMeta endpoint to be displayed on the dashboard.