### PR TITLE
CUMULUS-2676: control concurrency for DiscoverGranules duplicate checking (needs review)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Notable Changes
+
+- **CUMULUS-2583**
+  - The `queue-granules` task now updates granule status to `queued` when a granule is queued. In order to prevent issues with the private API endpoint and Lambda API request and concurrency limits, this may increase the task's overall runtime when large numbers of granules are discovered. If you are facing Lambda timeout errors with this task, we recommend converting your `queue-granules` task to an ECS activity.
+- **CUMULUS-2676**
+  - The `discover-granules` task has been updated to limit concurrency on checks to identify and skip already ingested granules in order to prevent issues with the private API endpoint and Lambda API request and concurrency limits. This may increase the task's overall runtime when large numbers of granules are discovered. If you are facing Lambda timeout errors with this task, we recommend converting your `discover-granules` task to an ECS activity.
+
 ### Added
 
 - **CUMULUS-2576**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Notable Changes
 
 - **CUMULUS-2583**
-  - The `queue-granules` task now updates granule status to `queued` when a granule is queued. In order to prevent issues with the private API endpoint and Lambda API request and concurrency limits, this functionality runs with limited concurrency, which may increase the task's overall runtime when large numbers of granules are being queued. If you are facing Lambda timeout errors with this task, we recommend converting your `queue-granules` task to an ECS activity.
+  - The `queue-granules` task now updates granule status to `queued` when a granule is queued. In order to prevent issues with the private API endpoint and Lambda API request and concurrency limits, this functionality runs with limited concurrency, which may increase the task's overall runtime when large numbers of granules are being queued. If you are facing Lambda timeout errors with this task, we recommend converting your `queue-granules` task to an ECS activity. This concurrency is configurable via the task config's `concurrency` value.
 - **CUMULUS-2676**
-  - The `discover-granules` task has been updated to limit concurrency on checks to identify and skip already ingested granules in order to prevent issues with the private API endpoint and Lambda API request and concurrency limits. This may increase the task's overall runtime when large numbers of granules are discovered. If you are facing Lambda timeout errors with this task, we recommend converting your `discover-granules` task to an ECS activity.
+  - The `discover-granules` task has been updated to limit concurrency on checks to identify and skip already ingested granules in order to prevent issues with the private API endpoint and Lambda API request and concurrency limits. This may increase the task's overall runtime when large numbers of granules are discovered. If you are facing Lambda timeout errors with this task, we recommend converting your `discover-granules` task to an ECS activity. This concurrency is configurable via the task config's `concurrency` value.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Notable Changes
 
 - **CUMULUS-2583**
-  - The `queue-granules` task now updates granule status to `queued` when a granule is queued. In order to prevent issues with the private API endpoint and Lambda API request and concurrency limits, this may increase the task's overall runtime when large numbers of granules are discovered. If you are facing Lambda timeout errors with this task, we recommend converting your `queue-granules` task to an ECS activity.
+  - The `queue-granules` task now updates granule status to `queued` when a granule is queued. In order to prevent issues with the private API endpoint and Lambda API request and concurrency limits, this functionality runs with limited concurrency, which may increase the task's overall runtime when large numbers of granules are being queued. If you are facing Lambda timeout errors with this task, we recommend converting your `queue-granules` task to an ECS activity.
 - **CUMULUS-2676**
   - The `discover-granules` task has been updated to limit concurrency on checks to identify and skip already ingested granules in order to prevent issues with the private API endpoint and Lambda API request and concurrency limits. This may increase the task's overall runtime when large numbers of granules are discovered. If you are facing Lambda timeout errors with this task, we recommend converting your `discover-granules` task to an ECS activity.
 

--- a/tasks/discover-granules/index.js
+++ b/tasks/discover-granules/index.js
@@ -238,14 +238,12 @@ const checkGranuleHasNoDuplicate = async (granuleId, duplicateHandling) => {
  * @returns {Array.string} returns granuleIds parameter with applicable duplciates removed
  */
 const filterDuplicates = async (granuleIds, duplicateHandling, concurrency) => {
-  const keysPromises = await pMap(
+  const checkResults = await pMap(
     granuleIds,
     (key) => checkGranuleHasNoDuplicate(key, duplicateHandling),
     { concurrency }
   );
-
-  const filteredKeys = await Promise.all(keysPromises);
-  return filteredKeys.filter(Boolean);
+  return checkResults.filter(Boolean);
 };
 
 /**

--- a/tasks/discover-granules/package.json
+++ b/tasks/discover-granules/package.json
@@ -39,7 +39,8 @@
     "@cumulus/ingest": "9.5.0",
     "@cumulus/logger": "9.5.0",
     "got": "^9.2.1",
-    "lodash": "^4.17.20"
+    "lodash": "^4.17.20",
+    "p-map": "^4.0.0"
   },
   "devDependencies": {
     "@cumulus/aws-client": "9.5.0",

--- a/tasks/discover-granules/schemas/config.json
+++ b/tasks/discover-granules/schemas/config.json
@@ -90,6 +90,11 @@
       "description": "flag to set DiscoverGranules duplicate handling behavior",
       "default": "replace",
       "type": "string"
+    },
+    "concurrency": {
+      "description": "concurrency used when querying Cumulus API for already discovered granules",
+      "default": 3,
+      "type": "number"
     }
   }
 }

--- a/tasks/queue-granules/index.js
+++ b/tasks/queue-granules/index.js
@@ -4,6 +4,7 @@ const get = require('lodash/get');
 const pMap = require('p-map');
 const cumulusMessageAdapter = require('@cumulus/cumulus-message-adapter-js');
 const { enqueueGranuleIngestMessage } = require('@cumulus/ingest/queue');
+const { constructCollectionId } = require('@cumulus/message/Collections');
 const { buildExecutionArn } = require('@cumulus/message/Executions');
 const {
   providers: providersApi,
@@ -64,6 +65,7 @@ async function queueGranules(event) {
       });
       if (executionArn) {
         const queuedGranule = {
+          collectionId: constructCollectionId(granule.dataType, granule.version),
           granuleId: granule.granuleId,
           status: 'queued',
           retries: 3,


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2676](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2676)

## Changes

- **CUMULUS-2676**
  - The `discover-granules` task has been updated to limit concurrency on checks to identify and skip already ingested granules in order to prevent issues with the private API endpoint and Lambda API request and concurrency limits. This may increase the task's overall runtime when large numbers of granules are discovered. If you are facing Lambda timeout errors with this task, we recommend converting your `discover-granules` task to an ECS activity.

- Changelog note for CUMULUS-2583

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
