### PR TITLE
Update concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,11 +28,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - `QueueGranules` task now updates granule status to `queued` once it is added to the queue.
 - **CUMULUS-2695**
   - Updates the example/cumulus-tf deployment to change
-    `archive_api_reserved_concurrency` from 8 to 15 to prevent throttling on
-    the dashboard.
+    `archive_api_reserved_concurrency` from 8 to 5 to use fewer reserved lambda
+    functions. If you see throttling errors on the `<stack>-apiEndpoints` you
+    should increase this value.
   - Updates cumulus-tf/cumulus/variables.tf to change
     `archive_api_reserved_concurrency` from 8 to 15 to prevent throttling on
-    the dashboard.
+    the dashboard for default deployments.
 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Updates the example/cumulus-tf deployment to change
     `archive_api_reserved_concurrency` from 8 to 15 to prevent throttling on
     the dashboard.
+  - Updates cumulus-tf/cumulus/variables.tf to change
+    `archive_api_reserved_concurrency` from 8 to 15 to prevent throttling on
+    the dashboard.
 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - **CUMULUS-2583**
   - `QueueGranules` task now updates granule status to `queued` once it is added to the queue.
+- **CUMULUS-2695**
+  - Updates the example/cumulus-tf deployment to change
+    `archive_api_reserved_concurrency` from 8 to 15 to prevent throttling on
+    the dashboard.
+
 
 ### Fixed
 

--- a/example/cumulus-tf/variables.tf
+++ b/example/cumulus-tf/variables.tf
@@ -166,7 +166,7 @@ variable "api_gateway_stage" {
 
 variable "api_reserved_concurrency" {
   type = number
-  default = 15
+  default = 5
   description = "Archive API Lambda reserved concurrency"
 }
 

--- a/example/cumulus-tf/variables.tf
+++ b/example/cumulus-tf/variables.tf
@@ -166,7 +166,7 @@ variable "api_gateway_stage" {
 
 variable "api_reserved_concurrency" {
   type = number
-  default = 8
+  default = 15
   description = "Archive API Lambda reserved concurrency"
 }
 

--- a/tf-modules/cumulus/variables.tf
+++ b/tf-modules/cumulus/variables.tf
@@ -172,7 +172,7 @@ variable "archive_api_port" {
 variable "archive_api_reserved_concurrency" {
   description = "Reserved Concurrency for the API lambda function"
   type = number
-  default = 8
+  default = 15
 }
 
 variable "archive_api_users" {


### PR DESCRIPTION
Still received status 429 from lambda just running the dashboard.

{
    "Reason": "ReservedFunctionConcurrentInvocationLimitExceeded",
    "Type": "User",
    "message": "Rate Exceeded."
}

**Summary:** Summary of changes

Addresses [CUMULUS-2695](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2695)

## Changes



## PR Checklist

- [X] Update CHANGELOG
- [ ] Unit tests
- [X] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
