### PR TITLE
CUMULUS-2584: Update execution-status.js with associated granules

### DIFF
--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -72,13 +72,18 @@ export {
   translateApiExecutionToPostgresExecution,
   translatePostgresExecutionToApiExecution,
 } from './translate/executions';
-export { translateApiGranuleToPostgresGranule } from './translate/granules';
+export {
+  translateApiGranuleToPostgresGranule,
+  translatePostgresGranuleToApiGranule,
+ } from './translate/granules';
 export { translateApiPdrToPostgresPdr } from './translate/pdrs';
 
 export {
   executionArnsFromGranuleIdsAndWorkflowNames,
   newestExecutionArnFromGranuleIdWorkflowName,
   getWorkflowNameIntersectFromGranuleIds,
+  getApiExecutionCumulusIds,
+  getApiGranuleExecutionCumulusIdsByExecution,
 } from './lib/execution';
 
 export {

--- a/packages/db/src/lib/execution.ts
+++ b/packages/db/src/lib/execution.ts
@@ -1,6 +1,7 @@
 import Knex from 'knex';
 import { RecordDoesNotExist } from '@cumulus/errors';
 import { tableNames } from '../tables';
+import { ExecutionPgModel, GranulesExecutionsPgModel } from '..';
 
 const Logger = require('@cumulus/logger');
 
@@ -11,6 +12,41 @@ export interface arnRecord {
 }
 
 const log = new Logger({ sender: '@cumulus/db/lib/execution' });
+
+/**
+ * Returns a list of executionArns sorted by most recent first, for an input
+ * Granule Cumulus ID.
+ *
+ * @param {Knex | Knex.Transaction} knexOrTransaction
+ *   Knex client for reading from RDS database
+ * @param {number} granuleCumulusId - The primary ID for a Granule
+ * @param {number} limit - limit to number of executions to query
+ * @returns {Promise<arnRecord[]>} - Array of arn objects with the most recent first.
+ */
+ export const getExecutionArnsByGranuleCumulusId = async (
+  knexOrTransaction: Knex | Knex.Transaction,
+  granuleCumulusId: Number,
+  limit?: number
+): Promise<arnRecord[]> => {
+  const knexQuery = knexOrTransaction(tableNames.executions)
+    .select(`${tableNames.executions}.arn`)
+    .where(`${tableNames.granules}.cumulus_id`, granuleCumulusId)
+    .join(
+      tableNames.granulesExecutions,
+      `${tableNames.executions}.cumulus_id`,
+      `${tableNames.granulesExecutions}.execution_cumulus_id`
+    )
+    .join(
+      tableNames.granules,
+      `${tableNames.granules}.cumulus_id`,
+      `${tableNames.granulesExecutions}.granule_cumulus_id`
+    )
+    .orderBy(`${tableNames.executions}.timestamp`, 'desc');
+  if (limit) {
+    knexQuery.limit(limit);
+  }
+  return await knexQuery;
+};
 
 /**
  * Returns a list of executionArns sorted by most recent first, for an input
@@ -109,4 +145,51 @@ export const getWorkflowNameIntersectFromGranuleIds = async (
     });
   return aggregatedWorkflowCounts
     .map((workflowCounts: { workflow_name: string }) => workflowCounts.workflow_name);
+};
+
+/**
+ * Get cumulus IDs for list of executions
+ *
+ * @param {Knex | Knex.Transaction} knexOrTransaction -
+ *  DB client or transaction
+ * @param {Array<Object>} executions - array of executions
+ * @param {Object} [executionPgModel] - Execution PG model class instance
+ * @returns {Promise<number[]>}
+ */
+ export const getApiExecutionCumulusIds = async (
+  knexOrTransaction: Knex | Knex.Transaction,
+  executions: Array<{ arn: string }>,
+  executionPgModel = new ExecutionPgModel(),
+) => {
+  const executionCumulusIds: Array<number> = await Promise.all(executions.map(async (execution) => {
+    return await executionPgModel.getRecordCumulusId(knexOrTransaction, {
+      arn: execution.arn,
+    });
+  }));
+  return [...new Set(executionCumulusIds)];
+};
+
+/**
+ * Get cumulus IDs for all granules associated to a set of executions
+ *
+ * @param {Knex | Knex.Transaction} knexOrTransaction -
+ *  DB client or transaction
+ * @param {Array<Object>} executions - array of executions
+ * @param {Object} [granulesExecutionsPgModel]
+ *   Granules/executions PG model class instance
+ * @returns {Promise<number[]>}
+ */
+export const getApiGranuleExecutionCumulusIdsByExecution = async (
+  knexOrTransaction: Knex | Knex.Transaction,
+  executions: Array<{ arn: string }>,
+  executionPgModel = new ExecutionPgModel(),
+  granulesExecutionsPgModel = new GranulesExecutionsPgModel()
+): Promise<Array<number>> => {
+  const executionCumulusIds = await getApiExecutionCumulusIds(
+    knexOrTransaction, executions, executionPgModel
+  );
+  const granuleCumulusIds = await granulesExecutionsPgModel
+    .searchByExecutionCumulusIds(knexOrTransaction, executionCumulusIds);
+
+  return granuleCumulusIds;
 };

--- a/packages/db/src/models/granule.ts
+++ b/packages/db/src/models/granule.ts
@@ -7,6 +7,7 @@ import { PostgresGranule, PostgresGranuleRecord, PostgresGranuleUniqueColumns } 
 import { BasePgModel } from './base';
 import { GranulesExecutionsPgModel } from './granules-executions';
 import { translateDateToUTC } from '../lib/timestamp';
+import { getSortFields } from '../lib/sort';
 
 interface RecordSelect {
   cumulus_id: number
@@ -127,6 +128,42 @@ export default class GranulePgModel extends BasePgModel<PostgresGranule, Postgre
       .merge()
       .where(knexOrTrx.raw(`${this.tableName}.created_at <= to_timestamp(${translateDateToUTC(granule.created_at)})`))
       .returning('cumulus_id');
+  }
+
+  /**
+   * Get granules from the granule cumulus_id
+   *
+   * @param {Knex | Knex.Transaction} knexOrTrx -
+   *  DB client or transaction
+   * @param {Array<number>} granuleCumulusIds -
+   * single granule cumulus_id or array of granule cumulus_ids
+   * @param {Object} [params] - Optional object with addition params for query
+   * @param {number} [params.limit] - number of records to be returned
+   * @param {number} [params.offset] - record offset
+   * @returns {Promise<Array<number>>} An array of granules
+   */
+  async searchByCumulusIds(
+    knexOrTrx: Knex | Knex.Transaction,
+    granuleCumulusIds: Array<number> | number,
+    params: { limit: number, offset: number }
+  ): Promise<Array<number>> {
+    const { limit, offset, ...sortQueries } = params || {};
+    const sortFields = getSortFields(sortQueries);
+    const granuleCumulusIdsArray = [granuleCumulusIds].flat();
+    const granules = await knexOrTrx(this.tableName)
+      .whereIn('cumulus_id', granuleCumulusIdsArray)
+      .modify((queryBuilder) => {
+        if (limit) queryBuilder.limit(limit);
+        if (offset) queryBuilder.offset(offset);
+        if (sortFields.length >= 1) {
+          sortFields.forEach((sortObject: { [key: string]: { order: string } }) => {
+            const sortField = Object.keys(sortObject)[0];
+            const { order } = sortObject[sortField];
+            queryBuilder.orderBy(sortField, order);
+          });
+        }
+      });
+    return granules;
   }
 }
 

--- a/packages/db/src/models/granules-executions.ts
+++ b/packages/db/src/models/granules-executions.ts
@@ -59,6 +59,27 @@ export default class GranulesExecutionsPgModel {
     return granuleExecutions.map((granuleExecution) => granuleExecution.execution_cumulus_id);
   }
 
+  /**
+   * Get granule_cumulus_id column values from the execution_cumulus_id
+   *
+   * @param {Knex | Knex.Transaction} knexOrTransaction -
+   *  DB client or transaction
+   * @param {number | Array<number>} executionCumulusIds -
+   * single execution_cumulus_id or array of execution_cumulus_ids
+   * @returns {Promise<Array<number>>} An array of granule_cumulus_ids
+   */
+   async searchByExecutionCumulusIds(
+    knexOrTransaction: Knex | Knex.Transaction,
+    executionCumulusIds: Array<number> | number
+  ): Promise<Array<number>> {
+    const executionCumulusIdsArray = [executionCumulusIds].flat();
+    const granuleExecutions = await knexOrTransaction(this.tableName)
+      .select('granule_cumulus_id')
+      .whereIn('execution_cumulus_id', executionCumulusIdsArray)
+      .groupBy('granule_cumulus_id');
+    return granuleExecutions.map((granuleExecution) => granuleExecution.granule_cumulus_id);
+  }
+
   async delete(
     knexTransaction: Knex.Transaction,
     params: Partial<PostgresGranuleExecution>

--- a/packages/db/src/translate/file.ts
+++ b/packages/db/src/translate/file.ts
@@ -1,8 +1,9 @@
 import { ApiFile } from '@cumulus/types/api/files';
 
-import { PostgresFile } from '../types/file';
+import { PostgresFile, PostgresFileRecord } from '../types/file';
 
 const { parseS3Uri } = require('@cumulus/aws-client/S3');
+const { removeNilProperties } = require('@cumulus/common/util');
 
 const getBucket = (file: ApiFile): string | undefined => {
   if (file.bucket) return file.bucket;
@@ -15,6 +16,18 @@ const getKey = (file: ApiFile) => {
   if (file.filename) return parseS3Uri(file.filename).Key;
   return undefined;
 };
+
+export const translatePostgresFileToApiFile = (
+  filePgRecord: PostgresFileRecord
+): Omit<ApiFile, 'granuleId'> => removeNilProperties({
+  bucket: filePgRecord.bucket,
+  checksum: filePgRecord.checksum_value,
+  checksumType: filePgRecord.checksum_type,
+  fileName: filePgRecord.file_name,
+  key: filePgRecord.key,
+  size: filePgRecord.file_size ? filePgRecord.file_size : undefined,
+  source: filePgRecord.source,
+});
 
 export const translateApiFiletoPostgresFile = (
   file: ApiFile

--- a/packages/db/src/translate/granules.ts
+++ b/packages/db/src/translate/granules.ts
@@ -1,10 +1,119 @@
 import Knex from 'knex';
 
+import { deconstructCollectionId, constructCollectionId } from '@cumulus/message/Collections';
+import { getExecutionUrlFromArn } from '@cumulus/message/Executions';
+import { ApiGranule, GranuleStatus } from '@cumulus/types/api/granules';
+import { removeNilProperties } from '@cumulus/common/util';
+import { ValidationError } from '@cumulus/errors';
+
 import { CollectionPgModel } from '../models/collection';
 import { PdrPgModel } from '../models/pdr';
-import { PostgresGranule } from '../types/granule';
+import { PostgresGranule, PostgresGranuleRecord } from '../types/granule';
 import { ProviderPgModel } from '../models/provider';
-const { deconstructCollectionId } = require('@cumulus/message/Collections');
+import { FilePgModel } from '../models/file';
+import { translatePostgresFileToApiFile } from './file';
+import { getExecutionArnsByGranuleCumulusId } from '../lib/execution';
+import { PostgresCollectionRecord } from '../types/collection';
+
+/**
+ * Generate an API Granule object from a Postgres Granule with associated Files.
+ *
+ * @param {Object} params
+ * @param {PostgresGranuleRecord} params.granulePgRecord - Granule from Postgres
+ * @param {PostgresCollectionRecord} params.collectionPgRecord - Collection from Postgres
+ * @param {Knex | Knex.Transaction} params.knexOrTransaction
+ *   Knex client for reading from RDS database
+ * @param {Object} params.collectionPgModel - Instance of the collection database model
+ * @param {Object} params.pdrPgModel - Instance of the pdr database model
+ * @param {Object} params.providerPgModel - Instance of the provider database model
+ * @param {Object} params.filePgModel - Instance of the file database model
+ * @param {Object} params.executionPgModel - Instance of the execution database model
+ * @returns {Object} An API Granule with associated Files
+ */
+export const translatePostgresGranuleToApiGranule = async ({
+  granulePgRecord,
+  collectionPgRecord,
+  knexOrTransaction,
+  collectionPgModel = new CollectionPgModel(),
+  pdrPgModel = new PdrPgModel(),
+  providerPgModel = new ProviderPgModel(),
+  filePgModel = new FilePgModel(),
+}: {
+  granulePgRecord: PostgresGranuleRecord,
+  collectionPgRecord: PostgresCollectionRecord,
+  knexOrTransaction: Knex | Knex.Transaction,
+  collectionPgModel: CollectionPgModel,
+  pdrPgModel: PdrPgModel,
+  providerPgModel: ProviderPgModel,
+  filePgModel: FilePgModel,
+}): Promise<ApiGranule> => {
+  console.log("processing!: " + JSON.stringify(granulePgRecord));
+
+  const collection = collectionPgRecord || await collectionPgModel.get(
+    knexOrTransaction, { cumulus_id: granulePgRecord.collection_cumulus_id }
+  );
+
+  if (granulePgRecord.collection_cumulus_id !== collection.cumulus_id) {
+    throw new ValidationError(`Collection ${collection.cumulus_id} does not match the Granule's Collection ${granulePgRecord.collection_cumulus_id}`);
+  }
+
+  const files = await filePgModel.search(
+    knexOrTransaction, { granule_cumulus_id: granulePgRecord.cumulus_id }
+  );
+  const executionArns = await getExecutionArnsByGranuleCumulusId(
+    knexOrTransaction,
+    granulePgRecord.cumulus_id,
+    1
+  );
+
+  let pdr;
+
+  if (granulePgRecord.pdr_cumulus_id) {
+    pdr = await pdrPgModel.get(
+      knexOrTransaction, { cumulus_id: granulePgRecord.pdr_cumulus_id }
+    );
+  }
+
+  let provider;
+
+  if (granulePgRecord.provider_cumulus_id) {
+    provider = await providerPgModel.get(
+      knexOrTransaction, { cumulus_id: granulePgRecord.provider_cumulus_id }
+    );
+  }
+
+  const apiGranule: ApiGranule = removeNilProperties({
+    beginningDateTime: granulePgRecord.beginning_date_time?.toISOString(),
+    cmrLink: granulePgRecord.cmr_link,
+    collectionId: constructCollectionId(collection.name, collection.version),
+    createdAt: granulePgRecord.created_at?.getTime(),
+    duration: granulePgRecord.duration,
+    endingDateTime: granulePgRecord.ending_date_time?.toISOString(),
+    error: granulePgRecord.error,
+    execution: executionArns[0] ? getExecutionUrlFromArn(executionArns[0].arn) : undefined,
+    files: files.map((file) => ({
+      ...translatePostgresFileToApiFile(file),
+    })),
+    granuleId: granulePgRecord.granule_id,
+    lastUpdateDateTime: granulePgRecord.last_update_date_time?.toISOString(),
+    pdrName: pdr ? pdr.name : undefined,
+    processingEndDateTime: granulePgRecord.processing_end_date_time?.toISOString(),
+    processingStartDateTime: granulePgRecord.processing_start_date_time?.toISOString(),
+    productionDateTime: granulePgRecord.production_date_time?.toISOString(),
+    productVolume: granulePgRecord.product_volume
+      ? granulePgRecord.product_volume : undefined,
+    provider: provider ? provider.name : undefined,
+    published: granulePgRecord.published,
+    queryFields: granulePgRecord.query_fields,
+    status: granulePgRecord.status as GranuleStatus,
+    timestamp: granulePgRecord.timestamp?.getTime(),
+    timeToArchive: granulePgRecord.time_to_archive,
+    timeToPreprocess: granulePgRecord.time_to_process,
+    updatedAt: granulePgRecord.updated_at?.getTime(),
+  }) as ApiGranule;
+
+  return apiGranule;
+};
 
 /**
  * Generate a Postgres granule record from a DynamoDB record.


### PR DESCRIPTION
**Summary:** Updated execution-status.js with associated granules

Addresses [CUMULUS-2584: Dashboard: Update Established Pages for Multiple Executions](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2584)

## Changes

* Pulled `translatePostgresGranuleToApiGranule` from RDS-Phase2 into master
* Updated execution-status.js to include associated granules

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
