### PR TITLE
downgrade docker cluster to use elasticsearch that matches AWS version 5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   issue in previous version.
 - **CUMULUS-2583**
   - `QueueGranules` task now updates granule status to `queued` once it is added to the queue.
+- **CUMULUS-NONE**
+  - Downgrades elasticsearch version in testing container to 5.3 to match AWS version.
 
 ### Fixed
 

--- a/bamboo/docker-compose-local.yml
+++ b/bamboo/docker-compose-local.yml
@@ -25,7 +25,7 @@ services:
   localstack:
     image: localstack/localstack:0.10.7
   elasticsearch:
-    image: elasticsearch:5.6
+    image: elasticsearch:5.3
   sftp:
     image: nsidc/panubo_sshd:latest
   http:

--- a/bamboo/docker-compose.yml
+++ b/bamboo/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - SFTP_MODE=true
       - CI=true
   elasticsearch:
-    image: maven.earthdata.nasa.gov/elasticsearch:5.6
+    image: maven.earthdata.nasa.gov/elasticsearch:5.3
     network_mode: "service:build_env"
     environment:
       ES_JAVA_OPTS: "-Xms750m -Xmx750m"

--- a/tf-modules/cumulus/variables.tf
+++ b/tf-modules/cumulus/variables.tf
@@ -172,7 +172,7 @@ variable "archive_api_port" {
 variable "archive_api_reserved_concurrency" {
   description = "Reserved Concurrency for the API lambda function"
   type = number
-  default = 15
+  default = 8
 }
 
 variable "archive_api_users" {

--- a/tf-modules/cumulus/variables.tf
+++ b/tf-modules/cumulus/variables.tf
@@ -172,7 +172,7 @@ variable "archive_api_port" {
 variable "archive_api_reserved_concurrency" {
   description = "Reserved Concurrency for the API lambda function"
   type = number
-  default = 8
+  default = 15
 }
 
 variable "archive_api_users" {


### PR DESCRIPTION
-------

**Summary:**

Just changes docker container versions of elasticsearch from 5.6 => 5.3 to match AWS.

Addresses [CUMULUS-bugfix: CI problems, but also we should just do this.](https://bugs.earthdata.nasa.gov/browse/CUMULUS-001)

## Changes

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests