### PR TITLE
Remove schema autogeneration to resolve master break

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "docs-build-packages": "lerna run build-docs",
     "docs-build-tasks": "./bin/build-tasks-doc.js",
     "docs-install": "(cd website && npm install)",
-    "docs-build": "npm run db:local:migrate && npm run docs-install && npm run docs-build-tasks && npm run docs-build-schema && (cd website && npm run build)",
+    "docs-build": "npm run docs-install && npm run docs-build-tasks && (cd website && npm run build)",
     "docs-build-schema": "./bin/build_db_schema.sh",
     "docs-serve": "npm run docs-build && (cd website && npm run start)",
     "eslint": "eslint --ext .js --ext .ts .",


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2705](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2705)

## Changes

* Remove auto-generation of schema from main branch docs publish

This process should be part of the release process/doc update process only, including it as part of docs build would require bamboo re-tooling and shouldn't be needed as it can be included as part of the release generation *or* required as part of PRs that include a database structure migration. 

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
