### PR TITLE
CUMULUS-2324 & 2491: extractDOY function for url path template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     the 'url_path' date extraction utilities. Added 'dateFormat' function as
     an option for extracting and formating the entire date. See
     docs/workflow/workflow-configuration-how-to.md for more information.
+- CUMULUS-2324
+  - Added `extractDOY` function to url-path-template. Similar to `extractYear`,
+    etc., this function will extract the day of year from a given date.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     an option for extracting and formating the entire date. See
     docs/workflow/workflow-configuration-how-to.md for more information.
 - CUMULUS-2324
-  - Added `extractDOY` function to url-path-template. Similar to `extractYear`,
-    etc., this function will extract the day of year from a given date. This
-    function will also 0-pad any DOY number less than three digits, e.g. `002`.
+  - New `extractDOY` function added to url_path template support. Similar to
+    `extractYear`, etc., this function extracts the day of year from a given
+    date. It will also 0-pad any DOY number less than three digits, e.g. `002`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     docs/workflow/workflow-configuration-how-to.md for more information.
 - CUMULUS-2324
   - Added `extractDOY` function to url-path-template. Similar to `extractYear`,
-    etc., this function will extract the day of year from a given date.
+    etc., this function will extract the day of year from a given date. This
+    function will also 0-pad any DOY number less than three digits, e.g. `002`.
 
 ### Changed
 

--- a/packages/ingest/package.json
+++ b/packages/ingest/package.json
@@ -47,6 +47,7 @@
     "@cumulus/sftp-client": "9.8.0",
     "aws-sdk": "^2.585.0",
     "cksum": "^1.3.0",
+    "date-fns": "^2.25.0",
     "delay": "^4.3.0",
     "encodeurl": "^1.0.2",
     "fs-extra": "^5.0.0",

--- a/packages/ingest/src/url-path-template.js
+++ b/packages/ingest/src/url-path-template.js
@@ -1,5 +1,11 @@
 const get = require('lodash/get');
 const moment = require('moment');
+const { getDayOfYear } = require('date-fns');
+
+function getDOY(date) {
+  const doy = getDayOfYear(date);
+  return `${doy}`.padStart(3, '0');
+}
 
 /**
 * evaluate the operation specified in template
@@ -11,6 +17,9 @@ const moment = require('moment');
 function evaluateOperation(name, args) {
   const valueStr = args[0];
   switch (name) {
+  case 'extractDOY': {
+    return getDOY(new Date(valueStr));
+  }
   case 'extractYear': {
     return new Date(valueStr).getUTCFullYear();
   }
@@ -82,4 +91,7 @@ function urlPathTemplate(pathTemplate, context) {
   }
 }
 
-module.exports.urlPathTemplate = urlPathTemplate;
+module.exports = {
+  getDOY,
+  urlPathTemplate,
+};

--- a/packages/ingest/test/test-url-path-template.js
+++ b/packages/ingest/test/test-url-path-template.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const { parseString } = require('xml2js');
 const { xmlParseOptions } = require('@cumulus/cmrjs/utils');
-const { urlPathTemplate } = require('../url-path-template');
+const { getDOY, urlPathTemplate } = require('../url-path-template');
 
 const modisXmlFile = path.join(
   __dirname,
@@ -33,6 +33,12 @@ function getTestMetadata(xmlFile) {
     });
   });
 }
+
+test('getDOY returns DOY and correctly pads with leading zeros', (t) => {
+  t.is(getDOY(new Date('Dec 31, 2020')), '366');
+  t.is(getDOY(new Date('Jan 31, 2020')), '031');
+  t.is(getDOY(new Date('Jan 1, 2020')), '001');
+});
 
 test('test basic usage', (t) => {
   const urlPath = '/{file.bucket}/{file.name}';
@@ -64,6 +70,10 @@ test('url path has operations on metadata date components', async (t) => {
   const urlPath = yearPart.concat(monthPart, datePart, hourPart);
   const result = urlPathTemplate(urlPath, { cmrMetadata: metadataObject });
   t.is(result, '2016/12/23/13/');
+  const doyPart = '{extractDOY(cmrMetadata.Granule.Temporal.RangeDateTime.BeginningDateTime)}/';
+  const doyUrlPath = yearPart.concat(doyPart);
+  const doyResult = urlPathTemplate(doyUrlPath, { cmrMetadata: metadataObject });
+  t.is(doyResult, '2016/358/');
 });
 
 test('url path has substring operation', async (t) => {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2324: As a cumulus integrator, I'd like to easily use Julian Date in collection url_path specification](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2324)

## Changes

* extractDOY function for url path template
* Unit tests

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests 
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
