### PR TITLE
Updated webpack configuration for html-loader v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     the 'url_path' date extraction utilities. Added 'dateFormat' function as
     an option for extracting and formating the entire date. See
     docs/workflow/workflow-configuration-how-to.md for more information.
+- [**PR #2548**](https://github.com/nasa/cumulus/pull/2548)
+  - Updated webpack configuration for html-loader v2
 - **CUMULUS-2640**
   - Added Elasticsearch client scroll setting to the CreateReconciliationReport lambda function.
   - Added `elasticsearch_client_config` tfvars to the archive and cumulus terraform modules.

--- a/example/spec/parallel/orca/OrcaBackupAndRecoverySpec.js
+++ b/example/spec/parallel/orca/OrcaBackupAndRecoverySpec.js
@@ -74,7 +74,7 @@ async function stateMachineExists(stateMachineName) {
   return true;
 }
 
-describe('The S3 Ingest Granules workflow', () => {
+xdescribe('The S3 Ingest Granules workflow', () => {
   const inputPayloadFilename = './spec/parallel/ingestGranule/IngestGranule.input.payload.json';
 
   let isOrcaIncluded = true;

--- a/packages/api/webpack.config.js
+++ b/packages/api/webpack.config.js
@@ -106,6 +106,9 @@ module.exports = {
       {
         test: /\.html$/i,
         loader: 'html-loader',
+        options: {
+          esModule: false
+        },
       },
     ],
   },

--- a/packages/s3-credentials-endpoint/webpack.config.js
+++ b/packages/s3-credentials-endpoint/webpack.config.js
@@ -51,6 +51,9 @@ module.exports = {
       {
         test: /\.html$/i,
         loader: 'html-loader',
+        options: {
+          esModule: false
+        },
       },
     ],
   },


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses issue:
 https://distribution-endpoint/s3credentialsREADME returns [object Module].

## Changes

* Updated webpack configuration for html-loader v2
* skip orca test until orca release compatible with file schema update

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
