### PR TITLE
release-9.9.0: moved git diff call to enable skipping

### DIFF
--- a/bamboo/lint.sh
+++ b/bamboo/lint.sh
@@ -12,8 +12,7 @@ set -ex
 (npm run ci:bootstrap-no-scripts || true) && npm run ci:bootstrap-no-scripts
 npm run lint
 
-GIT_DIFF=$(git --no-pager diff --name-only origin/$PR_BRANCH:CHANGELOG.md -- CHANGELOG.md)
-if [[ $SKIP_CHANGELOG != "true" && ! $GIT_DIFF =~ ^CHANGELOG.md$ ]]; then
+if [[ $SKIP_CHANGELOG != "true" && ! $(git --no-pager diff --name-only origin/$PR_BRANCH:CHANGELOG.md -- CHANGELOG.md) =~ ^CHANGELOG.md$ ]]; then
   echo "**** ERROR -- NO CHANGELOG CHANGE DETECTED.  Failing Lint...."
   echo "GIT DIFF OUTPUT: $GIT_DIFF"
   exit 1


### PR DESCRIPTION
**Summary:** Moved git diff to allow SKIP_CHANGELOG to bypass call

Addresses [CUMULUS-XX: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-XXX)

## Changes

* Detailed list or prose of changes
* ...

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
