### PR TITLE
Update bamboo env vars to set CHANGELOG check to false on same branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+Garbage update to show CL CI works
+
 ### Migration steps
 
 - Please read the [documentation on the updates to the granule files schema for our Cumulus workflow tasks and how to upgrade your deployment for compatibility](https://nasa.github.io/cumulus/docs/upgrade-notes/update-task-file-schemas).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-Garbage update to show CL CI works
-
 ### Migration steps
 
 - Please read the [documentation on the updates to the granule files schema for our Cumulus workflow tasks and how to upgrade your deployment for compatibility](https://nasa.github.io/cumulus/docs/upgrade-notes/update-task-file-schemas).

--- a/bamboo/set-bamboo-env-variables.sh
+++ b/bamboo/set-bamboo-env-variables.sh
@@ -76,12 +76,6 @@ if [[ $BRANCH == master ]]; then
   echo export GIT_PR=true >> .bamboo_env_vars
 fi
 
-## SKIP CL eval if current branch is equal to the PR branch
-if [[ $BRANCH == "$PR_BRANCH" ]]; then
-   export SKIP_CHANGELOG=true
-   echo export SKIP_CHANGELOG=true >> .bamboo_env_vars
-fi
-
 ## This should take a blank value from the global options, and
 ## is intended to allow an override for a custom branch build.
 if [[ -n $bamboo_GIT_PR ]]; then
@@ -105,6 +99,12 @@ if [[ -z $BRANCH ]]; then
 fi
 echo export BRANCH="$BRANCH" >> .bamboo_env_vars
 
+
+## SKIP CL eval if current branch is equal to the PR branch
+if [[ $BRANCH == "$PR_BRANCH" ]]; then
+   export SKIP_CHANGELOG=true
+   echo export SKIP_CHANGELOG=true >> .bamboo_env_vars
+fi
 
 ## If tag matching the current ref is a version tag, set
 GIT_TAG=$(git describe --exact-match HEAD 2>/dev/null | sed -n '1p')

--- a/bamboo/set-bamboo-env-variables.sh
+++ b/bamboo/set-bamboo-env-variables.sh
@@ -79,6 +79,7 @@ fi
 ## SKIP CL eval if current branch is equal to the PR branch
 if [[ $BRANCH == "$PR_BRANCH" ]]; then
    export SKIP_CHANGELOG=true
+   echo export SKIP_CHANGELOG=true >> .bamboo_env_vars
 fi
 
 ## This should take a blank value from the global options, and

--- a/bamboo/set-bamboo-env-variables.sh
+++ b/bamboo/set-bamboo-env-variables.sh
@@ -146,7 +146,7 @@ fi
 # Target master by default.
 # Update with appropriate conditional
 # when creating a feature branch.
-export PR_BRANCH="jk/CUMULUS-1-fix-bamboo-script"
+export PR_BRANCH="master"
 
 ## Run detect-pr script and set flag to true/false
 ## depending on if there is a PR associated with the

--- a/bamboo/set-bamboo-env-variables.sh
+++ b/bamboo/set-bamboo-env-variables.sh
@@ -76,6 +76,11 @@ if [[ $BRANCH == master ]]; then
   echo export GIT_PR=true >> .bamboo_env_vars
 fi
 
+## SKIP CL eval if current branch is equal to the PR branch
+if [[ $BRANCH == "$PR_BRANCH" ]]; then
+   export SKIP_CHANGELOG=true
+fi
+
 ## This should take a blank value from the global options, and
 ## is intended to allow an override for a custom branch build.
 if [[ -n $bamboo_GIT_PR ]]; then

--- a/bamboo/set-bamboo-env-variables.sh
+++ b/bamboo/set-bamboo-env-variables.sh
@@ -146,7 +146,7 @@ fi
 # Target master by default.
 # Update with appropriate conditional
 # when creating a feature branch.
-export PR_BRANCH=master
+export PR_BRANCH="jk/CUMULUS-1-fix-bamboo-script"
 
 ## Run detect-pr script and set flag to true/false
 ## depending on if there is a PR associated with the

--- a/bamboo/set-bamboo-env-variables.sh
+++ b/bamboo/set-bamboo-env-variables.sh
@@ -146,7 +146,7 @@ fi
 # Target master by default.
 # Update with appropriate conditional
 # when creating a feature branch.
-export PR_BRANCH="master"
+export PR_BRANCH=master
 
 ## Run detect-pr script and set flag to true/false
 ## depending on if there is a PR associated with the


### PR DESCRIPTION

**Summary:** Update bamboo script to *not* check for CL updates when current branch is the target branch. 
## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
