### PR TITLE
CUMULUS-2743 -- Update docker image to install latest pip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Upgraded all Cumulus workflow tasks to use `@cumulus/cumulus-message-adapter-js` version `2.0.1`
+- **CUMULUS-2743**
+  - Updated bamboo Dockerfile to upgrade pip as part of the image creation process
 - **CUMULUS-2725**
   - Updated providers endpoint to return encrypted password
   - Updated providers model to try decrypting credentials before encryption to allow for better handling of updating providers

--- a/bamboo/Dockerfile
+++ b/bamboo/Dockerfile
@@ -1,5 +1,5 @@
 ## Dockerfile to create integration/unit test environment
-FROM node:12.18.0-buster
+FROM node:12.22-buster
 RUN apt update && npm config set unsafe-perm true &&\
     apt install -y netcat zip jq rsync zip
 RUN apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \

--- a/bamboo/Dockerfile
+++ b/bamboo/Dockerfile
@@ -1,5 +1,5 @@
 ## Dockerfile to create integration/unit test environment
-FROM node:12.22-buster
+FROM node:12.18.0-buster
 RUN apt update && npm config set unsafe-perm true &&\
     apt install -y netcat zip jq rsync zip
 RUN apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
@@ -7,5 +7,6 @@ libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
 xz-utils tk-dev libffi-dev liblzma-dev python3-pip
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.7 1 && \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+RUN python -m pip install -U pip
 RUN npm install -g npm@6.14 && npm config --global set script-shell /bin/bash
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install


### PR DESCRIPTION
This update addresses pip/pakcage issue with default python3.7/pip available in
the node:12 image repositories

**Summary:** Summary of changes

Addresses [CUMULUS-2743](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2743)

## Changes

* Updates CI build image to bring in latest version of pip

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
