### PR TITLE
Fix linting for PR #2549

### DIFF
--- a/packages/cmrjs/tests/cmr-utils/test-cmr-utils.js
+++ b/packages/cmrjs/tests/cmr-utils/test-cmr-utils.js
@@ -359,7 +359,6 @@ test('granuleToCmrFileObject returns correct objects for files with a bucket/key
   );
 });
 
-
 test('granuleToCmrFileObject returns correct objects for files with a bucket/key, filtering for ISO and CMR files', (t) => {
   const granule = {
     granuleId: 'fake-id',


### PR DESCRIPTION
Fix linting for PR #2549 

Fixes this issue from [Bamboo build output](https://ci.earthdata.nasa.gov/browse/CUM-CBA2710-AUD-12):

```
build	10-Nov-2021 10:41:11	/cumulus/packages/cmrjs/tests/cmr-utils/test-cmr-utils.js
build	10-Nov-2021 10:41:11	  362:1  error  More than 1 blank line not allowed  no-multiple-empty-lines
build	10-Nov-2021 10:41:11	
```