### PR TITLE
Fix TypeError thrown by `getGranuleTemporalInfo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - **CUMULUS-2638**
   - Transparent to users, remove typescript type `BucketType`.
 
+- [**PR #2569**](https://github.com/nasa/cumulus/pull/2569)
+  - Fixed `TypeError` thrown by `@cumulus/cmrjs/cmr-utils.getGranuleTemporalInfo` when
+    a granule's associated UMM-G JSON metadata file does not contain a `ProviderDates`
+    element that has a `Type` of either `"Update"` or `"Insert"`.  If neither are
+    present, the granule's last update date falls back to the `"Create"` type
+    provider date, or `undefined`, if none is present.
+
 ## [v9.9.0] 2021-11-03
 
 ### Added

--- a/packages/cmrjs/src/cmr-utils.js
+++ b/packages/cmrjs/src/cmr-utils.js
@@ -1124,11 +1124,9 @@ async function getGranuleTemporalInfo(granule) {
     const beginningDateTime = get(metadata, 'TemporalExtent.RangeDateTime.BeginningDateTime');
     const endingDateTime = get(metadata, 'TemporalExtent.RangeDateTime.EndingDateTime');
     const productionDateTime = get(metadata, 'DataGranule.ProductionDateTime');
-    let updateDate = metadata.ProviderDates.filter((d) => d.Type === 'Update');
-    if (updateDate.length === 0) {
-      updateDate = metadata.ProviderDates.filter((d) => d.Type === 'Insert');
-    }
-    const lastUpdateDateTime = updateDate[0].Date;
+    const lastUpdateDateTime = (metadata.ProviderDates.find((d) => d.Type === 'Update')
+      || metadata.ProviderDates.find((d) => d.Type === 'Insert') || {}).Date;
+
     return {
       beginningDateTime, endingDateTime, productionDateTime, lastUpdateDateTime,
     };

--- a/packages/cmrjs/src/cmr-utils.js
+++ b/packages/cmrjs/src/cmr-utils.js
@@ -1125,7 +1125,8 @@ async function getGranuleTemporalInfo(granule) {
     const endingDateTime = get(metadata, 'TemporalExtent.RangeDateTime.EndingDateTime');
     const productionDateTime = get(metadata, 'DataGranule.ProductionDateTime');
     const lastUpdateDateTime = (metadata.ProviderDates.find((d) => d.Type === 'Update')
-      || metadata.ProviderDates.find((d) => d.Type === 'Insert') || {}).Date;
+      || metadata.ProviderDates.find((d) => d.Type === 'Insert')
+      || metadata.ProviderDates.find((d) => d.Type === 'Create') || {}).Date;
 
     return {
       beginningDateTime, endingDateTime, productionDateTime, lastUpdateDateTime,

--- a/packages/cmrjs/tests/cmr-utils/test-cmr-utils.js
+++ b/packages/cmrjs/tests/cmr-utils/test-cmr-utils.js
@@ -728,7 +728,7 @@ test.serial('getGranuleTemporalInfo returns temporal information from granule CM
     beginningDateTime: '2016-01-09T11:40:45.032Z',
     endingDateTime: '2016-01-09T11:41:12.027Z',
     productionDateTime: '2016-01-09T11:40:45.032Z',
-    lastUpdateDateTime: '2018-12-19T17:30:31.424Z',
+    lastUpdateDateTime: '2018-12-21T17:30:31.424Z',
   };
 
   try {
@@ -746,7 +746,34 @@ test.serial('getGranuleTemporalInfo returns temporal information from granule CM
   }
 });
 
-test.serial('getGranuleTemporalInfo returns temporal information from granule CMR json file with only a "Create" ProviderDate', async (t) => {
+test.serial('getGranuleTemporalInfo returns temporal information from granule CMR json falling back to "Insert" ProviderDate', async (t) => {
+  const cmrJSON = await fs.readFile('./tests/fixtures/MOD09GQ.A3411593.1itJ_e.006.9747594822314_insert.cmr.json', 'utf8');
+  const cmrMetadata = JSON.parse(cmrJSON);
+  const revertMetaObject = cmrUtil.__set__('metadataObjectFromCMRJSONFile', () => cmrMetadata);
+
+  const expectedTemporalInfo = {
+    beginningDateTime: '2016-01-09T11:40:45.032Z',
+    endingDateTime: '2016-01-09T11:41:12.027Z',
+    productionDateTime: '2016-01-09T11:40:45.032Z',
+    lastUpdateDateTime: '2018-12-20T17:30:31.424Z',
+  };
+
+  try {
+    const temporalInfo = await getGranuleTemporalInfo({
+      granuleId: 'testGranuleId',
+      files: [{
+        bucket: 'bucket',
+        key: 'test.cmr.json',
+      }],
+    });
+
+    t.deepEqual(temporalInfo, expectedTemporalInfo);
+  } finally {
+    revertMetaObject();
+  }
+});
+
+test.serial('getGranuleTemporalInfo returns temporal information from granule CMR json falling back to "Create" ProviderDate', async (t) => {
   const cmrJSON = await fs.readFile('./tests/fixtures/MOD09GQ.A3411593.1itJ_e.006.9747594822314_create.cmr.json', 'utf8');
   const cmrMetadata = JSON.parse(cmrJSON);
   const revertMetaObject = cmrUtil.__set__('metadataObjectFromCMRJSONFile', () => cmrMetadata);
@@ -755,7 +782,7 @@ test.serial('getGranuleTemporalInfo returns temporal information from granule CM
     beginningDateTime: '2016-01-09T11:40:45.032Z',
     endingDateTime: '2016-01-09T11:41:12.027Z',
     productionDateTime: '2016-01-09T11:40:45.032Z',
-    lastUpdateDateTime: undefined,
+    lastUpdateDateTime: '2018-12-19T17:30:31.424Z',
   };
 
   try {

--- a/packages/cmrjs/tests/cmr-utils/test-cmr-utils.js
+++ b/packages/cmrjs/tests/cmr-utils/test-cmr-utils.js
@@ -746,6 +746,33 @@ test.serial('getGranuleTemporalInfo returns temporal information from granule CM
   }
 });
 
+test.serial('getGranuleTemporalInfo returns temporal information from granule CMR json file with only a "Create" ProviderDate', async (t) => {
+  const cmrJSON = await fs.readFile('./tests/fixtures/MOD09GQ.A3411593.1itJ_e.006.9747594822314_create.cmr.json', 'utf8');
+  const cmrMetadata = JSON.parse(cmrJSON);
+  const revertMetaObject = cmrUtil.__set__('metadataObjectFromCMRJSONFile', () => cmrMetadata);
+
+  const expectedTemporalInfo = {
+    beginningDateTime: '2016-01-09T11:40:45.032Z',
+    endingDateTime: '2016-01-09T11:41:12.027Z',
+    productionDateTime: '2016-01-09T11:40:45.032Z',
+    lastUpdateDateTime: undefined,
+  };
+
+  try {
+    const temporalInfo = await getGranuleTemporalInfo({
+      granuleId: 'testGranuleId',
+      files: [{
+        bucket: 'bucket',
+        key: 'test.cmr.json',
+      }],
+    });
+
+    t.deepEqual(temporalInfo, expectedTemporalInfo);
+  } finally {
+    revertMetaObject();
+  }
+});
+
 test.serial('getGranuleTemporalInfo returns temporal information from granule CMR xml file', async (t) => {
   const cmrXml = await fs.readFile('./tests/fixtures/cmrFileUpdateFixture.cmr.xml', 'utf8');
   const cmrMetadata = await (promisify(xml2js.parseString))(cmrXml, xmlParseOptions);

--- a/packages/cmrjs/tests/fixtures/MOD09GQ.A3411593.1itJ_e.006.9747594822314_create.cmr.json
+++ b/packages/cmrjs/tests/fixtures/MOD09GQ.A3411593.1itJ_e.006.9747594822314_create.cmr.json
@@ -1,0 +1,75 @@
+{
+  "SpatialExtent": {
+    "HorizontalSpatialDomain": {
+      "Geometry": {
+        "BoundingRectangles": [
+          {
+            "WestBoundingCoordinate": -180,
+            "EastBoundingCoordinate": 180,
+            "NorthBoundingCoordinate": 90,
+            "SouthBoundingCoordinate": -90
+          }
+        ]
+      }
+    }
+  },
+  "ProviderDates": [
+    {
+      "Date": "2018-12-19T17:30:31.424Z",
+      "Type": "Create"
+    }
+  ],
+  "DataGranule": {
+    "DayNightFlag": "Unspecified",
+    "ProductionDateTime": "2016-01-09T11:40:45.032Z",
+    "ArchiveAndDistributionInformation": [
+      {
+        "Name": "Not provided",
+        "Size": 1.009857177734375,
+        "SizeUnit": "NA"
+      }
+    ]
+  },
+  "TemporalExtent": {
+    "RangeDateTime": {
+      "BeginningDateTime": "2016-01-09T11:40:45.032Z",
+      "EndingDateTime": "2016-01-09T11:41:12.027Z"
+    }
+  },
+  "GranuleUR": "MOD09GQ.A3411593.1itJ_e.006.9747594822314",
+  "CollectionReference": {
+    "ShortName": "MOD09GQ",
+    "Version": "006"
+  },
+  "RelatedUrls": [
+    {
+      "URL": "https://nasa.github.io/cumulus/docs/cumulus-docs-readme",
+      "Type": "GET DATA"
+    },
+    {
+      "URL": "http://localhost:5002/cumulus-test-sandbox-protected/MOD09GQ___006/2016/MOD/MOD09GQ.A3411593.1itJ_e.006.9747594822314.hdf",
+      "Description": "File to download",
+      "Type": "GET DATA"
+    },
+    {
+      "URL": "https://cumulus-test-sandbox-public.s3.amazonaws.com/MOD09GQ___006/MOD/MOD09GQ.A3411593.1itJ_e.006.9747594822314_ndvi.jpg",
+      "Description": "File to download",
+      "Type": "GET RELATED VISUALIZATION"
+    },
+    {
+      "URL": "http://localhost:5002/cumulus-test-sandbox-protected-2/MOD09GQ___006/MOD/MOD09GQ.A3411593.1itJ_e.006.9747594822314.cmr.json",
+      "Description": "File to download",
+      "Type": "EXTENDED METADATA"
+    },
+    {
+      "URL": "http://localhost:5002/s3credentials",
+      "Description": "api endpoint to retrieve temporary credentials valid for same-region direct s3 access",
+      "Type": "VIEW RELATED INFORMATION"
+    }
+  ],
+  "MetadataSpecification": {
+    "URL": "https://cdn.earthdata.nasa.gov/umm/granule/v1.5",
+    "Name": "UMM-G",
+    "Version": "1.5"
+  }
+}

--- a/packages/cmrjs/tests/fixtures/MOD09GQ.A3411593.1itJ_e.006.9747594822314_insert.cmr.json
+++ b/packages/cmrjs/tests/fixtures/MOD09GQ.A3411593.1itJ_e.006.9747594822314_insert.cmr.json
@@ -21,10 +21,6 @@
     {
       "Date": "2018-12-20T17:30:31.424Z",
       "Type": "Insert"
-    },
-    {
-      "Date": "2018-12-21T17:30:31.424Z",
-      "Type": "Update"
     }
   ],
   "DataGranule": {


### PR DESCRIPTION
**Summary:** Fix TypeError thrown by `getGranuleTemporalInfo`

## Changes

Resolves TypeError thrown when a granule's metadata file is a UMM-G JSON
file, but has no entry in `ProviderDates` that is either of `Type`
`"Update"` or `"Insert"`. Now, in such cases, the `lastUpdatedDateTime`
property of the returned object is set to `undefined`, and no error is
thrown.

## PR Checklist

- [ ] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
