### PR TITLE
Update core lambdas to use cma-js 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - **CUMULUS-2638**
   - Transparent to users, remove typescript type `BucketType`.
-
+- **CUMULUS-2751**
+  - Upgraded all Cumulus (node.js) workflow tasks to use
+    `@cumulus/cumulus-message-adapter-js` version `2.0.2`, which includes an
+    update cma-js to better expose CMA stderr stream output on lambda timeouts
+    as well as minor logging enhancements.
 - [**PR #2569**](https://github.com/nasa/cumulus/pull/2569)
   - Fixed `TypeError` thrown by `@cumulus/cmrjs/cmr-utils.getGranuleTemporalInfo` when
     a granule's associated UMM-G JSON metadata file does not contain a `ProviderDates`

--- a/tasks/add-missing-file-checksums/package.json
+++ b/tasks/add-missing-file-checksums/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@cumulus/aws-client": "9.9.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1"
+    "@cumulus/cumulus-message-adapter-js": "2.0.2"
   },
   "devDependencies": {
     "@cumulus/schemas": "9.9.0-alpha.1",

--- a/tasks/discover-granules/package.json
+++ b/tasks/discover-granules/package.json
@@ -35,7 +35,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cumulus/api-client": "9.9.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "@cumulus/ingest": "9.9.0",
     "@cumulus/logger": "9.9.0",
     "got": "^9.2.1",

--- a/tasks/discover-pdrs/package.json
+++ b/tasks/discover-pdrs/package.json
@@ -34,7 +34,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cumulus/aws-client": "9.9.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "@cumulus/ingest": "9.9.0",
     "lodash": "^4.17.20",
     "p-filter": "^2.1.0"

--- a/tasks/files-to-granules/package.json
+++ b/tasks/files-to-granules/package.json
@@ -32,7 +32,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cumulus/aws-client": "9.9.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "lodash": "^4.17.20"
   },
   "devDependencies": {

--- a/tasks/hello-world/package.json
+++ b/tasks/hello-world/package.json
@@ -33,6 +33,6 @@
   "dependencies": {
     "@cumulus/aws-client": "9.9.0",
     "@cumulus/common": "9.9.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1"
+    "@cumulus/cumulus-message-adapter-js": "2.0.2"
   }
 }

--- a/tasks/hyrax-metadata-updates/package.json
+++ b/tasks/hyrax-metadata-updates/package.json
@@ -41,7 +41,7 @@
     "@cumulus/cmr-client": "9.9.0",
     "@cumulus/cmrjs": "9.9.0",
     "@cumulus/common": "9.9.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "@cumulus/errors": "9.9.0",
     "libxmljs": "^0.19.7",
     "lodash": "^4.17.20",

--- a/tasks/lzards-backup/package.json
+++ b/tasks/lzards-backup/package.json
@@ -45,7 +45,7 @@
     "@cumulus/api-client": "9.9.0",
     "@cumulus/aws-client": "9.9.0",
     "@cumulus/common": "9.9.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "@cumulus/distribution-utils": "9.9.0",
     "@cumulus/launchpad-auth": "9.9.0",
     "@cumulus/logger": "9.9.0",

--- a/tasks/move-granules/package.json
+++ b/tasks/move-granules/package.json
@@ -40,7 +40,7 @@
     "@cumulus/aws-client": "9.9.0",
     "@cumulus/cmrjs": "9.9.0",
     "@cumulus/common": "9.9.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "@cumulus/distribution-utils": "9.9.0",
     "@cumulus/errors": "9.9.0",
     "@cumulus/ingest": "9.9.0",

--- a/tasks/parse-pdr/package.json
+++ b/tasks/parse-pdr/package.json
@@ -33,7 +33,7 @@
     "@cumulus/aws-client": "9.9.0",
     "@cumulus/collection-config-store": "9.9.0",
     "@cumulus/common": "9.9.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "@cumulus/errors": "9.9.0",
     "@cumulus/ingest": "9.9.0",
     "@cumulus/pvl": "9.9.0",

--- a/tasks/pdr-status-check/package.json
+++ b/tasks/pdr-status-check/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@cumulus/aws-client": "9.9.0",
     "@cumulus/common": "9.9.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "@cumulus/errors": "9.9.0"
   }
 }

--- a/tasks/post-to-cmr/package.json
+++ b/tasks/post-to-cmr/package.json
@@ -35,7 +35,7 @@
     "@cumulus/aws-client": "9.9.0",
     "@cumulus/cmrjs": "9.9.0",
     "@cumulus/common": "9.9.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "@cumulus/errors": "9.9.0",
     "@cumulus/launchpad-auth": "9.9.0",
     "lodash": "^4.17.20"

--- a/tasks/queue-granules/package.json
+++ b/tasks/queue-granules/package.json
@@ -34,7 +34,7 @@
     "@cumulus/aws-client": "9.9.0",
     "@cumulus/collection-config-store": "9.9.0",
     "@cumulus/common": "9.9.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "@cumulus/ingest": "9.9.0",
     "@cumulus/message": "9.9.0",
     "lodash": "^4.17.20",

--- a/tasks/queue-pdrs/package.json
+++ b/tasks/queue-pdrs/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@cumulus/aws-client": "9.9.0",
     "@cumulus/common": "9.9.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "@cumulus/ingest": "9.9.0",
     "@cumulus/message": "9.9.0",
     "lodash": "^4.17.20"

--- a/tasks/queue-workflow/package.json
+++ b/tasks/queue-workflow/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@cumulus/aws-client": "9.9.0",
     "@cumulus/common": "9.9.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "@cumulus/ingest": "9.9.0",
     "@cumulus/message": "9.9.0",
     "lodash": "^4.17.20"

--- a/tasks/sf-sqs-report/package.json
+++ b/tasks/sf-sqs-report/package.json
@@ -32,7 +32,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cumulus/aws-client": "9.9.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "lodash": "^4.17.20"
   },
   "devDependencies": {

--- a/tasks/sync-granule/package.json
+++ b/tasks/sync-granule/package.json
@@ -39,7 +39,7 @@
     "@cumulus/aws-client": "9.9.0",
     "@cumulus/collection-config-store": "9.9.0",
     "@cumulus/common": "9.9.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "@cumulus/errors": "9.9.0",
     "@cumulus/ingest": "9.9.0",
     "@cumulus/message": "9.9.0",

--- a/tasks/test-processing/package.json
+++ b/tasks/test-processing/package.json
@@ -21,7 +21,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cumulus/aws-client": "9.9.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "@cumulus/integration-tests": "9.9.0"
   }
 }

--- a/tasks/update-cmr-access-constraints/package.json
+++ b/tasks/update-cmr-access-constraints/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@cumulus/aws-client": "9.9.0",
     "@cumulus/cmrjs": "9.9.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "lodash": "^4.17.5"
   },
   "devDependencies": {

--- a/tasks/update-granules-cmr-metadata-file-links/package.json
+++ b/tasks/update-granules-cmr-metadata-file-links/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@cumulus/cmrjs": "9.9.0",
     "@cumulus/common": "9.9.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "@cumulus/distribution-utils": "9.9.0",
     "lodash": "^4.17.15"
   },


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2751](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2751)

## Changes

*  Upgraded all Cumulus (node.js) workflow tasks to use
    `@cumulus/cumulus-message-adapter-js` version `2.0.2`, which includes an
    update cma-js to better expose CMA stderr stream output on lambda timeouts
    as well as minor logging enhancements.

## PR Checklist
- [x] Update CHANGELOG
- [x] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [x] Integration tests
