### PR TITLE
Backport: Update all core task lambdas to use cma-js 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [9.2.3] 2021-11-18
+
+- **CUMULUS-2751**
+  - Maintenance update to all Core node.js tasks to update cumulus-message-adpater-js dependency from 2.0.0 to 2.0.2
+
 ## [v9.2.2] 2021-08-06
 
 **Please note** changes in 9.2.2 may not yet be released in future versions, as

--- a/bamboo/docker-compose.yml
+++ b/bamboo/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - SFTP_MODE=true
       - CI=true
   elasticsearch:
-    image: maven.earthdata.nasa.gov/elasticsearch:5.6
+    image: maven.earthdata.nasa.gov/elasticsearch:5.3
     network_mode: "service:build_env"
     environment:
       ES_JAVA_OPTS: "-Xms750m -Xmx750m"

--- a/tasks/add-missing-file-checksums/package.json
+++ b/tasks/add-missing-file-checksums/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@cumulus/aws-client": "9.2.2",
-    "@cumulus/cumulus-message-adapter-js": "2.0.0"
+    "@cumulus/cumulus-message-adapter-js": "2.0.2"
   },
   "devDependencies": {
     "@cumulus/types": "9.2.2",

--- a/tasks/discover-granules/package.json
+++ b/tasks/discover-granules/package.json
@@ -35,7 +35,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cumulus/api-client": "9.2.2",
-    "@cumulus/cumulus-message-adapter-js": "2.0.0",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "@cumulus/ingest": "9.2.2",
     "@cumulus/logger": "9.2.2",
     "got": "^9.2.1",

--- a/tasks/discover-pdrs/package.json
+++ b/tasks/discover-pdrs/package.json
@@ -34,7 +34,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cumulus/aws-client": "9.2.2",
-    "@cumulus/cumulus-message-adapter-js": "2.0.0",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "@cumulus/ingest": "9.2.2",
     "lodash": "^4.17.20",
     "p-filter": "^2.1.0"

--- a/tasks/files-to-granules/package.json
+++ b/tasks/files-to-granules/package.json
@@ -31,7 +31,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cumulus/aws-client": "9.2.2",
-    "@cumulus/cumulus-message-adapter-js": "2.0.0",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "lodash": "^4.17.20"
   },
   "devDependencies": {

--- a/tasks/hello-world/package.json
+++ b/tasks/hello-world/package.json
@@ -33,6 +33,6 @@
   "dependencies": {
     "@cumulus/aws-client": "9.2.2",
     "@cumulus/common": "9.2.2",
-    "@cumulus/cumulus-message-adapter-js": "2.0.0"
+    "@cumulus/cumulus-message-adapter-js": "2.0.2"
   }
 }

--- a/tasks/hyrax-metadata-updates/package.json
+++ b/tasks/hyrax-metadata-updates/package.json
@@ -40,7 +40,7 @@
     "@cumulus/cmr-client": "9.2.2",
     "@cumulus/cmrjs": "9.2.2",
     "@cumulus/common": "9.2.2",
-    "@cumulus/cumulus-message-adapter-js": "2.0.0",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "@cumulus/errors": "9.2.2",
     "libxmljs": "^0.19.7",
     "lodash": "^4.17.20",

--- a/tasks/lzards-backup/package.json
+++ b/tasks/lzards-backup/package.json
@@ -44,7 +44,7 @@
     "@cumulus/api-client": "9.2.2",
     "@cumulus/aws-client": "9.2.2",
     "@cumulus/common": "9.2.2",
-    "@cumulus/cumulus-message-adapter-js": "2.0.0",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "@cumulus/distribution-utils": "9.2.2",
     "@cumulus/launchpad-auth": "9.2.2",
     "@cumulus/logger": "9.2.2",

--- a/tasks/move-granules/package.json
+++ b/tasks/move-granules/package.json
@@ -39,7 +39,7 @@
     "@cumulus/aws-client": "9.2.2",
     "@cumulus/cmrjs": "9.2.2",
     "@cumulus/common": "9.2.2",
-    "@cumulus/cumulus-message-adapter-js": "2.0.0",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "@cumulus/distribution-utils": "9.2.2",
     "@cumulus/errors": "9.2.2",
     "@cumulus/ingest": "9.2.2",

--- a/tasks/parse-pdr/package.json
+++ b/tasks/parse-pdr/package.json
@@ -33,7 +33,7 @@
     "@cumulus/aws-client": "9.2.2",
     "@cumulus/collection-config-store": "9.2.2",
     "@cumulus/common": "9.2.2",
-    "@cumulus/cumulus-message-adapter-js": "2.0.0",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "@cumulus/errors": "9.2.2",
     "@cumulus/ingest": "9.2.2",
     "@cumulus/pvl": "9.2.2",

--- a/tasks/pdr-status-check/package.json
+++ b/tasks/pdr-status-check/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@cumulus/aws-client": "9.2.2",
     "@cumulus/common": "9.2.2",
-    "@cumulus/cumulus-message-adapter-js": "2.0.0",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "@cumulus/errors": "9.2.2"
   }
 }

--- a/tasks/post-to-cmr/package.json
+++ b/tasks/post-to-cmr/package.json
@@ -34,7 +34,7 @@
     "@cumulus/aws-client": "9.2.2",
     "@cumulus/cmrjs": "9.2.2",
     "@cumulus/common": "9.2.2",
-    "@cumulus/cumulus-message-adapter-js": "2.0.0",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "@cumulus/errors": "9.2.2",
     "@cumulus/launchpad-auth": "9.2.2",
     "lodash": "^4.17.20"

--- a/tasks/queue-granules/package.json
+++ b/tasks/queue-granules/package.json
@@ -33,7 +33,7 @@
     "@cumulus/aws-client": "9.2.2",
     "@cumulus/collection-config-store": "9.2.2",
     "@cumulus/common": "9.2.2",
-    "@cumulus/cumulus-message-adapter-js": "2.0.0",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "@cumulus/ingest": "9.2.2",
     "@cumulus/message": "9.2.2",
     "lodash": "^4.17.20",

--- a/tasks/queue-pdrs/package.json
+++ b/tasks/queue-pdrs/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@cumulus/aws-client": "9.2.2",
     "@cumulus/common": "9.2.2",
-    "@cumulus/cumulus-message-adapter-js": "2.0.0",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "@cumulus/ingest": "9.2.2",
     "@cumulus/message": "9.2.2",
     "lodash": "^4.17.20"

--- a/tasks/queue-workflow/package.json
+++ b/tasks/queue-workflow/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@cumulus/aws-client": "9.2.2",
     "@cumulus/common": "9.2.2",
-    "@cumulus/cumulus-message-adapter-js": "2.0.0",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "@cumulus/ingest": "9.2.2",
     "@cumulus/message": "9.2.2",
     "lodash": "^4.17.20"

--- a/tasks/sf-sqs-report/package.json
+++ b/tasks/sf-sqs-report/package.json
@@ -32,7 +32,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cumulus/aws-client": "9.2.2",
-    "@cumulus/cumulus-message-adapter-js": "2.0.0",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "lodash": "^4.17.20"
   },
   "devDependencies": {

--- a/tasks/sync-granule/package.json
+++ b/tasks/sync-granule/package.json
@@ -38,7 +38,7 @@
     "@cumulus/aws-client": "9.2.2",
     "@cumulus/collection-config-store": "9.2.2",
     "@cumulus/common": "9.2.2",
-    "@cumulus/cumulus-message-adapter-js": "2.0.0",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "@cumulus/errors": "9.2.2",
     "@cumulus/ingest": "9.2.2",
     "@cumulus/message": "9.2.2",

--- a/tasks/test-processing/package.json
+++ b/tasks/test-processing/package.json
@@ -21,7 +21,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cumulus/aws-client": "9.2.2",
-    "@cumulus/cumulus-message-adapter-js": "2.0.0",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "@cumulus/integration-tests": "9.2.2"
   }
 }

--- a/tasks/update-cmr-access-constraints/package.json
+++ b/tasks/update-cmr-access-constraints/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@cumulus/aws-client": "9.2.2",
     "@cumulus/cmrjs": "9.2.2",
-    "@cumulus/cumulus-message-adapter-js": "2.0.0",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "lodash": "^4.17.5"
   },
   "devDependencies": {

--- a/tasks/update-granules-cmr-metadata-file-links/package.json
+++ b/tasks/update-granules-cmr-metadata-file-links/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@cumulus/cmrjs": "9.2.2",
     "@cumulus/common": "9.2.2",
-    "@cumulus/cumulus-message-adapter-js": "2.0.0",
+    "@cumulus/cumulus-message-adapter-js": "2.0.2",
     "@cumulus/distribution-utils": "9.2.2",
     "lodash": "^4.17.15"
   },


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2751 Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2751)

## Changes

This is a maintenance backport of https://github.com/nasa/cumulus/pull/2573

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
