### PR TITLE
Update Core task lambdas to use cma-js 2.0.3 (release-9.2.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [9.2.4] 2021-11-22
 
-This release is a bugfix patch release and supercedes release 9.2.3
+This release is a bugfix patch release and supersedes release 9.2.3
 
 **Please note** changes in 9.2.3 may not yet be released in future versions, as
 this is a backport and patch release on the 9.2.x series of releases. Updates that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,20 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-## [9.2.3] 2021-11-18
+## [9.2.4] 2021-11-22
+
+This release is a bugfix patch release and supercedes release 9.2.3
+
+**Please note** changes in 9.2.3 may not yet be released in future versions, as
+this is a backport and patch release on the 9.2.x series of releases. Updates that
+are included in the future will have a corresponding CHANGELOG entry in future
+releases.
+### Fixed
+
+- **CUMULUS-2751**
+  - Update all tasks to update to use `cumulus-message-adapter-js` version 2.0.3
+
+## [9.2.3] 2021-11-18 (removed)
 
 **Please note** changes in 9.2.3 may not yet be released in future versions, as
 this is a backport and patch release on the 9.2.x series of releases. Updates that

--- a/tasks/add-missing-file-checksums/package.json
+++ b/tasks/add-missing-file-checksums/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@cumulus/aws-client": "9.2.3",
-    "@cumulus/cumulus-message-adapter-js": "2.0.2"
+    "@cumulus/cumulus-message-adapter-js": "2.0.3"
   },
   "devDependencies": {
     "@cumulus/types": "9.2.3",

--- a/tasks/discover-granules/package.json
+++ b/tasks/discover-granules/package.json
@@ -35,7 +35,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cumulus/api-client": "9.2.3",
-    "@cumulus/cumulus-message-adapter-js": "2.0.2",
+    "@cumulus/cumulus-message-adapter-js": "2.0.3",
     "@cumulus/ingest": "9.2.3",
     "@cumulus/logger": "9.2.3",
     "got": "^9.2.1",

--- a/tasks/discover-pdrs/package.json
+++ b/tasks/discover-pdrs/package.json
@@ -34,7 +34,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cumulus/aws-client": "9.2.3",
-    "@cumulus/cumulus-message-adapter-js": "2.0.2",
+    "@cumulus/cumulus-message-adapter-js": "2.0.3",
     "@cumulus/ingest": "9.2.3",
     "lodash": "^4.17.20",
     "p-filter": "^2.1.0"

--- a/tasks/files-to-granules/package.json
+++ b/tasks/files-to-granules/package.json
@@ -31,7 +31,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cumulus/aws-client": "9.2.3",
-    "@cumulus/cumulus-message-adapter-js": "2.0.2",
+    "@cumulus/cumulus-message-adapter-js": "2.0.3",
     "lodash": "^4.17.20"
   },
   "devDependencies": {

--- a/tasks/hello-world/package.json
+++ b/tasks/hello-world/package.json
@@ -33,6 +33,6 @@
   "dependencies": {
     "@cumulus/aws-client": "9.2.3",
     "@cumulus/common": "9.2.3",
-    "@cumulus/cumulus-message-adapter-js": "2.0.2"
+    "@cumulus/cumulus-message-adapter-js": "2.0.3"
   }
 }

--- a/tasks/hyrax-metadata-updates/package.json
+++ b/tasks/hyrax-metadata-updates/package.json
@@ -40,7 +40,7 @@
     "@cumulus/cmr-client": "9.2.3",
     "@cumulus/cmrjs": "9.2.3",
     "@cumulus/common": "9.2.3",
-    "@cumulus/cumulus-message-adapter-js": "2.0.2",
+    "@cumulus/cumulus-message-adapter-js": "2.0.3",
     "@cumulus/errors": "9.2.3",
     "libxmljs": "^0.19.7",
     "lodash": "^4.17.20",

--- a/tasks/lzards-backup/package.json
+++ b/tasks/lzards-backup/package.json
@@ -44,7 +44,7 @@
     "@cumulus/api-client": "9.2.3",
     "@cumulus/aws-client": "9.2.3",
     "@cumulus/common": "9.2.3",
-    "@cumulus/cumulus-message-adapter-js": "2.0.2",
+    "@cumulus/cumulus-message-adapter-js": "2.0.3",
     "@cumulus/distribution-utils": "9.2.3",
     "@cumulus/launchpad-auth": "9.2.3",
     "@cumulus/logger": "9.2.3",

--- a/tasks/move-granules/package.json
+++ b/tasks/move-granules/package.json
@@ -39,7 +39,7 @@
     "@cumulus/aws-client": "9.2.3",
     "@cumulus/cmrjs": "9.2.3",
     "@cumulus/common": "9.2.3",
-    "@cumulus/cumulus-message-adapter-js": "2.0.2",
+    "@cumulus/cumulus-message-adapter-js": "2.0.3",
     "@cumulus/distribution-utils": "9.2.3",
     "@cumulus/errors": "9.2.3",
     "@cumulus/ingest": "9.2.3",

--- a/tasks/parse-pdr/package.json
+++ b/tasks/parse-pdr/package.json
@@ -33,7 +33,7 @@
     "@cumulus/aws-client": "9.2.3",
     "@cumulus/collection-config-store": "9.2.3",
     "@cumulus/common": "9.2.3",
-    "@cumulus/cumulus-message-adapter-js": "2.0.2",
+    "@cumulus/cumulus-message-adapter-js": "2.0.3",
     "@cumulus/errors": "9.2.3",
     "@cumulus/ingest": "9.2.3",
     "@cumulus/pvl": "9.2.3",

--- a/tasks/pdr-status-check/package.json
+++ b/tasks/pdr-status-check/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@cumulus/aws-client": "9.2.3",
     "@cumulus/common": "9.2.3",
-    "@cumulus/cumulus-message-adapter-js": "2.0.2",
+    "@cumulus/cumulus-message-adapter-js": "2.0.3",
     "@cumulus/errors": "9.2.3"
   }
 }

--- a/tasks/post-to-cmr/package.json
+++ b/tasks/post-to-cmr/package.json
@@ -34,7 +34,7 @@
     "@cumulus/aws-client": "9.2.3",
     "@cumulus/cmrjs": "9.2.3",
     "@cumulus/common": "9.2.3",
-    "@cumulus/cumulus-message-adapter-js": "2.0.2",
+    "@cumulus/cumulus-message-adapter-js": "2.0.3",
     "@cumulus/errors": "9.2.3",
     "@cumulus/launchpad-auth": "9.2.3",
     "lodash": "^4.17.20"

--- a/tasks/queue-granules/package.json
+++ b/tasks/queue-granules/package.json
@@ -33,7 +33,7 @@
     "@cumulus/aws-client": "9.2.3",
     "@cumulus/collection-config-store": "9.2.3",
     "@cumulus/common": "9.2.3",
-    "@cumulus/cumulus-message-adapter-js": "2.0.2",
+    "@cumulus/cumulus-message-adapter-js": "2.0.3",
     "@cumulus/ingest": "9.2.3",
     "@cumulus/message": "9.2.3",
     "lodash": "^4.17.20",

--- a/tasks/queue-pdrs/package.json
+++ b/tasks/queue-pdrs/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@cumulus/aws-client": "9.2.3",
     "@cumulus/common": "9.2.3",
-    "@cumulus/cumulus-message-adapter-js": "2.0.2",
+    "@cumulus/cumulus-message-adapter-js": "2.0.3",
     "@cumulus/ingest": "9.2.3",
     "@cumulus/message": "9.2.3",
     "lodash": "^4.17.20"

--- a/tasks/queue-workflow/package.json
+++ b/tasks/queue-workflow/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@cumulus/aws-client": "9.2.3",
     "@cumulus/common": "9.2.3",
-    "@cumulus/cumulus-message-adapter-js": "2.0.2",
+    "@cumulus/cumulus-message-adapter-js": "2.0.3",
     "@cumulus/ingest": "9.2.3",
     "@cumulus/message": "9.2.3",
     "lodash": "^4.17.20"

--- a/tasks/sf-sqs-report/package.json
+++ b/tasks/sf-sqs-report/package.json
@@ -32,7 +32,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cumulus/aws-client": "9.2.3",
-    "@cumulus/cumulus-message-adapter-js": "2.0.2",
+    "@cumulus/cumulus-message-adapter-js": "2.0.3",
     "lodash": "^4.17.20"
   },
   "devDependencies": {

--- a/tasks/sync-granule/package.json
+++ b/tasks/sync-granule/package.json
@@ -38,7 +38,7 @@
     "@cumulus/aws-client": "9.2.3",
     "@cumulus/collection-config-store": "9.2.3",
     "@cumulus/common": "9.2.3",
-    "@cumulus/cumulus-message-adapter-js": "2.0.2",
+    "@cumulus/cumulus-message-adapter-js": "2.0.3",
     "@cumulus/errors": "9.2.3",
     "@cumulus/ingest": "9.2.3",
     "@cumulus/message": "9.2.3",

--- a/tasks/test-processing/package.json
+++ b/tasks/test-processing/package.json
@@ -21,7 +21,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cumulus/aws-client": "9.2.3",
-    "@cumulus/cumulus-message-adapter-js": "2.0.2",
+    "@cumulus/cumulus-message-adapter-js": "2.0.3",
     "@cumulus/integration-tests": "9.2.3"
   }
 }

--- a/tasks/update-cmr-access-constraints/package.json
+++ b/tasks/update-cmr-access-constraints/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@cumulus/aws-client": "9.2.3",
     "@cumulus/cmrjs": "9.2.3",
-    "@cumulus/cumulus-message-adapter-js": "2.0.2",
+    "@cumulus/cumulus-message-adapter-js": "2.0.3",
     "lodash": "^4.17.5"
   },
   "devDependencies": {

--- a/tasks/update-granules-cmr-metadata-file-links/package.json
+++ b/tasks/update-granules-cmr-metadata-file-links/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@cumulus/cmrjs": "9.2.3",
     "@cumulus/common": "9.2.3",
-    "@cumulus/cumulus-message-adapter-js": "2.0.2",
+    "@cumulus/cumulus-message-adapter-js": "2.0.3",
     "@cumulus/distribution-utils": "9.2.3",
     "lodash": "^4.17.15"
   },


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2745: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2745)

## Changes

* Update all tasks to use cma-js 2.0.3

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
