### PR TITLE
CUMULUS-2735: Write Formatted Reconciliation Report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     present, the granule's last update date falls back to the `"Create"` type
     provider date, or `undefined`, if none is present.
 - **CUMULUS-2735**
-  - Updated reconciliation reports to write formatted JSON to S3 to improve readability for large reports
+  - Updated reconciliation reports to write formatted JSON to S3 to improve readability for
+    large reports
+  - Updated TEA version from 102 to 121 to address TEA deployment issue with the max size of
+    a policy role being exceeded
 
 ## [v9.9.0] 2021-11-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     element that has a `Type` of either `"Update"` or `"Insert"`.  If neither are
     present, the granule's last update date falls back to the `"Create"` type
     provider date, or `undefined`, if none is present.
+- **CUMULUS-2735**
+  - Updated reconciliation reports to write formatted JSON to S3 to improve readability for large reports
 
 ## [v9.9.0] 2021-11-03
 

--- a/bamboo/select-stack.js
+++ b/bamboo/select-stack.js
@@ -29,7 +29,7 @@ function determineIntegrationTestStackName(cb) {
     'Jennifer Tran': 'jtran-int',
     'Nate Pauzenga': 'np-ci',
     'Danielle Peters': 'dop-ci',
-    'Anthony Ortega': 'jao-ci-tf'
+    'Anthony Ortega': 'jao-ci',
   };
 
   return git('.').log({ '--max-count': '1' }, (e, r) => {

--- a/bamboo/select-stack.js
+++ b/bamboo/select-stack.js
@@ -29,6 +29,7 @@ function determineIntegrationTestStackName(cb) {
     'Jennifer Tran': 'jtran-int',
     'Nate Pauzenga': 'np-ci',
     'Danielle Peters': 'dop-ci',
+    'Anthony Ortega': 'jao-ci-tf'
   };
 
   return git('.').log({ '--max-count': '1' }, (e, r) => {

--- a/example/cumulus-tf/thin_egress_app.tf
+++ b/example/cumulus-tf/thin_egress_app.tf
@@ -32,7 +32,7 @@ resource "aws_s3_bucket_object" "bucket_map_yaml" {
 }
 
 module "thin_egress_app" {
-  source = "s3::https://s3.amazonaws.com/asf.public.code/thin-egress-app/tea-terraform-build.102.zip"
+  source = "s3::https://s3.amazonaws.com/asf.public.code/thin-egress-app/tea-terraform-build.121.zip"
 
   auth_base_url                 = "https://uat.urs.earthdata.nasa.gov"
   bucket_map_file               = aws_s3_bucket_object.bucket_map_yaml.id

--- a/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
+++ b/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
@@ -389,7 +389,6 @@ describe('When there are granule differences and granule reconciliation is run',
     // report record in db and report in s3
     let reportRecord;
     let report;
-    let reportString;
     let inventoryReportAsyncOperationId;
 
     afterAll(async () => {
@@ -444,7 +443,6 @@ describe('When there are granule differences and granule reconciliation is run',
       if (beforeAllFailed) fail(beforeAllFailed);
       const reportContent = await fetchReconciliationReport(config.stackName, reportRecord.name);
       report = JSON.parse(reportContent);
-      reportString = reportContent.toString();
       expect(report.reportType).toBe('Granule Not Found');
       expect(report.status).toBe('SUCCESS');
     });
@@ -540,16 +538,6 @@ describe('When there are granule differences and granule reconciliation is run',
         .toBe(2);
     });
 
-    it('generates a report with formatted JSON', () => {
-      if (beforeAllFailed) fail(beforeAllFailed);
-
-      const unformattedReportString = JSON.stringify(report, undefined, 0);
-
-      // Validate unformattedReportString contains no newline characters
-      expect(unformattedReportString).not.toContain('\n');
-      expect(reportString).toEqual(JSON.stringify(unformattedReportString, undefined, 2));
-    });
-
     it('deletes a reconciliation report through the Cumulus API', async () => {
       if (beforeAllFailed) fail(beforeAllFailed);
       await reconciliationReportsApi.deleteReconciliationReport({
@@ -581,7 +569,6 @@ describe('When there are granule differences and granule reconciliation is run',
     // report record in db and report in s3
     let reportRecord;
     let report;
-    let reportString;
     let internalReportAsyncOperationId;
 
     afterAll(async () => {
@@ -633,7 +620,6 @@ describe('When there are granule differences and granule reconciliation is run',
       if (beforeAllFailed) fail(beforeAllFailed);
       const reportContent = await fetchReconciliationReport(config.stackName, reportRecord.name);
       report = JSON.parse(reportContent);
-      reportString = reportContent.toString();
       expect(report.reportType).toBe('Internal');
       expect(report.status).toBe('SUCCESS');
     });
@@ -655,16 +641,6 @@ describe('When there are granule differences and granule reconciliation is run',
       }
       expect(report.granules.onlyInEs.length).toBe(0);
       expect(report.granules.onlyInDb.length).toBe(0);
-    });
-
-    it('generates a report with formatted JSON', () => {
-      if (beforeAllFailed) fail(beforeAllFailed);
-
-      const unformattedReportString = JSON.stringify(report, undefined, 0);
-
-      // Validate unformattedReportString contains no newline characters
-      expect(unformattedReportString).not.toContain('\n');
-      expect(reportString).toEqual(JSON.stringify(unformattedReportString, undefined, 2));
     });
 
     it('deletes a reconciliation report through the Cumulus API', async () => {

--- a/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
+++ b/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
@@ -541,7 +541,7 @@ describe('When there are granule differences and granule reconciliation is run',
     it('generates a report with formatted JSON', () => {
       if (beforeAllFailed) fail(beforeAllFailed);
 
-      const reportString = JSON.stringify(report);
+      const reportString = report.toString();
       const unformattedReportString = JSON.stringify(report, undefined, 0);
 
       // Validate unformattedReportString contains no newline characters
@@ -657,7 +657,7 @@ describe('When there are granule differences and granule reconciliation is run',
     it('generates a report with formatted JSON', () => {
       if (beforeAllFailed) fail(beforeAllFailed);
 
-      const reportString = JSON.stringify(report);
+      const reportString = report.toString();
       const unformattedReportString = JSON.stringify(report, undefined, 0);
 
       // Validate unformattedReportString contains no newline characters

--- a/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
+++ b/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
@@ -389,6 +389,7 @@ describe('When there are granule differences and granule reconciliation is run',
     // report record in db and report in s3
     let reportRecord;
     let report;
+    let reportString;
     let inventoryReportAsyncOperationId;
 
     afterAll(async () => {
@@ -443,6 +444,7 @@ describe('When there are granule differences and granule reconciliation is run',
       if (beforeAllFailed) fail(beforeAllFailed);
       const reportContent = await fetchReconciliationReport(config.stackName, reportRecord.name);
       report = JSON.parse(reportContent);
+      reportString = reportContent.toString();
       expect(report.reportType).toBe('Granule Not Found');
       expect(report.status).toBe('SUCCESS');
     });
@@ -541,7 +543,6 @@ describe('When there are granule differences and granule reconciliation is run',
     it('generates a report with formatted JSON', () => {
       if (beforeAllFailed) fail(beforeAllFailed);
 
-      const reportString = report.toString();
       const unformattedReportString = JSON.stringify(report, undefined, 0);
 
       // Validate unformattedReportString contains no newline characters
@@ -580,6 +581,7 @@ describe('When there are granule differences and granule reconciliation is run',
     // report record in db and report in s3
     let reportRecord;
     let report;
+    let reportString;
     let internalReportAsyncOperationId;
 
     afterAll(async () => {
@@ -631,6 +633,7 @@ describe('When there are granule differences and granule reconciliation is run',
       if (beforeAllFailed) fail(beforeAllFailed);
       const reportContent = await fetchReconciliationReport(config.stackName, reportRecord.name);
       report = JSON.parse(reportContent);
+      reportString = reportContent.toString();
       expect(report.reportType).toBe('Internal');
       expect(report.status).toBe('SUCCESS');
     });
@@ -657,7 +660,6 @@ describe('When there are granule differences and granule reconciliation is run',
     it('generates a report with formatted JSON', () => {
       if (beforeAllFailed) fail(beforeAllFailed);
 
-      const reportString = report.toString();
       const unformattedReportString = JSON.stringify(report, undefined, 0);
 
       // Validate unformattedReportString contains no newline characters

--- a/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
+++ b/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
@@ -538,6 +538,17 @@ describe('When there are granule differences and granule reconciliation is run',
         .toBe(2);
     });
 
+    it('generates a report with formatted JSON', () => {
+      if (beforeAllFailed) fail(beforeAllFailed);
+
+      const reportString = JSON.stringify(report);
+      const unformattedReportString = JSON.stringify(report, undefined, 0);
+
+      // Validate unformattedReportString contains no newline characters
+      expect(unformattedReportString).not.toContain('\n');
+      expect(reportString).toEqual(JSON.stringify(unformattedReportString, undefined, 2));
+    });
+
     it('deletes a reconciliation report through the Cumulus API', async () => {
       if (beforeAllFailed) fail(beforeAllFailed);
       await reconciliationReportsApi.deleteReconciliationReport({
@@ -641,6 +652,17 @@ describe('When there are granule differences and granule reconciliation is run',
       }
       expect(report.granules.onlyInEs.length).toBe(0);
       expect(report.granules.onlyInDb.length).toBe(0);
+    });
+
+    it('generates a report with formatted JSON', () => {
+      if (beforeAllFailed) fail(beforeAllFailed);
+
+      const reportString = JSON.stringify(report);
+      const unformattedReportString = JSON.stringify(report, undefined, 0);
+
+      // Validate unformattedReportString contains no newline characters
+      expect(unformattedReportString).not.toContain('\n');
+      expect(reportString).toEqual(JSON.stringify(unformattedReportString, undefined, 2));
     });
 
     it('deletes a reconciliation report through the Cumulus API', async () => {

--- a/packages/api/lambdas/create-reconciliation-report.js
+++ b/packages/api/lambdas/create-reconciliation-report.js
@@ -693,7 +693,7 @@ async function createReconciliationReport(recReportParams) {
   await s3().putObject({
     Bucket: systemBucket,
     Key: reportKey,
-    Body: JSON.stringify(report),
+    Body: JSON.stringify(report, undefined, 2),
   }).promise();
 
   // Internal consistency check S3 vs Cumulus DBs

--- a/packages/api/lambdas/create-reconciliation-report.js
+++ b/packages/api/lambdas/create-reconciliation-report.js
@@ -747,7 +747,7 @@ async function createReconciliationReport(recReportParams) {
   return s3().putObject({
     Bucket: systemBucket,
     Key: reportKey,
-    Body: JSON.stringify(report),
+    Body: JSON.stringify(report, undefined, 2),
   }).promise();
 }
 

--- a/packages/api/lambdas/internal-reconciliation-report.js
+++ b/packages/api/lambdas/internal-reconciliation-report.js
@@ -332,7 +332,7 @@ async function createInternalReconciliationReport(recReportParams) {
   await s3().putObject({
     Bucket: systemBucket,
     Key: reportKey,
-    Body: JSON.stringify(report),
+    Body: JSON.stringify(report, undefined, 2),
   }).promise();
 
   const [collectionsReport, granulesReport] = await Promise.all([

--- a/packages/api/lambdas/internal-reconciliation-report.js
+++ b/packages/api/lambdas/internal-reconciliation-report.js
@@ -349,7 +349,7 @@ async function createInternalReconciliationReport(recReportParams) {
   return s3().putObject({
     Bucket: systemBucket,
     Key: reportKey,
-    Body: JSON.stringify(report),
+    Body: JSON.stringify(report, undefined, 2),
   }).promise();
 }
 

--- a/packages/api/tests/lambdas/test-create-reconciliation-report.js
+++ b/packages/api/tests/lambdas/test-create-reconciliation-report.js
@@ -1814,7 +1814,7 @@ test.serial('Internal Reconciliation report JSON is formatted', async (t) => {
   const unformattedReportString = JSON.stringify(JSON.parse(formattedReport), undefined, 0);
   const unformattedReportObj = JSON.parse(unformattedReportString);
 
-  t.true(!unformattedReportString.includes("\n")); // validate unformatted report is on a single line
+  t.true(!unformattedReportString.includes('\n')); // validate unformatted report is on a single line
   t.is(formattedReport, JSON.stringify(unformattedReportObj, undefined, 2));
 });
 
@@ -1869,13 +1869,6 @@ test.serial('Inventory reconciliation report JSON is formatted', async (t) => {
     reportType: 'Inventory',
   };
 
-  const eventSingleLine = {
-    systemBucket: t.context.systemBucket,
-    stackName: t.context.stackName,
-    reportType: 'Inventory',
-    prettyPrintReport: false,
-  }
-
   const reportRecordFormatted = await handler(eventFormatted);
   const formattedReport = await fetchCompletedReportString(reportRecordFormatted);
 
@@ -1883,6 +1876,6 @@ test.serial('Inventory reconciliation report JSON is formatted', async (t) => {
   const unformattedReportString = JSON.stringify(JSON.parse(formattedReport), undefined, 0);
   const unformattedReportObj = JSON.parse(unformattedReportString);
 
-  t.true(!unformattedReportString.includes("\n")); // validate unformatted report is on a single line
+  t.true(!unformattedReportString.includes('\n')); // validate unformatted report is on a single line
   t.is(formattedReport, JSON.stringify(unformattedReportObj, undefined, 2));
 });

--- a/packages/api/tests/lambdas/test-create-reconciliation-report.js
+++ b/packages/api/tests/lambdas/test-create-reconciliation-report.js
@@ -1781,3 +1781,108 @@ test.serial('Creates a valid Granule Inventory report', async (t) => {
   t.is(reportHeader, header);
   t.is(reportRows.length, 10);
 });
+
+test.serial('Internal Reconciliation report JSON is formatted', async (t) => {
+  const matchingColls = range(5).map(() => fakeCollectionFactory());
+  const collectionId = constructCollectionId(matchingColls[0].name, matchingColls[0].version);
+  const matchingGrans = range(10).map(() => fakeGranuleFactoryV2({ collectionId }));
+  await Promise.all(
+    matchingColls.map((collection) => indexer.indexCollection(esClient, collection, esAlias))
+  );
+  await new models.Collection().create(matchingColls);
+  await Promise.all(
+    matchingGrans.map((gran) => indexer.indexGranule(esClient, gran, esAlias))
+  );
+
+  await new models.Granule().create(matchingGrans);
+
+  const event = {
+    systemBucket: t.context.systemBucket,
+    stackName: t.context.stackName,
+    reportType: 'Internal',
+    reportName: randomId('reportName'),
+    collectionId,
+    startTimestamp: moment.utc().subtract(1, 'hour').format(),
+    endTimestamp: moment.utc().add(1, 'hour').format(),
+  };
+
+  const reportRecord = await handler(event);
+
+  const formattedReport = await fetchCompletedReportString(reportRecord);
+
+  // Force report to unformatted (single line)
+  const unformattedReportString = JSON.stringify(JSON.parse(formattedReport), undefined, 0);
+  const unformattedReportObj = JSON.parse(unformattedReportString);
+
+  t.true(!unformattedReportString.includes("\n")); // validate unformatted report is on a single line
+  t.is(formattedReport, JSON.stringify(unformattedReportObj, undefined, 2));
+});
+
+test.serial('Inventory reconciliation report JSON is formatted', async (t) => {
+  const dataBuckets = range(2).map(() => randomId('bucket'));
+  await Promise.all(dataBuckets.map((bucket) =>
+    createBucket(bucket)
+      .then(() => t.context.bucketsToCleanup.push(bucket))));
+
+  // Write the buckets config to S3
+  await storeBucketsConfigToS3(
+    dataBuckets,
+    t.context.systemBucket,
+    t.context.stackName
+  );
+
+  // Create random files
+  const files = range(10).map((i) => ({
+    bucket: dataBuckets[i % dataBuckets.length],
+    key: randomId('key'),
+    granuleId: randomId('granuleId'),
+  }));
+
+  // Store the files to S3 and DynamoDB
+  await Promise.all([
+    storeFilesToS3(files),
+    GranuleFilesCache.batchUpdate({ puts: files }),
+  ]);
+
+  // Create collections that are in sync
+  const matchingColls = range(10).map(() => ({
+    name: randomId('name'),
+    version: randomId('vers'),
+  }));
+
+  const cmrCollections = sortBy(matchingColls, ['name', 'version'])
+    .map((collection) => ({
+      umm: { ShortName: collection.name, Version: collection.version },
+    }));
+
+  CMR.prototype.searchConcept.restore();
+  const cmrSearchStub = sinon.stub(CMR.prototype, 'searchConcept');
+  cmrSearchStub.withArgs('collections').onCall(0).resolves(cmrCollections);
+  cmrSearchStub.withArgs('collections').onCall(1).resolves([]);
+  cmrSearchStub.withArgs('granules').resolves([]);
+
+  await storeCollectionsToElasticsearch(matchingColls);
+
+  const eventFormatted = {
+    systemBucket: t.context.systemBucket,
+    stackName: t.context.stackName,
+    reportType: 'Inventory',
+  };
+
+  const eventSingleLine = {
+    systemBucket: t.context.systemBucket,
+    stackName: t.context.stackName,
+    reportType: 'Inventory',
+    prettyPrintReport: false,
+  }
+
+  const reportRecordFormatted = await handler(eventFormatted);
+  const formattedReport = await fetchCompletedReportString(reportRecordFormatted);
+
+  // Force report to unformatted (single line)
+  const unformattedReportString = JSON.stringify(JSON.parse(formattedReport), undefined, 0);
+  const unformattedReportObj = JSON.parse(unformattedReportString);
+
+  t.true(!unformattedReportString.includes("\n")); // validate unformatted report is on a single line
+  t.is(formattedReport, JSON.stringify(unformattedReportObj, undefined, 2));
+});


### PR DESCRIPTION
**Summary:** Updated reconciliation reports to write formatted JSON to S3

Addresses [CUMULUS-2735: Write formatted Reconciliation report](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2735)

## Changes

* Updated api/lambdas/create-reconciliation-report.js to write formatted JSON to S3
* Updated api/lambdas/internal-reconciliation-report.js to write formatted JSON to S3

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
