### PR TITLE
CUMULUS-2661: Update executions PUT endpoint to send SNS message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -324,6 +324,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     - Updated database write logic in `sfEventSqsToDbRccords` to throw error if requirements to write execution to PostgreSQL cannot be met
   - **CUMULUS-2660**
     - Updated POST `/executions` endpoint to publish SNS message of created record to executions SNS topic
+  - **CUMULUS-2661**
+    - Updated PUT `/executions/<arn>` endpoint to publish SNS message of updated record to executions SNS topic
 
 ## [v9.9.0] 2021-11-03
 

--- a/example/spec/parallel/testAPI/executionSpec.js
+++ b/example/spec/parallel/testAPI/executionSpec.js
@@ -29,6 +29,7 @@ describe('The Executions API', () => {
   let executionRecord;
   let updatedExecutionRecord;
   let executionMessageKey;
+  let updatedExecutionMessageKey;
 
   beforeAll(async () => {
     try {
@@ -49,6 +50,7 @@ describe('The Executions API', () => {
       };
       executionArn = executionRecord.arn;
       executionMessageKey = `${config.stackName}/test-output/${executionRecord.name}-${executionRecord.status}.output`;
+      updatedExecutionMessageKey = `${config.stackName}/test-output/${updatedExecutionRecord.name}-${updatedExecutionRecord.status}.output`;
     } catch (error) {
       beforeAllFailed = true;
       console.log(error);
@@ -108,6 +110,13 @@ describe('The Executions API', () => {
       expect(response.statusCode).toBe(200);
       const { message } = JSON.parse(response.body);
       expect(message).toBe(`Successfully updated execution with arn ${executionArn}`);
+    });
+
+    it('publishes an SNS message for the updated execution', async () => {
+      await expectAsync(waitForObjectToExist({
+        bucket: config.bucket,
+        key: updatedExecutionMessageKey,
+      })).toBeResolved();
     });
 
     it('can search the execution in the API.', async () => {

--- a/packages/api/lib/publishSnsMessageUtils.js
+++ b/packages/api/lib/publishSnsMessageUtils.js
@@ -39,7 +39,9 @@ const constructGranuleSnsMessage = (record, eventType) => {
 
 const publishSnsMessageByDataType = async (record, dataType, eventType) => {
   const topicArn = envUtils.getRequiredEnvVar(`${dataType}_sns_topic_arn`, process.env);
-  logger.info(`About to publish SNS message for ${dataType} with event type ${eventType} to topic ARN ${topicArn}: ${JSON.stringify(record)} `);
+  let messageTypeInfo = dataType;
+  messageTypeInfo += eventType ? ` with event type ${eventType}` : '';
+  logger.info(`About to publish SNS message for ${messageTypeInfo} to topic ARN ${topicArn}: ${JSON.stringify(record)}`);
   if (dataType === 'collection') {
     const messageToPublish = constructCollectionSnsMessage(record, eventType);
     await publishSnsMessage(topicArn, messageToPublish);


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2661: Update executions PUT endpoint to send SNS message](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2661)

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [x] Integration tests
