### PR TITLE
CUMULUS-2769 -- Update collection PUT endpoint to rely on postgres as primary datastore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - **CUMULUS-2311** - RDS Migration Epic Phase 2
+  - **CUMULUS-2769**
+    - Update collection PUT endpoint to require existance of postgresql record
+      and to ignore lack of dynamoDbRecord on update
   - **CUMULUS-2759**
     - Updates collection/provider/rules/granules creation (post) endpoints to
       primarily check for existence/collision in PostgreSQL database instead of DynamoDB

--- a/packages/api/endpoints/collections.js
+++ b/packages/api/endpoints/collections.js
@@ -222,13 +222,12 @@ async function put(req, res) {
 
   try {
     await createRejectableTransaction(knex, async (trx) => {
-      const [pgCollection] = await collectionPgModel.upsert(trx, postgresCollection);
-      const translatedCollection = await translatePostgresCollectionToApiCollection(pgCollection);
+      await collectionPgModel.upsert(trx, postgresCollection);
       dynamoRecord = await collectionsModel.create(collection);
       // process.env.ES_INDEX is only used to isolate the index for
       // each unit test suite
       await indexCollection(esClient, dynamoRecord, process.env.ES_INDEX);
-      await publishCollectionUpdateSnsMessage(translatedCollection);
+      await publishCollectionUpdateSnsMessage(collection);
     });
   } catch (error) {
     // Revert Dynamo record update if any write fails

--- a/packages/api/endpoints/collections.js
+++ b/packages/api/endpoints/collections.js
@@ -227,7 +227,7 @@ async function put(req, res) {
       // process.env.ES_INDEX is only used to isolate the index for
       // each unit test suite
       await indexCollection(esClient, dynamoRecord, process.env.ES_INDEX);
-      await publishCollectionUpdateSnsMessage(collection);
+      await publishCollectionUpdateSnsMessage(dynamoRecord);
     });
   } catch (error) {
     // Revert Dynamo record update if any write fails

--- a/packages/api/tests/endpoints/collections/update-collection.js
+++ b/packages/api/tests/endpoints/collections/update-collection.js
@@ -17,6 +17,8 @@ const {
   generateLocalTestDb,
   localStackConnectionEnv,
   migrationDir,
+  translateApiCollectionToPostgresCollection,
+  fakeCollectionRecordFactory,
 } = require('@cumulus/db');
 const {
   constructCollectionId,
@@ -287,14 +289,14 @@ test.serial('PUT replaces an existing collection in all data stores with correct
   t.is(actualPgCollection.updated_at.getTime(), updatedEsRecord.updatedAt);
 });
 
-test.serial('PUT creates a new record in RDS if one does not exist  and sends an SNS message', async (t) => {
-  const knex = t.context.testKnex;
+test.serial('PUT creates a new record in Dynamo if one does not exist and sends an SNS message', async (t) => {
+  const { testKnex, collectionPgModel, collectionModel, QueueUrl } = t.context;
   const originalCollection = fakeCollectionFactory({
     duplicateHandling: 'replace',
     process: randomString(),
   });
-
-  await t.context.collectionModel.create(originalCollection);
+  const originalPgCollection = await translateApiCollectionToPostgresCollection(originalCollection);
+  await collectionPgModel.create(testKnex, originalPgCollection);
 
   const updatedCollection = {
     ...originalCollection,
@@ -310,12 +312,12 @@ test.serial('PUT creates a new record in RDS if one does not exist  and sends an
     .send(updatedCollection)
     .expect(200);
 
-  const fetchedDynamoRecord = await t.context.collectionModel.get({
+  const fetchedDynamoRecord = await collectionModel.get({
     name: updatedCollection.name,
     version: updatedCollection.version,
   });
 
-  const fetchedDbRecord = await t.context.collectionPgModel.get(knex, {
+  const fetchedDbRecord = await collectionPgModel.get(testKnex, {
     name: originalCollection.name, version: originalCollection.version,
   });
 
@@ -327,7 +329,7 @@ test.serial('PUT creates a new record in RDS if one does not exist  and sends an
   t.is(fetchedDbRecord.created_at.getTime(), fetchedDynamoRecord.createdAt);
   t.is(fetchedDbRecord.updated_at.getTime(), fetchedDynamoRecord.updatedAt);
   const { Messages } = await sqs().receiveMessage({
-    QueueUrl: t.context.QueueUrl,
+    QueueUrl,
     WaitTimeSeconds: 10,
   }).promise();
 
@@ -472,6 +474,7 @@ test.serial('put() does not write to Dynamo/Elasticsearch or publish SNS message
 
   const fakeCollectionPgModel = {
     upsert: () => Promise.reject(new Error('something bad')),
+    get: () => Promise.resolve(fakeCollectionRecordFactory()),
   };
 
   const updatedCollection = {

--- a/packages/api/tests/endpoints/collections/update-collection.js
+++ b/packages/api/tests/endpoints/collections/update-collection.js
@@ -43,6 +43,7 @@ const { buildFakeExpressResponse } = require('../utils');
 
 process.env.AccessTokensTable = randomString();
 process.env.CollectionsTable = randomString();
+process.env.RulesTable = randomString();
 process.env.stackName = randomString();
 process.env.system_bucket = randomString();
 process.env.TOKEN_SECRET = randomString();
@@ -77,6 +78,8 @@ test.before(async (t) => {
 
   await s3().createBucket({ Bucket: process.env.system_bucket }).promise();
 
+  const rulesModel = new models.Rule({ tableName: process.env.RulesTable });
+  await rulesModel.createTable();
   t.context.collectionModel = new models.Collection({ tableName: process.env.CollectionsTable });
   await t.context.collectionModel.createTable();
 
@@ -508,6 +511,77 @@ test.serial('put() does not write to Dynamo/Elasticsearch or publish SNS message
     }),
     originalCollection
   );
+  t.deepEqual(
+    await t.context.collectionPgModel.get(t.context.testKnex, {
+      name: updatedCollection.name,
+      version: updatedCollection.version,
+    }),
+    originalPgRecord
+  );
+  t.deepEqual(
+    await t.context.esCollectionClient.get(
+      constructCollectionId(originalCollection.name, originalCollection.version)
+    ),
+    originalEsRecord
+  );
+  const { Messages } = await sqs().receiveMessage({
+    QueueUrl: t.context.QueueUrl,
+    WaitTimeSeconds: 10,
+  }).promise();
+
+  t.is(Messages, undefined);
+});
+
+test.only('put() does not write to Dynamo/Elasticsearch or publish SNS message if writing to PostgreSQL fails and no Dynamo record existed previously', async (t) => {
+  const { testKnex, collectionModel } = t.context;
+  const {
+    originalCollection,
+    originalPgRecord,
+    originalEsRecord,
+  } = await createCollectionTestRecords(
+    t.context,
+    {
+      duplicateHandling: 'error',
+    }
+  );
+
+  await collectionModel.delete(originalCollection);
+
+  const fakeCollectionPgModel = {
+    upsert: () => Promise.reject(new Error('something bad')),
+    get: () => Promise.resolve(fakeCollectionRecordFactory()),
+  };
+
+  const updatedCollection = {
+    ...originalCollection,
+    duplicateHandling: 'replace',
+  };
+
+  const expressRequest = {
+    params: {
+      name: originalCollection.name,
+      version: originalCollection.version,
+    },
+    body: updatedCollection,
+    testContext: {
+      knex: testKnex,
+      collectionPgModel: fakeCollectionPgModel,
+    },
+  };
+
+  const response = buildFakeExpressResponse();
+
+  await t.throwsAsync(
+    put(expressRequest, response),
+    { message: 'something bad' }
+  );
+
+  await t.throwsAsync(() =>
+    t.context.collectionModel.get({
+      name: updatedCollection.name,
+      version: updatedCollection.version,
+    }),
+  { name: 'RecordDoesNotExist' });
   t.deepEqual(
     await t.context.collectionPgModel.get(t.context.testKnex, {
       name: updatedCollection.name,

--- a/packages/api/tests/endpoints/collections/update-collection.js
+++ b/packages/api/tests/endpoints/collections/update-collection.js
@@ -532,7 +532,7 @@ test.serial('put() does not write to Dynamo/Elasticsearch or publish SNS message
   t.is(Messages, undefined);
 });
 
-test.only('put() does not write to Dynamo/Elasticsearch or publish SNS message if writing to PostgreSQL fails and no Dynamo record existed previously', async (t) => {
+test.serial('put() does not write to Dynamo/Elasticsearch or publish SNS message if writing to PostgreSQL fails and no Dynamo record existed previously', async (t) => {
   const { testKnex, collectionModel } = t.context;
   const {
     originalCollection,


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2769: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2769)

## Changes

* Update collection PUT endpoint to require existance of postgresql record and to ignore lack of dynamoDbRecord on update

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
