### PR TITLE
Jk/cumulus 2767 -- Update provider PUT endpoint to use postgres as primary datastore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - **CUMULUS-2311** - RDS Migration Epic Phase 2
   - **CUMULUS-2769**
-    - Update provider PUT endpoint to require existance of postgresql record
+    - Update provider PUT endpoint to require existence of postgresql record
       and to ignore lack of dynamoDbRecord on update
   - **CUMULUS-2759**
     - Updates collection/provider/rules/granules creation (post) endpoints to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - **CUMULUS-2311** - RDS Migration Epic Phase 2
+  - **CUMULUS-2769**
+    - Update provider PUT endpoint to require existance of postgresql record
+      and to ignore lack of dynamoDbRecord on update
   - **CUMULUS-2759**
     - Updates collection/provider/rules/granules creation (post) endpoints to
       primarily check for existence/collision in PostgreSQL database instead of DynamoDB

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - **CUMULUS-2311** - RDS Migration Epic Phase 2
   - **CUMULUS-2769**
-    - Update provider PUT endpoint to require existence of postgresql record
-      and to ignore lack of dynamoDbRecord on update
+    - Update provider PUT endpoint to require existence of PostgreSQL record
+      and to ignore lack of DynamoDB record on update
   - **CUMULUS-2759**
     - Updates collection/provider/rules/granules creation (post) endpoints to
       primarily check for existence/collision in PostgreSQL database instead of DynamoDB

--- a/packages/api/endpoints/providers.js
+++ b/packages/api/endpoints/providers.js
@@ -165,7 +165,7 @@ async function put(req, res) {
     if (error.name !== 'RecordDoesNotExist') {
       throw error;
     }
-    log.warn(`Dynamo record for Provider ${id} not found, proceeding to update with postgresql record alone`);
+    log.warn(`Dynamo record for Provider ${id} not found, proceeding to update with PostgreSQL record alone`);
   }
 
   apiProvider.updatedAt = Date.now();


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2767](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2767)

## Changes

* Update provider PUT endpoint to require existence of postgresql record
      and to ignore lack of dynamoDbRecord on update

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
