### PR TITLE
CUMULUS-2771: Remove _updateGranuleStatus helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
       since it is redundant.
     - Removed function `addToLocalES` from `es-client` package since it is no
       longer used.
+  - **CUMULUS-2771**
+    - Removed `_updateGranuleStatus` to update granule to "running" from `@cumulus/api/lib/ingest.reingestGranule`
+    and `@cumulus/api/lib/ingest.applyWorkflow`
 
 ### Changed
 

--- a/packages/api/endpoints/granules.js
+++ b/packages/api/endpoints/granules.js
@@ -252,16 +252,12 @@ async function put(req, res) {
 
     await updateGranuleStatusToQueuedMethod({ granule: apiGranule, knex });
 
-    const reingestParams = {
+    await reingestHandler({
       granule: {
         ...apiGranule,
         ...(targetExecution && { execution: targetExecution }),
       },
       queueUrl: process.env.backgroundQueueUrl,
-    };
-
-    await reingestHandler({
-      reingestParams,
     });
 
     const response = {

--- a/packages/api/endpoints/granules.js
+++ b/packages/api/endpoints/granules.js
@@ -253,8 +253,10 @@ async function put(req, res) {
     await updateGranuleStatusToQueuedMethod({ granule: apiGranule, knex });
 
     const reingestParams = {
-      ...apiGranule,
-      ...(targetExecution && { execution: targetExecution }),
+      granule: {
+        ...apiGranule,
+        ...(targetExecution && { execution: targetExecution }),
+      },
       queueUrl: process.env.backgroundQueueUrl,
     };
 

--- a/packages/api/lambdas/bulk-operation.js
+++ b/packages/api/lambdas/bulk-operation.js
@@ -173,13 +173,13 @@ async function bulkGranuleReingest(
       try {
         const granule = await granuleModel.getRecord({ granuleId });
         const targetExecution = await chooseTargetExecution({ granuleId, workflowName });
-        const reingestParams = {
+        const granuleToReingest = {
           ...granule,
           ...(targetExecution && { execution: targetExecution }),
         };
-        await updateGranuleStatusToQueued({ granule: reingestParams, knex });
+        await updateGranuleStatusToQueued({ granule: granuleToReingest, knex });
         await reingestHandler({
-          reingestParams,
+          granule: granuleToReingest,
           asyncOperationId: process.env.asyncOperationId,
         });
 

--- a/packages/api/lib/ingest.js
+++ b/packages/api/lib/ingest.js
@@ -18,7 +18,7 @@ const { updateGranuleStatusToQueued } = require('./writeRecords/write-granules')
    *
    * @param {Object} params
    * @param {Object} params.granule - the granule object
-   * @param {Object} params.queueUrl - the granule object
+   * @param {Object} params.queueUrl - SQS queue URL to use for sending messages
    * @param {string} [params.asyncOperationId] - specify asyncOperationId origin
    * @param {Granule} [params.granuleModel] - API Granule model (optional, for testing)
    * @param {GranulePgModel} [params.granulePgModel] - Postgres Granule model

--- a/packages/api/lib/writeRecords/write-granules.js
+++ b/packages/api/lib/writeRecords/write-granules.js
@@ -576,7 +576,7 @@ const _updateGranule = async ({
       });
       log.info(`Successfully wrote granule ${granuleId} to Elasticsearch`);
     } catch (writeError) {
-      log.info(`Writes to DynamoDB/Elasticsearch failed, rolling back all writes for granule ${granuleId}`);
+      log.error(`Writes to DynamoDB/Elasticsearch failed, rolling back all writes for granule ${granuleId}`, writeError);
       // On error, recreate the DynamoDB record to revert it back to original
       // status to ensure that all systems stay in sync
       await granuleModel.create(apiGranule);

--- a/packages/api/lib/writeRecords/write-granules.js
+++ b/packages/api/lib/writeRecords/write-granules.js
@@ -423,6 +423,7 @@ const _publishPostgresGranuleUpdateToSns = async ({
     knexOrTransaction: knex,
   });
   await publishGranuleSnsMessageByEventType(granuletoPublish, snsEventType);
+  log.info('Successfully wrote granule %j to SNS topic', granuletoPublish);
 };
 
 /**
@@ -591,12 +592,11 @@ const _updateGranule = async ({
   );
   log.info('Successfully wrote granule %j to DynamoDB', apiGranule);
 
-  const granuletoPublish = await translatePostgresGranuleToApiGranule({
-    granulePgRecord: updatedPgGranule,
-    knexOrTransaction: knex,
+  await _publishPostgresGranuleUpdateToSns({
+    snsEventType,
+    pgGranule: updatedPgGranule,
+    knex,
   });
-  await publishGranuleSnsMessageByEventType(granuletoPublish, snsEventType);
-  log.info('Successfully wrote granule %j to SNS topic', granuletoPublish);
 };
 
 /**

--- a/packages/api/tests/endpoints/granules/test-reingest-granules.js
+++ b/packages/api/tests/endpoints/granules/test-reingest-granules.js
@@ -109,7 +109,7 @@ test('put request with reingest action queues granule and calls the reingestGran
 
   t.is(granuleReingestStub.calledOnce, true);
 
-  const { queueUrl } = granuleReingestStub.lastCall.args[0].reingestParams;
+  const { queueUrl } = granuleReingestStub.lastCall.args[0];
   const { granule } = updateGranuleStatusToQueuedMethod.lastCall.args[0];
   t.is(granule.granuleId, granuleId);
   t.is(queueUrl, process.env.backgroundQueueUrl);

--- a/packages/api/tests/endpoints/test-granules.js
+++ b/packages/api/tests/endpoints/test-granules.js
@@ -611,8 +611,8 @@ test.serial('reingest a granule', async (t) => {
     { granuleId: t.context.fakeGranules[0].granuleId }
   );
 
-  t.is(updatedPgGranule.status, 'running');
-  t.is(updatedDynamoGranule.status, 'running');
+  t.is(updatedPgGranule.status, 'queued');
+  t.is(updatedDynamoGranule.status, 'queued');
 });
 
 // This needs to be serial because it is stubbing aws.sfn's responses
@@ -670,8 +670,8 @@ test.serial('apply an in-place workflow to an existing granule', async (t) => {
     { granuleId: t.context.fakeGranules[0].granuleId }
   );
 
-  t.is(updatedPgGranule.status, 'running');
-  t.is(updatedDynamoGranule.status, 'running');
+  t.is(updatedPgGranule.status, 'queued');
+  t.is(updatedDynamoGranule.status, 'queued');
 });
 
 test.serial('remove a granule from CMR', async (t) => {

--- a/packages/api/tests/lambdas/test-bulk-operation.js
+++ b/packages/api/tests/lambdas/test-bulk-operation.js
@@ -706,9 +706,9 @@ test.serial('bulk operation BULK_GRANULE_REINGEST reingests list of granule IDs'
   t.is(reingestStub.callCount, 2);
   reingestStub.args.forEach((callArgs) => {
     const matchingGranule = granules.find((granule) =>
-      granule.granuleId === callArgs[0].reingestParams.granuleId);
+      granule.granuleId === callArgs[0].granule.granuleId);
 
-    t.deepEqual(matchingGranule, callArgs[0].reingestParams);
+    t.deepEqual(matchingGranule, callArgs[0].granule);
     t.is(callArgs[0].asyncOperationId, process.env.asyncOperationId);
   });
 });
@@ -736,14 +736,14 @@ test.serial('bulk operation BULK_GRANULE_REINGEST reingests list of granule IDs 
     // then compare all other fields except the execution against the model
     // granules.
     const matchingGranule = granules.find((granule) =>
-      granule.granuleId === callArgs[0].reingestParams.granuleId);
+      granule.granuleId === callArgs[0].granule.granuleId);
 
-    t.true(t.context.executionArns.includes(callArgs[0].reingestParams.execution));
+    t.true(t.context.executionArns.includes(callArgs[0].granule.execution));
 
     delete matchingGranule.execution;
-    delete callArgs[0].reingestParams.execution;
+    delete callArgs[0].granule.execution;
 
-    t.deepEqual(matchingGranule, callArgs[0].reingestParams);
+    t.deepEqual(matchingGranule, callArgs[0].granule);
     t.is(callArgs[0].asyncOperationId, process.env.asyncOperationId);
   });
 });
@@ -786,9 +786,9 @@ test.serial('bulk operation BULK_GRANULE_REINGEST reingests granule IDs returned
 
   reingestStub.args.forEach((callArgs) => {
     const matchingGranule = granules.find((granule) =>
-      granule.granuleId === callArgs[0].reingestParams.granuleId);
+      granule.granuleId === callArgs[0].granule.granuleId);
 
-    t.deepEqual(matchingGranule, callArgs[0].reingestParams);
+    t.deepEqual(matchingGranule, callArgs[0].granule);
     t.is(callArgs[0].asyncOperationId, process.env.asyncOperationId);
   });
 });

--- a/packages/api/tests/lib/test-ingest.js
+++ b/packages/api/tests/lib/test-ingest.js
@@ -1,6 +1,6 @@
 const test = require('ava');
 const sinon = require('sinon');
-const s3Utils = require('@cumulus/aws-client/S3');
+
 const { randomString } = require('@cumulus/common/test-utils');
 const Lambda = require('@cumulus/aws-client/Lambda');
 const StepFunctions = require('@cumulus/aws-client/StepFunctions');
@@ -131,17 +131,17 @@ test.after.always(async (t) => {
 });
 
 test.serial('reingestGranule pushes a message with the correct queueUrl', async (t) => {
+  const {
+    collectionId,
+  } = t.context;
   const buildPayloadSpy = sinon.stub(Rule, 'buildPayload');
-  const fileExists = () => Promise.resolve(true);
-  const fileExistsStub = sinon.stub(s3Utils, 'fileExists').callsFake(fileExists);
+
   const granuleModel = new Granule();
   const granulePgModel = new GranulePgModel();
   const queueUrl = 'testqueueUrl';
-  const updateStatusStub = sinon.stub(granuleModel, 'updateStatus');
-  const updateGranuleStatusToQueuedStub = () => Promise.resolve();
 
   const granule = fakeGranuleFactoryV2({
-    collectionId: t.context.collectionId,
+    collectionId,
   });
   const dynamoGranule = await granuleModel.create(granule);
   await granulePgModel.create(
@@ -152,7 +152,7 @@ test.serial('reingestGranule pushes a message with the correct queueUrl', async 
   const reingestParams = {
     granuleId: granule.granuleId,
     execution: 'some/execution',
-    collectionId: 'MyCollection___006',
+    collectionId,
     provider: 'someProvider',
     queueUrl,
   };
@@ -161,7 +161,6 @@ test.serial('reingestGranule pushes a message with the correct queueUrl', async 
       reingestParams,
       granuleModel,
       granulePgModel,
-      updateGranuleStatusToQueuedMethod: updateGranuleStatusToQueuedStub,
     });
     // Rule.buildPayload has its own unit tests to ensure the queue name
     // is used properly, so just ensure that we pass the correct argument
@@ -172,13 +171,11 @@ test.serial('reingestGranule pushes a message with the correct queueUrl', async 
       t.context.knex,
       granule.granuleId
     );
-    t.is(updatedPgGranule.status, 'running');
+    t.is(updatedPgGranule.status, 'queued');
   } catch (error) {
     console.log(error);
   } finally {
-    fileExistsStub.restore();
     buildPayloadSpy.restore();
-    updateStatusStub.restore();
   }
 });
 
@@ -195,10 +192,7 @@ test.serial('applyWorkflow throws error if workflow argument is missing', async 
   );
 });
 
-test.serial('applyWorkflow updates granule status and invokes Lambda to schedule workflow', async (t) => {
-  const granuleModel = new Granule();
-  const granulePgModel = new GranulePgModel();
-
+test.serial('applyWorkflow and invokes Lambda to schedule workflow', async (t) => {
   const granule = fakeGranuleFactoryV2({
     collectionId: t.context.collectionId,
   });
@@ -209,27 +203,12 @@ test.serial('applyWorkflow updates granule status and invokes Lambda to schedule
     },
   };
 
-  const dynamoGranule = await granuleModel.create(granule);
-  await granulePgModel.create(
-    t.context.knex,
-    await translateApiGranuleToPostgresGranule(dynamoGranule, t.context.knex)
-  );
-
   const buildPayloadStub = sinon.stub(Rule, 'buildPayload').resolves(lambdaPayload);
   const lambdaInvokeStub = sinon.stub(Lambda, 'invoke').resolves();
 
   await applyWorkflow({ granule, workflow });
 
   try {
-    const updatedDynamoGranule = await granuleModel.get({ granuleId: granule.granuleId });
-    t.is(updatedDynamoGranule.status, 'running');
-
-    const updatedPgGranule = await granuleLib.getUniqueGranuleByGranuleId(
-      t.context.knex,
-      granule.granuleId
-    );
-    t.is(updatedPgGranule.status, 'running');
-
     t.true(lambdaInvokeStub.called);
     t.deepEqual(lambdaInvokeStub.args[0][1], lambdaPayload);
   } finally {

--- a/packages/api/tests/lib/test-ingest.js
+++ b/packages/api/tests/lib/test-ingest.js
@@ -18,6 +18,9 @@ const {
   getUniqueGranuleByGranuleId,
 } = require('@cumulus/db');
 const {
+  createTestIndex,
+} = require('@cumulus/es-client/testUtils');
+const {
   fakeGranuleFactoryV2,
   fakeCollectionFactory,
 } = require('../../lib/testUtils');
@@ -51,6 +54,10 @@ test.before(async (t) => {
   t.context.knex = knex;
   t.context.knexAdmin = knexAdmin;
   t.context.granuleId = randomString();
+
+  // const { esIndex, esClient } = await createTestIndex();
+  // t.context.esIndex = esIndex;
+  // t.context.esClient = esClient;
 
   process.env.GranulesTable = randomString();
   await new Granule().createTable();
@@ -136,7 +143,7 @@ test.after.always(async (t) => {
   await sns().deleteTopic({ TopicArn: t.context.granules_sns_topic_arn }).promise();
 });
 
-test.serial('reingestGranule pushes a message with the correct queueUrl', async (t) => {
+test.serial.only('reingestGranule pushes a message with the correct queueUrl', async (t) => {
   const {
     collectionId,
   } = t.context;
@@ -155,17 +162,10 @@ test.serial('reingestGranule pushes a message with the correct queueUrl', async 
     await translateApiGranuleToPostgresGranule(dynamoGranule, t.context.knex)
   );
 
-  const granuleToReingest = {
-    granuleId: granule.granuleId,
-    execution: 'some/execution',
-    collectionId,
-    provider: 'someProvider',
-  };
-
   t.teardown(() => buildPayloadSpy.restore());
 
   await reingestGranule({
-    granule: granuleToReingest,
+    granule,
     queueUrl,
     granuleModel,
     granulePgModel,

--- a/packages/api/tests/lib/test-ingest.js
+++ b/packages/api/tests/lib/test-ingest.js
@@ -56,7 +56,8 @@ test.before(async (t) => {
   await new Granule().createTable();
 
   const { TopicArn } = await sns().createTopic({ Name: randomString() }).promise();
-  process.env.granule_sns_topic_arn = TopicArn;
+  t.context.granules_sns_topic_arn = TopicArn;
+  process.env.granule_sns_topic_arn = t.context.granules_sns_topic_arn;
 
   testCumulusMessage = {
     cumulus_meta: {
@@ -132,6 +133,7 @@ test.after.always(async (t) => {
     knexAdmin: t.context.knexAdmin,
     testDbName,
   });
+  await sns().deleteTopic({ TopicArn: t.context.granules_sns_topic_arn }).promise();
 });
 
 test.serial('reingestGranule pushes a message with the correct queueUrl', async (t) => {

--- a/packages/api/tests/lib/test-ingest.js
+++ b/packages/api/tests/lib/test-ingest.js
@@ -143,7 +143,7 @@ test.after.always(async (t) => {
   await sns().deleteTopic({ TopicArn: t.context.granules_sns_topic_arn }).promise();
 });
 
-test.serial.only('reingestGranule pushes a message with the correct queueUrl', async (t) => {
+test.serial('reingestGranule pushes a message with the correct queueUrl', async (t) => {
   const {
     collectionId,
   } = t.context;

--- a/packages/api/tests/lib/test-ingest.js
+++ b/packages/api/tests/lib/test-ingest.js
@@ -155,18 +155,18 @@ test.serial('reingestGranule pushes a message with the correct queueUrl', async 
     await translateApiGranuleToPostgresGranule(dynamoGranule, t.context.knex)
   );
 
-  const reingestParams = {
+  const granuleToReingest = {
     granuleId: granule.granuleId,
     execution: 'some/execution',
     collectionId,
     provider: 'someProvider',
-    queueUrl,
   };
 
   t.teardown(() => buildPayloadSpy.restore());
 
   await reingestGranule({
-    reingestParams,
+    granule: granuleToReingest,
+    queueUrl,
     granuleModel,
     granulePgModel,
   });

--- a/packages/api/tests/lib/test-ingest.js
+++ b/packages/api/tests/lib/test-ingest.js
@@ -55,9 +55,9 @@ test.before(async (t) => {
   t.context.knexAdmin = knexAdmin;
   t.context.granuleId = randomString();
 
-  // const { esIndex, esClient } = await createTestIndex();
-  // t.context.esIndex = esIndex;
-  // t.context.esClient = esClient;
+  const { esIndex, esClient } = await createTestIndex();
+  t.context.esIndex = esIndex;
+  t.context.esClient = esClient;
 
   process.env.GranulesTable = randomString();
   await new Granule().createTable();

--- a/packages/api/tests/lib/test-ingest.js
+++ b/packages/api/tests/lib/test-ingest.js
@@ -162,27 +162,24 @@ test.serial('reingestGranule pushes a message with the correct queueUrl', async 
     provider: 'someProvider',
     queueUrl,
   };
-  try {
-    await reingestGranule({
-      reingestParams,
-      granuleModel,
-      granulePgModel,
-    });
-    // Rule.buildPayload has its own unit tests to ensure the queue name
-    // is used properly, so just ensure that we pass the correct argument
-    // to that function.
-    t.is(buildPayloadSpy.args[0][0].queueUrl, queueUrl);
 
-    const updatedPgGranule = await getUniqueGranuleByGranuleId(
-      t.context.knex,
-      granule.granuleId
-    );
-    t.is(updatedPgGranule.status, 'queued');
-  } catch (error) {
-    console.log(error);
-  } finally {
-    buildPayloadSpy.restore();
-  }
+  t.teardown(() => buildPayloadSpy.restore());
+
+  await reingestGranule({
+    reingestParams,
+    granuleModel,
+    granulePgModel,
+  });
+  // Rule.buildPayload has its own unit tests to ensure the queue name
+  // is used properly, so just ensure that we pass the correct argument
+  // to that function.
+  t.is(buildPayloadSpy.args[0][0].queueUrl, queueUrl);
+
+  const updatedPgGranule = await getUniqueGranuleByGranuleId(
+    t.context.knex,
+    granule.granuleId
+  );
+  t.is(updatedPgGranule.status, 'queued');
 });
 
 test.serial('applyWorkflow throws error if workflow argument is missing', async (t) => {

--- a/packages/api/tests/lib/test-ingest.js
+++ b/packages/api/tests/lib/test-ingest.js
@@ -180,7 +180,6 @@ test.serial('reingestGranule pushes a message with the correct queueUrl', async 
     t.is(updatedPgGranule.status, 'queued');
   } catch (error) {
     console.log(error);
-    t.fail();
   } finally {
     buildPayloadSpy.restore();
   }

--- a/packages/api/tests/lib/test-ingest.js
+++ b/packages/api/tests/lib/test-ingest.js
@@ -192,7 +192,7 @@ test.serial('applyWorkflow throws error if workflow argument is missing', async 
   );
 });
 
-test.serial('applyWorkflow and invokes Lambda to schedule workflow', async (t) => {
+test.serial('applyWorkflow invokes Lambda to schedule workflow', async (t) => {
   const granule = fakeGranuleFactoryV2({
     collectionId: t.context.collectionId,
   });


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2771: Investigate if updateGranuleStatus is necessary and update to handle ES writes and publish to SNS if so](https://bugs.earthdata.nasa.gov/browse/CUMULUS-XXX)

## Changes

- Remove _updateGranuleStatus helper

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
