### PR TITLE
[CUMULUS-2776] Update deleteFnName in db-indexer for reconciliation reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -363,6 +363,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - **CUMULUS-2774**
     - Updated `constructGranuleSnsMessage` and `constructCollectionSnsMessage`
       to throw error if `eventType` is invalid or undefined.
+  - **CUMULUS-2776**
+    - Updated `getTableIndexDetails` in `db-indexer` to use correct
+      `deleteFnName` for reconciliation reports.
 
 ## [v9.9.0] 2021-11-03
 

--- a/packages/api/lambdas/db-indexer.js
+++ b/packages/api/lambdas/db-indexer.js
@@ -52,7 +52,7 @@ const getTableIndexDetails = (tableName) => {
     },
     [process.env.ReconciliationReportsTable]: {
       indexFnName: 'indexReconciliationReport',
-      deleteFnName: 'deleteRecord',
+      deleteFnName: 'deleteReconciliationReport',
       indexType: 'reconciliationReport',
     },
     [process.env.RulesTable]: {
@@ -157,11 +157,12 @@ function performIndex(indexFnName, esClient, data) {
 /**
  * Perform the delete operation for the given record
  *
- * @param {Object} esClient - ElasticSearch connection client
- * @param {string} type - type of record to index
- * @param {string} id - record ID
- * @param {string} parentId - ID of parent record
- * @returns {Promise<Object>} elasticsearch response
+ * @param {string} deleteFnName - Delete function name
+ * @param {Object} esClient     - Elasticsearch connection client
+ * @param {string} type         - Type of record to index
+ * @param {string} id           - Record ID
+ * @param {string} parentId     - ID of parent record
+ * @returns {Promise<Object>}   - Elasticsearch response
  */
 function performDelete(deleteFnName, esClient, type, id, parentId) {
   logger.debug(`deleting type: ${type} id: ${id}`);

--- a/packages/api/tests/lambdas/test-db-indexer.js
+++ b/packages/api/tests/lambdas/test-db-indexer.js
@@ -18,6 +18,7 @@ const {
   fakeExecutionFactory,
   fakeFileFactory,
   fakeProviderFactory,
+  fakeReconciliationReportFactory,
 } = require('../../lib/testUtils');
 const GranuleFilesCache = require('../../lib/GranuleFilesCache');
 
@@ -42,6 +43,7 @@ process.env.GranulesTable = randomString();
 process.env.PdrsTable = randomString();
 process.env.ProvidersTable = randomString();
 process.env.RulesTable = randomString();
+process.env.ReconciliationReportsTable = randomString();
 
 const buildDynamoStreamRecord = ({
   eventName, tableName, keys, oldImage, newImage,
@@ -119,10 +121,23 @@ const buildGranuleRecord = ({ type, oldGranule, newGranule }) => {
   });
 };
 
+const buildReconciliationReportRecord = ({ type, oldReport, newReport }) => {
+  const name = type === 'REMOVE' ? oldReport.name : newReport.name;
+
+  return buildDynamoStreamRecord({
+    eventName: type,
+    tableName: process.env.ReconciliationReportsTable,
+    keys: { name },
+    oldImage: oldReport,
+    newImage: newReport,
+  });
+};
+
 let collectionModel;
 let executionModel;
 let granuleModel;
 let ruleModel;
+let reconciliationReportModel;
 
 test.before(async (t) => {
   await awsServices.s3().createBucket({ Bucket: process.env.system_bucket }).promise();
@@ -132,12 +147,14 @@ test.before(async (t) => {
   granuleModel = new models.Granule();
   executionModel = new models.Execution();
   ruleModel = new models.Rule();
+  reconciliationReportModel = new models.ReconciliationReport();
 
   await Promise.all([
     collectionModel.createTable(),
     executionModel.createTable(),
     granuleModel.createTable(),
     ruleModel.createTable(),
+    reconciliationReportModel.createTable(),
   ]);
 
   // bootstrap the esIndex
@@ -154,6 +171,7 @@ test.after.always(async () => {
   await granuleModel.deleteTable();
   await executionModel.deleteTable();
   await ruleModel.deleteTable();
+  await reconciliationReportModel.deleteTable();
 
   await recursivelyDeleteS3Bucket(process.env.system_bucket);
   await esClient.indices.delete({ index: esIndex });
@@ -394,4 +412,49 @@ test.serial('The db-indexer does not throw an exception when execution fails', a
       },
     })(() => handler({ Records: [insertRecord] }))
   );
+});
+
+test.serial('Create, Update, and Delete reconciliation report succeeds in DynamoDB and Elasticsearch', async (t) => {
+  const { esAlias } = t.context;
+
+  const fakeReport = fakeReconciliationReportFactory();
+
+  const insertRecord = buildReconciliationReportRecord({
+    type: 'INSERT',
+    newReport: fakeReport,
+  });
+
+  // Fake the lambda trigger
+  await handler({ Records: [insertRecord] });
+
+  const recordIndex = new Search({}, 'reconciliationReport', esAlias);
+  let indexedRecord = await recordIndex.get(fakeReport.name);
+
+  console.log(indexedRecord);
+  t.is(indexedRecord.name, fakeReport.name);
+
+  // Modify the record
+  const modifyRecord = buildReconciliationReportRecord({
+    type: 'MODIFY',
+    oldReport: fakeReport,
+    newReport: { ...fakeReport, status: 'failed' },
+  });
+
+  // Fake the lambda trigger
+  await handler({ Records: [modifyRecord] });
+
+  indexedRecord = await recordIndex.get(fakeReport.name);
+  t.is(indexedRecord.status, 'failed');
+
+  // Delete the record
+  const removeRecord = buildReconciliationReportRecord({
+    type: 'REMOVE',
+    oldReport: { ...fakeReport, status: 'failed' },
+  });
+
+  // fake the lambda trigger
+  await handler({ Records: [removeRecord] });
+
+  indexedRecord = await recordIndex.get(fakeReport.name);
+  t.is(indexedRecord.detail, 'Record not found');
 });


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2776: deleting a reconciliation report fails to remove it from elasticsearch](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2776)

## Changes

* `deleteFnName` was using `deleteRecord` instead of [`deleteReconciliationReports`](https://github.com/nasa/cumulus/blob/feature/rds-phase-2/packages/es-client/indexer.js#L622) so I updated it to use the correct function
* Added a unit test 

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
