### PR TITLE
Remove api model code from queueGranuleSpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Removed
 
 - **CUMULUS-2311** - RDS Migration Epic Phase 2
+  - **CUMULUS-2770**
+    - Removed `waitForModelStatus` from `example/spec/helpers/apiUtils` integration test helpers
   - **CUMULUS-2510**
     - Removed `stream_enabled` and `stream_view_type` from `executions_table` TF
       definition.

--- a/example/spec/helpers/apiUtils.js
+++ b/example/spec/helpers/apiUtils.js
@@ -54,35 +54,8 @@ async function waitForApiStatus(getMethod, params, status, retryConfig = {}) {
   );
 }
 
-/**
- * Check a record for a particular set of statuses and retry until the record gets that status
- * This is to mitigate issues where a workflow completes, but there is a lag between
- * the workflow end, cloudwatch event sqs message, and database update
- *
- * @param {Object} model - model from api/models
- * @param {Object} params - params to pass to model.get
- * @param {string[] | string} status - status to wait for
- */
-async function waitForModelStatus(model, params, status) {
-  return await pRetry(
-    async () => {
-      const record = await model.get(params);
-      const checkStatus = [status].flat();
-      if (!checkStatus.includes(record.status)) {
-        throw new Error(`Record status ${record.status}. Expect status ${checkStatus}`);
-      }
-
-      return record;
-    },
-    {
-      maxTimeout: 60 * 1000,
-    }
-  );
-}
-
 module.exports = {
   setDistributionApiEnvVars,
   waitForApiRecord,
   waitForApiStatus,
-  waitForModelStatus,
 };


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2770: Replace Dynamo requests with private API requests in integration tests](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2770)

I looked through the spec, integration-tests and api helpers packages for api model includes and verified any remaining calls were needed (things like cleanup deletes) or were related to other model logic that needs to be refactored but is beyond the scope of this ticket/phase 3 work. 

Reviewers should look at comments in the PR ticket and cast a critical eye on the code for anything I might have missed in addition to the changeset review.  

## Changes

* Removes wait for model status from spec helpers
* Updated QueueGranulesSpec to use API calls instead of model awaits
## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [x] Integration tests
