### PR TITLE
CUMULUS-2775: Fix api-client logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     large reports
   - Updated TEA version from 102 to 121 to address TEA deployment issue with the max size of
     a policy role being exceeded
+- **CUMULUS-2775**
+  - Changed `@cumulus/api-client/invokeApi()` to accept a single accepted status code or an array
+  of accepted status codes via `expectedStatusCodes`
+
+### Fixed
+
+- **CUMULUS-2775**
+  - Updated `@cumulus/api-client` to not log an error for 201 response from `updateGranule`
 
 ## [v9.9.0] 2021-11-03
 

--- a/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
@@ -1230,7 +1230,7 @@ describe('The S3 Ingest Granules workflow', () => {
           await getGranule({
             prefix: config.stackName,
             granuleId: inputPayload.granules[0].granuleId,
-            expectedStatusCode: 404,
+            expectedStatusCodes: 404,
           });
         } catch (error) {
           granuleResponseError = error;

--- a/packages/api-client/src/cumulusApiClient.ts
+++ b/packages/api-client/src/cumulusApiClient.ts
@@ -26,9 +26,11 @@ export async function invokeApi(
   const {
     prefix,
     payload,
-    expectedStatusCode = 200,
+    expectedStatusCodes = 200,
     pRetryOptions = {},
   } = params;
+
+  const expectedStatusCodesFlat = [expectedStatusCodes].flat();
 
   return await pRetry(
     async () => {
@@ -51,7 +53,7 @@ export async function invokeApi(
         );
       }
 
-      if (parsedPayload?.statusCode !== expectedStatusCode) {
+      if (!expectedStatusCodesFlat.includes(parsedPayload?.statusCode)) {
         throw new CumulusApiClientError(
           `${payload.path} returned ${parsedPayload.statusCode}: ${parsedPayload.body}`,
           parsedPayload?.statusCode,

--- a/packages/api-client/src/deadLetterArchive.ts
+++ b/packages/api-client/src/deadLetterArchive.ts
@@ -32,6 +32,6 @@ export const postRecoverCumulusMessages = async (params: {
       path: '/deadLetterArchive/recoverCumulusMessages',
       body: JSON.stringify(payload),
     },
-    expectedStatusCode: 202,
+    expectedStatusCodes: 202,
   });
 };

--- a/packages/api-client/src/executions.ts
+++ b/packages/api-client/src/executions.ts
@@ -210,7 +210,7 @@ export const searchExecutionsByGranules = async (params: {
       path: '/executions/search-by-granules',
       body: JSON.stringify(payload),
     },
-    expectedStatusCode: 202,
+    expectedStatusCodes: 202,
   });
 };
 
@@ -243,6 +243,6 @@ export const workflowsByGranules = async (params: {
       path: '/executions/workflows-by-granules',
       body: JSON.stringify(payload),
     },
-    expectedStatusCode: 202,
+    expectedStatusCodes: 202,
   });
 };

--- a/packages/api-client/src/granules.ts
+++ b/packages/api-client/src/granules.ts
@@ -444,6 +444,7 @@ export const updateGranule = async (params: {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     },
+    expectedStatusCodes: [200, 201],
   });
 };
 
@@ -506,7 +507,7 @@ export const bulkGranules = async (params: {
       path: '/granules/bulk',
       body: JSON.stringify(body),
     },
-    expectedStatusCode: 202,
+    expectedStatusCodes: 202,
   });
 };
 
@@ -539,7 +540,7 @@ export const bulkDeleteGranules = async (params: {
       path: '/granules/bulkDelete',
       body: JSON.stringify(body),
     },
-    expectedStatusCode: 202,
+    expectedStatusCodes: 202,
   });
 };
 
@@ -561,7 +562,7 @@ export const bulkReingestGranules = async (params: {
       path: '/granules/bulkReingest',
       body: JSON.stringify(body),
     },
-    expectedStatusCode: 202,
+    expectedStatusCodes: 202,
   });
 };
 
@@ -597,6 +598,6 @@ export const bulkOperation = async (params: {
       },
       body: JSON.stringify({ ids, workflowName }),
     },
-    expectedStatusCode: 202,
+    expectedStatusCodes: 202,
   });
 };

--- a/packages/api-client/src/migrationCounts.ts
+++ b/packages/api-client/src/migrationCounts.ts
@@ -32,6 +32,6 @@ export const postMigrationCounts = async (params: {
       path: '/migrationCounts',
       body: JSON.stringify(payload),
     },
-    expectedStatusCode: 202,
+    expectedStatusCodes: 202,
   });
 };

--- a/packages/api-client/src/reconciliationReports.ts
+++ b/packages/api-client/src/reconciliationReports.ts
@@ -98,6 +98,6 @@ export async function createReconciliationReport(params: {
       path: '/reconciliationReports',
       body: JSON.stringify(request),
     },
-    expectedStatusCode: 202,
+    expectedStatusCodes: 202,
   });
 }

--- a/packages/api-client/src/replays.ts
+++ b/packages/api-client/src/replays.ts
@@ -33,7 +33,7 @@ export const postKinesisReplays = async (params: {
       path: '/replays',
       body: JSON.stringify(payload),
     },
-    expectedStatusCode: 202,
+    expectedStatusCodes: 202,
   });
 };
 
@@ -67,6 +67,6 @@ export const replaySqsMessages = async (params: {
       path: '/replays/sqs',
       body: JSON.stringify(payload),
     },
-    expectedStatusCode: 202,
+    expectedStatusCodes: 202,
   });
 };

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -29,7 +29,7 @@ export interface InvokeApiFunctionParams {
   prefix: string,
   payload: ApiGatewayLambdaProxyPayload,
   pRetryOptions?: pRetry.Options,
-  expectedStatusCode?: number
+  expectedStatusCodes?: number | number[]
 }
 
 export type InvokeApiFunction = (

--- a/packages/api-client/tests/test-CumulusApiClient.js
+++ b/packages/api-client/tests/test-CumulusApiClient.js
@@ -132,7 +132,7 @@ test.serial('invokeApi respects expected non-200 status code', async (t) => {
       minTimeout: 1,
       maxTimeout: 1,
     },
-    expectedStatusCode: 202,
+    expectedStatusCodes: 202,
   }));
 
   t.is(1, lambdaInvocations);

--- a/packages/api-client/tests/test-CumulusApiClient.js
+++ b/packages/api-client/tests/test-CumulusApiClient.js
@@ -137,3 +137,47 @@ test.serial('invokeApi respects expected non-200 status code', async (t) => {
 
   t.is(1, lambdaInvocations);
 });
+
+test.serial('invokeApi respects multiple accepted status codes', async (t) => {
+  let lambdaInvocations = 0;
+
+  fakeServices.lambda = () => ({
+    invoke: () => {
+      lambdaInvocations += 1;
+      return {
+        promise: () => Promise.resolve({
+          Payload: JSON.stringify({
+            statusCode: lambdaInvocations === 1 ? 201 : 200,
+            body: JSON.stringify({
+              message: 'success',
+            }),
+          }),
+        }),
+      };
+    },
+  });
+
+  const response1 = await apiClient.invokeApi({
+    prefix: t.context.testPrefix,
+    payload: t.context.testPayload,
+    pRetryOptions: {
+      minTimeout: 1,
+      maxTimeout: 1,
+    },
+    expectedStatusCodes: [200, 201],
+  });
+  t.is(response1.statusCode, 201);
+
+  const response2 = await apiClient.invokeApi({
+    prefix: t.context.testPrefix,
+    payload: t.context.testPayload,
+    pRetryOptions: {
+      minTimeout: 1,
+      maxTimeout: 1,
+    },
+    expectedStatusCodes: [200, 201],
+  });
+  t.is(response2.statusCode, 200);
+
+  t.is(2, lambdaInvocations);
+});

--- a/packages/api-client/tests/test-deadLetterArchive.js
+++ b/packages/api-client/tests/test-deadLetterArchive.js
@@ -16,7 +16,7 @@ test('postRecoverCumulusMessages call the callback with the expected object when
       path: '/deadLetterArchive/recoverCumulusMessages',
       body: undefined,
     },
-    expectedStatusCode: 202,
+    expectedStatusCodes: 202,
   };
 
   const callback = (configObject) => {
@@ -44,7 +44,7 @@ test('postRecoverCumulusMessages calls the callback with the expected object', a
       path: '/deadLetterArchive/recoverCumulusMessages',
       body: JSON.stringify(payload),
     },
-    expectedStatusCode: 202,
+    expectedStatusCodes: 202,
   };
 
   const callback = (configObject) => {

--- a/packages/api-client/tests/test-executions.js
+++ b/packages/api-client/tests/test-executions.js
@@ -193,7 +193,7 @@ test('searchExecutionsByGranules calls the callback with the expected object and
       path: '/executions/search-by-granules',
       body: JSON.stringify(payload),
     },
-    expectedStatusCode: 202,
+    expectedStatusCodes: 202,
   };
 
   const callback = (configObject) => {
@@ -226,7 +226,7 @@ test('workflowsByGranules calls the callback with the expected object and return
       path: '/executions/workflows-by-granules',
       body: JSON.stringify(payload),
     },
-    expectedStatusCode: 202,
+    expectedStatusCodes: 202,
   };
 
   const callback = (configObject) => {

--- a/packages/api-client/tests/test-granules.js
+++ b/packages/api-client/tests/test-granules.js
@@ -388,6 +388,7 @@ test('updateGranule calls the callback with the expected object', async (t) => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     },
+    expectedStatusCodes: [200, 201],
   };
 
   const callback = (configObject) => {

--- a/packages/api-client/tests/test-replays.js
+++ b/packages/api-client/tests/test-replays.js
@@ -22,7 +22,7 @@ test('postKinesisReplays calls the callback with the expected object', async (t)
       path: '/replays',
       body: JSON.stringify(payload),
     },
-    expectedStatusCode: 202,
+    expectedStatusCodes: 202,
   };
 
   const callback = (configObject) => {
@@ -53,7 +53,7 @@ test('replaySqsMessages calls the callback with the expected object and returns 
       path: '/replays/sqs',
       body: JSON.stringify(payload),
     },
-    expectedStatusCode: 202,
+    expectedStatusCodes: 202,
   };
   const callback = (configObject) => {
     t.deepEqual(expected, configObject);


### PR DESCRIPTION
- Fix `api-client` logs so successful 201 responses from api-client are not logged as errors

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
