### PR TITLE
CUMULUS-2441: add support for cmr env of PROD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Added CMR search client setting to the CreateReconciliationReport lambda function.
   - Added `cmr_search_client_config` tfvars to the archive and cumulus terraform modules.
   - Updated CreateReconciliationReport lambda to search CMR collections with CMRSearchConceptQueue.
+- **CUMULUS-2441**
+  - Added support for 'PROD' CMR environment.
 - **CUMULUS-2638**
   - Adds documentation to clarify bucket config object use.
 - **CUMULUS-2684**

--- a/packages/api/lib/mmt.js
+++ b/packages/api/lib/mmt.js
@@ -10,11 +10,12 @@ const log = new Logger({ sender: 'api/lib/mmt' });
 
 /**
  * Returns the environment specific identifier for the input cmr environment.
- * @param {string} env - cmr environment ['OPS', 'SIT', 'UAT']
+ * @param {string} env - cmr environment ['PROD', 'OPS', 'SIT', 'UAT']
  * @returns {string} - value to use to build correct cmr url for environment.
  */
 function hostId(env) {
   switch (env) {
+  case 'PROD':
   case 'OPS':
     return '';
   case 'UAT':

--- a/packages/api/tests/lib/test-mmt.js
+++ b/packages/api/tests/lib/test-mmt.js
@@ -181,6 +181,7 @@ test('buildMMTLink creates expected links', (t) => {
     { env: 'UAT', expected: 'https://mmt.uat.earthdata.nasa.gov/collections/' },
     { env: 'SIT', expected: 'https://mmt.sit.earthdata.nasa.gov/collections/' },
     { env: 'OPS', expected: 'https://mmt.earthdata.nasa.gov/collections/' },
+    { env: 'PROD', expected: 'https://mmt.earthdata.nasa.gov/collections/' },
   ];
 
   tests.forEach((aTest) => {

--- a/packages/cmr-client/src/getUrl.ts
+++ b/packages/cmr-client/src/getUrl.ts
@@ -22,6 +22,7 @@ export function getCmrHost({
     return cmrHost;
   }
   switch (cmrEnvironment) {
+    case 'PROD':
     case 'OPS':
       return 'https://cmr.earthdata.nasa.gov';
     case 'UAT':

--- a/packages/cmr-client/src/searchConcept.ts
+++ b/packages/cmr-client/src/searchConcept.ts
@@ -31,7 +31,7 @@ export interface UmmJsonResponse {
  * @param {Object} params
  * @param {string} params.type - Concept type to search, choices: ['collections', 'granules']
  * @param {string} params.cmrEnvironment - optional, CMR environment to
- *              use valid arguments are ['OPS', 'SIT', 'UAT']
+ *              use valid arguments are ['PROD', 'OPS', 'SIT', 'UAT']
  * @param {Object} params.searchParams - CMR search parameters
  * Note initial searchParams.page_num should only be set if recursive is false
  * @param {Array} [params.previousResults=[]] - array of results returned in previous recursive

--- a/packages/cmr-client/tests/test-getUrl.js
+++ b/packages/cmr-client/tests/test-getUrl.js
@@ -61,7 +61,7 @@ test.serial('getSearchUrl uses cmrEnv from parameter over env variable', (t) => 
   t.teardown(() => delete process.env.CMR_ENVIRONMENT);
 });
 
-test('getBucketAccessUrl returns correct url for UAT invornment.', (t) => {
+test('getBucketAccessUrl returns correct url for specified environment.', (t) => {
   t.is(getBucketAccessUrl({ cmrEnv: 'PROD' }), 'https://cmr.earthdata.nasa.gov/access-control/s3-buckets/');
   t.is(getBucketAccessUrl({ cmrEnv: 'OPS' }), 'https://cmr.earthdata.nasa.gov/access-control/s3-buckets/');
   t.is(getBucketAccessUrl({ cmrEnv: 'SIT' }), 'https://cmr.sit.earthdata.nasa.gov/access-control/s3-buckets/');

--- a/packages/cmr-client/tests/test-getUrl.js
+++ b/packages/cmr-client/tests/test-getUrl.js
@@ -5,6 +5,7 @@ const test = require('ava');
 const { getCmrHost, getSearchUrl, getBucketAccessUrl } = require('../getUrl');
 
 test('getCmrHost uses provided logical CMR environment', (t) => {
+  t.is(getCmrHost({ cmrEnvironment: 'PROD' }), 'https://cmr.earthdata.nasa.gov');
   t.is(getCmrHost({ cmrEnvironment: 'OPS' }), 'https://cmr.earthdata.nasa.gov');
   t.is(getCmrHost({ cmrEnvironment: 'UAT' }), 'https://cmr.uat.earthdata.nasa.gov');
   t.is(getCmrHost({ cmrEnvironment: 'SIT' }), 'https://cmr.sit.earthdata.nasa.gov');
@@ -32,6 +33,7 @@ test.serial('getCmrHost uses process.env.CMR_HOST custom host, if provided', (t)
 });
 
 test.serial('getSearchUrl returns value according to cmrEnvironment param', (t) => {
+  t.is(getSearchUrl({ cmrEnv: 'PROD' }), 'https://cmr.earthdata.nasa.gov/search/');
   t.is(getSearchUrl({ cmrEnv: 'OPS' }), 'https://cmr.earthdata.nasa.gov/search/');
   t.is(getSearchUrl({ cmrEnv: 'SIT' }), 'https://cmr.sit.earthdata.nasa.gov/search/');
   t.is(getSearchUrl({ cmrEnv: 'UAT' }), 'https://cmr.uat.earthdata.nasa.gov/search/');
@@ -47,6 +49,9 @@ test.serial('getSearchUrl pulls cmrEnvironment from environment variables', (t) 
   process.env.CMR_ENVIRONMENT = 'OPS';
   t.is(getSearchUrl(), 'https://cmr.earthdata.nasa.gov/search/');
 
+  process.env.CMR_ENVIRONMENT = 'PROD';
+  t.is(getSearchUrl(), 'https://cmr.earthdata.nasa.gov/search/');
+
   t.teardown(() => delete process.env.CMR_ENVIRONMENT);
 });
 
@@ -57,6 +62,7 @@ test.serial('getSearchUrl uses cmrEnv from parameter over env variable', (t) => 
 });
 
 test('getBucketAccessUrl returns correct url for UAT invornment.', (t) => {
+  t.is(getBucketAccessUrl({ cmrEnv: 'PROD' }), 'https://cmr.earthdata.nasa.gov/access-control/s3-buckets/');
   t.is(getBucketAccessUrl({ cmrEnv: 'OPS' }), 'https://cmr.earthdata.nasa.gov/access-control/s3-buckets/');
   t.is(getBucketAccessUrl({ cmrEnv: 'SIT' }), 'https://cmr.sit.earthdata.nasa.gov/access-control/s3-buckets/');
   t.is(getBucketAccessUrl({ cmrEnv: 'UAT' }), 'https://cmr.uat.earthdata.nasa.gov/access-control/s3-buckets/');


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-XX: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-XXX)

## Changes

* Add support for 'PROD' cmr env.

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
