### PR TITLE
CUMULUS-2299: support SHA algo types with hyphens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added Terraform data sources to `example/rds-cluster-tf` module to retrieve default VPC and subnets in NGAP accounts
   - Added `vpc_tag_name` variable which defines the tags used to look up a VPC. Defaults to VPC tag name used in NGAP accounts
   - Added `subnets_tag_name` variable which defines the tags used to look up VPC subnets. Defaults to tag names used in subnets in for NGAP accounts
+- **CUMULUS-2299**
+  - Added support for SHA checksum types with hyphens (e.g. `SHA-256` vs `SHA256`) to tasks that calculate checksums.
 - **CUMULUS-2439**
   - Added CMR search client setting to the CreateReconciliationReport lambda function.
   - Added `cmr_search_client_config` tfvars to the archive and cumulus terraform modules.

--- a/packages/checksum/src/checksum.ts
+++ b/packages/checksum/src/checksum.ts
@@ -2,6 +2,23 @@ import * as cksum from 'cksum';
 import * as crypto from 'crypto';
 import { Readable, TransformOptions } from 'stream';
 
+export function normalizeHashAlgorithm(algorithm: string): string {
+  switch(algorithm) {
+    case 'SHA-1':
+      return 'SHA1';
+    case 'SHA-2':
+      return 'SHA2';
+    case 'SHA-256':
+      return 'SHA256';
+    case 'SHA-384':
+      return 'SHA384';
+    case 'SHA-512':
+      return 'SHA512';
+    default:
+      return algorithm;
+  }
+}
+
 // Calculate the cksum of a readable stream
 async function getCksumFromStream(stream: Readable): Promise<string> {
   return await new Promise((resolve, reject) =>
@@ -16,8 +33,9 @@ async function getChecksumFromStream(
   stream: Readable,
   options: TransformOptions = {}
 ): Promise<string> {
+  const normalizedAlgorithm: string = normalizeHashAlgorithm(algorithm);
   return await new Promise((resolve, reject) => {
-    const hash = crypto.createHash(algorithm, options);
+    const hash = crypto.createHash(normalizedAlgorithm, options);
     stream.on('error', reject);
     stream.on('data', (chunk) => hash.update(chunk));
     stream.on('end', () => resolve(hash.digest('hex')));

--- a/packages/checksum/tests/test-checksum.js
+++ b/packages/checksum/tests/test-checksum.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const test = require('ava');
 const { generateChecksumFromStream } = require('..');
+const { normalizeHashAlgorithm } = require('../dist/checksum');
 
 test('generateChecksumFromStream returns correct cksum for file stream', async (t) => {
   const dummyFileCksum = '1685297147';
@@ -22,4 +23,23 @@ test('generateChecksumFromStream returns correct md5 for file stream', async (t)
     {}
   );
   t.is(result, dummyFileMD5);
+});
+
+test('normalizeHashAlgorithm returns expected values', (t) => {
+  t.is(normalizeHashAlgorithm('SHA1'), 'SHA1');
+  t.is(normalizeHashAlgorithm('SHA-1'), 'SHA1');
+
+  t.is(normalizeHashAlgorithm('SHA2'), 'SHA2');
+  t.is(normalizeHashAlgorithm('SHA-2'), 'SHA2');
+
+  t.is(normalizeHashAlgorithm('SHA256'), 'SHA256');
+  t.is(normalizeHashAlgorithm('SHA-256'), 'SHA256');
+
+  t.is(normalizeHashAlgorithm('SHA384'), 'SHA384');
+  t.is(normalizeHashAlgorithm('SHA-384'), 'SHA384');
+
+  t.is(normalizeHashAlgorithm('SHA512'), 'SHA512');
+  t.is(normalizeHashAlgorithm('SHA-512'), 'SHA512');
+
+  t.is(normalizeHashAlgorithm('OTHER'), 'OTHER');
 });


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2299: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2299)

## Changes

* Added support for SHA checksum types with hyphens (e.g. `SHA-256` vs `SHA256`) to tasks that calculate checksums.

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests