### PR TITLE
[CUMULUS-2835] hyrax-metadata-updates: better support for ECHO10 XML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,9 @@ all Cumulus workflow tasks
 
 - **CUMULUS-2775**
   - Updated `@cumulus/api-client` to not log an error for 201 response from `updateGranule`
+- **CUMULUS-2835**
+  - Updated `hyrax-metadata-updates` task to support reading the DatasetId from ECHO10 XML, and the EntryTitle from UMM-G JSON; these are both valid alternatives to the shortname and version ID.
+
 
 ## [v9.9.0] 2021-11-03
 

--- a/tasks/hyrax-metadata-updates/tests/data/echo10-dataset_id-in.xml
+++ b/tasks/hyrax-metadata-updates/tests/data/echo10-dataset_id-in.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Granule>
+    <GranuleUR>GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A20141230.020.nc4</GranuleUR>
+    <InsertTime>2018-02-09T11:01:38Z</InsertTime>
+    <LastUpdate>2018-02-09T11:01:38Z</LastUpdate>
+    <Collection>
+        <DataSetId>GLDAS_CLSM025_D_2.0</DataSetId>
+    </Collection>
+    <DataGranule>
+        <SizeMBDataGranule>24.5028533935547</SizeMBDataGranule>
+        <ProducerGranuleId>GLDAS_CLSM025_D.A20141230.020.nc4</ProducerGranuleId>
+        <DayNightFlag>UNSPECIFIED</DayNightFlag>
+        <ProductionDateTime>2018-02-09T11:01:38Z</ProductionDateTime>
+    </DataGranule>
+    <Temporal>
+        <RangeDateTime>
+            <BeginningDateTime>2014-12-30T00:00:00Z</BeginningDateTime>
+            <EndingDateTime>2014-12-30T23:59:59Z</EndingDateTime>
+        </RangeDateTime>
+    </Temporal>
+    <Spatial>
+        <HorizontalSpatialDomain>
+            <Geometry>
+                <BoundingRectangle>
+                    <WestBoundingCoordinate>-180.0</WestBoundingCoordinate>
+                    <NorthBoundingCoordinate>90.0</NorthBoundingCoordinate>
+                    <EastBoundingCoordinate>180.0</EastBoundingCoordinate>
+                    <SouthBoundingCoordinate>-60.0</SouthBoundingCoordinate>
+                </BoundingRectangle>
+            </Geometry>
+        </HorizontalSpatialDomain>
+    </Spatial>
+    <OnlineAccessURLs>
+        <OnlineAccessURL>
+            <URL>https://hydro1.gesdisc.eosdis.nasa.gov/data/GLDAS/GLDAS_CLSM025_D.2.0/2014/12/GLDAS_CLSM025_D.A20141230.020.nc4</URL>
+        </OnlineAccessURL>
+    </OnlineAccessURLs>
+    <OnlineResources>
+        <OnlineResource>
+            <URL>https://hydro1.gesdisc.eosdis.nasa.gov/data/GLDAS/GLDAS_CLSM025_D.2.0/2014/12/GLDAS_CLSM025_D.A20141230.020.nc4</URL>
+            <Description>Foo</Description>
+            <Type>Bar</Type>
+        </OnlineResource>
+    </OnlineResources>
+    <Orderable>false</Orderable>
+</Granule>

--- a/tasks/hyrax-metadata-updates/tests/data/umm-g-entry-title-in.json
+++ b/tasks/hyrax-metadata-updates/tests/data/umm-g-entry-title-in.json
@@ -1,0 +1,59 @@
+{
+    "RelatedUrls": [
+        {
+            "URL": "https://hydro1.gesdisc.eosdis.nasa.gov/data/GLDAS/GLDAS_CLSM025_D.2.0/2014/12/GLDAS_CLSM025_D.A20141230.020.nc4",
+            "Type": "GET DATA"
+        }
+    ],
+    "SpatialExtent": {
+        "HorizontalSpatialDomain": {
+            "Geometry": {
+                "BoundingRectangles": [
+                    {
+                        "WestBoundingCoordinate": -180.0,
+                        "EastBoundingCoordinate": 180.0,
+                        "NorthBoundingCoordinate": 90.0,
+                        "SouthBoundingCoordinate": -60.0
+                    }
+                ]
+            }
+        }
+    },
+    "ProviderDates": [
+        {
+            "Date": "2018-02-09T11:01:38.000Z",
+            "Type": "Insert"
+        },
+        {
+            "Date": "2018-02-09T11:01:38.000Z",
+            "Type": "Update"
+        }
+    ],
+    "CollectionReference": {
+            "EntryTitle": "GLDAS_CLSM025_D_2.0"
+    },
+    "DataGranule": {
+        "DayNightFlag": "Unspecified",
+        "Identifiers": [
+            {
+                "Identifier": "GLDAS_CLSM025_D.A20141230.020.nc4",
+                "IdentifierType": "ProducerGranuleId"
+            }
+        ],
+        "ProductionDateTime": "2018-02-09T11:01:38.000Z",
+        "ArchiveAndDistributionInformation": [
+            {
+                "Name": "Not provided",
+                "Size": 24.5028533935547,
+                "SizeUnit": "MB"
+            }
+        ]
+    },
+    "TemporalExtent": {
+        "RangeDateTime": {
+            "BeginningDateTime": "2014-12-30T00:00:00.000Z",
+            "EndingDateTime": "2014-12-30T23:59:59.000Z"
+        }
+    },
+    "GranuleUR": "GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A20141230.020.nc4"
+}

--- a/tasks/hyrax-metadata-updates/tests/test-index.js
+++ b/tasks/hyrax-metadata-updates/tests/test-index.js
@@ -18,6 +18,7 @@ const HyraxMetadataUpdate = rewire('../index');
 const generateAddress = HyraxMetadataUpdate.__get__('generateAddress');
 const getGranuleUr = HyraxMetadataUpdate.__get__('getGranuleUr');
 const addHyraxUrl = HyraxMetadataUpdate.__get__('addHyraxUrl');
+const getCmrSearchParams = HyraxMetadataUpdate.__get__('getCmrSearchParams');
 
 test.afterEach.always(() => {
   delete process.env.CMR_ENVIRONMENT;
@@ -127,4 +128,59 @@ test('Test adding OPeNDAP URL to ECHO10 file with two OnlineResources', async (t
   const expected = fs.readFileSync('tests/data/echo10out-2-online-resource-urls.xml', 'utf8');
   const actual = addHyraxUrl(metadata, false, 'https://opendap.earthdata.nasa.gov/collections/C1453188197-GES_DISC/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4');
   t.is(actual, expected.trim('\n'));
+});
+
+test('Test building CMR Search Params with short name and version', (t) => {
+  const inputSearchParams = {
+    shortName: 'GLDAS_CLSM025_D',
+    versionId: '2.0',
+  };
+  const expected = {
+    short_name: 'GLDAS_CLSM025_D',
+    version: '2.0',
+  };
+  const actual = getCmrSearchParams(inputSearchParams);
+  t.deepEqual(actual, expected);
+});
+
+test('Test building CMR Search Params with dataset ID', (t) => {
+  const inputSearchParams = {
+    datasetId: 'GLDAS_CLSM025_D.2.0',
+  };
+  const expected = {
+    dataset_id: 'GLDAS_CLSM025_D.2.0',
+  };
+  const actual = getCmrSearchParams(inputSearchParams);
+  t.deepEqual(actual, expected);
+});
+
+test('Test building invalid CMR Search Params with short name, version, and dataset ID', (t) => {
+  const inputSearchParams = {
+    datasetId: 'GLDAS_CLSM025_D.2.0',
+    shortName: 'GLDAS_CLSM025_D',
+    versionId: '2.0',
+  };
+
+  t.throws(
+    () => getCmrSearchParams(inputSearchParams),
+    {
+      message: 'Invalid list of keys for searchParams: dataset_id,short_name,version',
+      instanceOf: Error,
+    }
+  );
+});
+
+test('Test building invalid CMR Search Params with invalid params', (t) => {
+  const inputSearchParams = {
+    datasetId: 'GLDAS_CLSM025_D.2.0',
+    versionId: '2.0',
+  };
+
+  t.throws(
+    () => getCmrSearchParams(inputSearchParams),
+    {
+      message: 'Invalid list of keys for searchParams: dataset_id,version',
+      instanceOf: Error,
+    }
+  );
 });

--- a/tasks/hyrax-metadata-updates/tests/test-integration-index.js
+++ b/tasks/hyrax-metadata-updates/tests/test-integration-index.js
@@ -8,6 +8,7 @@ const test = require('ava');
 const proxyquire = require('proxyquire');
 const fs = require('fs');
 const xml2js = require('xml2js');
+const merge = require('lodash/merge');
 const pickAll = require('lodash/fp/pickAll');
 
 const xmlParseOptions = {
@@ -80,17 +81,17 @@ test.before(async () => {
   }).promise();
 });
 
-test.beforeEach(() => {
+const setupNock = (params) => {
+  const cmrParams = merge({
+    page_size: '50',
+    page_num: '1',
+    provider_short_name: 'GES_DISC',
+  }, params);
+
   // Mock out retrieval of collection entry from CMR
   const headers = { 'cmr-hits': 1, 'Content-Type': 'application/json;charset=utf-8' };
   nock('https://cmr.earthdata.nasa.gov').get('/search/collections.json')
-    .query({
-      short_name: 'GLDAS_CLSM025_D',
-      version: '2.0',
-      page_size: '50',
-      page_num: '1',
-      provider_short_name: 'GES_DISC',
-    })
+    .query(cmrParams)
     .replyWithFile(200, 'tests/data/cmr-results.json', headers);
 
   nock('https://cmr.earthdata.nasa.gov')
@@ -98,7 +99,13 @@ test.beforeEach(() => {
     .reply(200, { token: 'ABCDE' });
 
   process.env.CMR_ENVIRONMENT = 'OPS';
-});
+};
+
+test.beforeEach(() =>
+  setupNock({
+    short_name: 'GLDAS_CLSM025_D',
+    version: '2.0',
+  }));
 
 test.afterEach.always(() => {
   nock.cleanAll();
@@ -662,7 +669,7 @@ test.serial('Test retrieving optional entry collection from CMR using UMM-G', as
   t.is(actual, 'C1453188197-GES_DISC/GLDAS_CLSM025_D.2.0');
 });
 
-test.serial('Test retrieving default entry collection from CMR using UMM-G', async (t) => {
+test.serial('Test retrieving default entry collection from CMR using UMM-G with ShortName and Version', async (t) => {
   const data = fs.readFileSync('tests/data/umm-gin.json', 'utf8');
   const metadataObject = JSON.parse(data);
 
@@ -670,8 +677,25 @@ test.serial('Test retrieving default entry collection from CMR using UMM-G', asy
   t.is(actual, 'C1453188197-GES_DISC');
 });
 
-test.serial('Test retrieving entry collection from CMR using ECHO10', async (t) => {
+test.serial('Test retrieving default entry collection from CMR using UMM-G with EntryTitle', async (t) => {
+  setupNock({ dataset_id: 'GLDAS_CLSM025_D_2.0' });
+  const data = fs.readFileSync('tests/data/umm-g-entry-title-in.json', 'utf8');
+  const metadataObject = JSON.parse(data);
+
+  const actual = await getCollectionEntry(event.config, metadataObject, true);
+  t.is(actual, 'C1453188197-GES_DISC');
+});
+
+test.serial('Test retrieving entry collection from CMR using ECHO10 with ShortName and VersionId', async (t) => {
   const data = fs.readFileSync('tests/data/echo10in.xml', 'utf8');
+  const metadata = await (promisify(xml2js.parseString))(data, xmlParseOptions);
+  const actual = await getCollectionEntry(event.config, metadata, false);
+  t.is(actual, 'C1453188197-GES_DISC');
+});
+
+test.serial('Test retrieving entry collection from CMR using ECHO10 with DataSetId', async (t) => {
+  setupNock({ dataset_id: 'GLDAS_CLSM025_D_2.0' });
+  const data = fs.readFileSync('tests/data/echo10-dataset_id-in.xml', 'utf8');
   const metadata = await (promisify(xml2js.parseString))(data, xmlParseOptions);
   const actual = await getCollectionEntry(event.config, metadata, false);
   t.is(actual, 'C1453188197-GES_DISC');

--- a/tasks/hyrax-metadata-updates/tests/test-search-failures.js
+++ b/tasks/hyrax-metadata-updates/tests/test-search-failures.js
@@ -55,7 +55,7 @@ test.after.always(async () => {
   }).promise();
 });
 
-test.serial('Test retrieving collection entry with invalid result', async (t) => {
+test.serial('Test retrieving collection entry with invalid result (no "id" key)', async (t) => {
   // Mock out retrieval of entryTitle from CMR
   const headers = { 'cmr-hits': 1, 'Content-Type': 'application/json;charset=utf-8' };
   nock('https://cmr.earthdata.nasa.gov').get('/search/collections.json')
@@ -73,7 +73,7 @@ test.serial('Test retrieving collection entry with invalid result', async (t) =>
 
   await t.throwsAsync(getCollectionEntry(event.config, metadataObject, true), {
     instanceOf: RecordDoesNotExist,
-    message: 'Unable to query parent collection using short name GLDAS_CLSM025_D and version 2.0',
+    message: 'Unable to query parent collection using: {"short_name":"GLDAS_CLSM025_D","version":"2.0"}',
   });
 });
 
@@ -95,6 +95,6 @@ test.serial('Test retrieving entry title with no results', async (t) => {
 
   await t.throwsAsync(getCollectionEntry(event.config, metadataObject, true), {
     instanceOf: RecordDoesNotExist,
-    message: 'Unable to query parent collection using short name undefined and version undefined',
+    message: 'Unable to query parent collection using: {"short_name":"GLDAS_CLSM025_D","version":"2.0"}',
   });
 });


### PR DESCRIPTION
**Summary:**

Addresses [CUMULUS-2835](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2835)

allow `getCollectionEntry` to support DataSetId/EntryTitle

## Changes

- [per ECHO10 XML schema][0], the [Collection][1] can use short name and
  version, *or* dataset ID
- [per UMM-G JSON schema][2], the CollectionReference can use short name and
  version, *or* entry title
- new integration tests are copied from existing tests, using a copied fixture
  modified to use DatasetId/EntryTitle instead of short name and version

[0]: https://github.com/nasa/Common-Metadata-Repository/blob/1.186.0-r21.4.3/umm-spec-lib/resources/xml-schemas/echo10/Granule.xsd
[1]: https://github.com/nasa/Common-Metadata-Repository/blob/1.186.0-r21.4.3/umm-spec-lib/resources/xml-schemas/echo10/Collection.xsd#L200
[2]: https://github.com/nasa/Common-Metadata-Repository/blob/1.186.0-r21.4.3/umm-spec-lib/resources/json-schemas/granule/umm/v1.6.4/umm-g-json-schema.json

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests

Co-authored by: Mark Schwab <Mark.Schwab@colorado.edu>