### PR TITLE
Fix Misspellings across Cumulus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1177,7 +1177,7 @@ included in the future will have a corresponding CHANGELOG entry in future relea
   - Deploy ORCA with Cumulus, see `example/cumulus-tf/orca.tf` and `example/cumulus-tf/terraform.tfvars.example`
   - Add `CopyToGlacier` step to [example IngestAndPublishGranule workflow](https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/ingest_and_publish_granule_workflow.asl.json)
 - **CUMULUS-2424**
-  - Added `childWorkflowMeta` to `queue-pdrs` config. An object passed to this config value will be merged into a child workflow message's `meta` object. For an example of how this can be used, see `example/cumulus-tf/discover_and_queue_pdrs_with_child_workflow_meta_wworkflow.asl.json`.
+  - Added `childWorkflowMeta` to `queue-pdrs` config. An object passed to this config value will be merged into a child workflow message's `meta` object. For an example of how this can be used, see `example/cumulus-tf/discover_and_queue_pdrs_with_child_workflow_meta_workflow.asl.json`.
 - **CUMULUS-2427**
   - Added support for using a custom queue with SQS and Kinesis rules. Whatever queue URL is set on the `rule.queueUrl` property will be used to schedule workflows for that rule. This change allows SQS/Kinesis rules to use [any throttled queues defined for a deployment](https://nasa.github.io/cumulus/docs/data-cookbooks/throttling-queued-executions).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1720,7 +1720,7 @@ new `update-granules-cmr-metadata-file-links` task.
   - Changed `distribution_api_gateway_stage` variable for `cumulus` module to `tea_api_gateway_stage`
   - Changed `api_gateway_stage` variable for `distribution` module to `tea_api_gateway_stage`
 - **CUMULUS-2224**
-  - Updated `/reconciliationReport`'s file reconciliation to included `"EXTENDED METADATA"` as a valid CMR relatedUrls Type.
+  - Updated `/reconciliationReport`'s file reconciliation to include `"EXTENDED METADATA"` as a valid CMR relatedUrls Type.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -699,7 +699,7 @@ releases.
 
 - **[PR2224](https://github.com/nasa/cumulus/pull/2244)**
   - Changed timeout on `sfEventSqsToDbRecords` Lambda to 60 seconds to match
-    timeout for Knex library to acquire dataase connections
+    timeout for Knex library to acquire database connections
 - **CUMULUS-2208**
   - Moved all `@cumulus/api/es/*` code to new `@cumulus/es-client` package
 - Changed timeout on `sfEventSqsToDbRecords` Lambda to 60 seconds to match
@@ -722,7 +722,7 @@ releases.
     [1.6.2](https://cdn.earthdata.nasa.gov/umm/granule/v1.6.2/umm-g-json-schema.json)
 - **CUMULUS-2472**
   - Renamed `@cumulus/earthdata-login-client` to more generic
-    `@cumulus/oauth-client` as a parnt  class for new OAuth clients.
+    `@cumulus/oauth-client` as a parent  class for new OAuth clients.
   - Added `@cumulus/oauth-client/CognitoClient` to interface with AWS cognito login service.
 - **CUMULUS-2497**
   - Changed the `@cumulus/cmrjs` package:
@@ -1177,7 +1177,7 @@ included in the future will have a corresponding CHANGELOG entry in future relea
   - Deploy ORCA with Cumulus, see `example/cumulus-tf/orca.tf` and `example/cumulus-tf/terraform.tfvars.example`
   - Add `CopyToGlacier` step to [example IngestAndPublishGranule workflow](https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/ingest_and_publish_granule_workflow.asl.json)
 - **CUMULUS-2424**
-  - Added `childWorkflowMeta` to `queue-pdrs` config. An object passed to this config value will be merged into a child workflow message's `meta` object. For an example of how this can be used, see `example/cumulus-tf/discover_and_queue_pdrs_with_child_workflow_meta_workflow.asl.json`.
+  - Added `childWorkflowMeta` to `queue-pdrs` config. An object passed to this config value will be merged into a child workflow message's `meta` object. For an example of how this can be used, see `example/cumulus-tf/discover_and_queue_pdrs_with_child_workflow_meta_wworkflow.asl.json`.
 - **CUMULUS-2427**
   - Added support for using a custom queue with SQS and Kinesis rules. Whatever queue URL is set on the `rule.queueUrl` property will be used to schedule workflows for that rule. This change allows SQS/Kinesis rules to use [any throttled queues defined for a deployment](https://nasa.github.io/cumulus/docs/data-cookbooks/throttling-queued-executions).
 
@@ -1659,7 +1659,7 @@ new `update-granules-cmr-metadata-file-links` task.
   - Update reports to return breakdown by Granule of files both in DynamoDB and S3
 - **CUMULUS-2123**
   - Added `cumulus-rds-tf` DB cluster module to `tf-modules` that adds a
-    severless RDS Aurora/ PostgreSQL  database cluster to meet the PostgreSQL
+    serverless RDS Aurora/ PostgreSQL  database cluster to meet the PostgreSQL
     requirements for future releases.
   - Updated the default Cumulus module to take the following new required variables:
     - rds_user_access_secret_arn:
@@ -1720,7 +1720,7 @@ new `update-granules-cmr-metadata-file-links` task.
   - Changed `distribution_api_gateway_stage` variable for `cumulus` module to `tea_api_gateway_stage`
   - Changed `api_gateway_stage` variable for `distribution` module to `tea_api_gateway_stage`
 - **CUMULUS-2224**
-  - Updated `/reconciliationReport`'s file reconciliation to include `"EXTENDED METADATA"` as a valid CMR relatedUrls Type.
+  - Updated `/reconciliationReport`'s file reconciliation to included `"EXTENDED METADATA"` as a valid CMR relatedUrls Type.
 
 ### Fixed
 
@@ -1934,7 +1934,7 @@ the [release page](https://github.com/nasa/cumulus/releases)
   result in a "Client not connected" exception being thrown.
 - Instances of `@cumulus/ingest/SftpProviderClient` no longer implicitly
   disconnect from the SFTP server when `list` is called.
-- Instances of `@cumulus/sftp-client/SftpClient` must now be expclicitly closed
+- Instances of `@cumulus/sftp-client/SftpClient` must now be explicitly closed
   by calling `.end()`
 - Instances of `@cumulus/sftp-client/SftpClient` no longer implicitly connect to
   the server when `download`, `unlink`, `syncToS3`, `syncFromS3`, and `list` are

--- a/docs/data-cookbooks/about-cookbooks.md
+++ b/docs/data-cookbooks/about-cookbooks.md
@@ -10,7 +10,7 @@ The following data cookbooks are documents containing examples and explanations 
 
 ## Setup
 
-The data cookbooks assume you can configure providers, collections, and rules to run workflows. Visit [Cumulus data management types](../configuration/data-management-types) for information on how to conifgure Cumulus data management types.
+The data cookbooks assume you can configure providers, collections, and rules to run workflows. Visit [Cumulus data management types](../configuration/data-management-types) for information on how to configure Cumulus data management types.
 
 ## Adding a page
 

--- a/docs/data-cookbooks/queue-post-to-cmr.md
+++ b/docs/data-cookbooks/queue-post-to-cmr.md
@@ -4,7 +4,7 @@ title: Queue PostToCmr
 hide_title: false
 ---
 
-In this document, we walktrough handling CMR errors in workflows by queueing PostToCmr. We assume that the user already has an ingest workflow setup.
+In this document, we walkthrough handling CMR errors in workflows by queueing PostToCmr. We assume that the user already has an ingest workflow setup.
 
 ## Overview
 

--- a/docs/features/reports.md
+++ b/docs/features/reports.md
@@ -27,7 +27,7 @@ This report shows the following data:
 The Cumulus Dashboard offers an interface to create, manage and view these inventory reports.
 
 The Reconciliation Reports Overview page shows a full list of existing reports and the option to create a new report.
-![Screenshot of the Dashboard Rconciliation Reports Overview page](assets/rec_reports_overview.png)
+![Screenshot of the Dashboard Reconciliation Reports Overview page](assets/rec_reports_overview.png)
 
 Viewing an inventory report will show a detailed list of collections, granules and files.
 ![Screenshot of an Inventory Report page](assets/inventory_report.png)

--- a/docs/upgrade-notes/upgrading-tf-version-0.13.6.md
+++ b/docs/upgrade-notes/upgrading-tf-version-0.13.6.md
@@ -8,7 +8,7 @@ hide_title: false
 
 Cumulus pins its support to a specific version of Terraform [see: deployment documentation](../deployment/README.md#install-terraform). The reason for only supporting one specific Terraform version at a time is to avoid deployment errors than can be caused by deploying to the same target with different Terraform versions.
 
-Cumulus is upgrading its supported version of Terraform from **0.12.12** to **0.13.6**. This document contains instructions on how to perform the uprade for your deployments.
+Cumulus is upgrading its supported version of Terraform from **0.12.12** to **0.13.6**. This document contains instructions on how to perform the upgrade for your deployments.
 
 ### Prerequisites
 

--- a/docs/workflows/docker.md
+++ b/docs/workflows/docker.md
@@ -83,7 +83,7 @@ ENTRYPOINT ["/work/process.py"]
 CMD ["input", "output"]
 ```
 
-When this Dockerfile is built, docker will first use the latest cumulus-base image. It will then copy the entire GitHub repository (the processing required for a single data collection is a repository) to the `/work` directory which will now contain all the code necessary to process this data. In thie case, a C file is compiled to convert the supplied hdf5 files to NetCDF files. Note that this also requires installing the system libraries `nco` and `libhdf5-dev` via `apt-get`. Lastly, the Dockerfile sets the entrypoint to the processing handler, so that this command is run when the image is run. It expects two arguments to be handed to it: 'input' and 'output' meaning the input and output directories.
+When this Dockerfile is built, docker will first use the latest cumulus-base image. It will then copy the entire GitHub repository (the processing required for a single data collection is a repository) to the `/work` directory which will now contain all the code necessary to process this data. In this case, a C file is compiled to convert the supplied hdf5 files to NetCDF files. Note that this also requires installing the system libraries `nco` and `libhdf5-dev` via `apt-get`. Lastly, the Dockerfile sets the entrypoint to the processing handler, so that this command is run when the image is run. It expects two arguments to be handed to it: 'input' and 'output' meaning the input and output directories.
 
 ## Process Handler
 

--- a/example/README.md
+++ b/example/README.md
@@ -202,7 +202,7 @@ Run `terraform apply`.
 
 These steps should be performed in the `example` directory.
 
-Copy `.env.sample` to `.env`, filling in approriate values for your deployment.
+Copy `.env.sample` to `.env`, filling in appropriate values for your deployment.
 
 Set the `DEPLOYMENT` environment variable to match the `prefix` that you
 configured in your `terraform.tfvars` files.

--- a/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
@@ -1267,7 +1267,7 @@ describe('The S3 Ingest Granules workflow', () => {
         if (subTestSetupError) fail(subTestSetupError);
       });
 
-      it('returns a list of exeuctions', () => {
+      it('returns a list of executions', () => {
         failOnSetupError([beforeAllError, subTestSetupError]);
         expect(executions.results.length).toBeGreaterThan(0);
       });

--- a/packages/api/lambdas/create-reconciliation-report.js
+++ b/packages/api/lambdas/create-reconciliation-report.js
@@ -590,7 +590,7 @@ exports.reconciliationReportForGranules = reconciliationReportForGranules;
  * @param {number} [params.recReportParams.StartTimestamp]
  * @param {number} [params.recReportParams.EndTimestamp]
  * @param {string} [params.recReportparams.collectionIds]
- * @returns {Promise<Object>}                    - a reconcilation report
+ * @returns {Promise<Object>}                    - a reconciliation report
  */
 async function reconciliationReportForCumulusCMR(params) {
   log.info(`reconciliationReportForCumulusCMR with params ${JSON.stringify(params)}`);

--- a/packages/api/tests/lambdas/test-create-reconciliation-report.js
+++ b/packages/api/tests/lambdas/test-create-reconciliation-report.js
@@ -808,7 +808,7 @@ test.serial('Generates valid reconciliation report when there are both extra ES 
 });
 
 test.serial(
-  'With input time params, generates a valid filtered reconcilation report, when there are extra cumulus/ES and CMR collections',
+  'With input time params, generates a valid filtered reconciliation report, when there are extra cumulus/ES and CMR collections',
   async (t) => {
     const { startTimestamp, endTimestamp, ...setupVars } = await setupElasticAndCMRForTests({ t });
 
@@ -856,7 +856,7 @@ test.serial(
 );
 
 test.serial(
-  'With location param as S3, generates a valid reconcilation report for only S3 and DynamoDB',
+  'With location param as S3, generates a valid reconciliation report for only S3 and DynamoDB',
   async (t) => {
     const dataBuckets = range(2).map(() => randomId('bucket'));
     await Promise.all(dataBuckets.map((bucket) =>
@@ -914,7 +914,7 @@ test.serial(
 );
 
 test.serial(
-  'With location param as CMR, generates a valid reconcilation report for only Cumulus and CMR',
+  'With location param as CMR, generates a valid reconciliation report for only Cumulus and CMR',
   async (t) => {
     const params = {
       numMatchingCollectionsOutOfRange: 0,

--- a/packages/db/src/models/execution.ts
+++ b/packages/db/src/models/execution.ts
@@ -42,11 +42,11 @@ class ExecutionPgModel extends BasePgModel<PostgresExecution, PostgresExecutionR
    * @param {Knex | Knex.Transaction} knexOrTrx -
    *  DB client or transaction
    * @param {Array<number>} executionCumulusIds -
-   * single execution cumulus_id or array of exeuction cumulus_ids
+   * single execution cumulus_id or array of execution cumulus_ids
    * @param {Object} [params] - Optional object with addition params for query
    * @param {number} [params.limit] - number of records to be returned
    * @param {number} [params.offset] - record offset
-   * @returns {Promise<Array<number>>} An array of exeuctions
+   * @returns {Promise<Array<number>>} An array of executions
    */
   async searchByCumulusIds(
     knexOrTrx: Knex | Knex.Transaction,

--- a/packages/ingest/README.md
+++ b/packages/ingest/README.md
@@ -28,7 +28,7 @@ LOCALSTACK_HOST=localhost npm test
 
 All modules are accessible using require: `require('@cumulus/ingest/<MODULE_NAME>')` or import: `import <MODULE_NAME> from '@cumulus/ingest/<MODULE_NAME>'`.
 
-- [`consumer`](./consumer.js) - comsumer for SQS messages
+- [`consumer`](./consumer.js) - consumer for SQS messages
 - [`crypto`](./crypto.js) - provides encryption and decryption methods with a consistent API but differing mechanisms for dealing with encryption keys
 - [`ftp`](./ftp.js) - for accessing FTP servers
 - [`granule`](./granule.js) - discovers and ingests granules

--- a/packages/integration-tests/api/executions.js
+++ b/packages/integration-tests/api/executions.js
@@ -14,7 +14,7 @@ const executionsApi = require('@cumulus/api-client/executions');
  * @returns {Promise<Object>} - the execution fetched by the API
  */
 const getExecution = async (params) => {
-  deprecate('@cumulus/integration-tests/exeuctions.getExecution', '1.21.0', '@cumulus/api-client/ems.getExecution');
+  deprecate('@cumulus/integration-tests/executions.getExecution', '1.21.0', '@cumulus/api-client/ems.getExecution');
   return await executionsApi.getExecution(params);
 };
 
@@ -43,7 +43,7 @@ const getExecutions = async (params) => {
  * @returns {Promise<Object>} - the execution status fetched by the API
  */
 async function getExecutionStatus(params) {
-  deprecate('@cumulus/integration-tests/exeuctions.getExecutionStatus', '1.21.0', '@cumulus/api-client/executions.getExecutionStatus');
+  deprecate('@cumulus/integration-tests/executions.getExecutionStatus', '1.21.0', '@cumulus/api-client/executions.getExecutionStatus');
   return await executionsApi.getExecutionStatus(params);
 }
 

--- a/tf-modules/README.md
+++ b/tf-modules/README.md
@@ -55,6 +55,6 @@ If the module has been integrated into the Cumulus module or the example Cumulus
 If the module is a standalone module that should not be integrated as a submodule (e.g. [`data-persistence`](https://github.com/nasa/cumulus/blob/master/tf-modules/data-persistence/outputs.tf)), then you will need to follow these steps to include it in the CI/CD pipeline:
 
 1. Add a reference implementation for using your module in the `example` directory. See the [reference implementation for the `data-persistence` module](https://github.com/nasa/cumulus/blob/master/example/data-persistence-tf).
-    - Make sure to include a [`provider` configuration](https://www.terraform.io/docs/configuration/providers.html) in your `.tf` files, which defines what provider will be interpret the Terraform reosources
+    - Make sure to include a [`provider` configuration](https://www.terraform.io/docs/configuration/providers.html) in your `.tf` files, which defines what provider will be interpret the Terraform resources
 2. Update the [CI Terraform deployment script](https://github.com/nasa/cumulus/blob/master/bamboo/bootstrap-tf-deployment.sh) to deploy your module.
     - Make sure to add remote state handling for deploying your module so that each CI build only update the existing deployment as necessary, because local Terraform state in the CI will not persist between builds.

--- a/website/versioned_docs/version-1.11.0/data-cookbooks/setup.md
+++ b/website/versioned_docs/version-1.11.0/data-cookbooks/setup.md
@@ -7,7 +7,7 @@ original_id: setup
 
 # Setup
 
-### Getting setup to work with data-cookboooks
+### Getting setup to work with data-cookbooks
 
 In the following data cookbooks we'll go through things like setting up workflows, making configuration changes, and interacting with CNM. The point of this section is to set up, or at least better understand, collections, providers, and rules and how they are configured.
 

--- a/website/versioned_docs/version-1.11.0/upgrade/1.9.0.md
+++ b/website/versioned_docs/version-1.11.0/upgrade/1.9.0.md
@@ -11,7 +11,7 @@ original_id: 1.9.0
 
 ## Additional Functionality
 
-Cumulus 1.9 uses versioned collections to support granules from different collections and verison numbers.
+Cumulus 1.9 uses versioned collections to support granules from different collections and version numbers.
 These granules usually come from PDRs where objects are defined with a DATA_VERSION and DATA_TYPE
 The associated collections should reflect the same version and dataType.  CMR would also need to use the same dataType.
 If a dataType is not provided, Cumulus will use the collection name.

--- a/website/versioned_docs/version-1.12.0/data-cookbooks/setup.md
+++ b/website/versioned_docs/version-1.12.0/data-cookbooks/setup.md
@@ -7,7 +7,7 @@ original_id: setup
 
 # Setup
 
-### Getting setup to work with data-cookboooks
+### Getting setup to work with data-cookbooks
 
 In the following data cookbooks we'll go through things like setting up workflows, making configuration changes, and interacting with CNM. The point of this section is to set up, or at least better understand, collections, providers, and rules and how they are configured.
 

--- a/website/versioned_docs/version-1.15.0/data-cookbooks/hello-world.md
+++ b/website/versioned_docs/version-1.15.0/data-cookbooks/hello-world.md
@@ -87,7 +87,7 @@ Our goal here is to create a rule through the Cumulus dashboard that will define
 
 The `Executions` page presents a list of all executions, their status (running, failed, or completed), to which workflow the execution belongs, along with other information. The rule defined in the previous section should start an execution of its own accord, and the status of that execution can be tracked here.
 
-To get some deeper information on the execution, click on the value in the `Name` column of your execution of interest. This should bring up a visual representation of the worklfow similar to that shown above, execution details, and a list of events.
+To get some deeper information on the execution, click on the value in the `Name` column of your execution of interest. This should bring up a visual representation of the workflow similar to that shown above, execution details, and a list of events.
 
 ## Summary
 

--- a/website/versioned_docs/version-1.15.0/data-cookbooks/setup.md
+++ b/website/versioned_docs/version-1.15.0/data-cookbooks/setup.md
@@ -7,7 +7,7 @@ original_id: setup
 
 # Setup
 
-## Getting setup to work with data-cookboooks
+## Getting setup to work with data-cookbooks
 
 In the following data cookbooks we'll go through things like setting up workflows, making configuration changes, and interacting with CNM. The point of this section is to set up, or at least better understand, collections, providers, and rules and how they are configured.
 

--- a/website/versioned_docs/version-1.15.0/deployment/config_descriptions.md
+++ b/website/versioned_docs/version-1.15.0/deployment/config_descriptions.md
@@ -21,7 +21,7 @@ dynamos:
 
 ### config.yml Requirements
 
-This table describes the fields that must be present in `config.yml` to successfully deploy our cloudformation template, and under what conditions. For descriptions, see the complete table below or each item's entry in the invidivual listings on the rest of this page.
+This table describes the fields that must be present in `config.yml` to successfully deploy our cloudformation template, and under what conditions. For descriptions, see the complete table below or each item's entry in the individual listings on the rest of this page.
 
 | field | condition
 | ----- | -----------

--- a/website/versioned_docs/version-v1.10.1/data-cookbooks/hello-world.md
+++ b/website/versioned_docs/version-v1.10.1/data-cookbooks/hello-world.md
@@ -100,7 +100,7 @@ Our goal here is to create a rule through the Cumulus dashboard that will define
 
 The `Executions` page presents a list of all executions, their status (running, failed, or completed), to which workflow the execution belongs, along with other information. The rule defined in the previous section should start an execution of its own accord, and the status of that execution can be tracked here.
 
-To get some deeper information on the execution, click on the value in the `Name` column of your execution of interest. This should bring up a visual representation of the worklfow similar to that shown above, execution details, and a list of events.
+To get some deeper information on the execution, click on the value in the `Name` column of your execution of interest. This should bring up a visual representation of the workflow similar to that shown above, execution details, and a list of events.
 
 ## Summary
 

--- a/website/versioned_docs/version-v1.10.1/data-cookbooks/setup.md
+++ b/website/versioned_docs/version-v1.10.1/data-cookbooks/setup.md
@@ -7,7 +7,7 @@ original_id: setup
 
 # Setup
 
-### Getting setup to work with data-cookboooks
+### Getting setup to work with data-cookbooks
 
 In the following data cookbooks we'll go through things like setting up workflows, making configuration changes, and interacting with CNM. The point of this section is to set up, or at least better understand, collections, providers, and rules and how they are configured.
 

--- a/website/versioned_docs/version-v1.10.1/data-cookbooks/sips-workflow.md
+++ b/website/versioned_docs/version-v1.10.1/data-cookbooks/sips-workflow.md
@@ -110,7 +110,7 @@ _Example configuration for this workflow can be found in the `DiscoverAndQueuePd
 
 ## ParsePdr Workflow
 
-The ParsePdr workflow will parse a PDR, queue the specified granules (duplicates are handled according to the duplicate handling setting) and periodically check the status of those queued granules. This workflow will not succeed until all the granules included in the PDR are successfully ingested. If one of those fails, the ParsePdr worklfow will fail. **NOTE** that ParsePdr may spin up multiple IngestGranule workflows in parallel, depending on the granules included in the PDR.
+The ParsePdr workflow will parse a PDR, queue the specified granules (duplicates are handled according to the duplicate handling setting) and periodically check the status of those queued granules. This workflow will not succeed until all the granules included in the PDR are successfully ingested. If one of those fails, the ParsePdr workflow will fail. **NOTE** that ParsePdr may spin up multiple IngestGranule workflows in parallel, depending on the granules included in the PDR.
 
 1. ParsePdr - [npm package](https://www.npmjs.com/package/@cumulus/parse-pdr), [source](https://github.com/nasa/cumulus/tree/master/tasks/parse-pdr)
 2. QueueGranules - [npm package](https://www.npmjs.com/package/@cumulus/queue-granules), [source](https://github.com/nasa/cumulus/tree/master/tasks/queue-granules)

--- a/website/versioned_docs/version-v1.10.1/data-cookbooks/sns.md
+++ b/website/versioned_docs/version-v1.10.1/data-cookbooks/sns.md
@@ -108,7 +108,7 @@ SfSnsReport:
 
 ### Subscribing Additional Listeners
 
-Additional listeners to the SF tracker topic can be configured in `app/config.yml` under `sns.sftracker.subscriptions`. Shown below is configuration that subscribes an additional lambda function (`SnsS3Test`) to receive broadcasts from the `sftracker` SNS. The `endpoint` value depends on the protocol, and for a  lambda function, requres the function's Arn. In the configuration it is populated by finding the lambda's Arn attribute via [Fn::GetAtt](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html). Note the lambda name configured in `lambdas.yml` `SnsS3Test` needs to have it's name postpended with `LambdaFunction` to have the Arn correctly found.
+Additional listeners to the SF tracker topic can be configured in `app/config.yml` under `sns.sftracker.subscriptions`. Shown below is configuration that subscribes an additional lambda function (`SnsS3Test`) to receive broadcasts from the `sftracker` SNS. The `endpoint` value depends on the protocol, and for a  lambda function, requires the function's Arn. In the configuration it is populated by finding the lambda's Arn attribute via [Fn::GetAtt](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html). Note the lambda name configured in `lambdas.yml` `SnsS3Test` needs to have it's name postpended with `LambdaFunction` to have the Arn correctly found.
 
 ```yaml
 sns:
@@ -127,7 +127,7 @@ Make sure that the receiver lambda is configured in `lambdas.yml`.
 
 ### SNS message format
 
-The configured `SfSnsReport` lambda receives the Cumulus message [(as the lambda's task input)](../workflows/input_output.html#2-resolve-task-input) and is responsible for publishing the message to the sftracker SNS Topic. But before it publishes the message, `SfSnsReport` makes a determiniation about the workflow status and adds an additional metadata key to the message at `message.meta.status`.
+The configured `SfSnsReport` lambda receives the Cumulus message [(as the lambda's task input)](../workflows/input_output.html#2-resolve-task-input) and is responsible for publishing the message to the sftracker SNS Topic. But before it publishes the message, `SfSnsReport` makes a determination about the workflow status and adds an additional metadata key to the message at `message.meta.status`.
 
 First it determines whether the workflow has finished by looking for the `sfnEnd` key in the `config` object.  If the workflow has finished, it checks to see if it has failed by searching the input message for a non-empty `exception` object. The lambda updates the `message.meta.status` with `failed` or `completed` based on that result.  If the workflow is not finished the lambda sets `message.meta.status` to `running`.
 

--- a/website/versioned_docs/version-v1.10.1/upgrade/1.9.0.md
+++ b/website/versioned_docs/version-v1.10.1/upgrade/1.9.0.md
@@ -9,7 +9,7 @@ original_id: 1.9.0
 
 ## Additional Functionality
 
-Cumulus 1.9 uses versioned collections to support granules from different collections and verison numbers.
+Cumulus 1.9 uses versioned collections to support granules from different collections and version numbers.
 These granules usually come from PDRs where objects are defined with a DATA_VERSION and DATA_TYPE
 The associated collections should reflect the same version and dataType.  CMR would also need to use the same dataType.
 If a dataType is not provided, Cumulus will use the collection name.

--- a/website/versioned_docs/version-v1.10.1/workflows/docker.md
+++ b/website/versioned_docs/version-v1.10.1/workflows/docker.md
@@ -54,7 +54,7 @@ The generation of the released tagged images are created and deployed automatica
 
 ### docker-base
 
-Docker images are built in layers, allowing common dependencies to be shared to child Docker images. A base docker image is provided that includes some dependencies shared among the current HS3 data processing codes. This includes NetCDF liraries, AWS Cli, Python, Git, as well as py-cumulus, a collection of Python utilities that are used in the processing scripts. The docker-base repository is used to generate new images that are then stored in AWS ECR.
+Docker images are built in layers, allowing common dependencies to be shared to child Docker images. A base docker image is provided that includes some dependencies shared among the current HS3 data processing codes. This includes NetCDF libraries, AWS Cli, Python, Git, as well as py-cumulus, a collection of Python utilities that are used in the processing scripts. The docker-base repository is used to generate new images that are then stored in AWS ECR.
 
 The docker-base image can be interacted with by running it in interactive mode (ie, `docker run -it docker-base`, since the default "entrypoint" to the image is a bash shell.
 
@@ -82,7 +82,7 @@ ENTRYPOINT ["/work/process.py"]
 CMD ["input", "output"]
 ```
 
-When this Dockerfile is built, docker will first use the latest cumulus-base image. It will then copy the entire GitHub repository (the processing required for a single data collection is a repository) to the `/work` directory which will now contain all the code necessary to process this data. In thie case, a C file is compiled to convert the supplied hdf5 files to NetCDF files. Note that this also requires installing the system libraries `nco` and `libhdf5-dev` via `apt-get`. Lastly, the Dockerfile sets the entrypoint to the processing handler, so that this command is run when the image is run. It expects two arguments to be handed to it: 'input' and 'output' meaning the input and output directories.
+When this Dockerfile is built, docker will first use the latest cumulus-base image. It will then copy the entire GitHub repository (the processing required for a single data collection is a repository) to the `/work` directory which will now contain all the code necessary to process this data. In this case, a C file is compiled to convert the supplied hdf5 files to NetCDF files. Note that this also requires installing the system libraries `nco` and `libhdf5-dev` via `apt-get`. Lastly, the Dockerfile sets the entrypoint to the processing handler, so that this command is run when the image is run. It expects two arguments to be handed to it: 'input' and 'output' meaning the input and output directories.
 
 ## Process Handler
 

--- a/website/versioned_docs/version-v1.10.3/data-cookbooks/hello-world.md
+++ b/website/versioned_docs/version-v1.10.3/data-cookbooks/hello-world.md
@@ -100,7 +100,7 @@ Our goal here is to create a rule through the Cumulus dashboard that will define
 
 The `Executions` page presents a list of all executions, their status (running, failed, or completed), to which workflow the execution belongs, along with other information. The rule defined in the previous section should start an execution of its own accord, and the status of that execution can be tracked here.
 
-To get some deeper information on the execution, click on the value in the `Name` column of your execution of interest. This should bring up a visual representation of the worklfow similar to that shown above, execution details, and a list of events.
+To get some deeper information on the execution, click on the value in the `Name` column of your execution of interest. This should bring up a visual representation of the workflow similar to that shown above, execution details, and a list of events.
 
 ## Summary
 

--- a/website/versioned_docs/version-v1.10.3/data-cookbooks/sips-workflow.md
+++ b/website/versioned_docs/version-v1.10.3/data-cookbooks/sips-workflow.md
@@ -110,7 +110,7 @@ _Example configuration for this workflow can be found in the `DiscoverAndQueuePd
 
 ## ParsePdr Workflow
 
-The ParsePdr workflow will parse a PDR, queue the specified granules (duplicates are handled according to the duplicate handling setting) and periodically check the status of those queued granules. This workflow will not succeed until all the granules included in the PDR are successfully ingested. If one of those fails, the ParsePdr worklfow will fail. **NOTE** that ParsePdr may spin up multiple IngestGranule workflows in parallel, depending on the granules included in the PDR.
+The ParsePdr workflow will parse a PDR, queue the specified granules (duplicates are handled according to the duplicate handling setting) and periodically check the status of those queued granules. This workflow will not succeed until all the granules included in the PDR are successfully ingested. If one of those fails, the ParsePdr workflow will fail. **NOTE** that ParsePdr may spin up multiple IngestGranule workflows in parallel, depending on the granules included in the PDR.
 
 1. ParsePdr - [npm package](https://www.npmjs.com/package/@cumulus/parse-pdr), [source](https://github.com/nasa/cumulus/tree/master/tasks/parse-pdr)
 2. QueueGranules - [npm package](https://www.npmjs.com/package/@cumulus/queue-granules), [source](https://github.com/nasa/cumulus/tree/master/tasks/queue-granules)

--- a/website/versioned_docs/version-v1.10.3/workflows/docker.md
+++ b/website/versioned_docs/version-v1.10.3/workflows/docker.md
@@ -54,7 +54,7 @@ The generation of the released tagged images are created and deployed automatica
 
 ### docker-base
 
-Docker images are built in layers, allowing common dependencies to be shared to child Docker images. A base docker image is provided that includes some dependencies shared among the current HS3 data processing codes. This includes NetCDF liraries, AWS Cli, Python, Git, as well as py-cumulus, a collection of Python utilities that are used in the processing scripts. The docker-base repository is used to generate new images that are then stored in AWS ECR.
+Docker images are built in layers, allowing common dependencies to be shared to child Docker images. A base docker image is provided that includes some dependencies shared among the current HS3 data processing codes. This includes NetCDF libraries, AWS Cli, Python, Git, as well as py-cumulus, a collection of Python utilities that are used in the processing scripts. The docker-base repository is used to generate new images that are then stored in AWS ECR.
 
 The docker-base image can be interacted with by running it in interactive mode (ie, `docker run -it docker-base`, since the default "entrypoint" to the image is a bash shell.
 
@@ -82,7 +82,7 @@ ENTRYPOINT ["/work/process.py"]
 CMD ["input", "output"]
 ```
 
-When this Dockerfile is built, docker will first use the latest cumulus-base image. It will then copy the entire GitHub repository (the processing required for a single data collection is a repository) to the `/work` directory which will now contain all the code necessary to process this data. In thie case, a C file is compiled to convert the supplied hdf5 files to NetCDF files. Note that this also requires installing the system libraries `nco` and `libhdf5-dev` via `apt-get`. Lastly, the Dockerfile sets the entrypoint to the processing handler, so that this command is run when the image is run. It expects two arguments to be handed to it: 'input' and 'output' meaning the input and output directories.
+When this Dockerfile is built, docker will first use the latest cumulus-base image. It will then copy the entire GitHub repository (the processing required for a single data collection is a repository) to the `/work` directory which will now contain all the code necessary to process this data. In this case, a C file is compiled to convert the supplied hdf5 files to NetCDF files. Note that this also requires installing the system libraries `nco` and `libhdf5-dev` via `apt-get`. Lastly, the Dockerfile sets the entrypoint to the processing handler, so that this command is run when the image is run. It expects two arguments to be handed to it: 'input' and 'output' meaning the input and output directories.
 
 ## Process Handler
 

--- a/website/versioned_docs/version-v1.13.0/data-cookbooks/setup.md
+++ b/website/versioned_docs/version-v1.13.0/data-cookbooks/setup.md
@@ -7,7 +7,7 @@ original_id: setup
 
 # Setup
 
-### Getting setup to work with data-cookboooks
+### Getting setup to work with data-cookbooks
 
 In the following data cookbooks we'll go through things like setting up workflows, making configuration changes, and interacting with CNM. The point of this section is to set up, or at least better understand, collections, providers, and rules and how they are configured.
 

--- a/website/versioned_docs/version-v1.13.0/data-cookbooks/sns.md
+++ b/website/versioned_docs/version-v1.13.0/data-cookbooks/sns.md
@@ -110,7 +110,7 @@ SfSnsReport:
 
 ### Subscribing Additional Listeners
 
-Additional listeners to the SF tracker topic can be configured in `app/config.yml` under `sns.sftracker.subscriptions`. Shown below is configuration that subscribes an additional lambda function (`SnsS3Test`) to receive broadcasts from the `sftracker` SNS. The `endpoint` value depends on the protocol, and for a  lambda function, requres the function's Arn. In the configuration it is populated by finding the lambda's Arn attribute via [Fn::GetAtt](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html). Note the lambda name configured in `lambdas.yml` `SnsS3Test` needs to have it's name postpended with `LambdaFunction` to have the Arn correctly found.
+Additional listeners to the SF tracker topic can be configured in `app/config.yml` under `sns.sftracker.subscriptions`. Shown below is configuration that subscribes an additional lambda function (`SnsS3Test`) to receive broadcasts from the `sftracker` SNS. The `endpoint` value depends on the protocol, and for a  lambda function, requires the function's Arn. In the configuration it is populated by finding the lambda's Arn attribute via [Fn::GetAtt](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html). Note the lambda name configured in `lambdas.yml` `SnsS3Test` needs to have it's name postpended with `LambdaFunction` to have the Arn correctly found.
 
 ```yaml
 sns:
@@ -129,7 +129,7 @@ Make sure that the receiver lambda is configured in `lambdas.yml`.
 
 ### SNS message format
 
-The configured `SfSnsReport` lambda receives the Cumulus message [(as the lambda's task input)](../workflows/input_output.html#2-resolve-task-input) and is responsible for publishing the message to the sftracker SNS Topic. But before it publishes the message, `SfSnsReport` makes a determiniation about the workflow status and adds an additional metadata key to the message at `message.meta.status`.
+The configured `SfSnsReport` lambda receives the Cumulus message [(as the lambda's task input)](../workflows/input_output.html#2-resolve-task-input) and is responsible for publishing the message to the sftracker SNS Topic. But before it publishes the message, `SfSnsReport` makes a determination about the workflow status and adds an additional metadata key to the message at `message.meta.status`.
 
 First it determines whether the workflow has finished by looking for the `sfnEnd` key in the `config` object.  If the workflow has finished, it checks to see if it has failed by searching the input message for a non-empty `exception` object. The lambda updates the `message.meta.status` with `failed` or `completed` based on that result.  If the workflow is not finished the lambda sets `message.meta.status` to `running`.
 

--- a/website/versioned_docs/version-v1.14.0/data-cookbooks/setup.md
+++ b/website/versioned_docs/version-v1.14.0/data-cookbooks/setup.md
@@ -7,7 +7,7 @@ original_id: setup
 
 # Setup
 
-## Getting setup to work with data-cookboooks
+## Getting setup to work with data-cookbooks
 
 In the following data cookbooks we'll go through things like setting up workflows, making configuration changes, and interacting with CNM. The point of this section is to set up, or at least better understand, collections, providers, and rules and how they are configured.
 

--- a/website/versioned_docs/version-v1.14.0/data-cookbooks/sips-workflow.md
+++ b/website/versioned_docs/version-v1.14.0/data-cookbooks/sips-workflow.md
@@ -109,7 +109,7 @@ _Example configuration for this workflow can be found in the `DiscoverAndQueuePd
 
 ## ParsePdr Workflow
 
-The ParsePdr workflow will parse a PDR, queue the specified granules (duplicates are handled according to the duplicate handling setting) and periodically check the status of those queued granules. This workflow will not succeed until all the granules included in the PDR are successfully ingested. If one of those fails, the ParsePdr worklfow will fail. **NOTE** that ParsePdr may spin up multiple IngestGranule workflows in parallel, depending on the granules included in the PDR.
+The ParsePdr workflow will parse a PDR, queue the specified granules (duplicates are handled according to the duplicate handling setting) and periodically check the status of those queued granules. This workflow will not succeed until all the granules included in the PDR are successfully ingested. If one of those fails, the ParsePdr workflow will fail. **NOTE** that ParsePdr may spin up multiple IngestGranule workflows in parallel, depending on the granules included in the PDR.
 
 1. ParsePdr - [npm package](https://www.npmjs.com/package/@cumulus/parse-pdr), [source](https://github.com/nasa/cumulus/tree/master/tasks/parse-pdr)
 2. QueueGranules - [npm package](https://www.npmjs.com/package/@cumulus/queue-granules), [source](https://github.com/nasa/cumulus/tree/master/tasks/queue-granules)

--- a/website/versioned_docs/version-v1.14.0/data-cookbooks/sns.md
+++ b/website/versioned_docs/version-v1.14.0/data-cookbooks/sns.md
@@ -110,7 +110,7 @@ SfSnsReport:
 
 ### Subscribing Additional Listeners
 
-Additional listeners to the SF tracker topic can be configured in `app/config.yml` under `sns.sftracker.subscriptions`. Shown below is configuration that subscribes an additional lambda function (`SnsS3Test`) to receive broadcasts from the `sftracker` SNS. The `endpoint` value depends on the protocol, and for a  lambda function, requres the function's Arn. In the configuration it is populated by finding the lambda's Arn attribute via [Fn::GetAtt](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html). Note the lambda name configured in `lambdas.yml` `SnsS3Test` needs to have it's name postpended with `LambdaFunction` to have the Arn correctly found.
+Additional listeners to the SF tracker topic can be configured in `app/config.yml` under `sns.sftracker.subscriptions`. Shown below is configuration that subscribes an additional lambda function (`SnsS3Test`) to receive broadcasts from the `sftracker` SNS. The `endpoint` value depends on the protocol, and for a  lambda function, requires the function's Arn. In the configuration it is populated by finding the lambda's Arn attribute via [Fn::GetAtt](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html). Note the lambda name configured in `lambdas.yml` `SnsS3Test` needs to have it's name postpended with `LambdaFunction` to have the Arn correctly found.
 
 ```yaml
 sns:
@@ -129,7 +129,7 @@ Make sure that the receiver lambda is configured in `lambdas.yml`.
 
 ### SNS message format
 
-The configured `SfSnsReport` lambda receives the Cumulus message [(as the lambda's task input)](../workflows/input_output.html#2-resolve-task-input) and is responsible for publishing the message to the sftracker SNS Topic. But before it publishes the message, `SfSnsReport` makes a determiniation about the workflow status and adds an additional metadata key to the message at `message.meta.status`.
+The configured `SfSnsReport` lambda receives the Cumulus message [(as the lambda's task input)](../workflows/input_output.html#2-resolve-task-input) and is responsible for publishing the message to the sftracker SNS Topic. But before it publishes the message, `SfSnsReport` makes a determination about the workflow status and adds an additional metadata key to the message at `message.meta.status`.
 
 First it determines whether the workflow has finished by looking for the `sfnEnd` key in the `config` object.  If the workflow has finished, it checks to see if it has failed by searching the input message for a non-empty `exception` object. The lambda updates the `message.meta.status` with `failed` or `completed` based on that result.  If the workflow is not finished the lambda sets `message.meta.status` to `running`.
 

--- a/website/versioned_docs/version-v1.14.0/deployment/config_descriptions.md
+++ b/website/versioned_docs/version-v1.14.0/deployment/config_descriptions.md
@@ -21,7 +21,7 @@ dynamos:
 
 ### config.yml Requirements
 
-This table describes the fields that must be present in `config.yml` to successfully deploy our cloudformation template, and under what conditions. For descriptions, see the complete table below or each item's entry in the invidivual listings on the rest of this page.
+This table describes the fields that must be present in `config.yml` to successfully deploy our cloudformation template, and under what conditions. For descriptions, see the complete table below or each item's entry in the individual listings on the rest of this page.
 
 | field | condition
 | ----- | -----------

--- a/website/versioned_docs/version-v1.14.2/data-cookbooks/hello-world.md
+++ b/website/versioned_docs/version-v1.14.2/data-cookbooks/hello-world.md
@@ -109,7 +109,7 @@ Our goal here is to create a rule through the Cumulus dashboard that will define
 
 The `Executions` page presents a list of all executions, their status (running, failed, or completed), to which workflow the execution belongs, along with other information. The rule defined in the previous section should start an execution of its own accord, and the status of that execution can be tracked here.
 
-To get some deeper information on the execution, click on the value in the `Name` column of your execution of interest. This should bring up a visual representation of the worklfow similar to that shown above, execution details, and a list of events.
+To get some deeper information on the execution, click on the value in the `Name` column of your execution of interest. This should bring up a visual representation of the workflow similar to that shown above, execution details, and a list of events.
 
 ## Summary
 

--- a/website/versioned_docs/version-v1.14.2/data-cookbooks/sns.md
+++ b/website/versioned_docs/version-v1.14.2/data-cookbooks/sns.md
@@ -124,7 +124,7 @@ SfSnsReport:
 
 ### Subscribing Additional Listeners
 
-Additional listeners to the SF tracker topic can be configured in `app/config.yml` under `sns.sftracker.subscriptions`. Shown below is configuration that subscribes an additional lambda function (`SnsS3Test`) to receive broadcasts from the `sftracker` SNS. The `endpoint` value depends on the protocol, and for a  lambda function, requres the function's Arn. In the configuration it is populated by finding the lambda's Arn attribute via [Fn::GetAtt](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html). Note the lambda name configured in `lambdas.yml` `SnsS3Test` needs to have it's name postpended with `LambdaFunction` to have the Arn correctly found.
+Additional listeners to the SF tracker topic can be configured in `app/config.yml` under `sns.sftracker.subscriptions`. Shown below is configuration that subscribes an additional lambda function (`SnsS3Test`) to receive broadcasts from the `sftracker` SNS. The `endpoint` value depends on the protocol, and for a  lambda function, requires the function's Arn. In the configuration it is populated by finding the lambda's Arn attribute via [Fn::GetAtt](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html). Note the lambda name configured in `lambdas.yml` `SnsS3Test` needs to have it's name postpended with `LambdaFunction` to have the Arn correctly found.
 
 ```yaml
 sns:
@@ -143,7 +143,7 @@ Make sure that the receiver lambda is configured in `lambdas.yml`.
 
 ### SNS message format
 
-The configured `SfSnsReport` lambda receives the Cumulus message [(as the lambda's task input)](../workflows/input_output.html#2-resolve-task-input) and is responsible for publishing the message to the sftracker SNS Topic. But before it publishes the message, `SfSnsReport` makes a determiniation about the workflow status and adds an additional metadata key to the message at `message.meta.status`.
+The configured `SfSnsReport` lambda receives the Cumulus message [(as the lambda's task input)](../workflows/input_output.html#2-resolve-task-input) and is responsible for publishing the message to the sftracker SNS Topic. But before it publishes the message, `SfSnsReport` makes a determination about the workflow status and adds an additional metadata key to the message at `message.meta.status`.
 
 First it determines whether the workflow has finished by looking for the `sfnEnd` key in the `config` object.  If the workflow has finished, it checks to see if it has failed by searching the input message for a non-empty `exception` object. The lambda updates the `message.meta.status` with `failed` or `completed` based on that result.  If the workflow is not finished the lambda sets `message.meta.status` to `running`.
 

--- a/website/versioned_docs/version-v1.16.0/data-cookbooks/hello-world.md
+++ b/website/versioned_docs/version-v1.16.0/data-cookbooks/hello-world.md
@@ -88,7 +88,7 @@ _Executed workflow as seen in AWS Console_
 
 The `Executions` page presents a list of all executions, their status (running, failed, or completed), to which workflow the execution belongs, along with other information. The rule defined in the previous section should start an execution of its own accord, and the status of that execution can be tracked here.
 
-To get some deeper information on the execution, click on the value in the `Name` column of your execution of interest. This should bring up a visual representation of the worklfow similar to that shown above, execution details, and a list of events.
+To get some deeper information on the execution, click on the value in the `Name` column of your execution of interest. This should bring up a visual representation of the workflow similar to that shown above, execution details, and a list of events.
 
 ## Summary
 

--- a/website/versioned_docs/version-v1.16.0/data-cookbooks/setup.md
+++ b/website/versioned_docs/version-v1.16.0/data-cookbooks/setup.md
@@ -7,7 +7,7 @@ original_id: setup
 
 # Setup
 
-## Getting setup to work with data-cookboooks
+## Getting setup to work with data-cookbooks
 
 In the following data cookbooks we'll go through things like setting up workflows, making configuration changes, and interacting with CNM. The point of this section is to set up, or at least better understand, collections, providers, and rules and how they are configured.
 

--- a/website/versioned_docs/version-v1.16.0/data-cookbooks/sips-workflow.md
+++ b/website/versioned_docs/version-v1.16.0/data-cookbooks/sips-workflow.md
@@ -111,7 +111,7 @@ _**Please note:** To use this example workflow module as a template for a new wo
 
 ## ParsePdr Workflow
 
-The ParsePdr workflow will parse a PDR, queue the specified granules (duplicates are handled according to the duplicate handling setting) and periodically check the status of those queued granules. This workflow will not succeed until all the granules included in the PDR are successfully ingested. If one of those fails, the ParsePdr worklfow will fail. **NOTE** that ParsePdr may spin up multiple IngestGranule workflows in parallel, depending on the granules included in the PDR.
+The ParsePdr workflow will parse a PDR, queue the specified granules (duplicates are handled according to the duplicate handling setting) and periodically check the status of those queued granules. This workflow will not succeed until all the granules included in the PDR are successfully ingested. If one of those fails, the ParsePdr workflow will fail. **NOTE** that ParsePdr may spin up multiple IngestGranule workflows in parallel, depending on the granules included in the PDR.
 
 The lambdas below are included in the `cumulus` terraform module for use in your workflows:
 

--- a/website/versioned_docs/version-v1.16.0/workflows/docker.md
+++ b/website/versioned_docs/version-v1.16.0/workflows/docker.md
@@ -59,7 +59,7 @@ The generation of the released tagged images are created and deployed automatica
 
 ### docker-base
 
-Docker images are built in layers, allowing common dependencies to be shared to child Docker images. A base docker image is provided that includes some dependencies shared among the current HS3 data processing codes. This includes NetCDF liraries, AWS Cli, Python, Git, as well as py-cumulus, a collection of Python utilities that are used in the processing scripts. The docker-base repository is used to generate new images that are then stored in AWS ECR.
+Docker images are built in layers, allowing common dependencies to be shared to child Docker images. A base docker image is provided that includes some dependencies shared among the current HS3 data processing codes. This includes NetCDF libraries, AWS Cli, Python, Git, as well as py-cumulus, a collection of Python utilities that are used in the processing scripts. The docker-base repository is used to generate new images that are then stored in AWS ECR.
 
 The docker-base image can be interacted with by running it in interactive mode (ie, `docker run -it docker-base`, since the default "entrypoint" to the image is a bash shell.
 
@@ -86,7 +86,7 @@ ENTRYPOINT ["/work/process.py"]
 CMD ["input", "output"]
 ```
 
-When this Dockerfile is built, docker will first use the latest cumulus-base image. It will then copy the entire GitHub repository (the processing required for a single data collection is a repository) to the `/work` directory which will now contain all the code necessary to process this data. In thie case, a C file is compiled to convert the supplied hdf5 files to NetCDF files. Note that this also requires installing the system libraries `nco` and `libhdf5-dev` via `apt-get`. Lastly, the Dockerfile sets the entrypoint to the processing handler, so that this command is run when the image is run. It expects two arguments to be handed to it: 'input' and 'output' meaning the input and output directories.
+When this Dockerfile is built, docker will first use the latest cumulus-base image. It will then copy the entire GitHub repository (the processing required for a single data collection is a repository) to the `/work` directory which will now contain all the code necessary to process this data. In this case, a C file is compiled to convert the supplied hdf5 files to NetCDF files. Note that this also requires installing the system libraries `nco` and `libhdf5-dev` via `apt-get`. Lastly, the Dockerfile sets the entrypoint to the processing handler, so that this command is run when the image is run. It expects two arguments to be handed to it: 'input' and 'output' meaning the input and output directories.
 
 ## Process Handler
 

--- a/website/versioned_docs/version-v1.16.1/data-cookbooks/setup.md
+++ b/website/versioned_docs/version-v1.16.1/data-cookbooks/setup.md
@@ -7,7 +7,7 @@ original_id: setup
 
 # Setup
 
-## Getting setup to work with data-cookboooks
+## Getting setup to work with data-cookbooks
 
 In the following data cookbooks we'll go through things like setting up workflows, making configuration changes, and interacting with CNM. The point of this section is to set up, or at least better understand, collections, providers, and rules and how they are configured.
 

--- a/website/versioned_docs/version-v1.16.1/workflows/docker.md
+++ b/website/versioned_docs/version-v1.16.1/workflows/docker.md
@@ -86,7 +86,7 @@ ENTRYPOINT ["/work/process.py"]
 CMD ["input", "output"]
 ```
 
-When this Dockerfile is built, docker will first use the latest cumulus-base image. It will then copy the entire GitHub repository (the processing required for a single data collection is a repository) to the `/work` directory which will now contain all the code necessary to process this data. In thie case, a C file is compiled to convert the supplied hdf5 files to NetCDF files. Note that this also requires installing the system libraries `nco` and `libhdf5-dev` via `apt-get`. Lastly, the Dockerfile sets the entrypoint to the processing handler, so that this command is run when the image is run. It expects two arguments to be handed to it: 'input' and 'output' meaning the input and output directories.
+When this Dockerfile is built, docker will first use the latest cumulus-base image. It will then copy the entire GitHub repository (the processing required for a single data collection is a repository) to the `/work` directory which will now contain all the code necessary to process this data. In this case, a C file is compiled to convert the supplied hdf5 files to NetCDF files. Note that this also requires installing the system libraries `nco` and `libhdf5-dev` via `apt-get`. Lastly, the Dockerfile sets the entrypoint to the processing handler, so that this command is run when the image is run. It expects two arguments to be handed to it: 'input' and 'output' meaning the input and output directories.
 
 ## Process Handler
 

--- a/website/versioned_docs/version-v1.21.0/data-cookbooks/setup.md
+++ b/website/versioned_docs/version-v1.21.0/data-cookbooks/setup.md
@@ -7,7 +7,7 @@ original_id: setup
 
 # Setup
 
-## Getting setup to work with data-cookboooks
+## Getting setup to work with data-cookbooks
 
 In the following data cookbooks we'll go through things like setting up workflows, making configuration changes, and interacting with CNM. The point of this section is to set up, or at least better understand, collections, providers, and rules and how they are configured.
 

--- a/website/versioned_docs/version-v1.22.0/data-cookbooks/setup.md
+++ b/website/versioned_docs/version-v1.22.0/data-cookbooks/setup.md
@@ -7,7 +7,7 @@ original_id: setup
 
 # Setup
 
-## Getting setup to work with data-cookboooks
+## Getting setup to work with data-cookbooks
 
 In the following data cookbooks we'll go through things like setting up workflows, making configuration changes, and interacting with CNM. The point of this section is to set up, or at least better understand, collections, providers, and rules and how they are configured.
 

--- a/website/versioned_docs/version-v1.24.0/data-cookbooks/setup.md
+++ b/website/versioned_docs/version-v1.24.0/data-cookbooks/setup.md
@@ -7,7 +7,7 @@ original_id: setup
 
 # Setup
 
-## Getting setup to work with data-cookboooks
+## Getting setup to work with data-cookbooks
 
 In the following data cookbooks we'll go through things like setting up workflows, making configuration changes, and interacting with CNM. The point of this section is to set up, or at least better understand, collections, providers, and rules and how they are configured.
 

--- a/website/versioned_docs/version-v2.0.0/data-cookbooks/setup.md
+++ b/website/versioned_docs/version-v2.0.0/data-cookbooks/setup.md
@@ -7,7 +7,7 @@ original_id: setup
 
 # Setup
 
-## Getting setup to work with data-cookboooks
+## Getting setup to work with data-cookbooks
 
 In the following data cookbooks we'll go through things like setting up workflows, making configuration changes, and interacting with CNM. The point of this section is to set up, or at least better understand, collections, providers, and rules and how they are configured.
 

--- a/website/versioned_docs/version-v3.0.0/features/inventory-reports.md
+++ b/website/versioned_docs/version-v3.0.0/features/inventory-reports.md
@@ -18,10 +18,10 @@ These reports show the following data:
 The Cumulus Dashboard offers an interface to create, manage and view these inventory reports.
 
 The Reconciliation Reports Overview page shows a full list of existing reports and the option to create a new report.
-![Screenshot of the Dashboard Rconciliation Reports Overview page](assets/rec_reports_overview.png)
+![Screenshot of the Dashboard Reconciliation Reports Overview page](assets/rec_reports_overview.png)
 
 Viewing a report will show a detailed list of collections, granules and files.
-![Screenshot of the Dashboard Rconciliation Reports Overview page](assets/inventory_report.png)
+![Screenshot of the Dashboard Reconciliation Reports Overview page](assets/inventory_report.png)
 
 ## API
 

--- a/website/versioned_docs/version-v3.0.0/workflows/docker.md
+++ b/website/versioned_docs/version-v3.0.0/workflows/docker.md
@@ -84,7 +84,7 @@ ENTRYPOINT ["/work/process.py"]
 CMD ["input", "output"]
 ```
 
-When this Dockerfile is built, docker will first use the latest cumulus-base image. It will then copy the entire GitHub repository (the processing required for a single data collection is a repository) to the `/work` directory which will now contain all the code necessary to process this data. In thie case, a C file is compiled to convert the supplied hdf5 files to NetCDF files. Note that this also requires installing the system libraries `nco` and `libhdf5-dev` via `apt-get`. Lastly, the Dockerfile sets the entrypoint to the processing handler, so that this command is run when the image is run. It expects two arguments to be handed to it: 'input' and 'output' meaning the input and output directories.
+When this Dockerfile is built, docker will first use the latest cumulus-base image. It will then copy the entire GitHub repository (the processing required for a single data collection is a repository) to the `/work` directory which will now contain all the code necessary to process this data. In this case, a C file is compiled to convert the supplied hdf5 files to NetCDF files. Note that this also requires installing the system libraries `nco` and `libhdf5-dev` via `apt-get`. Lastly, the Dockerfile sets the entrypoint to the processing handler, so that this command is run when the image is run. It expects two arguments to be handed to it: 'input' and 'output' meaning the input and output directories.
 
 ## Process Handler
 

--- a/website/versioned_docs/version-v5.0.0/data-cookbooks/about-cookbooks.md
+++ b/website/versioned_docs/version-v5.0.0/data-cookbooks/about-cookbooks.md
@@ -11,7 +11,7 @@ The following data cookbooks are documents containing examples and explanations 
 
 ## Setup
 
-The data cookbooks assume you can configure providers, collections, and rules to run workflows. Visit [Cumulus data management types](../configuration/data-management-types) for information on how to conifgure Cumulus data management types.
+The data cookbooks assume you can configure providers, collections, and rules to run workflows. Visit [Cumulus data management types](../configuration/data-management-types) for information on how to configure Cumulus data management types.
 
 ## Adding a page
 

--- a/website/versioned_docs/version-v5.0.0/features/reports.md
+++ b/website/versioned_docs/version-v5.0.0/features/reports.md
@@ -28,7 +28,7 @@ This report shows the following data:
 The Cumulus Dashboard offers an interface to create, manage and view these inventory reports.
 
 The Reconciliation Reports Overview page shows a full list of existing reports and the option to create a new report.
-![Screenshot of the Dashboard Rconciliation Reports Overview page](assets/rec_reports_overview.png)
+![Screenshot of the Dashboard Reconciliation Reports Overview page](assets/rec_reports_overview.png)
 
 Viewing an inventory report will show a detailed list of collections, granules and files.
 ![Screenshot of an Inventory Report page](assets/inventory_report.png)

--- a/website/versioned_docs/version-v6.0.0/upgrade-notes/upgrading-tf-version-0.13.6.md
+++ b/website/versioned_docs/version-v6.0.0/upgrade-notes/upgrading-tf-version-0.13.6.md
@@ -9,7 +9,7 @@ original_id: upgrade_tf_version_0.13.6
 
 Cumulus pins its support to a specific version of Terraform [see: deployment documentation](../deployment/README.md#install-terraform). The reason for only supporting one specific Terraform version at a time is to avoid deployment errors than can be caused by deploying to the same target with different Terraform versions.
 
-Cumulus is upgrading its supported version of Terraform from **0.12.12** to **0.13.6**. This document contains instructions on how to perform the uprade for your deployments.
+Cumulus is upgrading its supported version of Terraform from **0.12.12** to **0.13.6**. This document contains instructions on how to perform the upgrade for your deployments.
 
 ### Prerequisites
 

--- a/website/versioned_docs/version-v8.0.0/data-cookbooks/queue-post-to-cmr.md
+++ b/website/versioned_docs/version-v8.0.0/data-cookbooks/queue-post-to-cmr.md
@@ -5,7 +5,7 @@ hide_title: false
 original_id: queue-post-to-cmr
 ---
 
-In this document, we walktrough handling CMR errors in workflows by queueing PostToCmr. We assume that the user already has an ingest workflow setup.
+In this document, we walkthrough handling CMR errors in workflows by queueing PostToCmr. We assume that the user already has an ingest workflow setup.
 
 ## Overview
 

--- a/website/versioned_docs/version-v8.1.0/data-cookbooks/queue-post-to-cmr.md
+++ b/website/versioned_docs/version-v8.1.0/data-cookbooks/queue-post-to-cmr.md
@@ -5,7 +5,7 @@ hide_title: false
 original_id: queue-post-to-cmr
 ---
 
-In this document, we walktrough handling CMR errors in workflows by queueing PostToCmr. We assume that the user already has an ingest workflow setup.
+In this document, we walkthrough handling CMR errors in workflows by queueing PostToCmr. We assume that the user already has an ingest workflow setup.
 
 ## Overview
 


### PR DESCRIPTION
## Summary

Addresses no open issue.

Fixes 70 major and minor spelling errors within 54 files either .md, .js, or .ts files.

## Changes
- fixed several minor misspellings in current and past .md files with misspellings
- fixed possibly major misspelling within `packages/integration-tests/api/executions.js`
  - Line 46 incorrectly references `@cumulus/integration-tests/exeuctions.getExecutionStatus` which does not exist. Changes `exeuctions` to `executions`
- fixed test output and documentation