### PR TITLE
Mhs/cumulus 2811/remove dynamo logic from provider delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - **CUMULUS-2312** - RDS Migration Epic Phase 3
   - **CUMULUS-2811**
-    - Removes dynamoDB from API endpoint DELETE /provider
+    - Removes deletion of DynamoDB record from API endpoint DELETE /provider/<name>
 
 ## Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## Unreleased Phase 3
+
+### Changed
+
+- **CUMULUS-2312** - RDS Migration Epic Phase 3
+  - **CUMULUS-2811**
+    - Removes dynamoDB from API endpoint DELETE /provider
+
 ## Unreleased
 
 ### Migration steps

--- a/bamboo/set-bamboo-env-variables.sh
+++ b/bamboo/set-bamboo-env-variables.sh
@@ -144,7 +144,7 @@ fi
 # Target master by default.
 # Update with appropriate conditional
 # when creating a feature branch.
-export PR_BRANCH='feature/rds-phase-2'
+export PR_BRANCH='feature/rds-phase-3'
 
 ## Run detect-pr script and set flag to true/false
 ## depending on if there is a PR associated with the

--- a/packages/api/lib/testUtils.js
+++ b/packages/api/lib/testUtils.js
@@ -464,7 +464,10 @@ const createProviderTestRecords = async (context, providerParams) => {
   const originalProvider = fakeProviderFactory(providerParams);
 
   const insertPgRecord = await translateApiProviderToPostgresProvider(originalProvider);
-  await providerModel.create(originalProvider);
+
+  if (providerModel) {
+    await providerModel.create(originalProvider);
+  }
   const [providerCumulusId] = await providerPgModel.create(testKnex, insertPgRecord);
   const originalPgRecord = await providerPgModel.get(
     testKnex, { cumulus_id: providerCumulusId }

--- a/packages/db/src/test-utils.ts
+++ b/packages/db/src/test-utils.ts
@@ -109,6 +109,8 @@ export const fakeProviderRecordFactory = (
   name: `provider${cryptoRandomString({ length: 5 })}`,
   host: 'test-bucket',
   protocol: 's3',
+  created_at: new Date(),
+  updated_at: new Date(),
   ...params,
 });
 


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2811: remove dynamo from DELETE /provider](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2811)

## Changes

* removes dynamoDB from api endpoint DELETE /provider 
* updates tests.

## PR Checklist

- [ X ] Update CHANGELOG
- [ X ] Unit tests
- [ X ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
