### PR TITLE
CUMULUS-2845: Decouple rule trigger creation from rule model create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -457,6 +457,7 @@ instances according to the [policy configuration](https://github.com/nasa/cumulu
   - **CUMULUS-2854**
     - Updated rules model to decouple `createRuleTrigger` from `create`.
     - Updated rules POST endpoint to call `rulesModel.createRuleTrigger` directly to create rule trigger.
+    - Updated rules PUT endpoints to call `rulesModel.createRuleTrigger` if update fails and reversion needs to occur.
 - **CUMULUS-2735**
   - Updated reconciliation reports to write formatted JSON to S3 to improve readability for
     large reports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -454,6 +454,9 @@ instances according to the [policy configuration](https://github.com/nasa/cumulu
     - Updated bulk granule reingest operation to read granules from PostgreSQL instead of DynamoDB.
   - **CUMULUS-2778**
     - Updated default value of `async_operation_image` in `tf-modules/cumulus/variables.tf` to `cumuluss/async-operation:38`
+  - **CUMULUS-2854**
+    - Updated rules model to decouple `createRuleTrigger` from `create`.
+    - Updated rules POST endpoint to call `rulesModel.createRuleTrigger` directly to create rule trigger.
 - **CUMULUS-2735**
   - Updated reconciliation reports to write formatted JSON to S3 to improve readability for
     large reports

--- a/lambdas/data-migration1/tests/test-index.js
+++ b/lambdas/data-migration1/tests/test-index.js
@@ -165,11 +165,12 @@ test('handler migrates async operations, collections, providers, rules', async (
     updatedAt: Date.now(),
   };
 
+  const ruleWithTrigger = await rulesModel.createRuleTrigger(fakeRule);
   await Promise.all([
     collectionsModel.create(fakeCollection),
     asyncOperationsModel.create(fakeAsyncOperation),
     providersModel.create(fakeProvider),
-    rulesModel.create(fakeRule),
+    rulesModel.create(ruleWithTrigger),
   ]);
 
   t.teardown(() => Promise.all([

--- a/lambdas/data-migration1/tests/test-rules.js
+++ b/lambdas/data-migration1/tests/test-rules.js
@@ -291,7 +291,8 @@ test.serial('migrateRules skips already migrated record', async (t) => {
   fakeRule.queueUrl = queueUrls.queueUrl;
 
   // This always sets updatedAt to Date.now()
-  await rulesModel.create(fakeRule);
+  const ruleWithTrigger = await rulesModel.createRuleTrigger(fakeRule);
+  await rulesModel.create(ruleWithTrigger);
 
   // We need to make the updateAt of the record we're about to migrate later
   // than the record in the dynamo table.
@@ -355,9 +356,11 @@ test.serial('migrateRules processes multiple rules', async (t) => {
   fakeRule1.queueUrl = queueUrls1.queueUrl;
   fakeRule2.queueUrl = queueUrls2.queueUrl;
 
+  const ruleWithTrigger1 = await rulesModel.createRuleTrigger(fakeRule1);
+  const ruleWithTrigger2 = await rulesModel.createRuleTrigger(fakeRule2);
   await Promise.all([
-    rulesModel.create(fakeRule1),
-    rulesModel.create(fakeRule2),
+    rulesModel.create(ruleWithTrigger1),
+    rulesModel.create(ruleWithTrigger2),
   ]);
   t.teardown(() => Promise.all([
     rulesModel.delete(fakeRule1),

--- a/packages/api/bin/serveUtils.js
+++ b/packages/api/bin/serveUtils.js
@@ -129,7 +129,8 @@ async function addRules(rules) {
   const rulePgModel = new RulePgModel();
   return await Promise.all(
     rules.map(async (r) => {
-      const dynamoRecord = await ruleModel.create(r);
+      const ruleWithTrigger = await ruleModel.createRuleTrigger(r);
+      const dynamoRecord = await ruleModel.create(ruleWithTrigger);
       await indexer.indexRule(es.client, dynamoRecord, es.index);
       const dbRecord = await translateApiRuleToPostgresRule(dynamoRecord, knex);
       await rulePgModel.create(knex, dbRecord);

--- a/packages/api/endpoints/rules.js
+++ b/packages/api/endpoints/rules.js
@@ -167,6 +167,7 @@ async function put(req, res) {
       });
     } catch (innerError) {
       // Revert Dynamo record update if any write fails
+      await ruleModel.createRuleTrigger(oldRule);
       await ruleModel.create(oldRule);
       throw innerError;
     }

--- a/packages/api/tests/endpoints/collections/delete-collection.js
+++ b/packages/api/tests/endpoints/collections/delete-collection.js
@@ -342,7 +342,8 @@ test.serial('Attempting to delete a collection with an associated rule returns a
     Body: JSON.stringify({}),
   }).promise();
 
-  await ruleModel.create(rule);
+  const ruleWithTrigger = await ruleModel.createRuleTrigger(rule);
+  await ruleModel.create(ruleWithTrigger);
 
   const response = await request(app)
     .delete(`/collections/${originalCollection.name}/${originalCollection.version}`)
@@ -375,7 +376,8 @@ test.serial('Attempting to delete a collection with an associated rule does not 
     Body: JSON.stringify({}),
   }).promise();
 
-  await ruleModel.create(rule);
+  const ruleWithTrigger = await ruleModel.createRuleTrigger(rule);
+  await ruleModel.create(ruleWithTrigger);
 
   await request(app)
     .delete(`/collections/${originalCollection.name}/${originalCollection.version}`)

--- a/packages/api/tests/endpoints/providers/delete-provider.js
+++ b/packages/api/tests/endpoints/providers/delete-provider.js
@@ -324,7 +324,8 @@ test('Attempting to delete a provider with an associated rule returns a 409 resp
     Body: JSON.stringify({}),
   }).promise();
 
-  await ruleModel.create(rule);
+  const ruleWithTrigger = await ruleModel.createRuleTrigger(rule);
+  await ruleModel.create(ruleWithTrigger);
 
   const response = await request(app)
     .delete(`/providers/${testProvider.id}`)
@@ -353,7 +354,8 @@ test('Attempting to delete a provider with an associated rule does not delete th
     Body: JSON.stringify({}),
   }).promise();
 
-  await ruleModel.create(rule);
+  const ruleWithTrigger = await ruleModel.createRuleTrigger(rule);
+  await ruleModel.create(ruleWithTrigger);
 
   await request(app)
     .delete(`/providers/${testProvider.id}`)

--- a/packages/api/tests/endpoints/test-rules.js
+++ b/packages/api/tests/endpoints/test-rules.js
@@ -831,6 +831,7 @@ test('put() does not write to PostgreSQL/Elasticsearch if writing to Dynamo fail
       throw new Error('something bad');
     },
     create: () => Promise.resolve(originalDynamoRule),
+    createRuleTrigger: () => Promise.resolve(originalDynamoRule),
   };
 
   const updatedRule = {

--- a/packages/api/tests/endpoints/test-rules.js
+++ b/packages/api/tests/endpoints/test-rules.js
@@ -378,6 +378,10 @@ test('POST creates a rule in all data stores', async (t) => {
     name: fakeCollection.name,
     version: fakeCollection.version,
   };
+  newRule.rule = {
+    type: 'kinesis',
+    value: 'my-kinesis-arn',
+  };
 
   const [pgCollection] = await t.context.collectionPgModel.create(
     t.context.testKnex,
@@ -415,11 +419,11 @@ test('POST creates a rule in all data stores', async (t) => {
         ...fetchedDynamoRecord,
         collection_cumulus_id: collectionCumulusId,
         provider_cumulus_id: providerCumulusId,
-        arn: null,
-        value: null,
-        type: newRule.rule.type,
+        arn: fetchedDynamoRecord.rule.arn,
+        value: fetchedDynamoRecord.rule.value,
+        type: fetchedDynamoRecord.rule.type,
         enabled: false,
-        log_event_arn: null,
+        log_event_arn: fetchedDynamoRecord.rule.logEventArn,
         execution_name_prefix: null,
         payload: null,
         queue_url: null,
@@ -646,6 +650,7 @@ test.serial('post() does not write to Elasticsearch/PostgreSQL if writing to Dyn
   const { newRule, testKnex } = t.context;
 
   const failingRulesModel = {
+    createRuleTrigger: () => Promise.resolve(newRule),
     exists: () => Promise.resolve(false),
     create: () => {
       throw new Error('Rule error');

--- a/packages/api/tests/endpoints/test-rules.js
+++ b/packages/api/tests/endpoints/test-rules.js
@@ -1020,7 +1020,8 @@ test('DELETE deletes rule that exists in PostgreSQL and DynamoDB but not Elastic
   const newRule = fakeRuleFactoryV2();
   delete newRule.collection;
   delete newRule.provider;
-  const apiRule = await ruleModel.create(newRule);
+  const ruleWithTrigger = await ruleModel.createRuleTrigger(newRule);
+  const apiRule = await ruleModel.create(ruleWithTrigger);
   const translatedRule = await translateApiRuleToPostgresRule(apiRule, testKnex);
   await rulePgModel.create(testKnex, translatedRule);
 
@@ -1056,7 +1057,8 @@ test('DELETE deletes rule that exists in Elasticsearch but not PostgreSQL', asyn
     testKnex,
   } = t.context;
   const newRule = fakeRuleFactoryV2();
-  await ruleModel.create(newRule);
+  const ruleWithTrigger = await ruleModel.createRuleTrigger(newRule);
+  await ruleModel.create(ruleWithTrigger);
   await indexer.indexRule(esClient, newRule, esIndex);
 
   t.true(

--- a/packages/api/tests/endpoints/test-rules.js
+++ b/packages/api/tests/endpoints/test-rules.js
@@ -50,6 +50,8 @@ const assertions = require('../../lib/assertions');
   'stackName',
   'system_bucket',
   'TOKEN_SECRET',
+  'messageConsumer',
+  'KinesisInboundEventLogger',
   // eslint-disable-next-line no-return-assign
 ].forEach((varName) => process.env[varName] = randomString());
 

--- a/packages/api/tests/models/rules/test-query-rules.js
+++ b/packages/api/tests/models/rules/test-query-rules.js
@@ -40,6 +40,8 @@ const kinesisRule1 = {
   ...kinesisRuleParams,
   name: 'testRule1',
   state: 'ENABLED',
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
 };
 
 // if the state is not provided, it will be set to default value 'ENABLED'
@@ -47,6 +49,8 @@ const kinesisRule2 = {
   ...commonRuleParams,
   ...kinesisRuleParams,
   name: 'testRule2',
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
 };
 
 const kinesisRule3 = {
@@ -58,6 +62,8 @@ const kinesisRule3 = {
   },
   name: 'testRule3',
   state: 'ENABLED',
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
 };
 
 const kinesisRule4 = {
@@ -68,6 +74,8 @@ const kinesisRule4 = {
     type: 'kinesis',
     value: 'kinesisarn-4',
   },
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
 };
 
 const kinesisRule5 = {
@@ -82,6 +90,8 @@ const kinesisRule5 = {
     type: 'kinesis',
     value: 'kinesisarn-5',
   },
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
 };
 
 const disabledKinesisRule = {
@@ -89,6 +99,8 @@ const disabledKinesisRule = {
   ...kinesisRuleParams,
   name: 'disabledRule',
   state: 'DISABLED',
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
 };
 
 test.before(async () => {
@@ -151,7 +163,10 @@ test.before(async () => {
     kinesisRule5,
     disabledKinesisRule,
   ];
-  await Promise.all(kinesisRules.map((rule) => rulesModel.create(rule)));
+  await Promise.all(kinesisRules.map(async (rule) => {
+    const ruleWithTrigger = await rulesModel.createRuleTrigger(rule);
+    return rulesModel.create(ruleWithTrigger);
+  }));
 });
 
 test.after.always(async () => {
@@ -213,7 +228,10 @@ test.serial('queryRules defaults to returning only ENABLED rules', async (t) => 
       state: 'DISABLED',
     }),
   ];
-  await Promise.all(rules.map((rule) => rulesModel.create(rule)));
+  await Promise.all(rules.map(async (rule) => {
+    const ruleWithTrigger = await rulesModel.createRuleTrigger(rule);
+    return rulesModel.create(ruleWithTrigger);
+  }));
   const results = await rulesModel.queryRules({
     type: 'onetime',
   });
@@ -256,7 +274,10 @@ test.serial('queryRules should look up sns-type rules which are associated with 
       state: 'DISABLED',
     }),
   ];
-  const createdRules = await Promise.all(rules.map((rule) => rulesModel.create(rule)));
+  const createdRules = await Promise.all(rules.map(async (rule) => {
+    const ruleWithTrigger = await rulesModel.createRuleTrigger(rule);
+    return rulesModel.create(ruleWithTrigger);
+  }));
 
   const result = await rulesModel.queryRules({
     type: 'sns',
@@ -305,7 +326,10 @@ test.serial('queryRules should look up sns-type rules which are associated with 
       state: 'ENABLED',
     }),
   ];
-  const createdRules = await Promise.all(rules.map((rule) => rulesModel.create(rule)));
+  const createdRules = await Promise.all(rules.map(async (rule) => {
+    const ruleWithTrigger = await rulesModel.createRuleTrigger(rule);
+    return rulesModel.create(ruleWithTrigger);
+  }));
 
   const result = await rulesModel.queryRules({
     type: 'sns',

--- a/packages/api/tests/models/rules/test-query-rules.js
+++ b/packages/api/tests/models/rules/test-query-rules.js
@@ -197,7 +197,10 @@ test.serial('queryRules returns correct rules for given state and type', async (
       state: 'DISABLED',
     }),
   ];
-  await Promise.all(onetimeRules.map((rule) => rulesModel.create(rule)));
+  const rulesWithTriggers = await Promise.all(
+    onetimeRules.map((rule) => rulesModel.createRuleTrigger(rule))
+  );
+  await Promise.all(rulesWithTriggers.map((rule) => rulesModel.create(rule)));
 
   const result = await rulesModel.queryRules({
     status: 'ENABLED',
@@ -228,10 +231,12 @@ test.serial('queryRules defaults to returning only ENABLED rules', async (t) => 
       state: 'DISABLED',
     }),
   ];
-  await Promise.all(rules.map(async (rule) => {
-    const ruleWithTrigger = await rulesModel.createRuleTrigger(rule);
-    return rulesModel.create(ruleWithTrigger);
-  }));
+
+  const rulesWithTriggers = await Promise.all(
+    rules.map((rule) => rulesModel.createRuleTrigger(rule))
+  );
+  await Promise.all(rulesWithTriggers.map((rule) => rulesModel.create(rule)));
+
   const results = await rulesModel.queryRules({
     type: 'onetime',
   });

--- a/packages/api/tests/models/test-collections-model.js
+++ b/packages/api/tests/models/test-collections-model.js
@@ -239,7 +239,8 @@ test.serial('Collection.delete() throws an exception if the collection has assoc
     }).promise(),
   ]);
 
-  await ruleModel.create(rule);
+  const ruleWithTrigger = await ruleModel.createRuleTrigger(rule);
+  await ruleModel.create(ruleWithTrigger);
 
   try {
     await collectionsModel.delete({ name, version });

--- a/packages/api/tests/models/test-providers-model.js
+++ b/packages/api/tests/models/test-providers-model.js
@@ -89,7 +89,8 @@ test('Providers.delete() throws an exception if the provider has associated rule
     ),
   ]);
 
-  await ruleModel.create(rule);
+  const ruleWithTrigger = await ruleModel.createRuleTrigger(rule);
+  await ruleModel.create(ruleWithTrigger);
 
   try {
     await providersModel.delete({ id: providerId });


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2845: Decouple rule trigger creation from rule model create](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2845)

## Changes

* Decoupled rule trigger creation from rule model create by calling createRuleTrigger directly in POST endpoint logic
* createRuleTrigger returns a rule, so I used that rule to generate the translated PG->API rule to ensure both PG and DynamoDB have the same rule values
* Updated the unit test `POST creates a rule in all data stores` to create a Kinesis type rule to ensure that the rule triggers match for PG and DynamoDB. Previously, the rule was a onetime rule so `arn` and `logEventArn` were null

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
