### PR TITLE
cumulus 2833/update schema with correct titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **CUMULUS-2833**
+  - Updates provider model schema titles to display on the dashboard.
 - **CUMULUS-2837**
   - Update process-s3-dead-letter-archive to unpack SQS events in addition to
     Cumulus Messages

--- a/packages/api/models/schemas.js
+++ b/packages/api/models/schemas.js
@@ -632,7 +632,7 @@ module.exports.provider = {
       type: 'string',
     },
     allowedRedirects: {
-      title: 'Allowed redirects',
+      title: 'Allowed Redirects',
       description: 'Only hosts in this list will have the provider username/password forwarded for authentication. Entries should be specified as host.com or host.com:7000 if redirect port is different than the provider port.',
       type: 'array',
       items: {
@@ -666,12 +666,12 @@ module.exports.provider = {
       description: 'filename assumed to be in s3://bucketInternal/stackName/crypto',
     },
     cmKeyId: {
-      title: 'AWS KMS Customer Master Key ARN or Alias',
+      title: 'AWS KMS Customer Master Key ARN Or Alias',
       type: 'string',
-      description: 'AWS KMS Customer Master Key arn or alias',
+      description: 'AWS KMS Customer Master Key ARN Or Alias',
     },
     certificateUri: {
-      title: 'S3 URI for custom SSL certificate',
+      title: 'S3 URI For Custom SSL Certificate',
       type: 'string',
       description: 'Optional SSL Certificate S3 URI for custom or self-signed SSL (TLS) certificate',
     },


### PR DESCRIPTION
**Summary:** 
Corrects titles on the provider schema that the dashboard will show when creating providers.

Addresses [CUMULUS-2843: Fix dashboard schema converter that is changing 'S3 URI for custom SSL certificate’ to ’S 3…’](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2843)

## Changes

* Updates titles on the provider schema that the dashboard will show when creating providers.
* Notes this in changelog

This doesn't need a release, but will require a PR on the dashboard when this is released officially 

## PR Checklist

- [x ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
