### PR TITLE
CUMULUS-2848 -- Move database table names into API secret (forward port CUMULUS-2847)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **CUMULUS-2847**
+  - Move DyanmoDb table name into API keystore and initialize only on lambda cold start
 - **CUMULUS-2833**
   - Updates provider model schema titles to display on the dashboard.
 - **CUMULUS-2837**
@@ -24,7 +26,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     @cumulus/message/StepFunctions
 - **CUMULUS-2781**
   - Update API lambda to utilize api_config secret for initial environment variables
-  - 
 
 ### Fixed
 

--- a/packages/api/app/index.js
+++ b/packages/api/app/index.js
@@ -13,8 +13,6 @@ const awsServerlessExpressMiddleware = require('aws-serverless-express/middlewar
 
 const { getRequiredEnvVar } = require('@cumulus/common/env');
 const { inTestMode } = require('@cumulus/common/test-utils');
-const { getJsonS3Object } = require('@cumulus/aws-client/S3');
-const { MissingRequiredEnvVar } = require('@cumulus/errors');
 const { secretsManager } = require('@cumulus/aws-client/services');
 const Logger = require('@cumulus/logger');
 
@@ -97,17 +95,7 @@ const server = awsServerlessExpress.createServer(app);
 
 const handler = async (event, context) => {
   await initEnvVars; // Wait for environment vars to resolve from initEnvVarsFunction
-  const dynamoTableNamesParameterName = getRequiredEnvVar('dynamoTableNamesParameterName');
-  log.info('Starting API handler');
-  if (!dynamoTableNamesParameterName) {
-    throw new MissingRequiredEnvVar('dynamoTableNamesParameterName environment variable is required for API Lambda');
-  }
-  log.info('Getting dynamo table names from S3');
-  const dynamoTableNamesParameter = await getJsonS3Object(
-    process.env.system_bucket,
-    `${process.env.stackName}/api/dynamo_table_names.json`
-  );
-  const dynamoTableNames = JSON.parse(dynamoTableNamesParameter.Parameter.Value);
+  const dynamoTableNames = JSON.parse(getRequiredEnvVar('dynamoTableNameString'));
   // Set Dynamo table names as environment variables for Lambda
   Object.keys(dynamoTableNames).forEach((tableEnvVarName) => {
     process.env[tableEnvVarName] = dynamoTableNames[tableEnvVarName];

--- a/packages/api/app/index.js
+++ b/packages/api/app/index.js
@@ -119,7 +119,7 @@ const handler = async (event, context) => {
     ...event,
     queryStringParameters: event.multiValueQueryStringParameters || event.queryStringParameters,
   };
-  log.info('Running servelessExpress.proxy');
+  log.info('Running serverlessExpress.proxy');
   // see https://github.com/vendia/serverless-express/issues/297
   return new Promise((resolve, reject) => {
     awsServerlessExpress.proxy(

--- a/packages/api/app/index.js
+++ b/packages/api/app/index.js
@@ -102,7 +102,7 @@ const handler = async (event, context) => {
   });
 
   // workaround to support multiValueQueryStringParameters
-  // untill this is fixed: https://github.com/awslabs/aws-serverless-express/issues/214
+  // until this is fixed: https://github.com/awslabs/aws-serverless-express/issues/214
   const modifiedEvent = {
     ...event,
     queryStringParameters: event.multiValueQueryStringParameters || event.queryStringParameters,

--- a/packages/api/app/index.js
+++ b/packages/api/app/index.js
@@ -11,9 +11,9 @@ const morgan = require('morgan');
 const awsServerlessExpress = require('aws-serverless-express');
 const awsServerlessExpressMiddleware = require('aws-serverless-express/middleware');
 
-const { services } = require('@cumulus/aws-client');
 const { getRequiredEnvVar } = require('@cumulus/common/env');
 const { inTestMode } = require('@cumulus/common/test-utils');
+const { getJsonS3Object } = require('@cumulus/aws-client/S3');
 const { MissingRequiredEnvVar } = require('@cumulus/errors');
 const { secretsManager } = require('@cumulus/aws-client/services');
 const Logger = require('@cumulus/logger');
@@ -98,14 +98,15 @@ const server = awsServerlessExpress.createServer(app);
 const handler = async (event, context) => {
   await initEnvVars; // Wait for environment vars to resolve from initEnvVarsFunction
   const dynamoTableNamesParameterName = getRequiredEnvVar('dynamoTableNamesParameterName');
+  log.info('Starting API handler');
   if (!dynamoTableNamesParameterName) {
     throw new MissingRequiredEnvVar('dynamoTableNamesParameterName environment variable is required for API Lambda');
   }
-
-  const ssmClient = context.ssmClient || services.systemsManager();
-  const dynamoTableNamesParameter = await ssmClient.getParameter({
-    Name: dynamoTableNamesParameterName,
-  }).promise();
+  log.info('Getting dynamo table names from S3');
+  const dynamoTableNamesParameter = await getJsonS3Object(
+    process.env.system_bucket,
+    `${process.env.stackName}/api/dynamo_table_names.json`
+  );
   const dynamoTableNames = JSON.parse(dynamoTableNamesParameter.Parameter.Value);
   // Set Dynamo table names as environment variables for Lambda
   Object.keys(dynamoTableNames).forEach((tableEnvVarName) => {
@@ -118,6 +119,7 @@ const handler = async (event, context) => {
     ...event,
     queryStringParameters: event.multiValueQueryStringParameters || event.queryStringParameters,
   };
+  log.info('Running servelessExpress.proxy');
   // see https://github.com/vendia/serverless-express/issues/297
   return new Promise((resolve, reject) => {
     awsServerlessExpress.proxy(

--- a/packages/api/endpoints/collections.js
+++ b/packages/api/endpoints/collections.js
@@ -88,13 +88,11 @@ async function activeList(req, res) {
  * @returns {Promise<Object>} the promise of express response object
  */
 async function get(req, res) {
-  log.info('starting get endpoint for single collection');
   const name = req.params.name;
   const version = req.params.version;
   try {
     const c = new models.Collection();
     const result = await c.get({ name, version });
-    log.info('collection retrieved, returning result');
     // const stats = await collection.getStats([res], [res.name]);
     return res.send(result);
   } catch (error) {

--- a/packages/api/endpoints/collections.js
+++ b/packages/api/endpoints/collections.js
@@ -88,12 +88,13 @@ async function activeList(req, res) {
  * @returns {Promise<Object>} the promise of express response object
  */
 async function get(req, res) {
+  log.info('starting get endpoint for single collection');
   const name = req.params.name;
   const version = req.params.version;
-
   try {
     const c = new models.Collection();
     const result = await c.get({ name, version });
+    log.info('collection retrieved, returning result');
     // const stats = await collection.getStats([res], [res.name]);
     return res.send(result);
   } catch (error) {

--- a/packages/api/tests/app/test-app-env-vars-throws-on-missing-secret.js
+++ b/packages/api/tests/app/test-app-env-vars-throws-on-missing-secret.js
@@ -5,25 +5,8 @@ process.env.dynamoTableNamesParameterName = 'fake-param-name';
 
 test('handler throws error if environment variable for secret ID is missing', async (t) => {
   process.env.INIT_ENV_VARS_FUNCTION_TEST = 'true';
-  const dynamoTableNames = {
-    DynamoTableName: 'prefix-dynamoTableName',
-  };
-  const ssmClient = {
-    getParameter: () => ({
-      promise: () => Promise.resolve({
-        Parameter: {
-          Value: JSON.stringify(dynamoTableNames),
-        },
-      }),
-    }),
-  };
+  process.env.dynamoTableNameString = '{}';
   // eslint-disable-next-line global-require
   const { handler } = require('../../app');
-  await t.throwsAsync(handler(
-    {},
-    {
-      ssmClient,
-      succeed: () => true,
-    }
-  ), { instanceOf: MissingRequiredEnvVarError });
+  await t.throwsAsync(handler({}), { instanceOf: MissingRequiredEnvVarError });
 });

--- a/packages/api/tests/app/test-app-env-vars.js
+++ b/packages/api/tests/app/test-app-env-vars.js
@@ -14,29 +14,13 @@ test('handler sets environment variables based on configured secretsManager secr
     Name: secretId,
     SecretString: JSON.stringify({
       randomTestVal: 'randomTestVal',
+      dynamoTableNameString: JSON.stringify({}),
     }),
   }).promise();
   process.env.api_config_secret_id = secretId;
 
-  const dynamoTableNames = {
-    DynamoTableName: 'prefix-dynamoTableName',
-  };
-  const ssmClient = {
-    getParameter: () => ({
-      promise: () => Promise.resolve({
-        Parameter: {
-          Value: JSON.stringify(dynamoTableNames),
-        },
-      }),
-    }),
-  };
   // eslint-disable-next-line global-require
   const { handler } = require('../../app');
-  await handler(
-    {},
-    {
-      ssmClient,
-    }
-  );
+  await handler({});
   t.is(process.env.randomTestVal, 'randomTestVal');
 });

--- a/packages/api/tests/app/test-app.js
+++ b/packages/api/tests/app/test-app.js
@@ -3,37 +3,9 @@ const test = require('ava');
 const { MissingRequiredEnvVarError } = require('@cumulus/errors');
 const { handler } = require('../../app');
 
-test.beforeEach(() => {
-  process.env.dynamoTableNamesParameterName = 'fake-param-name';
-});
-
 test.serial('handler throws error if environment variable for Dynamo tables parameter name is missing', async (t) => {
-  delete process.env.dynamoTableNamesParameterName;
   await t.throwsAsync(
     handler(),
     { instanceOf: MissingRequiredEnvVarError }
   );
-});
-
-test.serial('handler adds Dynamo table names from parameter to environment variables', async (t) => {
-  const dynamoTableNames = {
-    DynamoTableName: 'prefix-dynamoTableName',
-  };
-  const ssmClient = {
-    getParameter: () => ({
-      promise: () => Promise.resolve({
-        Parameter: {
-          Value: JSON.stringify(dynamoTableNames),
-        },
-      }),
-    }),
-  };
-  t.falsy(process.env.DynamoTableName);
-  await handler(
-    {},
-    {
-      ssmClient,
-    }
-  );
-  t.is(process.env.DynamoTableName, dynamoTableNames.DynamoTableName);
 });

--- a/tf-modules/archive/api.tf
+++ b/tf-modules/archive/api.tf
@@ -1,7 +1,9 @@
-resource "aws_s3_bucket_object" "dynamo_table_list" {
-  bucket = var.system_bucket
-  key = "${var.prefix}/api/dynamo_table_names.json"
-  source = jsonencode({
+locals {
+  api_port_substring        = var.api_port == null ? "" : ":${var.api_port}"
+  api_id                    = var.deploy_to_ngap ? aws_api_gateway_rest_api.api[0].id : aws_api_gateway_rest_api.api_outside_ngap[0].id
+  api_uri                   = var.api_url == null ? "https://${local.api_id}.execute-api.${data.aws_region.current.name}.amazonaws.com${local.api_port_substring}/${var.api_gateway_stage}/" : var.api_url
+  api_redirect_uri          = "${local.api_uri}token"
+  dynamo_table_namestring   = jsonencode({
     AccessTokensTable          = var.dynamo_tables.access_tokens.name
     AsyncOperationsTable       = var.dynamo_tables.async_operations.name
     CollectionsTable           = var.dynamo_tables.collections.name
@@ -12,20 +14,13 @@ resource "aws_s3_bucket_object" "dynamo_table_list" {
     ReconciliationReportsTable = var.dynamo_tables.reconciliation_reports.name
     RulesTable                 = var.dynamo_tables.rules.name
   })
-}
-
-locals {
-  api_port_substring        = var.api_port == null ? "" : ":${var.api_port}"
-  api_id                    = var.deploy_to_ngap ? aws_api_gateway_rest_api.api[0].id : aws_api_gateway_rest_api.api_outside_ngap[0].id
-  api_uri                   = var.api_url == null ? "https://${local.api_id}.execute-api.${data.aws_region.current.name}.amazonaws.com${local.api_port_substring}/${var.api_gateway_stage}/" : var.api_url
-  api_redirect_uri          = "${local.api_uri}token"
   api_env_variables = {
         auth_mode                      = "public"
         api_config_secret_id           = aws_secretsmanager_secret_version.api_config.arn
   }
   api_secret_env_variables = {
       acquireTimeoutMillis             = var.rds_connection_timing_configuration.acquireTimeoutMillis
-      API_BASE_URL                     = local.api_uri 
+      API_BASE_URL                     = local.api_uri
       ASSERT_ENDPOINT                  = var.saml_assertion_consumer_service
       AsyncOperationTaskDefinition     = aws_ecs_task_definition.async_operation.arn
       backgroundQueueUrl               = var.background_queue_url
@@ -43,7 +38,7 @@ locals {
       DeadLetterProcessingLambda       = aws_lambda_function.process_dead_letter_archive.arn
       DISTRIBUTION_ENDPOINT            = var.distribution_url
       distributionApiId                = var.distribution_api_id
-      dynamoTableNamesParameterKey     = "${var.prefix}/api/dynamo_table_names.json"
+      dynamoTableNameString            = local.dynamo_table_namestring
       EARTHDATA_BASE_URL               = replace(var.urs_url, "//*$/", "/") # Makes sure there's one and only one trailing slash
       EARTHDATA_CLIENT_ID              = var.urs_client_id
       EARTHDATA_CLIENT_PASSWORD        = var.urs_client_password

--- a/tf-modules/archive/api.tf
+++ b/tf-modules/archive/api.tf
@@ -1,7 +1,7 @@
-resource "aws_ssm_parameter" "dynamo_table_names" {
-  name = "${var.prefix}-dynamo-table-names"
-  type = "String"
-  value = jsonencode({
+resource "aws_s3_bucket_object" "dynamo_table_list" {
+  bucket = var.system_bucket
+  key = "${var.prefix}/api/dynamo_table_names.json"
+  source = jsonencode({
     AccessTokensTable          = var.dynamo_tables.access_tokens.name
     AsyncOperationsTable       = var.dynamo_tables.async_operations.name
     CollectionsTable           = var.dynamo_tables.collections.name
@@ -25,7 +25,7 @@ locals {
   }
   api_secret_env_variables = {
       acquireTimeoutMillis             = var.rds_connection_timing_configuration.acquireTimeoutMillis
-      API_BASE_URL                     = local.api_uri
+      API_BASE_URL                     = local.api_uri 
       ASSERT_ENDPOINT                  = var.saml_assertion_consumer_service
       AsyncOperationTaskDefinition     = aws_ecs_task_definition.async_operation.arn
       backgroundQueueUrl               = var.background_queue_url
@@ -43,7 +43,7 @@ locals {
       DeadLetterProcessingLambda       = aws_lambda_function.process_dead_letter_archive.arn
       DISTRIBUTION_ENDPOINT            = var.distribution_url
       distributionApiId                = var.distribution_api_id
-      dynamoTableNamesParameterName    = aws_ssm_parameter.dynamo_table_names.name
+      dynamoTableNamesParameterKey     = "${var.prefix}/api/dynamo_table_names.json"
       EARTHDATA_BASE_URL               = replace(var.urs_url, "//*$/", "/") # Makes sure there's one and only one trailing slash
       EARTHDATA_CLIENT_ID              = var.urs_client_id
       EARTHDATA_CLIENT_PASSWORD        = var.urs_client_password

--- a/tf-modules/archive/iam.tf
+++ b/tf-modules/archive/iam.tf
@@ -183,13 +183,6 @@ data "aws_iam_policy_document" "lambda_api_gateway_policy" {
 
   statement {
     actions = [
-      "ssm:GetParameter"
-    ]
-    resources = [aws_ssm_parameter.dynamo_table_names.arn]
-  }
-
-  statement {
-    actions = [
       "iam:PassRole"
     ]
     resources = [


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2847](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2847)

## Changes

Forward port of https://github.com/nasa/cumulus/pull/2706

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
