### PR TITLE
Update release 9.9.1 cma-js to 2.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Updated version of `@cumulus/cumulus-message-adapter-js` from `2.0.3` to `2.0.4` for
+all Cumulus workflow tasks
 - **CUMULUS-2775**
   - Changed `@cumulus/api-client/invokeApi()` to accept a single accepted status code or an array
   of accepted status codes via `expectedStatusCodes`

--- a/tasks/add-missing-file-checksums/package.json
+++ b/tasks/add-missing-file-checksums/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@cumulus/aws-client": "9.9.1",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1"
+    "@cumulus/cumulus-message-adapter-js": "2.0.4"
   },
   "devDependencies": {
     "@cumulus/types": "9.9.1",

--- a/tasks/discover-granules/package.json
+++ b/tasks/discover-granules/package.json
@@ -35,7 +35,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cumulus/api-client": "9.9.1",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.4",
     "@cumulus/ingest": "9.9.1",
     "@cumulus/logger": "9.9.1",
     "got": "^9.2.1",

--- a/tasks/discover-pdrs/package.json
+++ b/tasks/discover-pdrs/package.json
@@ -34,7 +34,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cumulus/aws-client": "9.9.1",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.4",
     "@cumulus/ingest": "9.9.1",
     "lodash": "^4.17.20",
     "p-filter": "^2.1.0"

--- a/tasks/files-to-granules/package.json
+++ b/tasks/files-to-granules/package.json
@@ -31,7 +31,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cumulus/aws-client": "9.9.1",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.4",
     "lodash": "^4.17.20"
   },
   "devDependencies": {

--- a/tasks/hello-world/package.json
+++ b/tasks/hello-world/package.json
@@ -33,6 +33,6 @@
   "dependencies": {
     "@cumulus/aws-client": "9.9.1",
     "@cumulus/common": "9.9.1",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1"
+    "@cumulus/cumulus-message-adapter-js": "2.0.4"
   }
 }

--- a/tasks/hyrax-metadata-updates/package.json
+++ b/tasks/hyrax-metadata-updates/package.json
@@ -40,7 +40,7 @@
     "@cumulus/cmr-client": "9.9.1",
     "@cumulus/cmrjs": "9.9.1",
     "@cumulus/common": "9.9.1",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.4",
     "@cumulus/errors": "9.9.1",
     "libxmljs": "^0.19.7",
     "lodash": "^4.17.20",

--- a/tasks/lzards-backup/package.json
+++ b/tasks/lzards-backup/package.json
@@ -44,7 +44,7 @@
     "@cumulus/api-client": "9.9.1",
     "@cumulus/aws-client": "9.9.1",
     "@cumulus/common": "9.9.1",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.4",
     "@cumulus/distribution-utils": "9.9.1",
     "@cumulus/launchpad-auth": "9.9.1",
     "@cumulus/logger": "9.9.1",

--- a/tasks/move-granules/package.json
+++ b/tasks/move-granules/package.json
@@ -39,7 +39,7 @@
     "@cumulus/aws-client": "9.9.1",
     "@cumulus/cmrjs": "9.9.1",
     "@cumulus/common": "9.9.1",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.4",
     "@cumulus/distribution-utils": "9.9.1",
     "@cumulus/errors": "9.9.1",
     "@cumulus/ingest": "9.9.1",

--- a/tasks/parse-pdr/package.json
+++ b/tasks/parse-pdr/package.json
@@ -33,7 +33,7 @@
     "@cumulus/aws-client": "9.9.1",
     "@cumulus/collection-config-store": "9.9.1",
     "@cumulus/common": "9.9.1",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.4",
     "@cumulus/errors": "9.9.1",
     "@cumulus/ingest": "9.9.1",
     "@cumulus/pvl": "9.9.1",

--- a/tasks/pdr-status-check/package.json
+++ b/tasks/pdr-status-check/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@cumulus/aws-client": "9.9.1",
     "@cumulus/common": "9.9.1",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.4",
     "@cumulus/errors": "9.9.1"
   }
 }

--- a/tasks/post-to-cmr/package.json
+++ b/tasks/post-to-cmr/package.json
@@ -34,7 +34,7 @@
     "@cumulus/aws-client": "9.9.1",
     "@cumulus/cmrjs": "9.9.1",
     "@cumulus/common": "9.9.1",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.4",
     "@cumulus/errors": "9.9.1",
     "@cumulus/launchpad-auth": "9.9.1",
     "lodash": "^4.17.20"

--- a/tasks/queue-granules/package.json
+++ b/tasks/queue-granules/package.json
@@ -34,7 +34,7 @@
     "@cumulus/aws-client": "9.9.1",
     "@cumulus/collection-config-store": "9.9.1",
     "@cumulus/common": "9.9.1",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.4",
     "@cumulus/ingest": "9.9.1",
     "@cumulus/message": "9.9.1",
     "lodash": "^4.17.20",

--- a/tasks/queue-pdrs/package.json
+++ b/tasks/queue-pdrs/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@cumulus/aws-client": "9.9.1",
     "@cumulus/common": "9.9.1",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.4",
     "@cumulus/ingest": "9.9.1",
     "@cumulus/message": "9.9.1",
     "lodash": "^4.17.20"

--- a/tasks/queue-workflow/package.json
+++ b/tasks/queue-workflow/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@cumulus/aws-client": "9.9.1",
     "@cumulus/common": "9.9.1",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.4",
     "@cumulus/ingest": "9.9.1",
     "@cumulus/message": "9.9.1",
     "lodash": "^4.17.20"

--- a/tasks/sf-sqs-report/package.json
+++ b/tasks/sf-sqs-report/package.json
@@ -32,7 +32,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cumulus/aws-client": "9.9.1",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.4",
     "lodash": "^4.17.20"
   },
   "devDependencies": {

--- a/tasks/sync-granule/package.json
+++ b/tasks/sync-granule/package.json
@@ -38,7 +38,7 @@
     "@cumulus/aws-client": "9.9.1",
     "@cumulus/collection-config-store": "9.9.1",
     "@cumulus/common": "9.9.1",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.4",
     "@cumulus/errors": "9.9.1",
     "@cumulus/ingest": "9.9.1",
     "@cumulus/message": "9.9.1",

--- a/tasks/test-processing/package.json
+++ b/tasks/test-processing/package.json
@@ -21,7 +21,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cumulus/aws-client": "9.9.1",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.4",
     "@cumulus/integration-tests": "9.9.1"
   }
 }

--- a/tasks/update-cmr-access-constraints/package.json
+++ b/tasks/update-cmr-access-constraints/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@cumulus/aws-client": "9.9.1",
     "@cumulus/cmrjs": "9.9.1",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.4",
     "lodash": "^4.17.5"
   },
   "devDependencies": {

--- a/tasks/update-granules-cmr-metadata-file-links/package.json
+++ b/tasks/update-granules-cmr-metadata-file-links/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@cumulus/cmrjs": "9.9.1",
     "@cumulus/common": "9.9.1",
-    "@cumulus/cumulus-message-adapter-js": "2.0.1",
+    "@cumulus/cumulus-message-adapter-js": "2.0.4",
     "@cumulus/distribution-utils": "9.9.1",
     "lodash": "^4.17.15"
   },


### PR DESCRIPTION
**Summary:** 

Update 9.9.1 release cma-js to 2.0.4

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
