### PR TITLE
CUMULUS-2787: Add parameter querying to LZARDS API Call

### DIFF
--- a/packages/api/endpoints/lzards.js
+++ b/packages/api/endpoints/lzards.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const router = require('express-promise-router')();
+const util = require('util');
+const Logger = require('@cumulus/logger');
+const logger = new Logger({ sender: '@cumulus/api/lzards' });
+const { postRequestToLzards } = require('../lib/lzards');
+
+/**
+ * post request to ORCA
+ *
+ * @param {Object} req - express request object
+ * @param {Object} res - express response object
+ * @returns {Promise<Object>} the promise of express response object
+ */
+async function post(req, res) {
+  const { statusCode, body } = await postRequestToLzards({
+    queryParams: req.body.queryParams,
+  });
+
+  if (statusCode === 200) return res.send(body);
+
+  logger.error(`${req.path} Request failed - LZARDS api returned ${statusCode}: ${JSON.stringify(body)}`);
+  if (statusCode === 404) return res.boom.notFound(JSON.stringify(body));
+  return res.boom.badRequest(JSON.stringify(body));
+}
+
+router.post('/*', post);
+
+module.exports = router;

--- a/packages/api/lib/lzards.js
+++ b/packages/api/lib/lzards.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const { getRequiredEnvVar } = require('@cumulus/common/env');
+const { getSecretString } = require('@cumulus/aws-client/SecretsManager');
+const { getLaunchpadToken } = require('@cumulus/launchpad-auth');
+
+const got = require('got');
+
+const Logger = require('@cumulus/logger');
+const { GetAuthTokenError } = require('./errors');
+const log = new Logger({ sender: 'api/lib/lzards' });
+
+const getAuthToken = async () => {
+  const api = getRequiredEnvVar('launchpad_api');
+  const passphrase = await getSecretString(getRequiredEnvVar('launchpad_passphrase_secret_name'));
+  if (!passphrase) {
+    throw new GetAuthTokenError('The value stored in "launchpad_passphrase_secret_name" must be defined');
+  }
+  const certificate = getRequiredEnvVar('launchpad_certificate');
+  const token = await getLaunchpadToken({
+    api, passphrase, certificate,
+  });
+  return token;
+};
+
+/**
+ * post request to LZARDS
+ *
+ * @param {Object} params
+ * @param {string} params.lzardsApiUri - LZARDS endpoint url
+ * @param {string} params.queryParams - string containing query parameters to pass to lzards
+ * @returns {Promise<Object>} - resolves to the LZARDS return
+ */
+async function postRequestToLzards({ lzardsApiUri = process.env.lzards_api, queryParams }) {
+  if (!lzardsApiUri) {
+    const errMsg = 'The lzards_api environment variable is not set';
+    log.error(errMsg);
+    throw new Error(errMsg);
+  }
+
+  if (!queryParams) {
+    const errMsg = 'The required queryParams parameter is not set';
+    log.error(errMsg);
+    throw new Error(errMsg);
+  }
+
+  const authToken = await getAuthToken();
+
+  try {
+    return await got.post(
+      `${lzardsApiUri}${queryParams}`,
+      {
+        responseType: 'json',
+        throwHttpErrors: false,
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+      }
+    );
+  } catch (error) {
+    log.error('postRequestToLzards encountered error:', error);
+    throw error;
+  }
+}
+
+module.exports = {
+  postRequestToLzards,
+};


### PR DESCRIPTION
**Summary:** Pulled LZARDS API call into `api/lib` so that LZARDS API calls could be made from outside the LZARDS_BACKUP task

Addresses [CUMULUS-2787: Add parameter querying to LZARDS API calls](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2787)

## Changes
- Added LZARDS API library to the api package
- Updated LZARDS_BACKUP task to use LZARDS API library

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
