### PR TITLE
Port API auth config forward from #2724

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - **CUMULUS-2853**
-  - Move OAUTH_PROVIDER to lambda env variables to address regression in 9.9.2/CUMULUS-2275
+  - Move OAUTH_PROVIDER to lambda env variables to address regression in CUMULUS-2781
   - Add logging output to api app router
 - Added Cloudwatch permissions to `<prefix>-steprole` in `tf-modules/ingest/iam.tf` to address the
 `Error: error creating Step Function State Machine (xxx): AccessDeniedException: 'arn:aws:iam::XXX:role/xxx-steprole' is not authorized to create managed-rule`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **CUMULUS-2853**
+  - Move OAUTH_PROVIDER to lambda env variables to address regression in 9.9.2/CUMULUS-2275
+  - Add logging output to api app router
 - Added Cloudwatch permissions to `<prefix>-steprole` in `tf-modules/ingest/iam.tf` to address the
 `Error: error creating Step Function State Machine (xxx): AccessDeniedException: 'arn:aws:iam::XXX:role/xxx-steprole' is not authorized to create managed-rule`
 error in non-NGAP accounts:

--- a/tf-modules/archive/api.tf
+++ b/tf-modules/archive/api.tf
@@ -17,6 +17,7 @@ locals {
   api_env_variables = {
         auth_mode                      = "public"
         api_config_secret_id           = aws_secretsmanager_secret_version.api_config.arn
+        OAUTH_PROVIDER                   = var.oauth_provider
   }
   api_secret_env_variables = {
       acquireTimeoutMillis             = var.rds_connection_timing_configuration.acquireTimeoutMillis
@@ -67,7 +68,6 @@ locals {
       METRICS_ES_USER                  = var.metrics_es_username
       MigrationAsyncOperationLambda    = var.postgres_migration_async_operation_function_arn
       MigrationCountToolLambda         = var.postgres_migration_count_tool_function_arn
-      OAUTH_PROVIDER                   = var.oauth_provider
       oauth_user_group                 = var.oauth_user_group
       orca_api_uri                     = var.orca_api_uri
       protected_buckets                = join(",", local.protected_buckets)


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2853](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2853)

## Changes
  - Move OAUTH_PROVIDER to lambda env variables to address regression in 9.9.2/CUMULUS-2275
  - Add logging output to api app router

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
