### PR TITLE
Suggested update

### DIFF
--- a/tasks/queue-granules/index.js
+++ b/tasks/queue-granules/index.js
@@ -113,7 +113,7 @@ async function queueGranules(event, testMocks = {}) {
             ),
             granuleId: queuedGranule.granuleId,
             status: 'queued',
-            createdAt,
+            queuedGranule.createdAt,
           },
         }),
         { concurrency: pMapConcurrency }


### PR DESCRIPTION
This simplifies the logic in the queueGranules call and prevents the logic of
updateGranuleBatchCreatedAt from being repeated on L116.

Just a suggestion, but think you missed it in all of my suggestions.