### PR TITLE
CUMULUS-2810 remove dynamo logic from provider POST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     - Remove DynamoDB logic from rules `DELETE` endpoint
     - Move event resources deletion logic from `rulesModel` to `rulesHelper`
 
+### Fixed
+- **CUMULUS-2810**
+  - fixed bug in translatePostgresProviderToApiProvider and updated tests to prevent reintroduction.
+
 ## Unreleased
 
 ### Migration steps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - **CUMULUS-2810**
-  - fixed bug in translatePostgresProviderToApiProvider and updated tests to prevent reintroduction.
+  - Updated @cumulus/db/translate/translatePostgresProviderToApiProvider to correctly return provider password and updated tests to prevent reintroduction.
 
 ## Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - **CUMULUS-2312** - RDS Migration Epic Phase 3
+  - **CUMULUS-2810**
+    - Removes addition of DynamoDB record from API endpoint POST /provider/<name>
   - **CUMULUS-2811**
     - Removes deletion of DynamoDB record from API endpoint DELETE /provider/<name>
   - **CUMULUS-2817**

--- a/packages/api/endpoints/providers.js
+++ b/packages/api/endpoints/providers.js
@@ -95,7 +95,7 @@ async function post(req, res) {
     validateProviderHost(apiProvider.host);
 
     await createRejectableTransaction(knex, async (trx) => {
-      const [updatedPostgresProvider] = await providerPgModel.create(trx, postgresProvider);
+      const [updatedPostgresProvider] = await providerPgModel.create(trx, postgresProvider, '*');
       record = translatePostgresProviderToApiProvider(updatedPostgresProvider);
       await indexProvider(esClient, record, process.env.ES_INDEX);
     });

--- a/packages/api/endpoints/providers.js
+++ b/packages/api/endpoints/providers.js
@@ -96,8 +96,8 @@ async function post(req, res) {
     validateProviderHost(apiProvider.host);
 
     await createRejectableTransaction(knex, async (trx) => {
-      await providerPgModel.create(trx, postgresProvider);
-      record = translatePostgresProviderToApiProvider(postgresProvider);
+      const [updatedPostgresProvider] = await providerPgModel.create(trx, postgresProvider);
+      record = translatePostgresProviderToApiProvider(updatedPostgresProvider);
       await indexProvider(esClient, record, process.env.ES_INDEX);
     });
     return res.send({ record, message: 'Record saved' });

--- a/packages/api/endpoints/providers.js
+++ b/packages/api/endpoints/providers.js
@@ -108,7 +108,8 @@ async function post(req, res) {
       return res.boom.badRequest(error.message);
     }
     log.error('Error occurred while trying to create provider:', error);
-    log.error(`Error occurred with provider: ${JSON.stringify(postgresProvider)}`);
+    log.error(`Error occurred with user input provider: ${JSON.stringify(apiProvider)}`);
+    log.error(`Error occurred with translated postgres provider: ${JSON.stringify(postgresProvider)}`);
     return res.boom.badImplementation(error.message);
   }
 }

--- a/packages/api/endpoints/providers.js
+++ b/packages/api/endpoints/providers.js
@@ -20,7 +20,6 @@ const { Search } = require('@cumulus/es-client/search');
 const { indexProvider, deleteProvider } = require('@cumulus/es-client/indexer');
 const { removeNilProperties } = require('@cumulus/common/util');
 
-const Provider = require('../models/providers');
 const { isBadRequestError } = require('../lib/errors');
 const log = new Logger({ sender: '@cumulus/api/providers' });
 

--- a/packages/api/tests/endpoints/providers/create-provider.js
+++ b/packages/api/tests/endpoints/providers/create-provider.js
@@ -183,7 +183,7 @@ test('POST creates a new provider in all data stores', async (t) => {
   t.like(esRecord, record);
 });
 
-test('POST creates a new provider in Dynamo and PG with correct timestamps', async (t) => {
+test('POST creates a new provider in PG with correct timestamps', async (t) => {
   const { providerPgModel } = t.context;
   const newProviderId = randomString();
   const newProvider = fakeProviderFactory({
@@ -212,7 +212,7 @@ test('POST creates a new provider in Dynamo and PG with correct timestamps', asy
     newProvider.id
   );
 
-  // PG and Dynamo records have the same timestamps
+  // PG and ES and returned API records have the same timestamps
   t.is(providerPgRecord.created_at.getTime(), record.createdAt);
   t.is(providerPgRecord.updated_at.getTime(), record.updatedAt);
   t.is(providerPgRecord.created_at.getTime(), esRecord.createdAt);

--- a/packages/api/tests/endpoints/providers/create-provider.js
+++ b/packages/api/tests/endpoints/providers/create-provider.js
@@ -27,8 +27,6 @@ const {
 } = require('@cumulus/es-client/testUtils');
 
 const AccessToken = require('../../../models/access-tokens');
-const Provider = require('../../../models/providers');
-const Rule = require('../../../models/rules');
 const {
   createFakeJwtAuthToken,
   fakeProviderFactory,
@@ -41,8 +39,6 @@ const { buildFakeExpressResponse } = require('../utils');
 
 const testDbName = randomString(12);
 process.env.AccessTokensTable = randomString();
-process.env.ProvidersTable = randomString();
-process.env.RulesTable = randomString();
 process.env.stackName = randomString();
 process.env.system_bucket = randomString();
 process.env.TOKEN_SECRET = randomString();
@@ -55,13 +51,12 @@ process.env = {
 // import the express app after setting the env variables
 const { app } = require('../../../app');
 
-let providerModel;
 let jwtAuthToken;
 let accessTokenModel;
 
-const providerDoesNotExist = async (t, providerId) => {
+const providerDoesNotExist = async (t, name) => {
   await t.throwsAsync(
-    () => providerModel.get({ id: providerId }),
+    () => t.context.providerPgModel.get(t.context.testKnex, { name }),
     { instanceOf: RecordDoesNotExist }
   );
 };
@@ -83,12 +78,6 @@ test.before(async (t) => {
     t.context.esIndex
   );
 
-  providerModel = new Provider();
-  await providerModel.createTable();
-
-  t.context.rulesModel = new Rule();
-  await t.context.rulesModel.createTable();
-
   const username = randomString();
   await setAuthorizedOAuthUsers([username]);
 
@@ -100,8 +89,6 @@ test.before(async (t) => {
 
 test.after.always(async (t) => {
   await recursivelyDeleteS3Bucket(process.env.system_bucket);
-  await providerModel.deleteTable();
-  await t.context.rulesModel.deleteTable();
   await accessTokenModel.deleteTable();
   await cleanupTestIndex(t.context);
   await destroyLocalTestDb({
@@ -251,11 +238,10 @@ test('POST returns a 409 error if the provider already exists in postgres', asyn
 });
 
 test.serial('POST returns a 500 response if record creation throws unexpected error', async (t) => {
-  const stub = sinon.stub(Provider.prototype, 'create')
+  const stub = sinon.stub(ProviderPgModel.prototype, 'create')
     .callsFake(() => {
       throw new Error('unexpected error');
     });
-
   const newProvider = fakeProviderFactory();
 
   try {
@@ -324,46 +310,7 @@ test('CUMULUS-176 POST returns a 400 response if invalid JSON provided', async (
   );
 });
 
-test('post() does not write to PostgreSQL/Elasticsearch if writing to Dynamo fails', async (t) => {
-  const { testKnex } = t.context;
-
-  const provider = fakeProviderFactory();
-
-  const fakeProviderModel = {
-    get: () => {
-      throw new RecordDoesNotExist();
-    },
-    create: () => {
-      throw new Error('something bad');
-    },
-    delete: () => Promise.resolve(true),
-  };
-
-  const expressRequest = {
-    body: provider,
-    testContext: {
-      knex: testKnex,
-      providerModel: fakeProviderModel,
-    },
-  };
-
-  const response = buildFakeExpressResponse();
-
-  await post(expressRequest, response);
-
-  t.true(response.boom.badImplementation.calledWithMatch('something bad'));
-
-  t.false(await t.context.esProviderClient.exists(
-    provider.id
-  ));
-  t.false(
-    await t.context.providerPgModel.exists(t.context.testKnex, {
-      name: provider.id,
-    })
-  );
-});
-
-test('post() does not write to Dynamo/Elasticsearch if writing to PostgreSQL fails', async (t) => {
+test('post() does not write to Elasticsearch if writing to PostgreSQL fails', async (t) => {
   const provider = fakeProviderFactory();
 
   const fakeProviderPgModel = {
@@ -387,10 +334,9 @@ test('post() does not write to Dynamo/Elasticsearch if writing to PostgreSQL fai
   t.false(await t.context.esProviderClient.exists(
     provider.id
   ));
-  t.false(await providerModel.exists(provider.id));
 });
 
-test('post() does not write to Dynamo/PostgreSQL if writing to Elasticsearch fails', async (t) => {
+test('post() does not write to PostgreSQL if writing to Elasticsearch fails', async (t) => {
   const provider = fakeProviderFactory();
 
   const fakeEsClient = {
@@ -415,5 +361,4 @@ test('post() does not write to Dynamo/PostgreSQL if writing to Elasticsearch fai
       name: provider.id,
     })
   );
-  t.false(await providerModel.exists(provider.id));
 });

--- a/packages/db/src/translate/providers.ts
+++ b/packages/db/src/translate/providers.ts
@@ -27,7 +27,7 @@ export const translatePostgresProviderToApiProvider = (
     createdAt: record.created_at.getTime(),
     updatedAt: record.updated_at.getTime(),
     username: record.username,
-    password: record.username,
+    password: record.password,
     allowedRedirects: record.allowed_redirects,
   } as ApiProvider;
   if (record.username || record.password) {

--- a/packages/db/tests/translate/test-granules.js
+++ b/packages/db/tests/translate/test-granules.js
@@ -144,8 +144,8 @@ test.beforeEach(async (t) => {
   // Create files
   t.context.filePgModel = new FilePgModel();
   t.context.fileKeys = [
-    cryptoRandomString({ length: 10 }),
-    cryptoRandomString({ length: 10 }),
+    `file0-${cryptoRandomString({ length: 10 })}`,
+    `file1-${cryptoRandomString({ length: 10 })}`,
   ].sort();
   const files = [
     fakeFileRecordFactory({
@@ -244,6 +244,7 @@ test('translatePostgresGranuleToApiGranule converts Postgres granule to API gran
     providerPgModel,
     filePgModel,
   });
+  result.files.sort((a, b) => (a.fileName > b.fileName ? 1 : -1));
 
   t.deepEqual(
     result,
@@ -327,6 +328,7 @@ test('translatePostgresGranuleToApiGranule accepts an optional Collection', asyn
     providerPgModel,
     filePgModel,
   });
+  result.files.sort((a, b) => (a.fileName > b.fileName ? 1 : -1));
 
   t.deepEqual(
     result,
@@ -403,6 +405,7 @@ test('translatePostgresGranuleToApiGranule accepts an optional provider', async 
     providerPgModel,
     filePgModel,
   });
+  result.files.sort((a, b) => (a.fileName > b.fileName ? 1 : -1));
 
   t.deepEqual(
     result,
@@ -551,6 +554,7 @@ test('translatePostgresGranuleToApiGranule does not require a PDR or Provider', 
     providerPgModel,
     filePgModel,
   });
+  result.files.sort((a, b) => (a.fileName > b.fileName ? 1 : -1));
 
   t.deepEqual(
     result,
@@ -747,6 +751,7 @@ test('translatePostgresGranuleResultToApiGranule converts DB result to API granu
     knex,
     dbResult
   );
+  result.files.sort((a, b) => (a.fileName > b.fileName ? 1 : -1));
 
   t.deepEqual(
     result,

--- a/packages/db/tests/translate/test-providers.js
+++ b/packages/db/tests/translate/test-providers.js
@@ -19,12 +19,12 @@ test('translatePostgresProviderToApiProvider translates the expected API record'
     global_connection_limit: 1,
     host: 'fakeHost',
     name: 'testId',
-    password: 'fakeEncryptedString',
+    password: 'fakeEncryptedPasswordString',
     port: 1234,
     private_key: 'fakeKey',
     protocol: 'fakeProtocol',
     updated_at: new Date(5678),
-    username: 'fakeEncryptedString',
+    username: 'fakeEncryptedUsernameString',
     allowed_redirects: allowedRedirects,
   };
 
@@ -36,12 +36,12 @@ test('translatePostgresProviderToApiProvider translates the expected API record'
     globalConnectionLimit: 1,
     host: 'fakeHost',
     id: 'testId',
-    password: 'fakeEncryptedString',
+    password: 'fakeEncryptedPasswordString',
     port: 1234,
     privateKey: 'fakeKey',
     protocol: 'fakeProtocol',
     updatedAt: 5678,
-    username: 'fakeEncryptedString',
+    username: 'fakeEncryptedUsernameString',
     allowedRedirects,
   };
 
@@ -81,7 +81,7 @@ test('translatePostgresProviderToApiProvider does not return encrypted key if us
 });
 
 test('translateApiProviderToPostgresProvider translates a Cumulus Provider object to a Postgres Provider object', async (t) => {
-  const fakeEncryptFunction = () => Promise.resolve('fakeEncryptedString');
+  const fakeEncryptFunction = (str) => Promise.resolve(`encrypted[${str}]`);
   const allowedRedirects = ['host-1', 'host-2'];
   const cumulusProviderObject = {
     id: 'testId',
@@ -107,12 +107,12 @@ test('translateApiProviderToPostgresProvider translates a Cumulus Provider objec
     global_connection_limit: 1,
     host: 'fakeHost',
     name: 'testId',
-    password: 'fakeEncryptedString',
+    password: 'encrypted[fakePassword]',
     port: 1234,
     private_key: 'fakeKey',
     protocol: 'fakeProtocol',
     updated_at: new Date(5678),
-    username: 'fakeEncryptedString',
+    username: 'encrypted[fakeUsername]',
     allowed_redirects: allowedRedirects,
   };
   const result = await translateApiProviderToPostgresProvider(


### PR DESCRIPTION
-------

**Summary:**

removes all references to the dynamoDB for POST on /providers

Addresses [CUMULUS-2810: remove dynamo logic from provider POST](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2810)

## Changes

* Removes DynamoDB provider from the /providers endpoint
* Updates tests in api/provider/create-provider to rely on PG provider

## PR Checklist

- [X] Update CHANGELOG
- [X] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests