### PR TITLE
Forward port of translatePostgresProviderToApiProvider to phase2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -376,8 +376,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - **CUMULUS-2311** - RDS Migration Epic Phase 2
   - **CUMULUS-2810**
-    - fixed bug in translatePostgresProviderToApiProvider and updated tests to prevent reintroduction.
-
+    - Updated @cumulus/db/translate/translatePostgresProviderToApiProvider to
+      correctly return provider password and updated tests to prevent
+      reintroduction.
   - **CUMULUS-2778**
     - Fixed async operation docker image to correctly update record status in
     Elasticsearch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -375,6 +375,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - **CUMULUS-2311** - RDS Migration Epic Phase 2
+  - **CUMULUS-2810**
+    - fixed bug in translatePostgresProviderToApiProvider and updated tests to prevent reintroduction.
+
   - **CUMULUS-2778**
     - Fixed async operation docker image to correctly update record status in
     Elasticsearch
@@ -400,7 +403,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     @cumulus/message/StepFunctions
 - **CUMULUS-2781**
   - Update API lambda to utilize api_config secret for initial environment variables
-  - 
+  -
 
 ### Fixed
 

--- a/packages/db/src/translate/providers.ts
+++ b/packages/db/src/translate/providers.ts
@@ -27,7 +27,7 @@ export const translatePostgresProviderToApiProvider = (
     createdAt: record.created_at.getTime(),
     updatedAt: record.updated_at.getTime(),
     username: record.username,
-    password: record.username,
+    password: record.password,
     allowedRedirects: record.allowed_redirects,
   } as ApiProvider;
   if (record.username || record.password) {

--- a/packages/db/tests/translate/test-providers.js
+++ b/packages/db/tests/translate/test-providers.js
@@ -19,12 +19,12 @@ test('translatePostgresProviderToApiProvider translates the expected API record'
     global_connection_limit: 1,
     host: 'fakeHost',
     name: 'testId',
-    password: 'fakeEncryptedString',
+    password: 'fakeEncryptedPasswordString',
     port: 1234,
     private_key: 'fakeKey',
     protocol: 'fakeProtocol',
     updated_at: new Date(5678),
-    username: 'fakeEncryptedString',
+    username: 'fakeEncryptedUsernameString',
     allowed_redirects: allowedRedirects,
   };
 
@@ -36,12 +36,12 @@ test('translatePostgresProviderToApiProvider translates the expected API record'
     globalConnectionLimit: 1,
     host: 'fakeHost',
     id: 'testId',
-    password: 'fakeEncryptedString',
+    password: 'fakeEncryptedPasswordString',
     port: 1234,
     privateKey: 'fakeKey',
     protocol: 'fakeProtocol',
     updatedAt: 5678,
-    username: 'fakeEncryptedString',
+    username: 'fakeEncryptedUsernameString',
     allowedRedirects,
   };
 
@@ -81,7 +81,7 @@ test('translatePostgresProviderToApiProvider does not return encrypted key if us
 });
 
 test('translateApiProviderToPostgresProvider translates a Cumulus Provider object to a Postgres Provider object', async (t) => {
-  const fakeEncryptFunction = () => Promise.resolve('fakeEncryptedString');
+  const fakeEncryptFunction = (str) => Promise.resolve(`encrypted[${str}]`);
   const allowedRedirects = ['host-1', 'host-2'];
   const cumulusProviderObject = {
     id: 'testId',
@@ -107,12 +107,12 @@ test('translateApiProviderToPostgresProvider translates a Cumulus Provider objec
     global_connection_limit: 1,
     host: 'fakeHost',
     name: 'testId',
-    password: 'fakeEncryptedString',
+    password: 'encrypted[fakePassword]',
     port: 1234,
     private_key: 'fakeKey',
     protocol: 'fakeProtocol',
     updated_at: new Date(5678),
-    username: 'fakeEncryptedString',
+    username: 'encrypted[fakeUsername]',
     allowed_redirects: allowedRedirects,
   };
   const result = await translateApiProviderToPostgresProvider(


### PR DESCRIPTION
Found in phase3 work.  Moving fix to phase2

**Summary:**  Fix of translation bug

Addresses [CUMULUS-2810: discovered bug](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2810)

## Changes

* Fixes translatePostgresProviderToApiProvider


## PR Checklist

- [ x] Update CHANGELOG
- [x ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
