### PR TITLE
Mhs/cumulus 2877/granule timestamps bugfix

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -3,5 +3,5 @@
   "line-length": false,
   "no-duplicate-header": false,
   "ol-prefix": { "style": "ordered" },
-  "no-inline-html": { "allowed_elements": ["code", "br", "b", "ul", "li", "details", "summary"] }
+  "no-inline-html": { "allowed_elements": ["code", "br", "b", "ul", "li", "details", "summary", "JSON"] }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -385,6 +385,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     - Fixed async operation docker image to correctly update record status in
     Elasticsearch
   - Updated localAPI to set additional env variable, and fixed `GET /executions/status` response
+  - **CUMULUS-2877**
+    - Ensure database records receive a timestamp when writing granules.
 
 ## Unreleased
 

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -2,5 +2,7 @@
     "high": true,
     "pass-enoaudit": true,
     "retry-count": 20,
-    "allowlist": ["underscore"]
+    "allowlist": ["underscore",
+		  "minimist",
+		  "node-forge"]
 }

--- a/docs/configuration/data-management-types.md
+++ b/docs/configuration/data-management-types.md
@@ -51,7 +51,7 @@ Looking at our API schema [definitions](https://github.com/nasa/cumulus/tree/mas
 
 Please note:
 
-- While *connection* configuration is defined here, things that are more specific to a specific ingest setup (e.g. 'What target directory should we be pulling from' or 'How is duplicate handling configured?') are generally defined in a Rule or Collection, not the Provider.
+- While _connection_ configuration is defined here, things that are more specific to a specific ingest setup (e.g. 'What target directory should we be pulling from' or 'How is duplicate handling configured?') are generally defined in a Rule or Collection, not the Provider.
 - There is some provider behavior which is controlled by task-specific configuration and not the provider definition. This configuration has to be set on a **per-workflow** basis. For example, see the [`httpListTimeout` configuration on the `discover-granules` task](https://github.com/nasa/cumulus/blob/master/tasks/discover-granules/schemas/config.json#L84)
 
 #### Provider Configuration
@@ -79,7 +79,7 @@ The Provider configuration is defined by a JSON object that takes different conf
 |protocol|string|Yes|The protocol for this provider.  Must be `http` for this provider type |
 |host|string|Yes|The host to pull data from (e.g. `nasa.gov`)
 |username|string|No|Configured username for basic authentication.   Cumulus encrypts this using KMS and uses it in a `Basic` auth header if needed for authentication |
-|password|string|*Only if username is specified*|Configured password for basic authentication.   Cumulus encrypts this using KMS and uses it in a `Basic` auth header if needed for authentication |
+|password|string|_Only if username is specified_|Configured password for basic authentication.   Cumulus encrypts this using KMS and uses it in a `Basic` auth header if needed for authentication |
 |port|integer|No|Port to connect to the provider on.   Defaults to `80`|
 |allowedRedirects|string[]|No|Only hosts in this list will have the provider username/password forwarded for authentication. Entries should be specified as host.com or host.com:7000 if redirect port is different than the provider port.
 |certificateUri|string|No|SSL Certificate S3 URI for custom or self-signed SSL (TLS) certificate
@@ -93,7 +93,7 @@ The Provider configuration is defined by a JSON object that takes different conf
 |protocol|string|Yes|The protocol for this provider.  Must be `https` for this provider type |
 |host|string|Yes|The host to pull data from (e.g. `nasa.gov`) |
 |username|string|No|Configured username for basic authentication.   Cumulus encrypts this using KMS and uses it in a `Basic` auth header if needed for authentication |
-|password|string|*Only if username is specified*|Configured password for basic authentication.   Cumulus encrypts this using KMS and uses it in a `Basic` auth header if needed for authentication |
+|password|string|_Only if username is specified_|Configured password for basic authentication.   Cumulus encrypts this using KMS and uses it in a `Basic` auth header if needed for authentication |
 |port|integer|No|Port to connect to the provider on.   Defaults to `443` |
 |allowedRedirects|string[]|No|Only hosts in this list will have the provider username/password forwarded for authentication. Entries should be specified as host.com or host.com:7000 if redirect port is different than the provider port.
 |certiciateUri|string|No|SSL Certificate S3 URI for custom or self-signed SSL (TLS) certificate
@@ -134,6 +134,7 @@ The Provider configuration is defined by a JSON object that takes different conf
 
 <details>
   <summary><b>Break down of [s3_MOD09GQ_006.json](https://github.com/nasa/cumulus/blob/master/example/data/collections/s3_MOD09GQ_006/s3_MOD09GQ_006.json)</b></summary>
+
 |Key  |Value  |Required  |Description|
 |:---:|:-----:|:--------:|-----------|
 |name |`"MOD09GQ"`|Yes|The name attribute designates the name of the collection. This is the name under which the collection will be displayed on the dashboard|
@@ -159,6 +160,7 @@ The Provider configuration is defined by a JSON object that takes different conf
 |bucket|`"internal"`|Yes|Name of the bucket where the file will be stored|
 |url_path|`"${collectionShortName}/{substring(file.fileName, 0, 3)}"`|No|Folder used to save the granule in the bucket. Defaults to the collection `url_path`|
 |checksumFor|`"^MOD09GQ\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$"`|No|If this is a checksum file, set `checksumFor` to the `regex` of the target file.|
+
 </details>
 
 ### Rules

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -253,7 +253,7 @@ This secret should provide access to a PostgreSQL database provisioned on the cl
 
 To configure Cumulus you will need:
 
-- The AWS Secrets Manager ARN for the *user* Core will write with (e.g. `arn:aws:secretsmanager:AWS-REGION:xxxxx:secret:xxxxxxxxxx20210407182709367700000002-dpmpXA` ) for use in configuring `rds_user_access_secret_arn`.
+- The AWS Secrets Manager ARN for the _user_ Core will write with (e.g. `arn:aws:secretsmanager:AWS-REGION:xxxxx:secret:xxxxxxxxxx20210407182709367700000002-dpmpXA` ) for use in configuring `rds_user_access_secret_arn`.
 - (Optionally) The security group ID that provides access to the cluster to configure `rds_security_group`.
 
 ---

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -120,14 +120,14 @@ Lerna will handle updating the packages and all of the dependent package version
 
 **Note:** Lerna can struggle to correctly update the versions on any non-standard/alpha versions (e.g. `1.17.0-alpha0`). Additionally some packages may have been left at the previous version.
 Please be sure to check any packages that are new or have been manually published since the previous release and any packages that list it as a dependency to ensure the listed versions are correct.
-It's useful to use the search feature of your code editor or `grep` to see if there any references to the ***old*** package versions.
+It's useful to use the search feature of your code editor or `grep` to see if there any references to the **_old_** package versions.
 In bash shell you can run
 
 ```bash
 find . -name package.json -exec grep -nH "@cumulus/.*MAJOR\.MINOR\.PATCH.*" {} \;
 ```
 
-Verify that each of those is updated to the ***new*** `MAJOR.MINOR.PATCH` verion you are trying to release.
+Verify that each of those is updated to the **_new_** `MAJOR.MINOR.PATCH` verion you are trying to release.
 
 A similar search for alpha and beta versions should be run on the release version and any problems should be fixed.
 
@@ -240,7 +240,7 @@ If this is a new minor version branch, then you will need to create a new Bamboo
 
 - Click `Create plan branch manually`.
 
-- Add the values in that list. Choose a display name that makes it *very* clear this is a deployment branch plan. `Release (minor version branch name)` seems to work well (e.g. `Release (1.2.x)`)).
+- Add the values in that list. Choose a display name that makes it _very_ clear this is a deployment branch plan. `Release (minor version branch name)` seems to work well (e.g. `Release (1.2.x)`)).
   - **Make sure** you enter the correct branch name (e.g. `release-1.2.x`).
 
 - **Important** Deselect Enable Branch - if you do not do this, it will immediately fire off a build.

--- a/example/cumulus-tf/main.tf
+++ b/example/cumulus-tf/main.tf
@@ -163,7 +163,6 @@ module "cumulus" {
   token_secret = var.token_secret
   archive_api_users = [
     "aortega527",
-    "dopeters",
     "jasmine",
     "jennyhliu",
     "jmccoy_uat",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "latest-version": "^4.0.0",
     "lerna": "4.0.0",
     "lodash": "^4.17.21",
-    "markdownlint-cli": "^0.19.0",
+    "markdownlint-cli": "^0.31.1",
     "md5": "^2.2.1",
     "mime-types": "^2.1.22",
     "moment": "2.24.0",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "retry": "^0.12.0",
     "rewire": "^4.0.1",
     "semver": "^5.5.0",
-    "simple-git": "^1.96.0",
+    "simple-git": "^3.3.0",
     "sinon": "^9.0.2",
     "snake-camel": "^1.0.6",
     "ssh2-streams": "^0.4.8",

--- a/packages/api/lib/writeRecords/write-granules.js
+++ b/packages/api/lib/writeRecords/write-granules.js
@@ -731,7 +731,7 @@ const writeGranuleFromApi = async (
     provider,
     error = {},
     createdAt = new Date().valueOf(),
-    updatedAt = new Date().valueOf(),
+    updatedAt,
     duration,
     productVolume,
     timeToPreprocess,

--- a/packages/api/lib/writeRecords/write-granules.js
+++ b/packages/api/lib/writeRecords/write-granules.js
@@ -884,6 +884,7 @@ const writeGranulesFromMessage = async ({
       const duration = getWorkflowDuration(workflowStartTime, now);
       const status = getGranuleStatus(workflowStatus, granule);
       const updatedAt = now;
+      const timestamp = now;
 
       const apiGranuleRecord = await generateGranuleApiRecord({
         granule,
@@ -895,6 +896,7 @@ const writeGranulesFromMessage = async ({
         error,
         pdrName,
         workflowStatus,
+        timestamp,
         timeToArchive,
         timeToPreprocess,
         productVolume,

--- a/packages/api/tests/endpoints/collections/update-collection.js
+++ b/packages/api/tests/endpoints/collections/update-collection.js
@@ -240,7 +240,7 @@ test.serial('PUT replaces an existing collection and sends an SNS message', asyn
   t.deepEqual(message.record, actualCollection);
 });
 
-test('PUT replaces an existing collection and correctly removes fields', async (t) => {
+test.serial('PUT replaces an existing collection and correctly removes fields', async (t) => {
   const origProcess = randomString();
 
   const {
@@ -302,7 +302,7 @@ test('PUT replaces an existing collection and correctly removes fields', async (
   });
 });
 
-test('PUT replaces an existing collection in Dynamo and PG with correct timestamps', async (t) => {
+test.serial('PUT replaces an existing collection in Dynamo and PG with correct timestamps', async (t) => {
   const knex = t.context.testKnex;
   const { originalCollection } = await createCollectionTestRecords(
     t.context,

--- a/packages/api/tests/endpoints/test-granules.js
+++ b/packages/api/tests/endpoints/test-granules.js
@@ -1830,7 +1830,7 @@ test.serial('PUT replaces an existing granule in all data stores', async (t) => 
     executionUrl,
     knex,
   } = t.context;
-
+  const timestamp = Date.now();
   const {
     newPgGranule,
     newDynamoGranule,
@@ -1858,6 +1858,7 @@ test.serial('PUT replaces an existing granule in all data stores', async (t) => 
     ...newDynamoGranule,
     status: 'completed',
     queryFields: newQueryFields,
+    timestamp,
   };
 
   await request(app)
@@ -1873,6 +1874,7 @@ test.serial('PUT replaces an existing granule in all data stores', async (t) => 
   t.deepEqual(actualGranule, {
     ...newDynamoGranule,
     status: 'completed',
+    timestamp,
     queryFields: newQueryFields,
     updatedAt: actualGranule.updatedAt,
     error: {},
@@ -1888,6 +1890,7 @@ test.serial('PUT replaces an existing granule in all data stores', async (t) => 
 
   t.deepEqual(actualPgGranule, {
     ...newPgGranule,
+    timestamp: new Date(timestamp),
     status: 'completed',
     query_fields: newQueryFields,
     updated_at: actualPgGranule.updated_at,

--- a/packages/api/tests/lib/writeRecords/test-write-granules.js
+++ b/packages/api/tests/lib/writeRecords/test-write-granules.js
@@ -1373,7 +1373,7 @@ test.serial('writeGranuleFromApi() throws with granule with an execution url tha
   );
 });
 
-test.serial('writeGranuleFromApi() saves granule records to Dynamo and Postgres with same input time values.', async (t) => {
+test.serial('writeGranuleFromApi() saves granule records to Dynamo, Postgres and ElasticSearch with same input time values.', async (t) => {
   const {
     esClient,
     knex,
@@ -1397,13 +1397,19 @@ test.serial('writeGranuleFromApi() saves granule records to Dynamo and Postgres 
     knex,
     { granule_id: granuleId, collection_cumulus_id: collectionCumulusId }
   );
+  const esRecord = await t.context.esGranulesClient.get(granuleId);
+
   t.truthy(dynamoRecord.timestamp);
   t.is(postgresRecord.created_at.getTime(), dynamoRecord.createdAt);
   t.is(postgresRecord.updated_at.getTime(), dynamoRecord.updatedAt);
   t.is(postgresRecord.timestamp.getTime(), dynamoRecord.timestamp);
+
+  t.is(postgresRecord.created_at.getTime(), esRecord.createdAt);
+  t.is(postgresRecord.updated_at.getTime(), esRecord.updatedAt);
+  t.is(postgresRecord.timestamp.getTime(), esRecord.timestamp);
 });
 
-test.serial('writeGranuleFromApi() saves granule records to Dynamo and Postgres with same default time values.', async (t) => {
+test.serial('writeGranuleFromApi() saves granule records to Dynamo, Postgres and ElasticSearch with same default time values.', async (t) => {
   const {
     esClient,
     knex,
@@ -1427,13 +1433,18 @@ test.serial('writeGranuleFromApi() saves granule records to Dynamo and Postgres 
     knex,
     { granule_id: granuleId, collection_cumulus_id: collectionCumulusId }
   );
+  const esRecord = await t.context.esGranulesClient.get(granuleId);
+
   t.truthy(dynamoRecord.timestamp);
   t.is(postgresRecord.created_at.getTime(), dynamoRecord.createdAt);
   t.is(postgresRecord.updated_at.getTime(), dynamoRecord.updatedAt);
   t.is(postgresRecord.timestamp.getTime(), dynamoRecord.timestamp);
   t.is(postgresRecord.timestamp.getTime(), dynamoRecord.updatedAt);
-});
 
+  t.is(postgresRecord.created_at.getTime(), esRecord.createdAt);
+  t.is(postgresRecord.updated_at.getTime(), esRecord.updatedAt);
+  t.is(postgresRecord.timestamp.getTime(), esRecord.timestamp);
+});
 
 test.serial('writeGranuleFromApi() saves file records to Postgres if Postgres write is enabled and workflow status is "completed"', async (t) => {
   const {

--- a/packages/api/tests/lib/writeRecords/test-write-granules.js
+++ b/packages/api/tests/lib/writeRecords/test-write-granules.js
@@ -546,7 +546,7 @@ test.serial('writeGranulesFromMessage() removes preexisting granule file from po
   t.deepEqual(granuleFiles.filter((file) => file.bucket === fakeFile.bucket), []);
 });
 
-test.serial('writeGranulesFromMessage() saves granule records to Dynamo/PostgreSQL/Elasticsearch with same created at, updated at and timestamp', async (t) => {
+test.serial('writeGranulesFromMessage() saves granule records to Dynamo/PostgreSQL/Elasticsearch with same created at, updated at and timestamp values', async (t) => {
   const {
     cumulusMessage,
     granuleModel,
@@ -575,6 +575,8 @@ test.serial('writeGranulesFromMessage() saves granule records to Dynamo/PostgreS
   );
 
   const esRecord = await t.context.esGranulesClient.get(granuleId);
+
+  t.truthy(dynamoRecord.timestamp);
   t.is(granulePgRecord.timestamp.getTime(), dynamoRecord.timestamp);
   t.is(granulePgRecord.created_at.getTime(), dynamoRecord.createdAt);
   t.is(granulePgRecord.updated_at.getTime(), dynamoRecord.updatedAt);

--- a/packages/api/tests/lib/writeRecords/test-write-granules.js
+++ b/packages/api/tests/lib/writeRecords/test-write-granules.js
@@ -546,7 +546,7 @@ test.serial('writeGranulesFromMessage() removes preexisting granule file from po
   t.deepEqual(granuleFiles.filter((file) => file.bucket === fakeFile.bucket), []);
 });
 
-test.serial('writeGranulesFromMessage() saves granule records to Dynamo/PostgreSQL/Elasticsearch with same timestamps', async (t) => {
+test.serial('writeGranulesFromMessage() saves granule records to Dynamo/PostgreSQL/Elasticsearch with same created at, updated at and timestamp', async (t) => {
   const {
     cumulusMessage,
     granuleModel,
@@ -575,12 +575,13 @@ test.serial('writeGranulesFromMessage() saves granule records to Dynamo/PostgreS
   );
 
   const esRecord = await t.context.esGranulesClient.get(granuleId);
-
+  t.is(granulePgRecord.timestamp.getTime(), dynamoRecord.timestamp);
   t.is(granulePgRecord.created_at.getTime(), dynamoRecord.createdAt);
   t.is(granulePgRecord.updated_at.getTime(), dynamoRecord.updatedAt);
 
   t.is(granulePgRecord.created_at.getTime(), esRecord.createdAt);
   t.is(granulePgRecord.updated_at.getTime(), esRecord.updatedAt);
+  t.is(granulePgRecord.timestamp.getTime(), esRecord.timestamp);
 });
 
 test.serial('writeGranulesFromMessage() saves the same files to DynamoDB, PostgreSQL and Elasticsearch', async (t) => {

--- a/packages/message/src/Granules.ts
+++ b/packages/message/src/Granules.ts
@@ -252,6 +252,10 @@ export const generateGranuleApiRecord = async ({
     createdAt,
   } = granule;
 
+  const now = Date.now();
+  if (!updatedAt) { updatedAt = now; }
+  if (!timestamp) { timestamp = now; }
+
   // Get CMR temporalInfo
   const temporalInfo = await getGranuleCmrTemporalInfo({
     granule,

--- a/packages/message/src/Granules.ts
+++ b/packages/message/src/Granules.ts
@@ -253,8 +253,8 @@ export const generateGranuleApiRecord = async ({
   } = granule;
 
   const now = Date.now();
-  if (!updatedAt) { updatedAt = now; }
-  if (!timestamp) { timestamp = now; }
+  const actualUpdatedAt = updatedAt ?? now;
+  const actualTimestamp = timestamp ?? now;
 
   // Get CMR temporalInfo
   const temporalInfo = await getGranuleCmrTemporalInfo({
@@ -276,8 +276,8 @@ export const generateGranuleApiRecord = async ({
     error,
     published,
     createdAt: createdAt || workflowStartTime,
-    timestamp,
-    updatedAt,
+    timestamp: actualTimestamp,
+    updatedAt: actualUpdatedAt,
     duration,
     productVolume,
     timeToPreprocess,

--- a/packages/message/src/Granules.ts
+++ b/packages/message/src/Granules.ts
@@ -253,8 +253,8 @@ export const generateGranuleApiRecord = async ({
   } = granule;
 
   const now = Date.now();
-  const actualUpdatedAt = updatedAt ?? now;
-  const actualTimestamp = timestamp ?? now;
+  const recordUpdatedAt = updatedAt ?? now;
+  const recordTimestamp = timestamp ?? now;
 
   // Get CMR temporalInfo
   const temporalInfo = await getGranuleCmrTemporalInfo({
@@ -276,8 +276,8 @@ export const generateGranuleApiRecord = async ({
     error,
     published,
     createdAt: createdAt || workflowStartTime,
-    timestamp: actualTimestamp,
-    updatedAt: actualUpdatedAt,
+    timestamp: recordTimestamp,
+    updatedAt: recordUpdatedAt,
     duration,
     productVolume,
     timeToPreprocess,


### PR DESCRIPTION
**Summary:** ensure all DB have conistent timestamp value when creating granules.

Addresses [CUMULUS-2877: In phase 2 feature branch, give 'timestamp' a default value consistent with updatedAt](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2877)

## Changes

* adds a default timestamp that is added to the dynamo, ElasticSearch and Postgres databases.

Ad hoc testing included running discover granules and verifying the value timestamp exists in postgres and dynamodb 
also verified the updated at value re-appears on dashboard as it does on the main branch.

## PR Checklist

- [x] Update CHANGELOG
- [X] Unit tests
- [X] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
