### PR TITLE
CUMULUS-2875 Update p2 branch config/versions

### DIFF
--- a/packages/db/src/models/base.ts
+++ b/packages/db/src/models/base.ts
@@ -103,6 +103,22 @@ class BasePgModel<ItemType, RecordType extends BaseRecord> {
       .whereBetween('cumulus_id', [startId, startId + pageSize - 1]);
   }
 
+ /**
+   * Builds query to fetch mulitple items from postgres
+   *
+   * @param {Knex | Knex.Transaction} knexOrTransaction - DB client or transaction
+   * @param {Object} params - An object or any portion of an object of type RecordType
+   * @returns {Object} - Knex querybuilder object
+   */
+
+  queryBuilderSearch(
+    knexOrTransaction: Knex | Knex.Transaction,
+    params: Partial<RecordType>
+  ) {
+    return knexOrTransaction(this.tableName)
+    .where(params);
+  }
+
   /**
    * Fetches multiple items from Postgres
    *
@@ -114,8 +130,7 @@ class BasePgModel<ItemType, RecordType extends BaseRecord> {
     knexOrTransaction: Knex | Knex.Transaction,
     params: Partial<RecordType>
   ): Promise<RecordType[]> {
-    const records: Array<RecordType> = await knexOrTransaction(this.tableName)
-      .where(params);
+    const records: Array<RecordType> = await this.queryBuilderSearch(knexOrTransaction, params)
     return records;
   }
 

--- a/packages/db/tests/models/test-base-model.js
+++ b/packages/db/tests/models/test-base-model.js
@@ -343,6 +343,26 @@ test('BasePgModel.delete() works with knex transaction', async (t) => {
   t.false(await basePgModel.exists(knex, { cumulus_id: recordCumulusId }));
 });
 
+test('BasePgModel.queryBuilderSearch returns an awaitable knex Builder object', async (t) => {
+  const { knex, basePgModel, tableName } = t.context;
+  const info = cryptoRandomString({ length: 5 });
+  const recordBody = { info };
+
+  await Promise.all([
+    knex(tableName).insert(recordBody),
+    knex(tableName).insert(recordBody),
+    knex(tableName).insert(recordBody),
+  ]);
+
+  const queryBuilderSearchResult = basePgModel.queryBuilderSearch(knex, recordBody);
+  queryBuilderSearchResult.limit(2);
+  const searchResponse = await queryBuilderSearchResult;
+  t.is(searchResponse.length, 2);
+  searchResponse.forEach((r) => {
+    t.like(r, recordBody);
+  });
+})
+
 test('BasePgModel.search() returns an array of records', async (t) => {
   const { knex, basePgModel, tableName } = t.context;
   const info = cryptoRandomString({ length: 5 });


### PR DESCRIPTION
 **Summary:** Summary of changes

Addresses [CUMULUS-2875: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2875)

## Changes

This commit updates the granule upsert logic to evaluate
running/queued status writes for existence of
an execution and it's status from the executions table instead of the
linking table.  This is due to the linking record not being written
before the granule causing an out-of-order write edge case when the
running *and* completed granule are being written at the same time

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
