### PR TITLE
[CUMULUS-2870] Update terraform to redeploy ECS service when lambda is modified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     allow this timeout to be user configurable
 - **CUMULUS-2868**
   - Added `iam:PassRole` permission to `step_policy` in `tf-modules/ingest/iam.tf`
+- **CUMULUS-2870**
+  - Added `last_modified_date` as output to `hello_world_task` in Terraform `ingest` module.
+
+### Changed
+
+- **CUMULUS-2870**
+  - Updated `hello_world_service` module to pass in `lastModified` parameter in command list to trigger a Terraform state change when the `hello_world_task` is modified.
 
 ## [v10.1.1] 2022-03-04
 

--- a/example/cumulus-tf/ecs_hello_world_workflow.tf
+++ b/example/cumulus-tf/ecs_hello_world_workflow.tf
@@ -31,7 +31,9 @@ module "hello_world_service" {
     "--activityArn",
     aws_sfn_activity.ecs_task_hello_world.id,
     "--lambdaArn",
-    module.cumulus.hello_world_task.task_arn
+    module.cumulus.hello_world_task.task_arn,
+    "--lastModified",
+    module.cumulus.hello_world_task.last_modified_date
   ]
 }
 

--- a/example/cumulus-tf/main.tf
+++ b/example/cumulus-tf/main.tf
@@ -97,7 +97,8 @@ module "cumulus" {
   rds_user_access_secret_arn             = local.rds_credentials_secret_arn
   rds_connection_timing_configuration    = var.rds_connection_timing_configuration
 
-  async_operation_image = "${data.aws_ecr_repository.async_operation.name}:${var.async_operation_image_version}@${data.aws_ecr_image.async_operation.image_digest}"
+  async_operation_image = "${data.aws_ecr_repository.async_operation.repository_url}:${var.async_operation_image_version}"
+  // async_operation_image = "${data.aws_ecr_repository.async_operation.repository_url}:${var.async_operation_image_version}@${data.aws_ecr_image.async_operation.image_digest}"
 
   ecs_cluster_instance_image_id   = data.aws_ssm_parameter.ecs_image_id.value
   ecs_cluster_instance_subnet_ids = length(var.ecs_cluster_instance_subnet_ids) == 0 ? local.subnet_ids : var.ecs_cluster_instance_subnet_ids

--- a/example/cumulus-tf/main.tf
+++ b/example/cumulus-tf/main.tf
@@ -70,6 +70,11 @@ data "aws_ecr_repository" "async_operation" {
   name = "async_operations"
 }
 
+data "aws_ecr_image" "async_operation" {
+  repository_name = "async_operations"
+  image_tag       = var.async_operation_image_version
+}
+
 module "cumulus" {
   source = "../../tf-modules/cumulus"
 
@@ -92,7 +97,7 @@ module "cumulus" {
   rds_user_access_secret_arn             = local.rds_credentials_secret_arn
   rds_connection_timing_configuration    = var.rds_connection_timing_configuration
 
-  async_operation_image = "${data.aws_ecr_repository.async_operation.repository_url}:${var.async_operation_image_version}"
+  async_operation_image = "${data.aws_ecr_repository.async_operation.name}:${var.async_operation_image_version}@${data.aws_ecr_image.async_operation.image_digest}"
 
   ecs_cluster_instance_image_id   = data.aws_ssm_parameter.ecs_image_id.value
   ecs_cluster_instance_subnet_ids = length(var.ecs_cluster_instance_subnet_ids) == 0 ? local.subnet_ids : var.ecs_cluster_instance_subnet_ids

--- a/example/cumulus-tf/main.tf
+++ b/example/cumulus-tf/main.tf
@@ -98,7 +98,6 @@ module "cumulus" {
   rds_connection_timing_configuration    = var.rds_connection_timing_configuration
 
   async_operation_image = "${data.aws_ecr_repository.async_operation.repository_url}:${var.async_operation_image_version}"
-  // async_operation_image = "${data.aws_ecr_repository.async_operation.repository_url}:${var.async_operation_image_version}@${data.aws_ecr_image.async_operation.image_digest}"
 
   ecs_cluster_instance_image_id   = data.aws_ssm_parameter.ecs_image_id.value
   ecs_cluster_instance_subnet_ids = length(var.ecs_cluster_instance_subnet_ids) == 0 ? local.subnet_ids : var.ecs_cluster_instance_subnet_ids

--- a/example/cumulus-tf/python_processing_workflow.tf
+++ b/example/cumulus-tf/python_processing_workflow.tf
@@ -8,6 +8,11 @@ data "aws_ecr_repository" "cumulus_test_ingest_process" {
   name = "cumulus-test-ingest-process"
 }
 
+data "aws_ecr_image" "cumulus_test_ingest_process" {
+  repository_name = "cumulus-test-ingest-process"
+  image_tag       = var.cumulus_test_ingest_image_version
+}
+
 module "python_test_ingest_processing_service" {
   source = "../../tf-modules/cumulus_ecs_service"
 
@@ -17,7 +22,7 @@ module "python_test_ingest_processing_service" {
 
   cluster_arn                           = module.cumulus.ecs_cluster_arn
   desired_count                         = 1
-  image                                 = "${data.aws_ecr_repository.cumulus_test_ingest_process.repository_url}:${var.cumulus_test_ingest_image_version}"
+  image                                 = "${data.aws_ecr_repository.cumulus_test_ingest_process.name}:${var.cumulus_test_ingest_image_version}@${data.aws_ecr_image.cumulus_test_ingest_process.image_digest}"
 
   cpu                = 400
   memory_reservation = 700

--- a/example/cumulus-tf/python_processing_workflow.tf
+++ b/example/cumulus-tf/python_processing_workflow.tf
@@ -22,7 +22,8 @@ module "python_test_ingest_processing_service" {
 
   cluster_arn                           = module.cumulus.ecs_cluster_arn
   desired_count                         = 1
-  image                                 = "${data.aws_ecr_repository.cumulus_test_ingest_process.name}:${var.cumulus_test_ingest_image_version}@${data.aws_ecr_image.cumulus_test_ingest_process.image_digest}"
+  image                                 = "${data.aws_ecr_repository.cumulus_test_ingest_process.repository_url}:${var.cumulus_test_ingest_image_version}"
+
 
   cpu                = 400
   memory_reservation = 700

--- a/example/cumulus-tf/python_reference_workflow.tf
+++ b/example/cumulus-tf/python_reference_workflow.tf
@@ -22,7 +22,7 @@ module "python_processing_service" {
 
   cluster_arn                           = module.cumulus.ecs_cluster_arn
   desired_count                         = 1
-  image                                 = "${data.aws_ecr_repository.cumulus_process_activity.name}:${var.cumulus_process_activity_version}@${data.aws_ecr_image.cumulus_process_activity.image_digest}"
+  image                                 = "${data.aws_ecr_repository.cumulus_process_activity.repository_url}:${var.cumulus_process_activity_version}"
 
   cpu                = 400
   memory_reservation = 700

--- a/example/cumulus-tf/python_reference_workflow.tf
+++ b/example/cumulus-tf/python_reference_workflow.tf
@@ -8,6 +8,11 @@ data "aws_ecr_repository" "cumulus_process_activity" {
   name = "cumulus-process-activity"
 }
 
+data "aws_ecr_image" "cumulus_process_activity" {
+  repository_name = "cumulus-process-activity"
+  image_tag       = var.cumulus_process_activity_version
+}
+
 module "python_processing_service" {
   source = "../../tf-modules/cumulus_ecs_service"
 
@@ -17,7 +22,7 @@ module "python_processing_service" {
 
   cluster_arn                           = module.cumulus.ecs_cluster_arn
   desired_count                         = 1
-  image                                 = "${data.aws_ecr_repository.cumulus_process_activity.repository_url}:${var.cumulus_process_activity_version}"
+  image                                 = "${data.aws_ecr_repository.cumulus_process_activity.name}:${var.cumulus_process_activity_version}@${data.aws_ecr_image.cumulus_process_activity.image_digest}"
 
   cpu                = 400
   memory_reservation = 700

--- a/tf-modules/cumulus_ecs_service/main.tf
+++ b/tf-modules/cumulus_ecs_service/main.tf
@@ -71,7 +71,6 @@ resource "aws_ecs_service" "default" {
   task_definition                    = aws_ecs_task_definition.default.arn
   deployment_maximum_percent         = 100
   deployment_minimum_healthy_percent = 0
-  force_new_deployment               = true
   # TODO Re-enable tags once this warning is addressed:
   #   The new ARN and resource ID format must be enabled to add tags to the
   #   service. Opt in to the new format and try again.

--- a/tf-modules/cumulus_ecs_service/main.tf
+++ b/tf-modules/cumulus_ecs_service/main.tf
@@ -71,6 +71,7 @@ resource "aws_ecs_service" "default" {
   task_definition                    = aws_ecs_task_definition.default.arn
   deployment_maximum_percent         = 100
   deployment_minimum_healthy_percent = 0
+  force_new_deployment               = true
   # TODO Re-enable tags once this warning is addressed:
   #   The new ARN and resource ID format must be enabled to add tags to the
   #   service. Opt in to the new format and try again.

--- a/tf-modules/ingest/outputs.tf
+++ b/tf-modules/ingest/outputs.tf
@@ -31,7 +31,8 @@ output "files_to_granules_task" {
 
 output "hello_world_task" {
   value = {
-    task_arn = aws_lambda_function.hello_world_task.arn
+    task_arn           = aws_lambda_function.hello_world_task.arn
+    last_modified_date = aws_lambda_function.hello_world_task.last_modified
   }
 }
 


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2870: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2870)

## Changes
Leveraging `aws_lambda_function`'s exported attribute `last_modified`, I added this value to the command list of the `hello_world_service` module to force a state change whenever the lambda is modified, causing terraform to redeploy the ECS service. I recognize that the `cumulus-ecs-task` won't do anything with the `lastModified` parameter since it doesn't expect it. 
(https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function)

* Added `last_modified_date` as output to `hello_world_task` in Terraform `ingest` module.
* Tested manually by:
  * deploying changes (which triggers Terraform to redeploy ECS service anyway), 
  * and then updating the task (tasks/hello-world/index.js) to return a string other than `Hello World`, 
  * packaged new task (`npm run package`)
  * and then ran `terraform apply` (where I saw :
    * `# module.cumulus.module.ingest.aws_lambda_function.hello_world_task will be updated in-place`
    ` ~ last_modified                  = "2022-03-29T18:46:07.000+0000" -> (known after apply)`
  * Finally ran `HelloWorldEcsSpec` to verify that the integration test fails since the lambda now contains a new string. 

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
