### PR TITLE
CUMULUS-2930: use scroll API for listing granules

### DIFF
--- a/packages/api/endpoints/granules.js
+++ b/packages/api/endpoints/granules.js
@@ -20,7 +20,7 @@ const {
   translatePostgresCollectionToApiCollection,
   translatePostgresGranuleToApiGranule,
 } = require('@cumulus/db');
-const { Search } = require('@cumulus/es-client/search');
+const ESScrollSearch = require('@cumulus/es-client/esScrollSearch');
 
 const { deleteGranuleAndFiles } = require('../src/lib/granule-delete');
 const { chooseTargetExecution } = require('../lib/executions');
@@ -69,7 +69,7 @@ function _returnPutGranuleStatus(isNewRecord, granule, res) {
  */
 async function list(req, res) {
   const { getRecoveryStatus, ...queryStringParameters } = req.query;
-  const es = new Search(
+  const es = new ESScrollSearch(
     { queryStringParameters },
     'granule',
     process.env.ES_INDEX
@@ -95,7 +95,7 @@ const create = async (req, res) => {
     knex = await getKnexClient(),
     collectionPgModel = new CollectionPgModel(),
     granulePgModel = new GranulePgModel(),
-    esClient = await Search.es(),
+    esClient = await ESScrollSearch.es(),
   } = req.testContext || {};
 
   const granule = req.body || {};
@@ -138,7 +138,7 @@ const putGranule = async (req, res) => {
     granulePgModel = new GranulePgModel(),
     collectionPgModel = new CollectionPgModel(),
     knex = await getKnexClient(),
-    esClient = await Search.es(),
+    esClient = await ESScrollSearch.es(),
   } = req.testContext || {};
   const apiGranule = req.body || {};
 
@@ -356,7 +356,7 @@ const associateExecution = async (req, res) => {
     granulePgModel = new GranulePgModel(),
     collectionPgModel = new CollectionPgModel(),
     knex = await getKnexClient(),
-    esClient = await Search.es(),
+    esClient = await ESScrollSearch.es(),
   } = req.testContext || {};
 
   let pgGranule;
@@ -433,11 +433,11 @@ async function del(req, res) {
   const {
     granuleModelClient = new Granule(),
     knex = await getKnexClient(),
-    esClient = await Search.es(),
+    esClient = await ESScrollSearch.es(),
   } = req.testContext || {};
 
   const granuleId = req.params.granuleName;
-  const esGranulesClient = new Search(
+  const esGranulesClient = new ESScrollSearch(
     {},
     'granule',
     process.env.ES_INDEX

--- a/packages/es-client/esFileQueue.js
+++ b/packages/es-client/esFileQueue.js
@@ -97,7 +97,7 @@ class ESFileQueue {
         this.index
       );
     }
-    const response = await this.esClient.query();
+    const response = (await this.esClient.query()).results;
     this.items = buildFilesResponse(response, this.bucket);
   }
 }

--- a/packages/es-client/esSearchQueue.js
+++ b/packages/es-client/esSearchQueue.js
@@ -75,7 +75,7 @@ class ESSearchQueue {
         this.index
       );
     }
-    this.items = await this.scrollClient.query();
+    this.items = (await this.scrollClient.query()).results;
   }
 }
 

--- a/packages/es-client/tests/test-esScrollSearch.js
+++ b/packages/es-client/tests/test-esScrollSearch.js
@@ -46,7 +46,7 @@ test.serial(
       );
 
       let allResults = [];
-      let results = await esScrollSearch.query();
+      let results = (await esScrollSearch.query()).results;
       t.is(results.length, testScrollSize);
 
       const spy = sinon.spy(esScrollSearch.client, 'scroll');
@@ -54,7 +54,7 @@ test.serial(
       /* eslint-disable no-await-in-loop */
       do {
         allResults = allResults.concat(results);
-        results = await esScrollSearch.query();
+        results = (await esScrollSearch.query()).results;
         calls += 1;
       } while (results.length > 0);
       /* eslint-enable no-await-in-loop */


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2930: Correct the API code to allow a user to retrieve all data’s granules using the APIs granule pagination method](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2930)

## Changes

* Detailed list or prose of changes
* ...

## PR Checklist

- [ ] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
