### PR TITLE
CUMULUS-2863 allow 0 retries and 0 visibilityTimeout for sqs rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - **CUMULUS-2939**
   - Updated `@cumulus/api` `granules/bulk*`, `elasticsearch/index-from-database` and
     `POST reconciliationReports` endpoints to invoke StartAsyncOperation lambda
+### Fixed
 
+- **CUMULUS-2863**
+  - Fixed `@cumulus/api` `validateAndUpdateSqsRule` method to allow 0 retries and 0 visibilityTimeout
+    in rule's meta.
 ## [v12.0.0] 2022-05-20
 
 ### Breaking Changes

--- a/packages/api/models/rules.js
+++ b/packages/api/models/rules.js
@@ -556,11 +556,11 @@ class Rule extends Manager {
     }
 
     // update rule meta
-    if (!get(rule, 'meta.visibilityTimeout')) {
+    if (get(rule, 'meta.visibilityTimeout') === undefined) {
       set(rule, 'meta.visibilityTimeout', Number.parseInt(attributes.Attributes.VisibilityTimeout, 10));
     }
 
-    if (!get(rule, 'meta.retries')) set(rule, 'meta.retries', 3);
+    if (get(rule, 'meta.retries') === undefined) set(rule, 'meta.retries', 3);
     return rule;
   }
 


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2863: Setting meta.retries to 0 for Cumulus rule does not work](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2863)

## Changes

* Detailed list or prose of changes
* ...

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
