### PR TITLE
Tell terraform to ignore when AWS performs upgrades to the rds engine version

### DIFF
--- a/tf-modules/cumulus-rds-tf/main.tf
+++ b/tf-modules/cumulus-rds-tf/main.tf
@@ -91,4 +91,8 @@ resource "aws_rds_cluster" "cumulus" {
   final_snapshot_identifier       = "${var.cluster_identifier}-final-snapshot"
   snapshot_identifier             = var.snapshot_identifier
   db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.rds_cluster_group.id
+
+  lifecycle {
+    ignore_changes = [engine_version]
+  }
 }


### PR DESCRIPTION
**Summary:**
I just ran into this issue and I saw it come up a few times before in slack:

```
Error: Failed to modify RDS Cluster (sds-n-cumulus-dev-rds-cluster): InvalidParameterCombination: Cannot find upgrade target from 10.serverless_18 with requested version 10.14 for serverless engine mode.
	status code: 400, request id: c21bf34b-704d-491a-9474-2f730e5079ef

  on .terraform/modules/rds_cluster/main.tf line 69, in resource "aws_rds_cluster" "cumulus":
  69: resource "aws_rds_cluster" "cumulus" {
```

According to [this stackoverflow post](https://stackoverflow.com/questions/63909346/specify-aws-aurora-engine-version-only-to-major-version-number-in-terraform) the problem is that terraform is trying to downgrade the engine version after AWS automatically upgrades it. These changes tell terraform to ignore when that happens.

## Changes

* Add lifecycle config to rds_cluster to ignore engine version updates

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
