### PR TITLE
[CUMULUS-2965] Tell terraform to ignore when AWS performs upgrades to the rds engine…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,12 +31,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - **CUMULUS-2929**
   - Added optional collection configuration `meta.granuleMetadataFileExtension` to specify CMR metadata
-    file extension for tasks that utilize metadata file lookups 
+    file extension for tasks that utilize metadata file lookups
 
 - **CUMULUS-2939**
   - Added `@cumulus/api/lambdas/start-async-operation` to start an async operation
 
 ### Changed
+
+- **CUMULUS-2965**
+  - Update `cumulus-rds-tf` module to ignore `engine_version` lifecycle changes
 
 - **CUMULUS-2923**
   - Changed public key setup for SFTP local testing.

--- a/tf-modules/cumulus-rds-tf/main.tf
+++ b/tf-modules/cumulus-rds-tf/main.tf
@@ -91,4 +91,8 @@ resource "aws_rds_cluster" "cumulus" {
   final_snapshot_identifier       = "${var.cluster_identifier}-final-snapshot"
   snapshot_identifier             = var.snapshot_identifier
   db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.rds_cluster_group.id
+
+  lifecycle {
+    ignore_changes = [engine_version]
+  }
 }


### PR DESCRIPTION


**Summary:** Summary of changes

Bringing in user contrib https://github.com/nasa/cumulus/pull/2981 -- this PR updates the rds cluster resource to ignore engine changes, this is required as AWS automatically updates/modifies the engine version such that it conflicts with the initially configured value *OR* the resource default.     

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
