### PR TITLE
Update data-migration2 to handle empty values for granule.execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,11 +78,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - **CUMULUS-2939**
   - Updated `@cumulus/api` `granules/bulk*`, `elasticsearch/index-from-database` and
     `POST reconciliationReports` endpoints to invoke StartAsyncOperation lambda
+
 ### Fixed
 
 - **CUMULUS-2863**
-  - Fixed `@cumulus/api` `validateAndUpdateSqsRule` method to allow 0 retries and 0 visibilityTimeout
-    in rule's meta.
+  - Fixed `@cumulus/api` `validateAndUpdateSqsRule` method to allow 0 retries
+    and 0 visibilityTimeout in rule's meta.
+- **CUMULUS-2961**
+  - Fixed `data-migration-2` granule migration logic to allow for DynamoDb granules that have a null/empty string value for `execution`.   The migration will now migrate them without a linked execution.
+
 ## [v12.0.0] 2022-05-20
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Fixed `@cumulus/api` `validateAndUpdateSqsRule` method to allow 0 retries
     and 0 visibilityTimeout in rule's meta.
 - **CUMULUS-2961**
-  - Fixed `data-migration-2` granule migration logic to allow for DynamoDb granules that have a null/empty string value for `execution`.   The migration will now migrate them without a linked execution.
+  - Fixed `data-migration2` granule migration logic to allow for DynamoDb granules that have a null/empty string value for `execution`.   The migration will now migrate them without a linked execution.
   - Fixed `@cumulus/api` `validateAndUpdateSqsRule` method to allow 0 retries and 0 visibilityTimeout
     in rule's meta.
 

--- a/lambdas/data-migration2/src/granulesAndFiles.ts
+++ b/lambdas/data-migration2/src/granulesAndFiles.ts
@@ -106,15 +106,21 @@ export const migrateGranuleRecord = async (
   // fail granule migration if execution cannot be found.
   let executionCumulusId: number | undefined;
   try {
-    executionCumulusId = await executionPgModel.getRecordCumulusId(
-      trx,
-      {
-        url: record.execution,
-      }
-    );
+    if (record.execution) {
+      executionCumulusId = await executionPgModel.getRecordCumulusId(
+        trx,
+        {
+          url: record.execution,
+        }
+      );
+    } else {
+      logger.warn('Migration of granule ID %j linked no executions as record did not have an ARN associated with it', record.id);
+    }
   } catch (error) {
     if (!(error instanceof RecordDoesNotExist)) {
       throw error;
+    } else {
+      logger.warn(`Migration of granule ID ${record.id} linked no executions as execution ${record.execution} does not exist in the postGreSQL database`);
     }
   }
 

--- a/lambdas/data-migration2/src/granulesAndFiles.ts
+++ b/lambdas/data-migration2/src/granulesAndFiles.ts
@@ -114,13 +114,13 @@ export const migrateGranuleRecord = async (
         }
       );
     } else {
-      logger.warn('Migration of granule ID %j linked no executions as record did not have an ARN associated with it', record.id);
+      logger.warn('Migration of granule ID %j linked no executions as record did not have an ARN associated with it', record.granuleId);
     }
   } catch (error) {
     if (!(error instanceof RecordDoesNotExist)) {
       throw error;
     } else {
-      logger.warn(`Migration of granule ID ${record.id} linked no executions as execution ${record.execution} does not exist in the postGreSQL database`);
+      logger.warn(`Migration of granule ID ${record.granuleId} linked no executions as execution ${record.execution} does not exist in the postGreSQL database`);
     }
   }
 


### PR DESCRIPTION
## Summary: 

This update modifies the data-migration2 script to allow for dynamo
granule.execution values of empty string/''/etc.   This is in response
to CUMULUS-2961/a user report that they have executions returning from
dynamo with an empty string value, which was resulting in the
execution lookup query to fail.   This is presumptively due to the
inclusion of the granule API endpoints that allow direct user
mainupulation of data given the granules are recent and the
event-driven write code doesn't allow for a situation where the
execution is missing from dynamo.**Summary:** Summary of changes

Addresses [CUMULUS-2961](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2961)

## Changes
- **CUMULUS-2961**
  - Fixed `data-migration-2` granule migration logic to allow for DynamoDb granules that have a null/empty string value for `execution`.   The migration will now migrate them without a linked execution.

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
