### PR TITLE
Add names to all security groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Added names to all security groups
+
 ### MIGRATION NOTES
 
 - The changes introduced in CUMULUS-2955 should result in removal of

--- a/lambdas/db-provision-user-database/main.tf
+++ b/lambdas/db-provision-user-database/main.tf
@@ -41,8 +41,8 @@ resource "aws_lambda_function" "provision_database" {
 resource "aws_security_group" "db_provision" {
   count = length(var.subnet_ids) == 0 ? 0 : 1
 
-  name_prefix = "${var.prefix}-db-provision"
-  vpc_id      = var.vpc_id
+  name   = "${var.prefix}-db-provision"
+  vpc_id = var.vpc_id
 
   egress {
     from_port   = 0

--- a/tf-modules/cumulus-rds-tf/main.tf
+++ b/tf-modules/cumulus-rds-tf/main.tf
@@ -20,9 +20,9 @@ resource "aws_db_subnet_group" "default" {
 }
 
 resource "aws_security_group" "rds_cluster_access" {
-  name_prefix = var.security_group_name
-  vpc_id      = var.vpc_id
-  tags        = var.tags
+  name   = var.security_group_name
+  vpc_id = var.vpc_id
+  tags   = var.tags
 }
 
 resource "aws_secretsmanager_secret" "rds_login" {

--- a/tf-modules/cumulus/ecs_cluster.tf
+++ b/tf-modules/cumulus/ecs_cluster.tf
@@ -193,6 +193,7 @@ resource "aws_iam_instance_profile" "ecs_cluster_instance" {
 }
 
 resource "aws_security_group" "ecs_cluster_instance" {
+  name   = "${var.prefix}-ecs-cluster-instance"
   vpc_id = var.vpc_id
   tags   = var.tags
 }

--- a/tf-modules/data-persistence/elasticsearch.tf
+++ b/tf-modules/data-persistence/elasticsearch.tf
@@ -62,6 +62,8 @@ resource "aws_elasticsearch_domain_policy" "es_domain_policy" {
 # Elasticsearch domain in a VPC
 resource "aws_security_group" "es_vpc" {
   count  = local.deploy_inside_vpc ? 1 : 0
+
+  name   = "${var.prefix}-es-vpc"
   vpc_id = var.vpc_id
 
   egress {

--- a/tf-modules/distribution/main.tf
+++ b/tf-modules/distribution/main.tf
@@ -115,6 +115,7 @@ resource "aws_iam_role_policy" "s3_credentials_lambda" {
 resource "aws_security_group" "s3_credentials_lambda" {
   count = (var.deploy_s3_credentials_endpoint && var.vpc_id != null) ? 1 : 0
 
+  name   = "${var.prefix}-s3-credentials-lambda"
   vpc_id = var.vpc_id
 
   egress {

--- a/tf-modules/internal/cumulus-test-cleanup/main.tf
+++ b/tf-modules/internal/cumulus-test-cleanup/main.tf
@@ -27,7 +27,10 @@ locals {
 
 resource "aws_security_group" "test_cleanup_lambda" {
   count  = local.security_group_ids_set ? 0 : 1
+
+  name   = "${var.prefix}-test-cleanup-lambda"
   vpc_id = var.vpc_id
+
   egress {
     from_port   = 0
     to_port     = 0

--- a/tf-modules/s3-replicator/main.tf
+++ b/tf-modules/s3-replicator/main.tf
@@ -22,7 +22,10 @@ data "archive_file" "replicator_package" {
 
 resource "aws_security_group" "s3_replicator_lambda" {
   count  = local.security_group_ids_set ? 0 : 1
+
+  name   = "${var.prefix}-s3-replicator-lambda"
   vpc_id = var.vpc_id
+
   egress {
     from_port   = 0
     to_port     = 0


### PR DESCRIPTION
**Summary:**
If you don't give security groups a name, terraform will generate one automatically based on the time e.g. `terraform-20210730180207019300000001`. When you have several of these in the same account it becomes impossible to tell which terraform resource they belong to. This problem becomes even worse when you have 12 cumulus stacks deployed each with 5 unnamed security groups as we do in our sandbox account.

## Changes

* Added `name` attribute for all security groups that didn't have one
* Replaced `name_prefix` with `name` for the few groups that were using `name_prefix`. I did this just for consistency. This is in it's own commit so it can easily be reverted if not desired.

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
