### PR TITLE
Port 2967 to release 13 feature branch 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **CUMULUS-2967**
+  - Added fix example/spec/helpers/Provider that doesn't fail deletion 404 in
+    case of deletion race conditions
 - **CUMULUS-2955**
   - Updates `20220126172008_files_granule_id_index` to *not* create an index on
     `granule_cumulus_id` on the files table.

--- a/example/spec/helpers/Providers.js
+++ b/example/spec/helpers/Providers.js
@@ -236,6 +236,7 @@ const deleteProvidersAndAllDependenciesByHost = async (prefix, host) => {
   const providerDeletes = ids.map((id) => providersApi.deleteProvider({
     prefix,
     providerId: id,
+    expectedStatusCodes: [404, 200],
   }));
   await Promise.all(providerDeletes);
   await Promise.all(ids.map((id) => waitForProviderRecordInOrNotInList(prefix, id, false)));

--- a/packages/api-client/src/cumulusApiClient.ts
+++ b/packages/api-client/src/cumulusApiClient.ts
@@ -16,6 +16,8 @@ const logger = new Logger({ sender: '@api-client/cumulusApiClient' });
  * @param {string} params.payload - the payload object (e.g. httpMethod,
  *   resource, headers, path, body) containing params the lambda expects in the
  *   payload
+ * @param {number[]} params.expectedStatusCodes - list of status codes that will
+ *                                                not cause a retry/failure
  * @param {pRetry.Options} [params.pRetryOptions={}]
  * @returns {Promise<Object|undefined>} - Returns promise that resolves to the
  *   output payload from the API lambda

--- a/packages/api-client/src/providers.ts
+++ b/packages/api-client/src/providers.ts
@@ -45,11 +45,13 @@ export const createProvider = async (params: {
 export const deleteProvider = async (params: {
   prefix: string,
   providerId: string,
+  expectedStatusCodes: number[],
   callback?: InvokeApiFunction
 }): Promise<ApiGatewayLambdaHttpProxyResponse> => {
-  const { prefix, providerId, callback = invokeApi } = params;
+  const { expectedStatusCodes = 200, prefix, providerId, callback = invokeApi } = params;
 
   return await callback({
+    expectedStatusCodes,
     prefix,
     payload: {
       httpMethod: 'DELETE',

--- a/packages/api-client/tests/test-providers.js
+++ b/packages/api-client/tests/test-providers.js
@@ -39,6 +39,7 @@ test('deleteProvider calls the callback with the expected object', async (t) => 
       resource: '/{proxy+}',
       path: `/providers/${t.context.testProviderId}`,
     },
+    expectedStatusCodes: [404, 200],
   };
   const callback = (configObject) => {
     t.deepEqual(configObject, expected);
@@ -47,6 +48,7 @@ test('deleteProvider calls the callback with the expected object', async (t) => 
   await t.notThrowsAsync(providersApi.deleteProvider({
     prefix: t.context.testPrefix,
     providerId: t.context.testProviderId,
+    expectedStatusCodes: [404, 200],
     callback,
   }));
 });


### PR DESCRIPTION
This PR brings the fix for 2967 into the release v13 branch as release integration tests are failing on this integration test: 

Addresses [CUMULUS-XX: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2968)

This should not require a NPM version bump as example is not a released npm package.

## Changes

- **CUMULUS-2967**
  - Added fix example/spec/helpers/Provider that doesn't fail deletion 404 in
    case of deletion race conditions

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
