### PR TITLE
CUMULUS-2966: Added extractPath operation and support of nested string replacement to url_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Added `@cumulus/api/lambdas/start-async-operation` to start an async operation
 
 - **CUMULUS-2966**
-  - Added extractPath operation and nested string replacement to `url_path` in the collection configuration
+  - Added extractPath operation and support of nested string replacement to `url_path` in the collection configuration
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - **CUMULUS-2939**
   - Added `@cumulus/api/lambdas/start-async-operation` to start an async operation
 
+- **CUMULUS-2966**
+  - Added extractPath operation and nested string replacement to `url_path` in the collection configuration
+
 ### Changed
 
 - **CUMULUS-2967**


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2966: Add extractPath functionality and support nested string replacement in url_path](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2966)

## Changes

* Detailed list or prose of changes
* ...

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
