### PR TITLE
CUMULUS-2557: add test for moveGranules to encounter a zero byte xml file in a granule and not fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - **CUMULUS-2939**
   - Added `@cumulus/api/lambdas/start-async-operation` to start an async operation
 
+  **CUMULUS-2557**
+  - Added test for moveGranules that allows for a zero byte xml file in a granule to be encountered and not fail
+
 ### Changed
 
 - **CUMULUS-2923**

--- a/tasks/move-granules/tests/data/meta.json
+++ b/tasks/move-granules/tests/data/meta.json
@@ -1,0 +1,101 @@
+{
+    "TemporalExtent": {
+        "RangeDateTime": {
+            "EndingDateTime": "2022-06-04T21:00:00.000Z",
+            "BeginningDateTime": "2022-06-03T21:00:00.000Z"
+        }
+    },
+    "MetadataSpecification": {
+        "Version": "1.6.3",
+        "URL": "https://cdn.earthdata.nasa.gov/umm/granule/v1.6.3",
+        "Name": "UMM-G"
+    },
+    "GranuleUR": "20220604090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1",
+    "ProviderDates": [
+        {
+            "Type": "Insert",
+            "Date": "2022-06-13T07:35:02.664Z"
+        },
+        {
+            "Type": "Update",
+            "Date": "2022-06-13T07:35:02.664Z"
+        }
+    ],
+    "SpatialExtent": {
+        "HorizontalSpatialDomain": {
+            "Geometry": {
+                "BoundingRectangles": [
+                    {
+                        "WestBoundingCoordinate": -180,
+                        "SouthBoundingCoordinate": -90,
+                        "EastBoundingCoordinate": 180,
+                        "NorthBoundingCoordinate": 90
+                    }
+                ]
+            }
+        }
+    },
+    "DataGranule": {
+        "ArchiveAndDistributionInformation": [
+            {
+                "SizeUnit": "MB",
+                "Size": 708.484824180603,
+                "Checksum": {
+                    "Value": "94d73a29f71426e70854ba4429f08e19",
+                    "Algorithm": "MD5"
+                },
+                "SizeInBytes": 742900183,
+                "Name": "20220604090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc"
+            },
+            {
+                "SizeUnit": "MB",
+                "Size": 0.00009059906005859375,
+                "Checksum": {
+                    "Value": "54a12e77c038393a7a750b0d99c0cf91",
+                    "Algorithm": "MD5"
+                },
+                "SizeInBytes": 95,
+                "Name": "20220604090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc.md5"
+            }
+        ],
+        "DayNightFlag": "Unspecified",
+        "ProductionDateTime": "2022-06-13T07:26:11.000Z"
+    },
+    "CollectionReference": {
+        "Version": "4.1",
+        "ShortName": "MUR-JPL-L4-GLOB-v4.1"
+    },
+    "RelatedUrls": [
+        {
+            "URL": "https://archive.podaac.earthdata.nasa.gov/podaac-ops-cumulus-public/MUR-JPL-L4-GLOB-v4.1/20220604090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc.md5",
+            "Description": "Download 20220604090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc.md5",
+            "Type": "EXTENDED METADATA"
+        },
+        {
+            "URL": "s3://podaac-ops-cumulus-public/MUR-JPL-L4-GLOB-v4.1/20220604090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc.md5",
+            "Description": "This link provides direct download access via S3 to the granule",
+            "Type": "EXTENDED METADATA"
+        },
+        {
+            "URL": "https://archive.podaac.earthdata.nasa.gov/podaac-ops-cumulus-protected/MUR-JPL-L4-GLOB-v4.1/20220604090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc",
+            "Description": "Download 20220604090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc",
+            "Type": "GET DATA"
+        },
+        {
+            "URL": "s3://podaac-ops-cumulus-protected/MUR-JPL-L4-GLOB-v4.1/20220604090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc",
+            "Description": "This link provides direct download access via S3 to the granule",
+            "Type": "GET DATA VIA DIRECT ACCESS"
+        },
+        {
+            "URL": "https://archive.podaac.earthdata.nasa.gov/s3credentials",
+            "Description": "api endpoint to retrieve temporary credentials valid for same-region direct s3 access",
+            "Type": "VIEW RELATED INFORMATION"
+        },
+        {
+            "URL": "https://opendap.earthdata.nasa.gov/collections/C1996881146-POCLOUD/granules/20220604090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1",
+            "Type": "USE SERVICE API",
+            "Subtype": "OPENDAP DATA",
+            "Description": "OPeNDAP request URL"
+        }
+    ]
+}

--- a/tasks/move-granules/tests/data/payload_with_empty_xml.json
+++ b/tasks/move-granules/tests/data/payload_with_empty_xml.json
@@ -1,0 +1,96 @@
+{
+  "config": {
+    "bucket": "cumulus-internal",
+    "buckets": {
+      "internal": {
+        "name": "cumulus-internal",
+        "type": "internal"
+      },
+      "private": {
+        "name": "cumulus-private",
+        "type": "private"
+      },
+      "protected": {
+        "name": "cumulus-protected",
+        "type": "protected"
+      },
+      "public": {
+        "name": "cumulus-public",
+        "type": "public"
+      }
+    },
+    "distribution_endpoint": "https://something.api.us-east-1.amazonaws.com/",
+    "collection": {
+      "files": [
+        {
+          "regex": "^MOD11A1\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf$",
+          "sampleFileName": "MOD11A1.A2017200.h19v04.006.2017201090724.hdf",
+          "bucket": "protected"
+        },
+        {
+          "regex": "^BROWSE\\.MOD11A1\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf$",
+          "sampleFileName": "BROWSE.MOD11A1.A2017200.h19v04.006.2017201090724.hdf",
+          "bucket": "private"
+        },
+        {
+          "regex": "^MOD11A1\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.hdf\\.met$",
+          "sampleFileName": "MOD11A1.A2017200.h19v04.006.2017201090724.hdf.met",
+          "bucket": "private"
+        },
+        {
+          "regex": "^MOD11A1\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}\\.empty\\.cmr\\.xml$",
+          "sampleFileName": "MOD11A1.A2017200.h19v04.006.2017201090724.empty.cmr.xml",
+          "bucket": "public"
+        },
+        {
+          "regex": "^MOD11A1\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}_2\\.jpg$",
+          "sampleFileName": "MOD11A1.A2017200.h19v04.006.2017201090724_2.jpg",
+          "bucket": "public"
+        },
+        {
+          "regex": "^MOD11A1\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}_1\\.jpg$",
+          "sampleFileName": "MOD11A1.A2017200.h19v04.006.2017201090724_1.jpg",
+          "bucket": "public",
+          "url_path": "jpg/example/"
+        }
+      ],
+      "url_path": "example/test/emptyxml",
+      "name": "MOD11A1",
+      "granuleId": "^MOD11A1\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}$",
+      "dataType": "MOD11A1",
+      "process": "modis",
+      "version": "006",
+      "sampleFileName": "MOD11A1.A2017200.h19v04.006.2017201090724.hdf",
+      "id": "MOD11A1"
+    }
+  },
+  "input": {
+    "granules": [
+      {
+        "granuleId": "MOD11A1.A2017200.h19v04.006.2017201090724",
+        "files": [
+          {
+            "key": "file-staging/subdir/MOD11A1.A2017200.h19v04.006.2017201090724.hdf",
+            "bucket": "cumulus-internal",
+            "type": "data"
+          },
+          {
+            "key": "file-staging/subdir/MOD11A1.A2017200.h19v04.006.2017201090724_1.jpg",
+            "bucket": "cumulus-internal",
+            "type": "browse"
+          },
+          {
+            "key": "file-staging/subdir/MOD11A1.A2017200.h19v04.006.2017201090724_2.jpg",
+            "bucket": "cumulus-internal",
+            "type": "browse"
+          },
+          {
+            "key": "file-staging/subdir/MOD11A1.A2017200.h19v04.006.2017201090724.empty.cmr.xml",
+            "bucket": "cumulus-internal",
+            "type": "metadata"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tasks/move-granules/tests/data/payload_with_empty_xml.json
+++ b/tasks/move-granules/tests/data/payload_with_empty_xml.json
@@ -54,7 +54,7 @@
           "url_path": "jpg/example/"
         }
       ],
-      "url_path": "example/test/emptyxml",
+      "url_path": "example/test/emptyxml/",
       "name": "MOD11A1",
       "granuleId": "^MOD11A1\\.A[\\d]{7}\\.[\\S]{6}\\.006.[\\d]{13}$",
       "dataType": "MOD11A1",

--- a/tasks/move-granules/tests/data/payload_with_empty_xml_2.json
+++ b/tasks/move-granules/tests/data/payload_with_empty_xml_2.json
@@ -1,0 +1,104 @@
+{
+  "config": {
+    "bucket": "cumulus-internal",
+    "buckets": {
+      "internal": {
+        "name": "cumulus-internal",
+        "type": "internal"
+      },
+      "private": {
+        "name": "cumulus-private",
+        "type": "private"
+      },
+      "protected": {
+        "name": "cumulus-protected",
+        "type": "protected"
+      },
+      "public": {
+        "name": "cumulus-public",
+        "type": "public"
+      }
+    },
+    "distribution_endpoint": "https://something.api.us-east-1.amazonaws.com/",
+    "collection": {
+      "files": [
+        {
+          "bucket": "protected",
+          "regex": "^SWOT_(IVK|KRX|AUX|HBX|KUX|SST)_([0-9]{8}T[0-9]{6})_([0-9]{8}T[0-9]{6})_([0-9]{8}T[0-9]{6})_([O])_APID([0-9]{4})\\.PTM_([0-9]{1,2})$",
+          "type": "data",
+          "reportToEms": true,
+          "sampleFileName": "SWOT_SST_20210610T081948_20220616T004239_20220616T022710_O_APID1040.PTM_0",
+          "lzards": {
+            "backup": true
+          }
+        },
+        {
+          "bucket": "protected",
+          "regex": "^SWOT_(IVK|KRX|AUX|HBX|KUX|SST)_([0-9]{8}T[0-9]{6})_([0-9]{8}T[0-9]{6})_([0-9]{8}T[0-9]{6})_([O])_APID([0-9]{4})\\.PTM_([0-9]{1,2})\\.archive\\.xml$",
+          "type": "metadata",
+          "reportToEms": true,
+          "sampleFileName": "SWOT_SST_20210610T081948_20220616T004239_20220616T022710_O_APID1040.PTM_0.archive.xml",
+          "lzards": {
+            "backup": true
+          }
+        },
+        {
+          "bucket": "protected",
+          "regex": "^SWOT_(IVK|KRX|AUX|HBX|KUX|SST)_([0-9]{8}T[0-9]{6})_([0-9]{8}T[0-9]{6})_([0-9]{8}T[0-9]{6})_([O])_APID([0-9]{4})\\.PTM_([0-9]{1,2})\\.cmr\\.json$",
+          "type": "metadata",
+          "reportToEms": true,
+          "sampleFileName": "SWOT_SST_20210610T081948_20220616T004239_20220616T022710_O_APID1040.PTM_0.cmr.json"
+        },
+        {
+          "bucket": "protected",
+          "checksumFor": "^SWOT_(IVK|KRX|AUX|HBX|KUX|SST)_([0-9]{8}T[0-9]{6})_([0-9]{8}T[0-9]{6})_([0-9]{8}T[0-9]{6})_([O])_APID([0-9]{4})\\.PTM_([0-9]{1,2})$",
+          "regex": "^SWOT_(IVK|KRX|AUX|HBX|KUX|SST)_([0-9]{8}T[0-9]{6})_([0-9]{8}T[0-9]{6})_([0-9]{8}T[0-9]{6})_([O])_APID([0-9]{4})\\.PTM_([0-9]{1,2})\\.md5$",
+          "type": "metadata",
+          "reportToEms": true,
+          "sampleFileName": "SWOT_SST_20210610T081948_20220616T004239_20220616T022710_O_APID1040.PTM_0.md5"
+        },
+        {
+          "bucket": "protected",
+          "checksumFor": "^SWOT_(IVK|KRX|AUX|HBX|KUX|SST)_([0-9]{8}T[0-9]{6})_([0-9]{8}T[0-9]{6})_([0-9]{8}T[0-9]{6})_([O])_APID([0-9]{4})\\.PTM_([0-9]{1,2})\\.archive\\.xml$",
+          "regex": "^SWOT_(IVK|KRX|AUX|HBX|KUX|SST)_([0-9]{8}T[0-9]{6})_([0-9]{8}T[0-9]{6})_([0-9]{8}T[0-9]{6})_([O])_APID([0-9]{4})\\.PTM_([0-9]{1,2})\\.archive\\.xml\\.md5$",
+          "type": "metadata",
+          "reportToEms": true,
+          "sampleFileName": "SWOT_SST_20210610T081948_20220616T004239_20220616T022710_O_APID1040.PTM_0.archive.xml.md5"
+        }
+      ],
+      "url_path": "",
+      "name": "MOD11A1",
+      "granuleId": "^SWOT_(IVK|KRX|AUX|HBX|KUX|SST)_([0-9]{8}T[0-9]{6})_([0-9]{8}T[0-9]{6})_([0-9]{8}T[0-9]{6})_([O])_APID([0-9]{4})$",
+      "dataType": "MOD11A1",
+      "process": "modis",
+      "version": "006",
+      "sampleFileName": "MOD11A1.A2017200.h19v04.006.2017201090724.hdf",
+      "id": "MOD11A1"
+    }
+  },
+  "input": {
+    "granules": [
+      {
+        "granuleId": "SWOT_IVK_20210612T081400_20210612T072103_20210612T080137_O_APID1040.PTM_1",
+        "dataType": "SWOT_L0A_NALT_COMBO_RAW_1.0",
+        "files": [
+          {
+            "bucket": "cumulus-internal",
+            "type": "data",
+            "key": "file-staging/podaac-swot-uat-cumulus/SWOT_L0A_NALT_COMBO_RAW_1.0/SWOT_IVK_20210612T081400_20210612T072103_20210612T080137_O_APID1040.PTM_1"
+          },
+          {
+            "bucket": "cumulus-internal",
+            "key": "file-staging/podaac-swot-uat-cumulus/SWOT_L0A_NALT_COMBO_RAW_1.0/SWOT_IVK_20210612T081400_20210612T072103_20210612T080137_O_APID1040.PTM_1.archive.xml",
+            "type": "metadata"
+          },
+          {
+            "bucket": "cumulus-internal",
+            "type": "metadata",
+            "key": "file-staging/podaac-swot-uat-cumulus/SWOT_L0A_NALT_COMBO_RAW_1.0/SWOT_IVK_20210612T081400_20210612T072103_20210612T080137_O_APID1040.PTM_1.cmr.json"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tasks/move-granules/tests/test-index.js
+++ b/tasks/move-granules/tests/test-index.js
@@ -803,7 +803,7 @@ test.serial('should move files even when there is a zero byte xml file', async (
 
   const check = await s3ObjectExists({
     Bucket: t.context.publicBucket,
-    Key: 'jpg/example/MOD11A1.A2017200.h19v04.006.2017201090724_1.jpg',
+    Key: 'example/test/emptyxml/MOD11A1.A2017200.h19v04.006.2017201090724.empty.cmr.xml',
   });
 
   t.true(check);


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2557: Move-granules fails with MalformedXML error on 0 byte file](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2557)

## Changes

* Added a zero byte xml file and payload specifying the file
* Added a test using the added payload for moveGranules to use the zero byte xml file

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
