### PR TITLE
CUMULUS-2971: update S3ObjectStore to take string query parameters

### DIFF
--- a/tasks/lzards-backup/src/index.ts
+++ b/tasks/lzards-backup/src/index.ts
@@ -42,7 +42,7 @@ import {
 
 const log = new Logger({ sender: '@cumulus/lzards-backup' });
 
-const CREDS_EXPIRY_SECONDS = 1000;
+const CREDS_EXPIRY_SECONDS = 3600;
 const S3_LINK_EXPIRY_SECONDS_DEFAULT = 3600;
 
 export const generateCloudfrontUrl = async (params: {
@@ -70,10 +70,11 @@ export const generateDirectS3Url = async (params: {
   const secretAccessKey = roleCreds?.Credentials?.SecretAccessKey;
   const sessionToken = roleCreds?.Credentials?.SessionToken;
   const accessKeyId = roleCreds?.Credentials?.AccessKeyId;
+  const expiration = roleCreds?.Credentials?.Expiration;
 
-  const s3AccessTimeoutSeconds = (
-    process.env.lzards_s3_link_timeout || S3_LINK_EXPIRY_SECONDS_DEFAULT
-  );
+  const s3AccessTimeoutSeconds = process.env.lzards_s3_link_timeout
+    ? Number(process.env.lzards_s3_link_timeout) : S3_LINK_EXPIRY_SECONDS_DEFAULT;
+
   let s3Config;
   if ((!inTestMode() || usePassedCredentials) && (secretAccessKey && accessKeyId)) {
     s3Config = {
@@ -82,12 +83,13 @@ export const generateDirectS3Url = async (params: {
         secretAccessKey,
         accessKeyId,
         sessionToken,
+        expiration,
       },
     };
   }
   const s3ObjectStore = new S3ObjectStore(s3Config);
   const s3Uri = buildS3Uri(Bucket, Key);
-  return await s3ObjectStore.signGetObject(s3Uri, {}, { Expires: s3AccessTimeoutSeconds });
+  return await s3ObjectStore.signGetObject(s3Uri, {}, {}, { expiresIn: s3AccessTimeoutSeconds });
 };
 
 export const generateAccessUrl = async (params: {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2971: Cumulus 11.1.1 does not work with LZARDS](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2971)

## Changes

* Detailed list or prose of changes
* ...

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
