### PR TITLE
Sort results in unit test before comparison

### DIFF
--- a/packages/api/tests/lib/writeRecords/test-write-granules.js
+++ b/packages/api/tests/lib/writeRecords/test-write-granules.js
@@ -577,8 +577,8 @@ test.serial('writeGranulesFromMessage() removes preexisting granule file from po
   );
 
   t.deepEqual(
-    existingPgFiles.map((file) => file.bucket).concat(filesFromCumulusMessage),
-    updatedPgFiles.map((file) => file.bucket)
+    existingPgFiles.map((file) => file.bucket).concat(filesFromCumulusMessage).sort(),
+    updatedPgFiles.map((file) => file.bucket).sort()
   );
 });
 


### PR DESCRIPTION
This test was failing intermittently. We were not doing anything guarantee an order result so sorting both lists should ensure that we're comparing arrays correctly.