### PR TITLE
Pin tough-cookie dependency to avoid breaking change in 4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "ssh2-streams": "^0.4.8",
     "string-replace-loader": "^3.0.3",
     "supertest": "^4.0.2",
-    "tough-cookie": "^4.0.0",
+    "tough-cookie": "~4.0.0",
     "tsc-watch": "^4.2.8",
     "typescript": "^4.4.3",
     "uuid": "^8.2.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -110,7 +110,7 @@
     "saml2-js": "^3.0.1",
     "semver": "^7.3.2",
     "split2": "^2.2.0",
-    "tough-cookie": "^2.4.3",
+    "tough-cookie": "~4.0.0",
     "url-join": "^4.0.0",
     "uuid": "^3.2.1",
     "xml2js": "^0.4.22"

--- a/packages/ingest/package.json
+++ b/packages/ingest/package.json
@@ -58,7 +58,7 @@
     "mime-types": "^2.1.22",
     "moment": "2.29.4",
     "simplecrawler": "^1.1.9",
-    "tough-cookie": "^4.0.0"
+    "tough-cookie": "~4.0.0"
   },
   "devDependencies": {
     "@cumulus/checksum": "13.2.1",


### PR DESCRIPTION
This pins our direct dependencies for `tough-cookie` to version ~4.0. There is an issue with the latest minor release 4.1 which is causing unit tests to fail: https://github.com/salesforce/tough-cookie/issues/246

Once the dependency issue is resolved and verified we should switch this back to the latest version.