### PR TITLE
Update CNM lambdas to utilize newer releases

### DIFF
--- a/example/cumulus-tf/cnm_response_task.tf
+++ b/example/cumulus-tf/cnm_response_task.tf
@@ -1,5 +1,5 @@
 locals {
-  cnm_response_version  = "2.0.2"
+  cnm_response_version  = "2.0.3"
   cnm_response_filename = "cnmResponse-${local.cnm_response_version}.zip"
 }
 

--- a/example/cumulus-tf/cnm_to_cma_task.tf
+++ b/example/cumulus-tf/cnm_to_cma_task.tf
@@ -1,5 +1,5 @@
 locals {
-  cnm_to_cma_version  = "1.5.3"
+  cnm_to_cma_version  = "1.5.4"
   cnm_to_cma_filename = "cnmToGranule-${local.cnm_to_cma_version}.zip"
 }
 


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3036](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3036)

## Changes

* Update CNM lambda versions  to address CVE-2021-44832 for integration tests

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
