### PR TITLE
CUMULUS-3027 -- Tightly constrain typescript version due to knex typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - **CUMULUS-3027**
   - Pinned typescript to ~4.7.x to address typing incompatibility issues
     discussed in https://github.com/knex/knex/pull/5279
+  - Update generate-ts-build-cache script to always install root project dependencies
 - **CUMULUS-2940**
   - Updated bulk operation lambda to utilize system wide rds_connection_timing
     configuration parameters from the main `cumulus` module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **CUMULUS-3027**
+  - Pinned typescript to ~4.7.x to address typing incompatibility issues
+    discussed in https://github.com/knex/knex/pull/5279
 - **CUMULUS-2940**
   - Updated bulk operation lambda to utilize system wide rds_connection_timing
     configuration parameters from the main `cumulus` module

--- a/bamboo/generate-ts-build-cache.sh
+++ b/bamboo/generate-ts-build-cache.sh
@@ -27,8 +27,9 @@ if [[ $USE_CACHED_BOOTSTRAP == true ]]; then
   git checkout "$GIT_SHA"
 else
   CURRENT_WORKING_DIR=$(pwd)
-  npm install
 fi
+
+npm install
 
 # Bootstrap to install/link packages
 npm run ci:bootstrap-no-scripts

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "supertest": "^4.0.2",
     "tough-cookie": "~4.0.0",
     "tsc-watch": "^4.2.8",
-    "typescript": "^4.4.3",
+    "typescript": "~4.7.3",
     "uuid": "^8.2.0",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0",


### PR DESCRIPTION
Unpinned dependency resulted in typescript 4.8 being installed,
however knex (all versions) has an outstanding bug:
https://github.com/knex/knex/pull/5279

**Summary:** Summary of changes

Addresses [CUMULUS-3027](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3027)

## Changes

* More tightly constrain typescript dependency due to knex incompatibility

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
