### PR TITLE
Cumulus 2998 - Make Memory Size configurable in all Cumulus tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **CUMULUS-2557**
+  - Updated `@cumulus/aws-client/S3/moveObject` to handle zero byte files (0 byte files).
 - **CUMULUS-2969**
   - Updated `@cumulus/api/models/rules.buildPayload` to only include
     stepFunction name and arn in for the `definition` return value, excluding

--- a/example/cumulus-tf/main.tf
+++ b/example/cumulus-tf/main.tf
@@ -163,21 +163,17 @@ module "cumulus" {
   # Archive API settings
   token_secret = var.token_secret
   archive_api_users = [
-    "aortega527",
+    "chuang14",
+    "ds_jennifertran",
     "jasmine",
     "jennyhliu",
     "jmccoy_uat",
-    "kbaynes",
     "kkelly",
     "kovarik",
-    "lfrederick",
-    "matthewsavoie",
-    "mboyd",
     "menno.vandiermen",
     "mobrien84",
+    "nnageswa",
     "npauzenga",
-    "ds_jennifertran",
-    "nnageswa"
   ]
   archive_api_url             = var.archive_api_url
   archive_api_port            = var.archive_api_port

--- a/example/spec/parallel/SyncGranuleTask/SyncZeroByteFileSpec.js
+++ b/example/spec/parallel/SyncGranuleTask/SyncZeroByteFileSpec.js
@@ -1,5 +1,11 @@
 'use strict';
 
+/*
+* Localstack does not behave the same as S3 when trying to move/sync 0 byte files with
+* multipartCopyObject. Since we are unable to accurately test syncing a 0 byte file with Localstack,
+* we are testing it here.
+*/
+
 const get = require('lodash/get');
 const pAll = require('p-all');
 const pTimeout = require('p-timeout');

--- a/example/spec/parallel/moveGranules/MoveGranulesTagsSpec.js
+++ b/example/spec/parallel/moveGranules/MoveGranulesTagsSpec.js
@@ -1,10 +1,15 @@
 'use strict';
 
+// TODO: rename this file to be clear it is also testing moving zero byte files
+
 /**
  * LocalStack has a bug where it ignores the `Tagging` parameter to the
  * `s3.createMultipartUpload` method. Since we are unable to verify that
  * MoveGranules preserves tags using LocalStack, we're going to have to test
  * it here instead.
+ * Also, Localstack does not behave the same as S3 when trying to move 0 byte files with
+ * multipartCopyObject. Since we are unable to accurately test moving a 0 byte file with Localstack,
+ * we are testing it here.
  */
 
 const get = require('lodash/get');
@@ -17,26 +22,30 @@ const { deleteS3Object, s3GetObjectTagging, s3PutObject } = require('@cumulus/aw
 const { randomId } = require('@cumulus/common/test-utils');
 
 const { moveGranules } = require('@cumulus/move-granules');
+const { headObject, s3ObjectExists } = require('@cumulus/aws-client/S3');
 const { loadConfig } = require('../../helpers/testUtils');
 
 describe('The MoveGranules task', () => {
-  it('preserves object tags', async () => {
-    let collection;
-    let granuleId;
-    let movedFile;
-    let sourceKey;
+  let beforeAllFailed = false;
+  let collection;
+  let config;
+  let granuleId;
+  let movedFile;
+  let moveGranulesResponse;
+  let prefix;
+  let sourceBucket;
+  let sourceKey;
 
-    const config = await loadConfig();
-    const prefix = config.stackName;
-    const sourceBucket = config.bucket;
-
-    process.env.stackName = config.stackName;
-    process.env.system_bucket = config.buckets.internal.name;
-
-    // The S3 path where granules will be ingested from
-    const stagingDir = 'file-staging';
-
+  // const zeroByteFilename = '0byte.dat';
+  beforeAll(async () => {
     try {
+      config = await loadConfig();
+      prefix = config.stackName;
+      sourceBucket = config.bucket;
+
+      process.env.stackName = config.stackName;
+      process.env.system_bucket = config.buckets.internal.name;
+
       // Create the collection
       collection = await createCollection(
         prefix,
@@ -48,17 +57,18 @@ describe('The MoveGranules task', () => {
 
       granuleId = randomId('granule-id-');
 
-      // Stage the granule file to S3
-      const stagedFilename = `${randomId('file-')}.txt`;
-      sourceKey = `${stagingDir}/${stagedFilename}`;
+      // Stage the granule file to S3 (zero byte file with tagging)
+      const stagingDir = 'file-staging';
+      const stagedZeroByteFilename = `${randomId('file-')}.dat`;
+      sourceKey = `${stagingDir}/${stagedZeroByteFilename}`;
       await s3PutObject({
         Bucket: sourceBucket,
         Key: sourceKey,
-        Body: 'asdf',
+        Body: '',
         Tagging: querystring.stringify({ granuleId }),
       });
 
-      const moveGranulesResponse = await moveGranules({
+      moveGranulesResponse = await moveGranules({
         config: {
           bucket: config.bucket,
           buckets: config.buckets,
@@ -72,7 +82,8 @@ describe('The MoveGranules task', () => {
                 {
                   bucket: sourceBucket,
                   key: sourceKey,
-                  fileName: stagedFilename,
+                  fileName: stagedZeroByteFilename,
+                  size: 0,
                 },
               ],
             },
@@ -80,35 +91,55 @@ describe('The MoveGranules task', () => {
         },
       });
 
-      // Verify that the tags of the moved granule match the tags of the source
       movedFile = moveGranulesResponse.granules[0].files[0];
-
-      const movedFileTags = await s3GetObjectTagging(
-        movedFile.bucket,
-        movedFile.key
-      );
-
-      const expectedTagSet = [
-        {
-          Key: 'granuleId',
-          Value: granuleId,
-        },
-      ];
-
-      expect(movedFileTags.TagSet).toEqual(expectedTagSet);
-    } finally {
-      await pAll(
-        [
-          () => deleteS3Object(sourceBucket, sourceKey),
-          () => deleteS3Object(movedFile.bucket, movedFile.filepath),
-          () => deleteCollection({
-            prefix,
-            collectionName: get(collection, 'name'),
-            collectionVersion: get(collection, 'version'),
-          }),
-        ],
-        { stopOnError: false }
-      ).catch(console.error);
+    } catch (error) {
+      beforeAllFailed = true;
+      throw error;
     }
+  });
+
+  afterAll(async () => {
+    await pAll(
+      [
+        () => deleteS3Object(sourceBucket, sourceKey),
+        () => deleteS3Object(movedFile.bucket, movedFile.filepath),
+        () => deleteCollection({
+          prefix,
+          collectionName: get(collection, 'name'),
+          collectionVersion: get(collection, 'version'),
+        }),
+      ],
+      { stopOnError: false }
+    ).catch(console.error);
+  });
+
+  it('succeeds moving the 0 byte file', async () => {
+    if (beforeAllFailed) fail('beforeAll() failed');
+
+    const existCheck = await s3ObjectExists({ Bucket: movedFile.bucket, Key: movedFile.key });
+    const object = await headObject(movedFile.bucket, movedFile.key);
+    const objectSize = object.ContentLength;
+
+    expect(existCheck).toEqual(true);
+    expect(objectSize).toEqual(0);
+  });
+
+  it('preserves object tags', async () => {
+    if (beforeAllFailed) fail('beforeAll() failed');
+
+    // Verify that the tags of the moved granule match the tags of the source
+    const movedFileTags = await s3GetObjectTagging(
+      movedFile.bucket,
+      movedFile.key
+    );
+
+    const expectedTagSet = [
+      {
+        Key: 'granuleId',
+        Value: granuleId,
+      },
+    ];
+
+    expect(movedFileTags.TagSet).toEqual(expectedTagSet);
   });
 });

--- a/packages/ingest/test/test-S3ProviderClient.js
+++ b/packages/ingest/test/test-S3ProviderClient.js
@@ -124,6 +124,9 @@ test.serial('S3ProviderClient.sync syncs a file to a target S3 location', async 
 });
 
 test.serial('S3ProviderClient.sync syncs a 0 byte file', async (t) => {
+  // This test doesn't really prove anything since Localstack does not behave exactly like S3.
+  // However, if Localstack fixes multipart upload handling to match real S3 behavior, this will
+  // be a useful test.
   const s3ProviderClient = new S3ProviderClient({ bucket: t.context.sourceBucket });
   const targetKey = '0byte.dat';
 


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2998: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-XXX)

## Changes

* Make Memory Size configurable in all Cumulus tasks

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
