### PR TITLE
CUMULUS-2969: Update rule/stepfunction invocation logic to avoid rule limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - **CUMULUS-2631**
   - Added 'Bearer token' support to s3credentials endpoint
-  
+
 ### Changed
 
 - **CUMULUS-3027**
@@ -20,6 +20,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **CUMULUS-2969**
+  - Updated `@cumulus/api/models/rules.buildPayload` to only include
+    stepFunction name and arn in for the `definition` return value, excluding
+    step function definition and other extraneous step function object
+    key/values that are not used downstream, but were causing rules to exceed internal AWS limits.
 - **CUMULUS-2971**
   - Updated `@cumulus/aws-client/S3ObjectStore` class to take string query parameters and
     its methods `signGetObject` and `signHeadObject` to take parameter presignOptions

--- a/example/cumulus-tf/large_workflow.asl.json
+++ b/example/cumulus-tf/large_workflow.asl.json
@@ -1,0 +1,389 @@
+{
+  "Comment": "Returns Hello World",
+  "StartAt": "HelloWorld",
+  "States": {
+    "HelloWorld": {
+      "Parameters": {
+        "randomGarbage": "0aa35a74d6dcfbe693003a2453216a74010a93690679f430e87564871d759224fe9c2ad1872eefb598759a25a37e612fca4e0570f21e2e00aea9ba93ebbf5db16353b20234c20c62f5311c18faf851738e299430cb4b2fb0d043a248536d7c463bd2118cb10c1497fd72ba5b55eda40e64f11d0166c4b614971f6cadf6851a7fc0769721079417f7679ceb120e720290cc7d5350b1fdf0dc0f0dfe65bbfb1c7a7b4dcc529ba70ceffcd735d8a40338dcab4e44175b8d6be9cd8502ec7d814529b17ff4055d0ae4bfe6019c9bd9cc276dbf09efb38cfbfa467ee3b6dce35b1fdae5995146552c416cc4f683c7e896ffb35d945fbe3fb12635c18e060b811cbb5704b184ba7fe827e46e3b4408295cf8b1b4665c26fd984790d40937738cc2f03151b48f4d0304a6689811dec2a998f9fcba4c176cdf6e9fc7b5f46e3a90f858b8e531f4722067435bbdf3b28231a5e8829188e8778e1a96dc662ff4ff5607ef5a96721eb3a130e5bdb37736c5b22da1c88e8b9d17a4cef52fd06081ed8b8888d683df8b35cf353771650afb4d028dc06238fd1ba12861a1c375aaa440925022eef475788853e615588aef249ef69282a099e512718df7a5288a20f8bbd1c8bbfe049fbecd4e1306c46a7b460e87750e8be7b83354db3bde13ea53cea7b8f13403742c53d03e41ce6227ac7954296fcf1c0668d61a",
+        "cma": {
+          "event.$": "$",
+          "task_config": {
+            "buckets": "{$.meta.buckets}",
+            "provider": "{$.meta.provider}",
+            "collection": "{$.meta.collection}"
+          }
+        }
+      },
+      "Type": "Task",
+      "Resource": "${hello_world_task_arn}",
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "HelloWorld2"
+    },
+    "HelloWorld2": {
+      "Parameters": {
+        "randomGarbage": "0aa35a74d6dcfbe693003a2453216a74010a93690679f430e87564871d759224fe9c2ad1872eefb598759a25a37e612fca4e0570f21e2e00aea9ba93ebbf5db16353b20234c20c62f5311c18faf851738e299430cb4b2fb0d043a248536d7c463bd2118cb10c1497fd72ba5b55eda40e64f11d0166c4b614971f6cadf6851a7fc0769721079417f7679ceb120e720290cc7d5350b1fdf0dc0f0dfe65bbfb1c7a7b4dcc529ba70ceffcd735d8a40338dcab4e44175b8d6be9cd8502ec7d814529b17ff4055d0ae4bfe6019c9bd9cc276dbf09efb38cfbfa467ee3b6dce35b1fdae5995146552c416cc4f683c7e896ffb35d945fbe3fb12635c18e060b811cbb5704b184ba7fe827e46e3b4408295cf8b1b4665c26fd984790d40937738cc2f03151b48f4d0304a6689811dec2a998f9fcba4c176cdf6e9fc7b5f46e3a90f858b8e531f4722067435bbdf3b28231a5e8829188e8778e1a96dc662ff4ff5607ef5a96721eb3a130e5bdb37736c5b22da1c88e8b9d17a4cef52fd06081ed8b8888d683df8b35cf353771650afb4d028dc06238fd1ba12861a1c375aaa440925022eef475788853e615588aef249ef69282a099e512718df7a5288a20f8bbd1c8bbfe049fbecd4e1306c46a7b460e87750e8be7b83354db3bde13ea53cea7b8f13403742c53d03e41ce6227ac7954296fcf1c0668d61a",
+        "cma": {
+          "event.$": "$",
+          "task_config": {
+            "buckets": "{$.meta.buckets}",
+            "provider": "{$.meta.provider}",
+            "collection": "{$.meta.collection}"
+          }
+        }
+      },
+      "Type": "Task",
+      "Resource": "${hello_world_task_arn}",
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "HelloWorld3"
+    },
+    "HelloWorld3": {
+      "Parameters": {
+        "randomGarbage": "0aa35a74d6dcfbe693003a2453216a74010a93690679f430e87564871d759224fe9c2ad1872eefb598759a25a37e612fca4e0570f21e2e00aea9ba93ebbf5db16353b20234c20c62f5311c18faf851738e299430cb4b2fb0d043a248536d7c463bd2118cb10c1497fd72ba5b55eda40e64f11d0166c4b614971f6cadf6851a7fc0769721079417f7679ceb120e720290cc7d5350b1fdf0dc0f0dfe65bbfb1c7a7b4dcc529ba70ceffcd735d8a40338dcab4e44175b8d6be9cd8502ec7d814529b17ff4055d0ae4bfe6019c9bd9cc276dbf09efb38cfbfa467ee3b6dce35b1fdae5995146552c416cc4f683c7e896ffb35d945fbe3fb12635c18e060b811cbb5704b184ba7fe827e46e3b4408295cf8b1b4665c26fd984790d40937738cc2f03151b48f4d0304a6689811dec2a998f9fcba4c176cdf6e9fc7b5f46e3a90f858b8e531f4722067435bbdf3b28231a5e8829188e8778e1a96dc662ff4ff5607ef5a96721eb3a130e5bdb37736c5b22da1c88e8b9d17a4cef52fd06081ed8b8888d683df8b35cf353771650afb4d028dc06238fd1ba12861a1c375aaa440925022eef475788853e615588aef249ef69282a099e512718df7a5288a20f8bbd1c8bbfe049fbecd4e1306c46a7b460e87750e8be7b83354db3bde13ea53cea7b8f13403742c53d03e41ce6227ac7954296fcf1c0668d61a",
+        "cma": {
+          "event.$": "$",
+          "task_config": {
+            "buckets": "{$.meta.buckets}",
+            "provider": "{$.meta.provider}",
+            "collection": "{$.meta.collection}"
+          }
+        }
+      },
+      "Type": "Task",
+      "Resource": "${hello_world_task_arn}",
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "HelloWorld4"
+    },
+    "HelloWorld4": {
+      "Parameters": {
+        "randomGarbage": "0aa35a74d6dcfbe693003a2453216a74010a93690679f430e87564871d759224fe9c2ad1872eefb598759a25a37e612fca4e0570f21e2e00aea9ba93ebbf5db16353b20234c20c62f5311c18faf851738e299430cb4b2fb0d043a248536d7c463bd2118cb10c1497fd72ba5b55eda40e64f11d0166c4b614971f6cadf6851a7fc0769721079417f7679ceb120e720290cc7d5350b1fdf0dc0f0dfe65bbfb1c7a7b4dcc529ba70ceffcd735d8a40338dcab4e44175b8d6be9cd8502ec7d814529b17ff4055d0ae4bfe6019c9bd9cc276dbf09efb38cfbfa467ee3b6dce35b1fdae5995146552c416cc4f683c7e896ffb35d945fbe3fb12635c18e060b811cbb5704b184ba7fe827e46e3b4408295cf8b1b4665c26fd984790d40937738cc2f03151b48f4d0304a6689811dec2a998f9fcba4c176cdf6e9fc7b5f46e3a90f858b8e531f4722067435bbdf3b28231a5e8829188e8778e1a96dc662ff4ff5607ef5a96721eb3a130e5bdb37736c5b22da1c88e8b9d17a4cef52fd06081ed8b8888d683df8b35cf353771650afb4d028dc06238fd1ba12861a1c375aaa440925022eef475788853e615588aef249ef69282a099e512718df7a5288a20f8bbd1c8bbfe049fbecd4e1306c46a7b460e87750e8be7b83354db3bde13ea53cea7b8f13403742c53d03e41ce6227ac7954296fcf1c0668d61a",
+        "cma": {
+          "event.$": "$",
+          "task_config": {
+            "buckets": "{$.meta.buckets}",
+            "provider": "{$.meta.provider}",
+            "collection": "{$.meta.collection}"
+          }
+        }
+      },
+      "Type": "Task",
+      "Resource": "${hello_world_task_arn}",
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "HelloWorld5"
+    },
+    "HelloWorld5": {
+      "Parameters": {
+        "cma": {
+          "event.$": "$",
+          "task_config": {
+            "buckets": "{$.meta.buckets}",
+            "provider": "{$.meta.provider}",
+            "collection": "{$.meta.collection}"
+          }
+        }
+      },
+      "Type": "Task",
+      "Resource": "${hello_world_task_arn}",
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "HelloWorld6"
+    },
+    "HelloWorld6": {
+      "Parameters": {
+        "randomGarbage": "0aa35a74d6dcfbe693003a2453216a74010a93690679f430e87564871d759224fe9c2ad1872eefb598759a25a37e612fca4e0570f21e2e00aea9ba93ebbf5db16353b20234c20c62f5311c18faf851738e299430cb4b2fb0d043a248536d7c463bd2118cb10c1497fd72ba5b55eda40e64f11d0166c4b614971f6cadf6851a7fc0769721079417f7679ceb120e720290cc7d5350b1fdf0dc0f0dfe65bbfb1c7a7b4dcc529ba70ceffcd735d8a40338dcab4e44175b8d6be9cd8502ec7d814529b17ff4055d0ae4bfe6019c9bd9cc276dbf09efb38cfbfa467ee3b6dce35b1fdae5995146552c416cc4f683c7e896ffb35d945fbe3fb12635c18e060b811cbb5704b184ba7fe827e46e3b4408295cf8b1b4665c26fd984790d40937738cc2f03151b48f4d0304a6689811dec2a998f9fcba4c176cdf6e9fc7b5f46e3a90f858b8e531f4722067435bbdf3b28231a5e8829188e8778e1a96dc662ff4ff5607ef5a96721eb3a130e5bdb37736c5b22da1c88e8b9d17a4cef52fd06081ed8b8888d683df8b35cf353771650afb4d028dc06238fd1ba12861a1c375aaa440925022eef475788853e615588aef249ef69282a099e512718df7a5288a20f8bbd1c8bbfe049fbecd4e1306c46a7b460e87750e8be7b83354db3bde13ea53cea7b8f13403742c53d03e41ce6227ac7954296fcf1c0668d61a",
+        "cma": {
+          "event.$": "$",
+          "task_config": {
+            "buckets": "{$.meta.buckets}",
+            "provider": "{$.meta.provider}",
+            "collection": "{$.meta.collection}"
+          }
+        }
+      },
+      "Type": "Task",
+      "Resource": "${hello_world_task_arn}",
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "HelloWorld7"
+    },
+    "HelloWorld7": {
+      "Parameters": {
+        "cma": {
+          "event.$": "$",
+          "task_config": {
+            "buckets": "{$.meta.buckets}",
+            "provider": "{$.meta.provider}",
+            "collection": "{$.meta.collection}"
+          }
+        }
+      },
+      "Type": "Task",
+      "Resource": "${hello_world_task_arn}",
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "HelloWorld8"
+    },
+    "HelloWorld8": {
+      "Parameters": {
+        "cma": {
+          "event.$": "$",
+          "task_config": {
+            "buckets": "{$.meta.buckets}",
+            "provider": "{$.meta.provider}",
+            "collection": "{$.meta.collection}"
+          }
+        }
+      },
+      "Type": "Task",
+      "Resource": "${hello_world_task_arn}",
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "HelloWorld9"
+    },
+    "HelloWorld9": {
+      "Parameters": {
+        "cma": {
+          "event.$": "$",
+          "task_config": {
+            "buckets": "{$.meta.buckets}",
+            "provider": "{$.meta.provider}",
+            "collection": "{$.meta.collection}"
+          }
+        }
+      },
+      "Type": "Task",
+      "Resource": "${hello_world_task_arn}",
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "HelloWorld10"
+    },
+    "HelloWorld10": {
+      "Parameters": {
+        "cma": {
+          "event.$": "$",
+          "task_config": {
+            "buckets": "{$.meta.buckets}",
+            "provider": "{$.meta.provider}",
+            "collection": "{$.meta.collection}"
+          }
+        }
+      },
+      "Type": "Task",
+      "Resource": "${hello_world_task_arn}",
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "HelloWorld11"
+    },
+    "HelloWorld11": {
+      "Parameters": {
+        "cma": {
+          "event.$": "$",
+          "task_config": {
+            "buckets": "{$.meta.buckets}",
+            "provider": "{$.meta.provider}",
+            "collection": "{$.meta.collection}"
+          }
+        }
+      },
+      "Type": "Task",
+      "Resource": "${hello_world_task_arn}",
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "HelloWorld12"
+    },
+    "HelloWorld12": {
+      "Parameters": {
+        "cma": {
+          "event.$": "$",
+          "task_config": {
+            "buckets": "{$.meta.buckets}",
+            "provider": "{$.meta.provider}",
+            "collection": "{$.meta.collection}"
+          }
+        }
+      },
+      "Type": "Task",
+      "Resource": "${hello_world_task_arn}",
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "HelloWorld13"
+    },
+    "HelloWorld13": {
+      "Parameters": {
+        "cma": {
+          "event.$": "$",
+          "task_config": {
+            "buckets": "{$.meta.buckets}",
+            "provider": "{$.meta.provider}",
+            "collection": "{$.meta.collection}"
+          }
+        }
+      },
+      "Type": "Task",
+      "Resource": "${hello_world_task_arn}",
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "HelloWorld14"
+    },
+    "HelloWorld14": {
+      "Parameters": {
+        "cma": {
+          "event.$": "$",
+          "task_config": {
+            "buckets": "{$.meta.buckets}",
+            "provider": "{$.meta.provider}",
+            "collection": "{$.meta.collection}"
+          }
+        }
+      },
+      "Type": "Task",
+      "Resource": "${hello_world_task_arn}",
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "End": true
+    }
+  }
+}

--- a/example/cumulus-tf/large_workflow.tf
+++ b/example/cumulus-tf/large_workflow.tf
@@ -1,0 +1,16 @@
+module "large_workflow" {
+  source = "../../tf-modules/workflow"
+
+  prefix          = var.prefix
+  name            = "LargeWorkflow"
+  workflow_config = module.cumulus.workflow_config
+  system_bucket   = var.system_bucket
+  tags            = local.tags
+
+  state_machine_definition = templatefile(
+    "${path.module}/large_workflow.asl.json",
+    {
+      hello_world_task_arn: module.cumulus.hello_world_task.task_arn
+    }
+  )
+}

--- a/example/spec/parallel/testAPI/scheduledRuleWithLargeWorkflow.js
+++ b/example/spec/parallel/testAPI/scheduledRuleWithLargeWorkflow.js
@@ -1,0 +1,121 @@
+'use strict';
+
+const {
+  addCollections,
+  cleanupCollections,
+  waitForTestExecutionStart,
+  waitForCompletedExecution,
+} = require('@cumulus/integration-tests');
+
+const rulesApi = require('@cumulus/api-client/rules');
+const { getExecution, deleteExecution } = require('@cumulus/api-client/executions');
+
+const { randomId } = require('@cumulus/common/test-utils');
+
+const {
+  waitForApiStatus,
+} = require('../../helpers/apiUtils');
+const {
+  createTestSuffix,
+  createTimestampedTestId,
+  loadConfig,
+  timestampedName,
+} = require('../../helpers/testUtils');
+
+describe('When I create a scheduled rule that targets a state machine with > 9k characters', () => {
+  let beforeAllError;
+  let config;
+  let execution;
+  let executionArn;
+  let executionFinalStatus;
+  let executionName;
+  let executionNamePrefix;
+  let scheduledHelloWorldRule;
+  let scheduledRuleName;
+  let testSuffix;
+
+  const collectionsDir = './data/collections/s3_MOD09GQ_006';
+
+  beforeAll(async () => {
+    try {
+      config = await loadConfig();
+      process.env.stackName = config.stackName;
+
+      executionNamePrefix = randomId('prefix');
+
+      const testId = createTimestampedTestId(config.stackName, 'SchedRulePrefix');
+      testSuffix = createTestSuffix(testId);
+      scheduledRuleName = timestampedName('SRLSM');
+      scheduledHelloWorldRule = {
+        name: scheduledRuleName,
+        collection: { name: `MOD09GQ${testSuffix}`, version: '006' },
+        workflow: 'LargeWorkflow',
+        rule: {
+          type: 'scheduled',
+          value: 'rate(2 minutes)',
+        },
+        meta: {
+          triggerRule: scheduledRuleName,
+        },
+        executionNamePrefix,
+      };
+
+      await addCollections(config.stackName, config.bucket, collectionsDir,
+        testSuffix, testId);
+      // Create a scheduled rule
+      console.log(`creating rule ${scheduledRuleName}`);
+      await rulesApi.postRule({
+        prefix: config.stackName,
+        rule: scheduledHelloWorldRule,
+      });
+
+      execution = await waitForTestExecutionStart({
+        workflowName: scheduledHelloWorldRule.workflow,
+        stackName: config.stackName,
+        bucket: config.bucket,
+        findExecutionFn: (taskInput, params) =>
+          taskInput.meta.triggerRule && (taskInput.meta.triggerRule === params.ruleName),
+        findExecutionFnParams: { ruleName: scheduledRuleName },
+        startTask: 'HelloWorld',
+      });
+
+      executionArn = execution.executionArn;
+      executionName = execution.executionArn.split(':').reverse()[0];
+      executionFinalStatus = await waitForCompletedExecution(execution.executionArn);
+    } catch (error) {
+      beforeAllError = error;
+    }
+  });
+
+  afterAll(async () => {
+    console.log(`deleting rule ${scheduledRuleName}`);
+
+    await rulesApi.deleteRule({
+      prefix: config.stackName,
+      ruleName: scheduledRuleName,
+    });
+
+    await waitForApiStatus(
+      getExecution,
+      { prefix: config.stackName, arn: executionArn },
+      'completed'
+    );
+    await deleteExecution({ prefix: config.stackName, executionArn });
+
+    await cleanupCollections(config.stackName, config.bucket, collectionsDir,
+      testSuffix);
+  });
+
+  beforeEach(() => {
+    if (beforeAllError) fail(beforeAllError);
+  });
+
+  it('the triggered execzution has the requested prefix', () => {
+    if (beforeAllError) fail(beforeAllError);
+    expect(executionName.startsWith(executionNamePrefix)).toBeTrue();
+  });
+
+  it('completes the workflow with the status "SUCCEEDED"', () => {
+    expect(executionFinalStatus).toBe('SUCCEEDED');
+  });
+});

--- a/packages/api/models/rules.js
+++ b/packages/api/models/rules.js
@@ -220,7 +220,7 @@ class Rule extends Manager {
     const exists = await s3Utils.fileExists(bucket, workflowFileKey);
     if (!exists) throw new Error(`Workflow doesn\'t exist: s3://${bucket}/${workflowFileKey} for ${item.name}`);
 
-    const definition = await s3Utils.getJsonS3Object(
+    const fullDefinition = await s3Utils.getJsonS3Object(
       bucket,
       workflowFileKey
     );
@@ -228,7 +228,10 @@ class Rule extends Manager {
 
     return {
       template,
-      definition,
+      definition: {
+        name: fullDefinition.name,
+        arn: fullDefinition.arn,
+      },
       provider: item.provider,
       collection: item.collection,
       meta: get(item, 'meta', {}),


### PR DESCRIPTION
**Summary:** Summary of changes

- **CUMULUS-2969**
  - Updated `@cumulus/api/models/rules.buildPayload` to only include stepFunction name and arn in for the `definition` return value, excluding step function definition and other extraneous step function object key/values that are not used downstream, but were causing rules to exceed internal AWS limits.


Addresses [CUMULUS-2969](https://bugs.earthdata.nasa.gov/browse/CUMULUS-XXX)

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [x] Integration tests
