### PR TITLE
Updated example/cumulus-tf/variables.tf to have cmr_oauth_provider default to launchpad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Updated `example/cumulus-tf/main.tf` to set `cmr_oauth_provider` to `launchpad`
+
 - **CUMULUS-2787**
   - Updated `lzards-backup-task` to send Cumulus provider and granule createdAt values as metadata in LZARDS backup request to support querying LZARDS for reconciliation reports
 - **CUMULUS-2913**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Updated `example/cumulus-tf/main.tf` to set `cmr_oauth_provider` to `launchpad`
+- Updated `example/cumulus-tf/variables.tf` to have `cmr_oauth_provider` default to `launchpad`
 
 - **CUMULUS-2787**
   - Updated `lzards-backup-task` to send Cumulus provider and granule createdAt values as metadata in LZARDS backup request to support querying LZARDS for reconciliation reports

--- a/example/cumulus-tf/main.tf
+++ b/example/cumulus-tf/main.tf
@@ -122,7 +122,7 @@ module "cumulus" {
 
   cmr_search_client_config = var.cmr_search_client_config
 
-  cmr_oauth_provider = var.cmr_oauth_provider
+  cmr_oauth_provider = "launchpad"
 
   default_s3_multipart_chunksize_mb = var.default_s3_multipart_chunksize_mb
 

--- a/example/cumulus-tf/main.tf
+++ b/example/cumulus-tf/main.tf
@@ -122,7 +122,7 @@ module "cumulus" {
 
   cmr_search_client_config = var.cmr_search_client_config
 
-  cmr_oauth_provider = "launchpad"
+  cmr_oauth_provider = var.cmr_oauth_provider
 
   default_s3_multipart_chunksize_mb = var.default_s3_multipart_chunksize_mb
 

--- a/example/cumulus-tf/terraform.tfvars.example
+++ b/example/cumulus-tf/terraform.tfvars.example
@@ -51,8 +51,6 @@ data_persistence_remote_state_config = {
   region = "us-east-1"
 }
 
-cmr_oauth_provider = "earthdata"
-
 # Make archive API run as a private API gateway and accessible on port 8000
 archive_api_port = 8000
 private_archive_api_gateway = true
@@ -78,12 +76,9 @@ deploy_cumulus_distribution = true
 # toggle this after deployed to put the correct port in. (and hosts and config)
 # tea_distribution_url = "TEA distribution URL"
 
-# Optional, uncomment if needed. Required if using cmr_oauth_provider = "launchpad".
-/*
 launchpad_api = "launchpadApi"
 launchpad_certificate = "certificate"
 launchpad_passphrase = "passphrase"
-*/
 
 oauth_provider   = "earthdata"
 

--- a/example/cumulus-tf/variables.tf
+++ b/example/cumulus-tf/variables.tf
@@ -32,7 +32,7 @@ variable "cumulus_message_adapter_lambda_layer_version_arn" {
 
 variable "cmr_oauth_provider" {
   type    = string
-  default = "earthdata"
+  default = "launchpad"
 }
 
 variable "csdap_client_id" {

--- a/example/cumulus-tf/variables.tf
+++ b/example/cumulus-tf/variables.tf
@@ -30,11 +30,6 @@ variable "cumulus_message_adapter_lambda_layer_version_arn" {
   description = "Layer version ARN of the Lambda layer for the Cumulus Message Adapter"
 }
 
-variable "cmr_oauth_provider" {
-  type    = string
-  default = "launchpad"
-}
-
 variable "csdap_client_id" {
   type        = string
   description = "The csdap client id"

--- a/example/cumulus-tf/variables.tf
+++ b/example/cumulus-tf/variables.tf
@@ -30,6 +30,11 @@ variable "cumulus_message_adapter_lambda_layer_version_arn" {
   description = "Layer version ARN of the Lambda layer for the Cumulus Message Adapter"
 }
 
+variable "cmr_oauth_provider" {
+  type    = string
+  default = "launchpad"
+}
+
 variable "csdap_client_id" {
   type        = string
   description = "The csdap client id"

--- a/example/deployments/cumulus/cumulus-source-tf.tfvars
+++ b/example/deployments/cumulus/cumulus-source-tf.tfvars
@@ -1,3 +1,2 @@
 prefix = "cumulus-source-tf"
-cmr_oauth_provider = "launchpad"
 oauth_provider   = "launchpad"

--- a/example/deployments/cumulus/jl-rds-tf.tfvars
+++ b/example/deployments/cumulus/jl-rds-tf.tfvars
@@ -26,7 +26,6 @@ buckets = {
     type = "public"
   }
 }
-cmr_oauth_provider = "launchpad"
 oauth_provider   = "earthdata"
 
 archive_api_port = 8000

--- a/example/deployments/cumulus/jl-tf.tfvars
+++ b/example/deployments/cumulus/jl-tf.tfvars
@@ -26,7 +26,6 @@ buckets = {
     type = "public"
   }
 }
-cmr_oauth_provider = "launchpad"
 oauth_provider   = "launchpad"
 
 saml_entity_id                  = "https://cumulus-sandbox.earthdata.nasa.gov/jl-tf"

--- a/example/deployments/cumulus/kk2-tf.tfvars
+++ b/example/deployments/cumulus/kk2-tf.tfvars
@@ -26,6 +26,5 @@ buckets = {
     type = "orca"
   }
 }
-cmr_oauth_provider = "launchpad"
 oauth_provider   = "earthdata"
 orca_default_bucket = "kk2-tf-orca-glacier"

--- a/example/deployments/cumulus/vkn-ci-tf.tfvars
+++ b/example/deployments/cumulus/vkn-ci-tf.tfvars
@@ -2,8 +2,6 @@ prefix = "vkn-ci-tf"
 key_name      = "vanhk-cumulus-sandbox"
 archive_api_port = 4343
 
-cmr_oauth_provider = "launchpad"
-
 system_bucket     = "vkn-ci-tf-internal"
 buckets = {
   glacier = {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses 
CUMULUS provider still uses ECHO token, https://wiki.earthdata.nasa.gov/display/CMR/Launchpad+Migration+Status+for+CMR+Ingest+Operations

## Changes

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
