### PR TITLE
Cumulus 3121

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 - **CUMULUS-3077**
   - Updated `lambdas/data-migration2` granule and files migration to have a `removeExcessFiles` function like in write-granules that will remove file records no longer associated with a granule being migrated
+- **CUMULUS-3121**
+  - Updated Terraform modules in order to support configurable CloudWatch retention periods.
 
 ## [v13.4.0] 10/31/2022
 

--- a/tf-modules/archive/api.tf
+++ b/tf-modules/archive/api.tf
@@ -114,13 +114,13 @@ resource "aws_secretsmanager_secret_version" "api_config" {
 
 resource "aws_cloudwatch_log_group" "private_api" {
   name              = "/aws/lambda/${aws_lambda_function.private_api.function_name}"
-  retention_in_days = 30
+  retention_in_days = var.cloudwatch_log_retention_in_days
   tags              = var.tags
 }
 
 resource "aws_cloudwatch_log_group" "api" {
   name              = "/aws/lambda/${aws_lambda_function.api.function_name}"
-  retention_in_days = 30
+  retention_in_days = var.cloudwatch_log_retention_in_days
   tags              = var.tags
 }
 

--- a/tf-modules/archive/async_operation.tf
+++ b/tf-modules/archive/async_operation.tf
@@ -1,6 +1,6 @@
 resource "aws_cloudwatch_log_group" "async_operation" {
   name = "${var.prefix}-AsyncOperationEcsLogs"
-  retention_in_days = 30
+  retention_in_days = var.cloudwatch_log_retention_in_days
   tags = var.tags
 }
 resource "aws_ecs_task_definition" "async_operation" {

--- a/tf-modules/archive/granule_files_cache_updater.tf
+++ b/tf-modules/archive/granule_files_cache_updater.tf
@@ -86,7 +86,7 @@ resource "aws_lambda_function" "granule_files_cache_updater" {
 
 resource "aws_cloudwatch_log_group" "granule_files_cache_updater_logs" {
   name              = "/aws/lambda/${aws_lambda_function.granule_files_cache_updater.function_name}"
-  retention_in_days = 30
+  retention_in_days = var.cloudwatch_log_retention_in_days
   tags              = var.tags
 }
 

--- a/tf-modules/archive/ingest-reporting.tf
+++ b/tf-modules/archive/ingest-reporting.tf
@@ -100,7 +100,7 @@ resource "aws_lambda_function" "publish_executions" {
 
 resource "aws_cloudwatch_log_group" "publish_executions_logs" {
   name              = "/aws/lambda/${var.prefix}-publishExecutions"
-  retention_in_days = 30
+  retention_in_days = var.cloudwatch_log_retention_in_days
   tags              = var.tags
 }
 
@@ -210,7 +210,7 @@ resource "aws_lambda_function" "publish_granules" {
 
 resource "aws_cloudwatch_log_group" "publish_granules_logs" {
   name              = "/aws/lambda/${aws_lambda_function.publish_granules.function_name}"
-  retention_in_days = 30
+  retention_in_days = var.cloudwatch_log_retention_in_days
   tags              = var.tags
 }
 
@@ -315,7 +315,7 @@ resource "aws_lambda_function" "publish_pdrs" {
 
 resource "aws_cloudwatch_log_group" "publish_pdrs_logs" {
   name              = "/aws/lambda/${aws_lambda_function.publish_pdrs.function_name}"
-  retention_in_days = 30
+  retention_in_days = var.cloudwatch_log_retention_in_days
   tags              = var.tags
 }
 

--- a/tf-modules/archive/replay_sqs_messages.tf
+++ b/tf-modules/archive/replay_sqs_messages.tf
@@ -83,6 +83,6 @@ resource "aws_lambda_function" "replay_sqs_messages" {
 
 resource "aws_cloudwatch_log_group" "replay_sqs_messages" {
   name = "/aws/lambda/${aws_lambda_function.replay_sqs_messages.function_name}"
-  retention_in_days = 30
+  retention_in_days = var.cloudwatch_log_retention_in_days
   tags = var.tags
 }

--- a/tf-modules/archive/variables.tf
+++ b/tf-modules/archive/variables.tf
@@ -376,5 +376,5 @@ variable "es_index_shards" {
 variable "cloudwatch_log_retention_in_days" {
   type        = number
   description = "Retention period to apply to CloudWatch logs"
-  default     = 30
+  default     = 365
 }

--- a/tf-modules/archive/variables.tf
+++ b/tf-modules/archive/variables.tf
@@ -372,3 +372,9 @@ variable "es_index_shards" {
   type        = number
   default     = 2
 }
+
+variable "cloudwatch_log_retention_in_days" {
+  type        = number
+  description = "Retention period to apply to CloudWatch logs"
+  default     = 30
+}

--- a/tf-modules/cumulus/variables.tf
+++ b/tf-modules/cumulus/variables.tf
@@ -598,3 +598,9 @@ variable "deploy_cumulus_distribution" {
   type        = bool
   default     = false
 }
+
+variable "cloudwatch_log_retention_in_days" {
+  type        = number
+  description = "Retention period to apply to CloudWatch logs"
+  default     = 365
+}

--- a/tf-modules/cumulus_distribution/api.tf
+++ b/tf-modules/cumulus_distribution/api.tf
@@ -36,7 +36,7 @@ resource "aws_secretsmanager_secret_version" "api_oauth_client_password" {
 
 resource "aws_cloudwatch_log_group" "api" {
   name              = "/aws/lambda/${aws_lambda_function.api.function_name}"
-  retention_in_days = 30
+  retention_in_days = var.cloudwatch_log_retention_in_days
   tags              = var.tags
 }
 

--- a/tf-modules/cumulus_distribution/variables.tf
+++ b/tf-modules/cumulus_distribution/variables.tf
@@ -118,3 +118,9 @@ variable "vpc_id" {
   description = "VPC used by Lambda functions"
   default     = null
 }
+
+variable "cloudwatch_log_retention_in_days" {
+  type        = number
+  description = "Retention period to apply to CloudWatch logs"
+  default     = 30
+}

--- a/tf-modules/cumulus_distribution/variables.tf
+++ b/tf-modules/cumulus_distribution/variables.tf
@@ -122,5 +122,5 @@ variable "vpc_id" {
 variable "cloudwatch_log_retention_in_days" {
   type        = number
   description = "Retention period to apply to CloudWatch logs"
-  default     = 30
+  default     = 365
 }

--- a/tf-modules/cumulus_ecs_service/main.tf
+++ b/tf-modules/cumulus_ecs_service/main.tf
@@ -16,7 +16,7 @@ data "aws_region" "current" {}
 
 resource "aws_cloudwatch_log_group" "default" {
   name              = "${local.full_name}EcsLogs"
-  retention_in_days = 30
+  retention_in_days = var.cloudwatch_log_retention_in_days
   tags              = var.tags
 }
 

--- a/tf-modules/cumulus_ecs_service/variables.tf
+++ b/tf-modules/cumulus_ecs_service/variables.tf
@@ -91,5 +91,5 @@ variable "log_destination_arn" {
 variable "cloudwatch_log_retention_in_days" {
   type        = number
   description = "Retention period to apply to CloudWatch logs"
-  default     = 30
+  default     = 365
 }

--- a/tf-modules/cumulus_ecs_service/variables.tf
+++ b/tf-modules/cumulus_ecs_service/variables.tf
@@ -87,3 +87,9 @@ variable "log_destination_arn" {
   default     = null
   description = "A shared AWS:Log:Destination that receives logs in log_groups"
 }
+
+variable "cloudwatch_log_retention_in_days" {
+  type        = number
+  description = "Retention period to apply to CloudWatch logs"
+  default     = 30
+}

--- a/tf-modules/ingest/discover-pdrs-task.tf
+++ b/tf-modules/ingest/discover-pdrs-task.tf
@@ -32,6 +32,6 @@ resource "aws_lambda_function" "discover_pdrs_task" {
 
 resource "aws_cloudwatch_log_group" "discover_pdrs_task" {
   name              = "/aws/lambda/${aws_lambda_function.discover_pdrs_task.function_name}"
-  retention_in_days = 30
+  retention_in_days = var.cloudwatch_log_retention_in_days
   tags              = var.tags
 }

--- a/tf-modules/ingest/hyrax-metadata-updates-task.tf
+++ b/tf-modules/ingest/hyrax-metadata-updates-task.tf
@@ -35,7 +35,7 @@ resource "aws_lambda_function" "hyrax_metadata_updates_task" {
 
 resource "aws_cloudwatch_log_group" "hyrax_metadata_updates_task" {
   name              = "/aws/lambda/${aws_lambda_function.hyrax_metadata_updates_task.function_name}"
-  retention_in_days = 30
+  retention_in_days = var.cloudwatch_log_retention_in_days
   tags              = var.tags
 }
 

--- a/tf-modules/ingest/parse-pdr-task.tf
+++ b/tf-modules/ingest/parse-pdr-task.tf
@@ -32,6 +32,6 @@ resource "aws_lambda_function" "parse_pdr_task" {
 
 resource "aws_cloudwatch_log_group" "parse_pdr_task" {
   name              = "/aws/lambda/${aws_lambda_function.parse_pdr_task.function_name}"
-  retention_in_days = 30
+  retention_in_days = var.cloudwatch_log_retention_in_days
   tags              = var.tags
 }

--- a/tf-modules/ingest/post-to-cmr-task.tf
+++ b/tf-modules/ingest/post-to-cmr-task.tf
@@ -35,6 +35,6 @@ resource "aws_lambda_function" "post_to_cmr_task" {
 
 resource "aws_cloudwatch_log_group" "post_to_cmr_task" {
   name = "/aws/lambda/${aws_lambda_function.post_to_cmr_task.function_name}"
-  retention_in_days = 30
+  retention_in_days = var.cloudwatch_log_retention_in_days
   tags = var.tags
 }

--- a/tf-modules/ingest/queue-pdrs-task.tf
+++ b/tf-modules/ingest/queue-pdrs-task.tf
@@ -32,6 +32,6 @@ resource "aws_lambda_function" "queue_pdrs_task" {
 
 resource "aws_cloudwatch_log_group" "queue_pdrs_task" {
   name              = "/aws/lambda/${aws_lambda_function.queue_pdrs_task.function_name}"
-  retention_in_days = 30
+  retention_in_days = var.cloudwatch_log_retention_in_days
   tags              = var.tags
 }

--- a/tf-modules/ingest/queue-workflow-task.tf
+++ b/tf-modules/ingest/queue-workflow-task.tf
@@ -32,6 +32,6 @@ resource "aws_lambda_function" "queue_workflow_task" {
 
 resource "aws_cloudwatch_log_group" "queue_workflow_task" {
   name              = "/aws/lambda/${aws_lambda_function.queue_workflow_task.function_name}"
-  retention_in_days = 30
+  retention_in_days = var.cloudwatch_log_retention_in_days
   tags              = var.tags
 }

--- a/tf-modules/ingest/sync-granule-task.tf
+++ b/tf-modules/ingest/sync-granule-task.tf
@@ -33,6 +33,6 @@ resource "aws_lambda_function" "sync_granule_task" {
 
 resource "aws_cloudwatch_log_group" "sync_granule_task" {
   name = "/aws/lambda/${aws_lambda_function.sync_granule_task.function_name}"
-  retention_in_days = 30
+  retention_in_days = var.cloudwatch_log_retention_in_days
   tags = var.tags
 }

--- a/tf-modules/ingest/update-cmr-access-constraints.tf
+++ b/tf-modules/ingest/update-cmr-access-constraints.tf
@@ -30,7 +30,7 @@ resource "aws_lambda_function" "update_cmr_access_constraints_task" {
 }
 
 resource "aws_cloudwatch_log_group" "update_cmr_access_constraints_task" {
-  name = "/aws/lambda/${aws_lambda_function.update_cmr_access_constraints_task.function_name}"
-  retention_in_days = 30
-  tags = var.tags
+  name              = "/aws/lambda/${aws_lambda_function.update_cmr_access_constraints_task.function_name}"
+  retention_in_days = var.cloudwatch_log_retention_in_days
+  tags              = var.tags
 }

--- a/tf-modules/ingest/variables.tf
+++ b/tf-modules/ingest/variables.tf
@@ -173,3 +173,9 @@ variable "vpc_id" {
   type    = string
   default = null
 }
+
+variable "cloudwatch_log_retention_in_days" {
+  type        = number
+  description = "Retention period to apply to CloudWatch logs"
+  default     = 30
+}

--- a/tf-modules/ingest/variables.tf
+++ b/tf-modules/ingest/variables.tf
@@ -177,5 +177,5 @@ variable "vpc_id" {
 variable "cloudwatch_log_retention_in_days" {
   type        = number
   description = "Retention period to apply to CloudWatch logs"
-  default     = 30
+  default     = 365
 }


### PR DESCRIPTION
**Summary:** Add support for configuring CloudWatch retention periods

Addresses [CUMULUS-3121: Support configurable CloudWatch retention periods](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3121)

## Changes

All changes are limited to Terraform configuration files. The goal is to allow configuration of CloudWatch retention periods in order to meet a NIST-5 requirement of maintaining logs for one year.

* Updated Terraform configuration files to allow a custom retention period to be applied.
* Updated default log retention period in Terraform to 365 days.

Unit and integration tests have not been run, however the code has been successfully built, deployed, and used to process granules in sbx and sit, with verification of updated log retention periods. If additional testing is required before review, please let us know what is needed.

## PR Checklist

- [X ] Update CHANGELOG
- [ ] Unit tests
- [X ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
