### PR TITLE
CUMULUS-3070: Address missing write granules logic block and add/update tests

### DIFF
--- a/packages/api/lib/writeRecords/write-granules.js
+++ b/packages/api/lib/writeRecords/write-granules.js
@@ -611,7 +611,7 @@ const _writeGranule = async ({
   // (e.g. "status: completed") and there is a valid `files` key in the granule.
   // An empty array of files will remove existing file records but a missing
   // `files` key will not.
-  if (isStatusFinalState(status) && ('files' in apiGranuleRecord)) {
+  if ((writeConstraints === false || (isStatusFinalState(status))) && 'files' in apiGranuleRecord) {
     await _writeGranuleFiles({
       granuleCumulusId: pgGranule.cumulus_id,
       granule: apiGranuleRecord,


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3070: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3070)

## Changes

* Fixes issue in the implementation of 3070 where API running/queued granules do not correctly update files on update due to missing logic/test 

## PR Checklist

- [ ] Update CHANGELOG
- [x] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
