### PR TITLE
Fix - Update GitHub FAQs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Updated API endpoint GET `/executions/status/${executionArn}` to return the
     presigned s3 URL in addition to execution status data
 - **CUMULUS-3045**
-  - Update GitHub FAQs: add new and refreshed content for previous sections and added a dedicated Workflows section
+  - Update GitHub FAQs:
+    - Add new and refreshed content for previous sections
+    - Add new dedicated Workflows section
 - **CUMULUS-3075**
   - Changed the API endpoint return value for a granule with no files. When a granule has no files, the return value beforehand for
     the translatePostgresGranuletoApiGranule, the function which does the translation of a Postgres granule to an API granule, was 

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -6,7 +6,32 @@ hide_title: false
 
 Below are some commonly asked questions that you may encounter that can assist you along the way when working with Cumulus.
 
+[General](#general) | [Workflows](#workflows) | [Integrators & Developers](#integrators--developers) | [Operators](#operators)
+
+---
+
 ### General
+
+<details>
+  <summary>What prerequisites are needed to setup Cumulus?</summary>
+  Answer: Here is a list of the tools and access that you will need in order to get started. To maintain the up-to-date versions that we are using please visit our [Cumulus main README](https://github.com/nasa/cumulus) for details.
+
+- [NVM](https://github.com/creationix/nvm) for node versioning
+- [AWS CLI](http://docs.aws.amazon.com/cli/latest/userguide/installing.html)
+- Bash
+- Docker (only required for testing)
+- docker-compose (only required for testing `pip install docker-compose`)
+- Python
+- [pipenv](https://pypi.org/project/pipenv/)
+  
+> Keep in mind you will need access to the AWS console and an [Earthdata account](https://urs.earthdata.nasa.gov/) before you can deploy Cumulus.
+</details>
+
+<details>
+  <summary>What is the preferred web browser for the Cumulus environment?</summary>
+
+  Answer: Our preferred web browser is the latest version of [Google Chrome](https://www.google.com/chrome/).
+</details>
 
 <details>
   <summary>How do I deploy a new instance in Cumulus?</summary>
@@ -15,15 +40,9 @@ Below are some commonly asked questions that you may encounter that can assist y
 </details>
 
 <details>
-  <summary>What prerequisites are needed to setup Cumulus?</summary>
+  <summary>Where can I find Cumulus release notes?</summary>
 
-  Answer: You will need access to the AWS console and an [Earthdata login](https://urs.earthdata.nasa.gov/) before you can deploy Cumulus.
-</details>
-
-<details>
-  <summary>What is the preferred web browser for the Cumulus environment?</summary>
-
-  Answer: Our preferred web browser is the latest version of [Google Chrome](https://www.google.com/chrome/).
+  Answer: To get the latest information about updates to Cumulus go to [Cumulus Versions](https://nasa.github.io/cumulus/versions).
 </details>
 
 <details>
@@ -37,9 +56,38 @@ Below are some commonly asked questions that you may encounter that can assist y
 
   Answer: The following options are available for assistance:
 
-* Cumulus: Outside NASA users should file a GitHub issue and inside NASA users should file a JIRA issue.
-* AWS: You can create a case in the [AWS Support Center](https://console.aws.amazon.com/support/home), accessible via your AWS Console.
+- Cumulus: Outside NASA users should file a [GitHub issue](https://github.com/nasa/cumulus/issues) and inside NASA users should file a Cumulus JIRA ticket.
+- AWS: You can create a case in the [AWS Support Center](https://console.aws.amazon.com/support/home), accessible via your AWS Console.
 
+> For more information on how to submit an issue or contribute to Cumulus follow our guidelines at [Contributing](https://github.com/nasa/cumulus/blob/master/CONTRIBUTING.md)
+</details>
+
+---
+
+### Workflows
+
+<details>
+  <summary>What is a Cumulus workflow?</summary>
+
+  Answer: A workflow is a provider-configured set of steps that describe the process to ingest data. Workflows are defined using [AWS Step Functions](https://docs.aws.amazon.com/step-functions/index.html). For more details, we suggest visiting the [Workflows](../workflows/workflows-readme) section.
+</details>
+
+<details>
+  <summary>How do I set up a Cumulus workflow?</summary>
+
+  Answer: You will need to create a provider, have an associated collection (add a new one), and generate a new rule first. Then you can set up a Cumulus workflow by following these steps [here](../workflows/developing-a-cumulus-workflow).
+</details>
+
+<details>
+  <summary>Where can I find a list of workflow tasks?</summary>
+
+  Answer: You can access a list of reusable tasks for Cumulus development at [Cumulus Tasks](../tasks).
+</details>
+
+<details>
+  <summary>Are there any third-party workflows or applications that I can use with Cumulus?</summary>
+
+  Answer: The Cumulus team works with various partners to help build a robust framework. You can visit our [External Contributions](../external-contributions/external-contributions) section to see what other options are available to help you customize Cumulus for your needs.
 </details>
 
 ---
@@ -51,9 +99,9 @@ Below are some commonly asked questions that you may encounter that can assist y
 
   Answer: Those who are working within Cumulus and AWS for deployments and to manage workflows. They may perform the following functions:
 
-* Configure and deploy Cumulus to the AWS environment
-* Configure Cumulus workflows
-* Write custom workflow tasks
+- Configure and deploy Cumulus to the AWS environment
+- Configure Cumulus workflows
+- Write custom workflow tasks
 
 </details>
 
@@ -82,25 +130,13 @@ Below are some commonly asked questions that you may encounter that can assist y
 </details>
 
 <details>
-  <summary>What is a Cumulus workflow?</summary>
-
-  Answer: A workflow is a provider-configured set of steps that describe the process to ingest data. Workflows are defined using [AWS Step Functions](https://docs.aws.amazon.com/step-functions/index.html). For more details, we suggest visiting [here](../workflows/workflows-readme).
-</details>
-
-<details>
-  <summary>How do I set up a Cumulus workflow?</summary>
-
-  Answer: You will need to create a provider, have an associated collection (add a new one), and generate a new rule first. Then you can set up a Cumulus workflow by following these steps [here](../workflows/developing-a-cumulus-workflow).
-</details>
-
-<details>
   <summary>What are the common use cases that a Cumulus integrator encounters?</summary>
 
   Answer: The following are some examples of possible use cases you may see:
 
-* [Creating Cumulus Data Management Types](../integrator-guide/create-cumulus-data-mgmt-types)
-* [Workflow: Add New Lambda](../integrator-guide/workflow-add-new-lambda)
-* [Workflow: Troubleshoot Failed Step(s)](../integrator-guide/workflow-ts-failed-step)
+- [Creating Cumulus Data Management Types](../integrator-guide/create-cumulus-data-mgmt-types)
+- [Workflow: Add New Lambda](../integrator-guide/workflow-add-new-lambda)
+- [Workflow: Troubleshoot Failed Step(s)](../integrator-guide/workflow-ts-failed-step)
 
 </details>
 
@@ -113,14 +149,14 @@ Below are some commonly asked questions that you may encounter that can assist y
 
   Answer: Those that ingests, archives, and troubleshoots datasets (called collections in Cumulus). Your daily activities might include but not limited to the following:
 
-* Ingesting datasets
-* Maintaining historical data ingest
-* Starting and stopping data handlers
-* Managing collections
-* Managing provider definitions
-* Creating, enabling, and disabling rules
-* Investigating errors for granules and deleting or re-ingesting granules
-* Investigating errors in executions and isolating failed workflow step(s)
+- Ingesting datasets
+- Maintaining historical data ingest
+- Starting and stopping data handlers
+- Managing collections
+- Managing provider definitions
+- Creating, enabling, and disabling rules
+- Investigating errors for granules and deleting or re-ingesting granules
+- Investigating errors in executions and isolating failed workflow step(s)
 
 </details>
 
@@ -129,10 +165,11 @@ Below are some commonly asked questions that you may encounter that can assist y
 
   Answer: The following are some examples of possible use cases you may see:
 
-* [Kinesis Stream For Ingest](../operator-docs/kinesis-stream-for-ingest)
-* [Create Rule In Cumulus](../operator-docs/create-rule-in-cumulus)
-* [Granule Workflows](../operator-docs/granule-workflows)
+- [Kinesis Stream For Ingest](../operator-docs/kinesis-stream-for-ingest)
+- [Create Rule In Cumulus](../operator-docs/create-rule-in-cumulus)
+- [Granule Workflows](../operator-docs/granule-workflows)
 
+Explore more Cumulus operator best practices and how-tos in the dedicated [Operator Docs](../operator-docs/).
 </details>
 
 <details>


### PR DESCRIPTION
**Summary:**

Addresses [CUMULUS-3045: Update GitHub FAQs](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3045)

Refresh and update open-source FAQs. This is the PR for the already approved PR from https://github.com/nasa/cumulus/pull/3139. Had to revert that PR because of a corrupt merge to master.

- [x] Update CHANGELOG
