### PR TITLE
Jk/cumulus 3071

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     - Granules being set to non-complete state will update all values passed in,
       instead of being restricted to `['createdAt', 'updatedAt', 'timestamp',
       'status', 'execution']`
-      
+
 
 ### Added
 
@@ -35,8 +35,25 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     `null` is explicitly set with intention to delete the value.
   - Removed dataType/version from api granule schema
   - Added `@cumulus/api/endpoints/granules` unit to cover duration overwrite
-    logic for PUT/PATCH endpoint
+    logic for PUT/PATCH endpoint.
+
 ### Changed
+
+- **CUMULUS-3071**
+  - Added 'PATCH' granules endpoint as an exact duplicate of the existing `PUT`
+    endpoint.    In future releases the `PUT` endpoint will be replaced with valid PUT logic
+    behavior (complete overwrite) in a future release.   **The existing PUT
+    implementation is deprecated** and users should move all existing usage of
+    `PUT` to `PATCH` before upgrading to a release with `CUMULUS-3072`.
+  - Updated `@cumulus/api-client` packages to use `PATCH` protocol for existing
+    granule `PUT` calls, this change should not require user updates for
+    `api-client` users.
+    - `@cumulus/api-client/granules.updateGranule`
+    - `@cumulus/api-client/granules.moveGranule`
+    - `@cumulus/api-client/granules.updateGranule`
+    - `@cumulus/api-client/granules.reingestGranule`
+    - `@cumulus/api-client/granules.removeFromCMR`
+    - `@cumulus/api-client/granules.applyWorkflow`
 
 -**CUMULUS-3100**
   - Updated `POST` granules endpoint to check if granuleId exists across all collections rather than a single collection.
@@ -56,14 +73,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     across all API granule writes.
   - Updated granule write code to validate written createdAt is synced between
     datastores in cases where granule.createdAt is not provided for a new granule.
-      
+
 
 ## [v13.4.0] 10/31/2022
 
 - **CUMULUS-3075**
   - Changed the API endpoint return value for a granule with no files. When a granule has no files, the return value beforehand for
-    the translatePostgresGranuletoApiGranule, the function which does the translation of a Postgres granule to an API granule, was 
-    undefined, now changed to an empty array. 
+    the translatePostgresGranuletoApiGranule, the function which does the translation of a Postgres granule to an API granule, was
+    undefined, now changed to an empty array.
   - Existing behavior which relied on the pre-disposed undefined value was changed to instead accept the empty array.
   - Standardized tests in order to expect an empty array for a granule with no files files' object instead of undefined.
 
@@ -98,8 +115,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     - Add new dedicated Workflows section
 - **CUMULUS-3075**
   - Changed the API endpoint return value for a granule with no files. When a granule has no files, the return value beforehand for
-    the translatePostgresGranuletoApiGranule, the function which does the translation of a Postgres granule to an API granule, was 
-    undefined, now changed to an empty array. 
+    the translatePostgresGranuletoApiGranule, the function which does the translation of a Postgres granule to an API granule, was
+    undefined, now changed to an empty array.
   - Existing behavior which relied on the pre-disposed undefined value was changed to instead accept the empty array.
   - Standardized tests in order to expect an empty array for a granule with no files files' object instead of undefined.
 - **CUMULUS-3077**

--- a/packages/api-client/src/granules.ts
+++ b/packages/api-client/src/granules.ts
@@ -136,7 +136,7 @@ export const waitForGranule = async (params: {
 
 /**
  * Reingest a granule from the Cumulus API
- * PUT /granules/{}
+ * PATCH /granules/{}
  *
  * @param {Object} params              - params
  * @param {string} params.prefix       - the prefix configured for the stack
@@ -161,7 +161,7 @@ export const reingestGranule = async (params: {
   return await callback({
     prefix: prefix,
     payload: {
-      httpMethod: 'PUT',
+      httpMethod: 'PATCH',
       resource: '/{proxy+}',
       path: `/granules/${granuleId}`,
       headers: {
@@ -178,7 +178,7 @@ export const reingestGranule = async (params: {
 
 /**
  * Removes a granule from CMR via the Cumulus API
- * PUT /granules/{granuleId}
+ * PATCH /granules/{granuleId}
  *
  * @param {Object} params             - params
  * @param {string} params.prefix      - the prefix configured for the stack
@@ -199,7 +199,7 @@ export const removeFromCMR = async (params: {
   return await callback({
     prefix: prefix,
     payload: {
-      httpMethod: 'PUT',
+      httpMethod: 'PATCH',
       resource: '/{proxy+}',
       path: `/granules/${granuleId}`,
       headers: {
@@ -212,7 +212,7 @@ export const removeFromCMR = async (params: {
 
 /**
  * Run a workflow with the given granule as the payload
- * PUT /granules/{granuleId}
+ * PATCH /granules/{granuleId}
  *
  * @param {Object} params             - params
  * @param {string} params.prefix      - the prefix configured for the stack
@@ -242,7 +242,7 @@ export const applyWorkflow = async (params: {
   return await callback({
     prefix: prefix,
     payload: {
-      httpMethod: 'PUT',
+      httpMethod: 'PATCH',
       resource: '/{proxy+}',
       headers: {
         'Content-Type': 'application/json',
@@ -292,7 +292,7 @@ export const deleteGranule = async (params: {
 
 /**
  * Move a granule via the API
- * PUT /granules/{granuleId}
+ * PATCH /granules/{granuleId}
  *
  * @param {Object} params                       - params
  * @param {string} params.prefix                - the prefix configured for the stack
@@ -320,7 +320,7 @@ export const moveGranule = async (params: {
   return await callback({
     prefix: prefix,
     payload: {
-      httpMethod: 'PUT',
+      httpMethod: 'PATCH',
       resource: '/{proxy+}',
       headers: {
         'Content-Type': 'application/json',
@@ -418,8 +418,10 @@ export const createGranule = async (params: {
 };
 
 /**
- * Update granule in cumulus.
- * PUT /granules/{granuleId}
+ * Update granule in cumulus via PATCH request.  Existing values will
+ * not be overwritten if not specified, null values will be removed and in
+ * some cases replaced with defaults.
+ * PATCH /granules/{granuleId}
  * @param {Object} params             - params
  * @param {Object} [params.body]      - granule to pass the API lambda
  * @param {Function} params.callback  - async function to invoke the api lambda
@@ -438,7 +440,7 @@ export const updateGranule = async (params: {
   return await callback({
     prefix,
     payload: {
-      httpMethod: 'PUT',
+      httpMethod: 'PATCH',
       resource: '/{proxy+}',
       path: `/granules/${body.granuleId}`,
       headers: { 'Content-Type': 'application/json' },

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -1,6 +1,6 @@
 import pRetry from 'p-retry';
 
-export type HttpMethod = 'DELETE' | 'GET' | 'POST' | 'PUT';
+export type HttpMethod = 'DELETE' | 'GET' | 'POST' | 'PUT' | 'PATCH';
 
 // https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html
 export interface ApiGatewayLambdaProxyPayload {

--- a/packages/api-client/tests/test-granules.js
+++ b/packages/api-client/tests/test-granules.js
@@ -143,7 +143,7 @@ test('reingestGranule calls the callback with the expected object', async (t) =>
   const expected = {
     prefix: t.context.testPrefix,
     payload: {
-      httpMethod: 'PUT',
+      httpMethod: 'PATCH',
       resource: '/{proxy+}',
       path: `/granules/${t.context.granuleId}`,
       headers: {
@@ -172,7 +172,7 @@ test('removeFromCmr calls the callback with the expected object', async (t) => {
   const expected = {
     prefix: t.context.testPrefix,
     payload: {
-      httpMethod: 'PUT',
+      httpMethod: 'PATCH',
       resource: '/{proxy+}',
       path: `/granules/${t.context.granuleId}`,
       headers: {
@@ -199,7 +199,7 @@ test('applyWorkflow calls the callback with the expected object', async (t) => {
   const expected = {
     prefix: t.context.testPrefix,
     payload: {
-      httpMethod: 'PUT',
+      httpMethod: 'PATCH',
       resource: '/{proxy+}',
       headers: {
         'Content-Type': 'application/json',
@@ -250,7 +250,7 @@ test('moveGranule calls the callback with the expected object', async (t) => {
   const expected = {
     prefix: t.context.testPrefix,
     payload: {
-      httpMethod: 'PUT',
+      httpMethod: 'PATCH',
       resource: '/{proxy+}',
       headers: {
         'Content-Type': 'application/json',
@@ -324,7 +324,7 @@ test('removePublishedGranule calls removeFromCmr and deleteGranule', async (t) =
 
   const callback = ({ payload }) => {
     if (
-      payload.httpMethod === 'PUT'
+      payload.httpMethod === 'PATCH'
       && payload.path === `/granules/${t.context.granuleId}`
       && payload.body.includes('removeFromCmr')
     ) {
@@ -382,7 +382,7 @@ test('updateGranule calls the callback with the expected object', async (t) => {
   const expected = {
     prefix: t.context.testPrefix,
     payload: {
-      httpMethod: 'PUT',
+      httpMethod: 'PATCH',
       resource: '/{proxy+}',
       path: `/granules/${t.context.granuleId}`,
       headers: { 'Content-Type': 'application/json' },

--- a/packages/api/endpoints/granules.js
+++ b/packages/api/endpoints/granules.js
@@ -246,6 +246,10 @@ const putGranule = async (req, res) => {
   return _returnPutGranuleStatus(isNewRecord, apiGranule, res);
 };
 
+function put(req, res) {
+  res.boom.badRequest('Put method not implemented');
+}
+
 /**
  * Update a single granule.
  * Supported Actions: reingest, move, applyWorkflow, RemoveFromCMR.
@@ -256,7 +260,7 @@ const putGranule = async (req, res) => {
  * @param {Object} res - express response object
  * @returns {Promise<Object>} the promise of express response object
  */
-async function put(req, res) {
+async function patch(req, res) {
   const {
     granuleModel = new Granule(),
     knex = await getKnexClient(),
@@ -711,7 +715,8 @@ router.get('/:granuleName', get);
 router.get('/', list);
 router.post('/:granuleName/executions', associateExecution);
 router.post('/', create);
-router.put('/:granuleName', put);
+router.put('/:granuleName', patch);
+router.patch('/:granuleName', patch);
 
 router.post(
   '/bulk',
@@ -739,6 +744,7 @@ module.exports = {
   bulkReingest,
   create,
   put,
+  patch,
   putGranule,
   router,
 };

--- a/packages/api/endpoints/granules.js
+++ b/packages/api/endpoints/granules.js
@@ -52,7 +52,7 @@ const log = new Logger({ sender: '@cumulus/api/granules' });
 * @param {Object} res        - express response object
 * @returns {Promise<Object>} Promise resolving to an express response object
 */
-function _returnPutGranuleStatus(isNewRecord, granule, res) {
+function _returnPatchGranuleStatus(isNewRecord, granule, res) {
   if (isNewRecord) {
     return res.status(201).send(
       { message: `Successfully wrote granule with Granule Id: ${granule.granuleId}, Collection Id: ${granule.collectionId}` }
@@ -180,7 +180,7 @@ const create = async (req, res) => {
  * @param {Object} res - express response object
  * @returns {Promise<Object>} promise of an express response object.
  */
-const putGranule = async (req, res) => {
+const patchGranule = async (req, res) => {
   const {
     granulePgModel = new GranulePgModel(),
     collectionPgModel = new CollectionPgModel(),
@@ -243,7 +243,7 @@ const putGranule = async (req, res) => {
     log.error('failed to update granule', error);
     return res.boom.badRequest(errorify(error));
   }
-  return _returnPutGranuleStatus(isNewRecord, apiGranule, res);
+  return _returnPatchGranuleStatus(isNewRecord, apiGranule, res);
 };
 
 function put(req, res) {
@@ -275,7 +275,7 @@ async function patch(req, res) {
 
   if (!action) {
     if (req.body.granuleId === req.params.granuleName) {
-      return putGranule(req, res);
+      return patchGranule(req, res);
     }
     return res.boom.badRequest(
       `input :granuleName (${req.params.granuleName}) must match body's granuleId (${req.body.granuleId})`
@@ -745,6 +745,6 @@ module.exports = {
   create,
   put,
   patch,
-  putGranule,
+  patchGranule,
   router,
 };

--- a/packages/api/endpoints/granules.js
+++ b/packages/api/endpoints/granules.js
@@ -247,7 +247,7 @@ const putGranule = async (req, res) => {
 };
 
 function put(req, res) {
-  res.boom.badRequest('Put method not implemented');
+  return res.boom.badRequest('put method not implemented');
 }
 
 /**

--- a/packages/api/tests/endpoints/granules/test-reingest-granules.js
+++ b/packages/api/tests/endpoints/granules/test-reingest-granules.js
@@ -21,7 +21,7 @@ const {
 
 const { setAuthorizedOAuthUsers } = require('../../../lib/testUtils');
 const models = require('../../../models');
-const { put } = require('../../../endpoints/granules');
+const { patch } = require('../../../endpoints/granules');
 const { buildFakeExpressResponse } = require('../utils');
 
 process.env.AccessTokensTable = randomString();
@@ -84,7 +84,7 @@ test.after.always(async (t) => {
   });
 });
 
-test('put request with reingest action queues granule and calls the reingestGranule function with expected parameters', async (t) => {
+test('PATCH request with reingest action queues granule and calls the reingestGranule function with expected parameters', async (t) => {
   const {
     granuleId,
   } = t.context;
@@ -95,7 +95,7 @@ test('put request with reingest action queues granule and calls the reingestGran
     action: 'reingest',
   };
 
-  await put({
+  await patch({
     body,
     params: {
       granuleName: granuleId,

--- a/packages/api/tests/endpoints/test-granules.js
+++ b/packages/api/tests/endpoints/test-granules.js
@@ -67,7 +67,7 @@ const { getBucketsConfigKey } = require('@cumulus/common/stack');
 const { getDistributionBucketMapKey } = require('@cumulus/distribution-utils');
 const { constructCollectionId } = require('@cumulus/message/Collections');
 
-const { create, put, patch, putGranule } = require('../../endpoints/granules');
+const { create, put, patch, patchGranule } = require('../../endpoints/granules');
 const assertions = require('../../lib/assertions');
 const { createGranuleAndFiles } = require('../helpers/create-test-data');
 const models = require('../../models');
@@ -2518,7 +2518,7 @@ test.serial("create() sets a default createdAt value for passed granule if it's 
   t.truthy(createGranuleFromApiMethodStub.getCalls()[0].args[0].createdAt);
 });
 
-test.serial("put() sets a default createdAt value for new granule if it's not set by the user", async (t) => {
+test.serial("patch() sets a default createdAt value for new granule if it's not set by the user", async (t) => {
   const {
     esClient,
     executionUrl,
@@ -2554,7 +2554,7 @@ test.serial("put() sets a default createdAt value for new granule if it's not se
     },
   };
   const response = buildFakeExpressResponse();
-  await putGranule(expressRequest, response);
+  await patchGranule(expressRequest, response);
 
   t.truthy(updateGranuleFromApiMethodStub.getCalls()[0].args[0].createdAt);
 });

--- a/packages/api/tests/endpoints/test-granules.js
+++ b/packages/api/tests/endpoints/test-granules.js
@@ -2955,7 +2955,7 @@ test.serial('PATCH() does not write to DynamoDB/Elasticsearch/SNS if writing to 
   t.is(Messages, undefined);
 });
 
-test.serial('PATCH() rolls back DynamoDB/PostgreSQL records and does not write to SNS if writing to Elasticsearch fails', async (t) => {
+test.serial('PATCH rolls back DynamoDB/PostgreSQL records and does not write to SNS if writing to Elasticsearch fails', async (t) => {
   const {
     esClient,
     executionUrl,

--- a/packages/api/tests/endpoints/test-granules.js
+++ b/packages/api/tests/endpoints/test-granules.js
@@ -2804,7 +2804,7 @@ test.serial("patch() sets a default createdAt value for new granule if it's not 
   t.truthy(updateGranuleFromApiMethodStub.getCalls()[0].args[0].createdAt);
 });
 
-test.serial('PATCH() does not write to PostgreSQL/Elasticsearch/SNS if writing to DynamoDB fails', async (t) => {
+test.serial('PATCH does not write to PostgreSQL/Elasticsearch/SNS if writing to DynamoDB fails', async (t) => {
   const {
     esClient,
     executionUrl,

--- a/packages/api/tests/endpoints/test-granules.js
+++ b/packages/api/tests/endpoints/test-granules.js
@@ -2879,7 +2879,7 @@ test.serial('PATCH does not write to PostgreSQL/Elasticsearch/SNS if writing to 
   t.is(Messages, undefined);
 });
 
-test.serial('PATCH() does not write to DynamoDB/Elasticsearch/SNS if writing to PostgreSQL fails', async (t) => {
+test.serial('PATCH does not write to DynamoDB/Elasticsearch/SNS if writing to PostgreSQL fails', async (t) => {
   const {
     esClient,
     executionUrl,

--- a/packages/api/tests/endpoints/test-granules.js
+++ b/packages/api/tests/endpoints/test-granules.js
@@ -490,7 +490,7 @@ test.serial('CUMULUS-911 GET with pathParameters.granuleName set and without an 
   assertions.isAuthorizationMissingResponse(t, response);
 });
 
-test.serial('CUMULUS-911 .patch with pathParameters.granuleName set and without an Authorization header returns an Authorization Missing response', async (t) => {
+test.serial('CUMULUS-911 PATCH with pathParameters.granuleName set and without an Authorization header returns an Authorization Missing response', async (t) => {
   const response = await request(app)
     .patch('/granules/asdf')
     .set('Accept', 'application/json')

--- a/packages/api/tests/endpoints/test-granules.js
+++ b/packages/api/tests/endpoints/test-granules.js
@@ -67,7 +67,7 @@ const { getBucketsConfigKey } = require('@cumulus/common/stack');
 const { getDistributionBucketMapKey } = require('@cumulus/distribution-utils');
 const { constructCollectionId } = require('@cumulus/message/Collections');
 
-const { create, put, putGranule } = require('../../endpoints/granules');
+const { create, patch, putGranule } = require('../../endpoints/granules');
 const assertions = require('../../lib/assertions');
 const { createGranuleAndFiles } = require('../helpers/create-test-data');
 const models = require('../../models');
@@ -465,9 +465,9 @@ test.serial('CUMULUS-911 GET with pathParameters.granuleName set and without an 
   assertions.isAuthorizationMissingResponse(t, response);
 });
 
-test.serial('CUMULUS-911 PUT with pathParameters.granuleName set and without an Authorization header returns an Authorization Missing response', async (t) => {
+test.serial('CUMULUS-911 .patch with pathParameters.granuleName set and without an Authorization header returns an Authorization Missing response', async (t) => {
   const response = await request(app)
-    .put('/granules/asdf')
+    .patch('/granules/asdf')
     .set('Accept', 'application/json')
     .expect(401);
 
@@ -521,7 +521,7 @@ test.todo('CUMULUS-912 GET with pathParameters.granuleName set and with an unaut
 
 test.serial('CUMULUS-912 PUT with pathParameters.granuleName set and with an invalid access token returns an unauthorized response', async (t) => {
   const response = await request(app)
-    .put('/granules/asdf')
+    .patch('/granules/asdf')
     .set('Accept', 'application/json')
     .set('Authorization', 'Bearer ThisIsAnInvalidAuthorizationToken')
     .expect(401);
@@ -608,9 +608,9 @@ test.serial('GET returns a 404 response if the granule is not found', async (t) 
   t.is(message, 'Granule not found');
 });
 
-test.serial('PUT fails if action is not supported', async (t) => {
+test.serial('PATCH fails if action is not supported', async (t) => {
   const response = await request(app)
-    .put(`/granules/${t.context.fakePGGranules[0].granule_id}`)
+    .patch(`/granules/${t.context.fakePGGranules[0].granule_id}`)
     .set('Accept', 'application/json')
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .send({ action: 'someUnsupportedAction' })
@@ -621,9 +621,9 @@ test.serial('PUT fails if action is not supported', async (t) => {
   t.true(message.includes('Action is not supported'));
 });
 
-test.serial('PUT without a body, fails to update granule.', async (t) => {
+test.serial('PATCH without a body, fails to update granule.', async (t) => {
   const response = await request(app)
-    .put(`/granules/${t.context.fakePGGranules[0].granule_id}`)
+    .patch(`/granules/${t.context.fakePGGranules[0].granule_id}`)
     .set('Accept', 'application/json')
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .expect(400);
@@ -654,7 +654,7 @@ test.serial('reingest a granule', async (t) => {
   });
   t.teardown(() => stub.restore());
   const response = await request(app)
-    .put(`/granules/${t.context.fakePGGranules[0].granule_id}`)
+    .patch(`/granules/${t.context.fakePGGranules[0].granule_id}`)
     .set('Accept', 'application/json')
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .send({ action: 'reingest' })
@@ -710,7 +710,7 @@ test.serial('apply an in-place workflow to an existing granule', async (t) => {
   t.teardown(() => stub.restore());
 
   const response = await request(app)
-    .put(`/granules/${t.context.fakePGGranules[0].granule_id}`)
+    .patch(`/granules/${t.context.fakePGGranules[0].granule_id}`)
     .set('Accept', 'application/json')
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .send({
@@ -760,7 +760,7 @@ test.serial('remove a granule from CMR', async (t) => {
 
   try {
     const response = await request(app)
-      .put(`/granules/${granuleId}`)
+      .patch(`/granules/${granuleId}`)
       .set('Accept', 'application/json')
       .set('Authorization', `Bearer ${jwtAuthToken}`)
       .send({ action: 'removeFromCmr' })
@@ -809,7 +809,7 @@ test.serial('remove a granule from CMR with launchpad authentication', async (t)
 
   try {
     const response = await request(app)
-      .put(`/granules/${t.context.fakePGGranules[0].granule_id}`)
+      .patch(`/granules/${t.context.fakePGGranules[0].granule_id}`)
       .set('Accept', 'application/json')
       .set('Authorization', `Bearer ${jwtAuthToken}`)
       .send({ action: 'removeFromCmr' })
@@ -1229,7 +1229,7 @@ test.serial('move a granule with no .cmr.xml file', async (t) => {
       ];
 
       const response = await request(app)
-        .put(`/granules/${newGranule.granuleId}`)
+        .patch(`/granules/${newGranule.granuleId}`)
         .set('Accept', 'application/json')
         .set('Authorization', `Bearer ${jwtAuthToken}`)
         .send({
@@ -1351,7 +1351,7 @@ test.serial('When a move granule request fails to move a file correctly, it reco
       ];
 
       const response = await request(app)
-        .put(`/granules/${newGranule.granuleId}`)
+        .patch(`/granules/${newGranule.granuleId}`)
         .set('Accept', 'application/json')
         .set('Authorization', `Bearer ${jwtAuthToken}`)
         .send({
@@ -1552,7 +1552,7 @@ test.serial('move a file and update ECHO10 xml metadata', async (t) => {
   ).returns({ result: { 'concept-id': 'id204842' } });
 
   const response = await request(app)
-    .put(`/granules/${newGranule.granuleId}`)
+    .patch(`/granules/${newGranule.granuleId}`)
     .set('Accept', 'application/json')
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .send({
@@ -1661,7 +1661,7 @@ test.serial('move a file and update its UMM-G JSON metadata', async (t) => {
   ).returns({ result: { 'concept-id': 'id204842' } });
 
   const response = await request(app)
-    .put(`/granules/${newGranule.granuleId}`)
+    .patch(`/granules/${newGranule.granuleId}`)
     .set('Accept', 'application/json')
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .send({
@@ -1709,7 +1709,7 @@ test.serial('move a file and update its UMM-G JSON metadata', async (t) => {
   await recursivelyDeleteS3Bucket(publicBucket);
 });
 
-test.serial('PUT with action move returns failure if one granule file exists', async (t) => {
+test.serial('PATCH with action move returns failure if one granule file exists', async (t) => {
   const filesExistingStub = sinon.stub(models.Granule.prototype, 'getFilesExistingAtLocation').returns([{ fileName: 'file1' }]);
 
   const granule = t.context.fakeGranules[0];
@@ -1726,7 +1726,7 @@ test.serial('PUT with action move returns failure if one granule file exists', a
   };
 
   const response = await request(app)
-    .put(`/granules/${granule.granuleId}`)
+    .patch(`/granules/${granule.granuleId}`)
     .set('Accept', 'application/json')
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .send(body)
@@ -1740,7 +1740,7 @@ test.serial('PUT with action move returns failure if one granule file exists', a
   filesExistingStub.restore();
 });
 
-test.serial('PUT with action move returns failure if more than one granule file exists', async (t) => {
+test.serial('PATCH with action move returns failure if more than one granule file exists', async (t) => {
   const filesExistingStub = sinon.stub(models.Granule.prototype, 'getFilesExistingAtLocation').returns([
     { fileName: 'file1' },
     { fileName: 'file2' },
@@ -1760,7 +1760,7 @@ test.serial('PUT with action move returns failure if more than one granule file 
   };
 
   const response = await request(app)
-    .put(`/granules/${granule.granuleId}`)
+    .patch(`/granules/${granule.granuleId}`)
     .set('Accept', 'application/json')
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .send(body)
@@ -1931,7 +1931,7 @@ test.serial('create (POST) returns bad request if a granule is submitted without
   t.true(response.text.includes('Error: granule `status` field must be set for a new granule write.  Please add a status field and value to your granule object and retry your request'));
 });
 
-test.serial('PUT returns bad request if a new granule is submitted without a status set', async (t) => {
+test.serial('PATCH returns bad request if a new granule is submitted without a status set', async (t) => {
   const newGranule = fakeGranuleFactoryV2({
     collectionId: t.context.collectionId,
     execution: t.context.executionUrl,
@@ -1940,7 +1940,7 @@ test.serial('PUT returns bad request if a new granule is submitted without a sta
   delete newGranule.status;
 
   const response = await request(app)
-    .put(`/granules/${newGranule.granuleId}`)
+    .patch(`/granules/${newGranule.granuleId}`)
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .set('Accept', 'application/json')
     .send(newGranule)
@@ -1948,7 +1948,7 @@ test.serial('PUT returns bad request if a new granule is submitted without a sta
 
   t.is(response.statusCode, 400);
   t.is(response.error.status, 400);
-  t.is(response.error.message, `cannot PUT /granules/${newGranule.granuleId} (400)`);
+  t.is(response.error.message, `cannot PATCH /granules/${newGranule.granuleId} (400)`);
   t.true(response.text.includes('Error: granule `status` field must be set for a new granule write.  Please add a status field and value to your granule object and retry your request'));
 });
 
@@ -2002,7 +2002,7 @@ test.serial('create (POST) throws conflict error if a granule with same granuleI
   t.is(errorText.message, `A granule already exists for granuleId: ${newGranule.granuleId}`);
 });
 
-test.serial('PUT replaces an existing granule in all data stores', async (t) => {
+test.serial('PATCH replaces an existing granule in all data stores', async (t) => {
   const {
     esClient,
     executionUrl,
@@ -2040,7 +2040,7 @@ test.serial('PUT replaces an existing granule in all data stores', async (t) => 
   };
 
   await request(app)
-    .put(`/granules/${newDynamoGranule.granuleId}`)
+    .patch(`/granules/${newDynamoGranule.granuleId}`)
     .set('Accept', 'application/json')
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .send(updatedGranule)
@@ -2091,10 +2091,10 @@ test.serial('PUT replaces an existing granule in all data stores', async (t) => 
   );
 });
 
-// FUTURE: this is explicitly a PATCH behavior test -
+// FUTURE: this is explicitly a .patch behavior test -
 // moving this is part of CUMULUS-3069/CUMULUS-3072
 test.serial(
-  'PUT does not overwrite existing duration of an existing granule if not specified in the payload',
+  'PATCH does not overwrite existing duration of an existing granule if not specified in the payload',
   async (t) => {
     const { esClient, executionUrl, knex } = t.context;
 
@@ -2126,7 +2126,7 @@ test.serial(
     };
 
     await request(app)
-      .put(`/granules/${newDynamoGranule.granuleId}`)
+      .patch(`/granules/${newDynamoGranule.granuleId}`)
       .set('Accept', 'application/json')
       .set('Authorization', `Bearer ${jwtAuthToken}`)
       .send(updatedGranule)
@@ -2148,7 +2148,7 @@ test.serial(
   }
 );
 
-test.serial('PUT does not overwrite existing createdAt of an existing granule if not specified in the payload',
+test.serial('PATCH does not overwrite existing createdAt of an existing granule if not specified in the payload',
   async (t) => {
     const { esClient, executionUrl, knex } = t.context;
 
@@ -2181,7 +2181,7 @@ test.serial('PUT does not overwrite existing createdAt of an existing granule if
     };
 
     await request(app)
-      .put(`/granules/${newDynamoGranule.granuleId}`)
+      .patch(`/granules/${newDynamoGranule.granuleId}`)
       .set('Accept', 'application/json')
       .set('Authorization', `Bearer ${jwtAuthToken}`)
       .send(updatedGranule)
@@ -2202,7 +2202,7 @@ test.serial('PUT does not overwrite existing createdAt of an existing granule if
     t.is(actualEsGranule.createdAt, createdAt);
   });
 
-test.serial('PUT creates a granule if one does not already exist in all data stores', async (t) => {
+test.serial('PATCH creates a granule if one does not already exist in all data stores', async (t) => {
   const {
     knex,
   } = t.context;
@@ -2218,7 +2218,7 @@ test.serial('PUT creates a granule if one does not already exist in all data sto
   });
 
   await request(app)
-    .put(`/granules/${fakeGranule.granuleId}`)
+    .patch(`/granules/${fakeGranule.granuleId}`)
     .set('Accept', 'application/json')
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .send(fakeGranule)
@@ -2267,7 +2267,7 @@ test.serial('PUT creates a granule if one does not already exist in all data sto
   );
 });
 
-test.serial('PUT sets a default value of false for `published` if one is not set', async (t) => {
+test.serial('PATCH sets a default value of false for `published` if one is not set', async (t) => {
   const {
     knex,
   } = t.context;
@@ -2283,7 +2283,7 @@ test.serial('PUT sets a default value of false for `published` if one is not set
   delete fakeGranule.published;
 
   await request(app)
-    .put(`/granules/${fakeGranule.granuleId}`)
+    .patch(`/granules/${fakeGranule.granuleId}`)
     .set('Accept', 'application/json')
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .send(fakeGranule)
@@ -2307,7 +2307,7 @@ test.serial('PUT sets a default value of false for `published` if one is not set
   t.is(fakeEsRecord.published, false);
 });
 
-test.serial('PUT replaces an existing granule in all data stores with correct timestamps', async (t) => {
+test.serial('PATCH replaces an existing granule in all data stores with correct timestamps', async (t) => {
   const {
     esClient,
     executionUrl,
@@ -2334,7 +2334,7 @@ test.serial('PUT replaces an existing granule in all data stores with correct ti
   };
 
   await request(app)
-    .put(`/granules/${newDynamoGranule.granuleId}`)
+    .patch(`/granules/${newDynamoGranule.granuleId}`)
     .set('Accept', 'application/json')
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .send(updatedGranule)
@@ -2360,7 +2360,7 @@ test.serial('PUT replaces an existing granule in all data stores with correct ti
   t.is(actualPgGranule.updated_at.getTime(), updatedEsRecord.updatedAt);
 });
 
-test.serial('PUT replaces an existing granule in all datastores with a granule that violates message-path write constraints, ignoring message write constraints and field selection', async (t) => {
+test.serial('PATCH replaces an existing granule in all datastores with a granule that violates message-path write constraints, ignoring message write constraints and field selection', async (t) => {
   const {
     esClient,
     executionUrl,
@@ -2390,7 +2390,7 @@ test.serial('PUT replaces an existing granule in all datastores with a granule t
   };
 
   await request(app)
-    .put(`/granules/${newDynamoGranule.granuleId}`)
+    .patch(`/granules/${newDynamoGranule.granuleId}`)
     .set('Accept', 'application/json')
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .send(updatedGranule)
@@ -2423,7 +2423,7 @@ test.serial('PUT replaces an existing granule in all datastores with a granule t
   t.is(updatedEsRecord.duration, updatedGranule.duration);
 });
 
-test.serial('PUT publishes an SNS message after a successful granule update', async (t) => {
+test.serial('PATCH publishes an SNS message after a successful granule update', async (t) => {
   const {
     collectionCumulusId,
     esClient,
@@ -2452,7 +2452,7 @@ test.serial('PUT publishes an SNS message after a successful granule update', as
   };
 
   await request(app)
-    .put(`/granules/${newDynamoGranule.granuleId}`)
+    .patch(`/granules/${newDynamoGranule.granuleId}`)
     .set('Accept', 'application/json')
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .send(updatedGranule)
@@ -2559,7 +2559,7 @@ test.serial("put() sets a default createdAt value for new granule if it's not se
   t.truthy(updateGranuleFromApiMethodStub.getCalls()[0].args[0].createdAt);
 });
 
-test.serial('put() does not write to PostgreSQL/Elasticsearch/SNS if writing to DynamoDB fails', async (t) => {
+test.serial('PATCH() does not write to PostgreSQL/Elasticsearch/SNS if writing to DynamoDB fails', async (t) => {
   const {
     esClient,
     executionUrl,
@@ -2605,7 +2605,7 @@ test.serial('put() does not write to PostgreSQL/Elasticsearch/SNS if writing to 
   };
 
   const response = buildFakeExpressResponse();
-  await put(expressRequest, response);
+  await patch(expressRequest, response);
   t.true(response.boom.badRequest.calledWithMatch('something bad'));
 
   t.deepEqual(
@@ -2634,7 +2634,7 @@ test.serial('put() does not write to PostgreSQL/Elasticsearch/SNS if writing to 
   t.is(Messages, undefined);
 });
 
-test.serial('put() does not write to DynamoDB/Elasticsearch/SNS if writing to PostgreSQL fails', async (t) => {
+test.serial('PATCH() does not write to DynamoDB/Elasticsearch/SNS if writing to PostgreSQL fails', async (t) => {
   const {
     esClient,
     executionUrl,
@@ -2681,7 +2681,7 @@ test.serial('put() does not write to DynamoDB/Elasticsearch/SNS if writing to Po
   };
 
   const response = buildFakeExpressResponse();
-  await put(expressRequest, response);
+  await patch(expressRequest, response);
   t.true(response.boom.badRequest.calledWithMatch('something bad'));
 
   t.deepEqual(
@@ -2710,7 +2710,7 @@ test.serial('put() does not write to DynamoDB/Elasticsearch/SNS if writing to Po
   t.is(Messages, undefined);
 });
 
-test.serial('put() rolls back DynamoDB/PostgreSQL records and does not write to SNS if writing to Elasticsearch fails', async (t) => {
+test.serial('PATCH() rolls back DynamoDB/PostgreSQL records and does not write to SNS if writing to Elasticsearch fails', async (t) => {
   const {
     esClient,
     executionUrl,
@@ -2751,7 +2751,7 @@ test.serial('put() rolls back DynamoDB/PostgreSQL records and does not write to 
 
   const response = buildFakeExpressResponse();
 
-  await put(expressRequest, response);
+  await patch(expressRequest, response);
   t.true(response.boom.badRequest.calledWithMatch('something bad'));
 
   const actualPgGranule = await t.context.granulePgModel.get(t.context.knex, {
@@ -2792,14 +2792,14 @@ test.serial('put() rolls back DynamoDB/PostgreSQL records and does not write to 
   t.is(Messages, undefined);
 });
 
-test.serial('PUT adds granule if it does not exist and returns a 201 status', async (t) => {
+test.serial('PATCH adds granule if it does not exist and returns a 201 status', async (t) => {
   const newGranule = fakeGranuleFactoryV2({
     collectionId: t.context.collectionId,
     execution: undefined,
   });
 
   const response = await request(app)
-    .put(`/granules/${newGranule.granuleId}`)
+    .patch(`/granules/${newGranule.granuleId}`)
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .set('Accept', 'application/json')
     .send(newGranule)
@@ -2810,7 +2810,7 @@ test.serial('PUT adds granule if it does not exist and returns a 201 status', as
   });
 });
 
-test.serial('PUT sets defaults and adds new granule', async (t) => {
+test.serial('PATCH sets defaults and adds new granule', async (t) => {
   const newGranule = fakeGranuleFactoryV2({
     collectionId: t.context.collectionId,
     execution: undefined,
@@ -2822,7 +2822,7 @@ test.serial('PUT sets defaults and adds new granule', async (t) => {
   const granuleId = newGranule.granuleId;
 
   const response = await request(app)
-    .put(`/granules/${newGranule.granuleId}`)
+    .patch(`/granules/${newGranule.granuleId}`)
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .set('Accept', 'application/json')
     .send(newGranule)
@@ -2861,7 +2861,7 @@ test.serial('PUT sets defaults and adds new granule', async (t) => {
   }), expectedApiGranule);
 });
 
-test.serial('PUT returns an updated granule with an undefined execution', async (t) => {
+test.serial('PATCH returns an updated granule with an undefined execution', async (t) => {
   const now = Date.now();
   const newGranule = fakeGranuleFactoryV2({
     collectionId: t.context.collectionId,
@@ -2886,7 +2886,7 @@ test.serial('PUT returns an updated granule with an undefined execution', async 
   };
 
   const modifiedResponse = await request(app)
-    .put(`/granules/${newGranule.granuleId}`)
+    .patch(`/granules/${newGranule.granuleId}`)
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .set('Accept', 'application/json')
     .send(modifiedGranule)
@@ -2919,7 +2919,7 @@ test.serial('PUT returns an updated granule with an undefined execution', async 
   t.deepEqual(fetchedPostgresRecord.error, { some: 'error' });
 });
 
-test.serial('PUT returns an updated granule with associated execution', async (t) => {
+test.serial('PATCH returns an updated granule with associated execution', async (t) => {
   const timestamp = Date.now();
   const createdAt = timestamp - 1000000;
   const newGranule = fakeGranuleFactoryV2({
@@ -2946,7 +2946,7 @@ test.serial('PUT returns an updated granule with associated execution', async (t
   };
 
   const modifiedResponse = await request(app)
-    .put(`/granules/${newGranule.granuleId}`)
+    .patch(`/granules/${newGranule.granuleId}`)
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .set('Accept', 'application/json')
     .send(modifiedGranule)
@@ -3004,12 +3004,12 @@ test.serial('PUT returns an updated granule with associated execution', async (t
   t.is(fetchedDynamoRecord.timestamp, fetchedPostgresRecord.timestamp.getTime());
 });
 
-test.serial('PUT returns bad request when the path param granuleName does not match the json granuleId', async (t) => {
+test.serial('PATCH returns bad request when the path param granuleName does not match the json granuleId', async (t) => {
   const newGranule = fakeGranuleFactoryV2({});
   const granuleName = `granuleName_${cryptoRandomString({ length: 10 })}`;
 
   const { body } = await request(app)
-    .put(`/granules/${granuleName}`)
+    .patch(`/granules/${granuleName}`)
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .set('Accept', 'application/json')
     .send(newGranule)
@@ -3037,7 +3037,7 @@ test.serial('update (PUT) can set running granule status to queued', async (t) =
   });
 
   const response = await request(app)
-    .put(`/granules/${granuleId}`)
+    .patch(`/granules/${granuleId}`)
     .set('Accept', 'application/json')
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .send({
@@ -3052,10 +3052,10 @@ test.serial('update (PUT) can set running granule status to queued', async (t) =
   });
 });
 
-test.serial('PUT will set completed status to queued', async (t) => {
+test.serial('PATCH will set completed status to queued', async (t) => {
   const granuleId = t.context.fakeGranules[0].granuleId;
   const response = await request(app)
-    .put(`/granules/${granuleId}`)
+    .patch(`/granules/${granuleId}`)
     .set('Accept', 'application/json')
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .send({
@@ -3076,10 +3076,10 @@ test.serial('PUT will set completed status to queued', async (t) => {
   t.is(fetchedDynamoRecord.status, 'queued');
 });
 
-test.serial('PUT can create a new granule with status queued', async (t) => {
+test.serial('PATCH can create a new granule with status queued', async (t) => {
   const granuleId = randomId('new-granule');
   const response = await request(app)
-    .put(`/granules/${granuleId}`)
+    .patch(`/granules/${granuleId}`)
     .set('Accept', 'application/json')
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .send({
@@ -3094,7 +3094,7 @@ test.serial('PUT can create a new granule with status queued', async (t) => {
   });
 });
 
-test.serial('PUT returns throws conflict error when trying to update the collectionId of a granule', async (t) => {
+test.serial('PATCH throws conflict error when trying to update the collectionId of a granule', async (t) => {
   const {
     collectionId,
     collectionPgModel,
@@ -3129,7 +3129,7 @@ test.serial('PUT returns throws conflict error when trying to update the collect
   };
 
   const { body } = await request(app)
-    .put(`/granules/${newGranule.granuleId}`)
+    .patch(`/granules/${newGranule.granuleId}`)
     .set('Accept', 'application/json')
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .send(updatedGranule)


### PR DESCRIPTION
**Summary:** Summary of changes

This PR updates the existing endpoint `put` method to be a `patch` method, and implements an 'unimplemented` `put` method to prevent inadvertent use prior to CUMULUS-3072 implementation.     The api-client methods are updated to use the PATCH protocol.       This is not a breaking change, as it still allows `PUT` method calls.    

Addresses [CUMULUS-3071](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3071)

## Changes

- **CUMULUS-3071**
  - Added 'PATCH' granules endpoint as an exact duplicate of the existing `PUT`
    endpoint.    In future releases the `PUT` endpoint will be replaced with valid PUT logic
    behavior (complete overwrite) in a future release.   **The existing PUT
    implementation is deprecated** and users should move all existing usage of
    `PUT` to `PATCH` before upgrading to a release with `CUMULUS-3072`.
  - Updated `@cumulus/api-client` packages to use `PATCH` protocol for existing
    granule `PUT` calls, this change should not require user updates for
    `api-client` users.
    - `@cumulus/api-client/granules.updateGranule`
    - `@cumulus/api-client/granules.moveGranule`
    - `@cumulus/api-client/granules.updateGranule`
    - `@cumulus/api-client/granules.reingestGranule`
    - `@cumulus/api-client/granules.removeFromCMR`
    - `@cumulus/api-client/granules.applyWorkflow`

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
