### PR TITLE
Introducing allFilesPresent metadata field for Cumulus Collections.  Fixes Issue #3193

### DIFF
--- a/tasks/discover-granules/index.js
+++ b/tasks/discover-granules/index.js
@@ -224,6 +224,62 @@ const checkGranuleHasNoDuplicate = async (granuleId, duplicateHandling) => {
 };
 
 /**
+ * Checks if all files from a collection are present for files from a granuleId
+ * 
+ * 
+ * @param {Object} config - the event config
+ * @param {Object} filesByGranuleId - Object with granuleId for keys with an array of
+ *                                    matching files for each
+ * @param {string} granuleId - the Id of a granule
+ * @returns {Boolean} - returns true if all file in collection config are present for granuleId
+ */
+ const checkGranuleHasAllFiles = (config, filesByGranuleId, granuleId) => {
+  return filesByGranuleId[granuleId].length >= config.collection.files.length;
+ }
+
+/**
+ * Filters out granules that are missing files from a collection
+ * 
+ * 
+ * @param {Object} params.filesByGranuleId - Object with granuleId for keys with an array of
+ *                                           matching files for each
+ * @param {Object} params.config - the event config
+ * @returns {Array.string} - returns granuleIds that contain all files from a collection
+ */
+ const filterGranulesWithoutAllFiles = ({ filesByGranuleId, config}) => {
+  const checkResults = Object.keys(filesByGranuleId).filter(
+    checkGranuleHasAllFiles.bind(this, config, filesByGranuleId)
+  );
+  return checkResults;
+};
+
+/**
+ * Handles granules without all files present according to the allFilesPresent boolean
+ * 
+ * allFilesPresent = true : granules missing files will be removed
+ * allFilesPresent = false: ignore missing files in granules
+ * 
+ * @param {Object} params.filesByGranuleId - Object with granuleId for keys with an array of
+ *                                           matching files for each
+ * @param {Boolean} params.allFilesPresent - boolean that defines whether or not all files should
+ *                                           be present in a granule before it can be discovered
+ * @param {Object} params.config - the event config
+ * @returns {Object} returns filesByGranuleId with all the granules missing files removed
+ */
+ const handleGranulesWithoutAllFilesPresent = ({ filesByGranuleId, allFilesPresent, config}) => {
+  if (!allFilesPresent) {
+    return filesByGranuleId;
+  }
+  const filteredKeys = filterGranulesWithoutAllFiles({
+    granuleIds: Object.keys(filesByGranuleId),
+    filesByGranuleId,
+    config
+  });
+  return pick(filesByGranuleId, filteredKeys);
+
+}
+
+/**
  * Filters granule duplicates from a list of granuleIds according to the
  * configuration in duplicateHandling:
  *
@@ -310,6 +366,16 @@ const discoverGranules = async ({ config }) => {
     filesByGranuleId,
     duplicateHandling,
     concurrency: get(config, 'concurrency', 3),
+  });
+
+  let allFilesPresent = false;
+  if (config.collection.meta) {
+    allFilesPresent = config.collection.meta.allFilesPresent || false;
+  }
+  filesByGranuleId = handleGranulesWithoutAllFilesPresent({
+    filesByGranuleId,
+    allFilesPresent,
+    config
   });
 
   const discoveredGranules = map(filesByGranuleId, buildGranule(config));

--- a/tasks/discover-granules/tests/index.js
+++ b/tasks/discover-granules/tests/index.js
@@ -191,8 +191,8 @@ const discoverGranulesUsingS3 = (configure, assert = assertDiscoveredGranules) =
     // State sample files
     const files = [
       'granule-1.nc', 'granule-1.nc.md5',
-      'granule-2.nc', 'granule-2.nc.md5',
-      'granule-3.nc', 'granule-3.nc.md5',
+      'granule-2.nc', 'granule-2.nc.md5', 'granule-2.nc.cmr.json',
+      'granule-3.nc', 'granule-3.nc.md5', 'granule-3.nc.cmr.json', 'granule-3.nc.xml',
     ];
 
     config.sourceBucketName = randomString();
@@ -216,6 +216,126 @@ const discoverGranulesUsingS3 = (configure, assert = assertDiscoveredGranules) =
       await recursivelyDeleteS3Bucket(config.sourceBucketName);
     }
   };
+
+  test('discover granules with allFilesPresent set to true',
+  discoverGranulesUsingS3(({ context: { event: { config } } }) => {
+    config.provider = {
+      id: 'MODAPS',
+      protocol: 's3',
+      host: config.sourceBucketName,
+    };
+    // Adds cmr.json files to collection config
+    config.collection.granuleIdExtraction = "^(.*)\\.(nc|nc\\.md5|nc\\.cmr\\.json)$"
+    config.collection.meta =  {
+      "allFilesPresent": true
+    }
+    config.collection.files = [
+      {
+        "regex": ".*.nc.cmr.json$",
+        "sampleFileName": "20170603090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc.cmr.json",
+        "bucket": "protected",
+        "type": "metadata"
+      },
+      {
+        "regex": ".*.nc$",
+        "sampleFileName": "20170603090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc",
+        "bucket": "protected",
+        "type": "data"
+      },
+      {
+        "regex": ".*.nc.md5$",
+        "sampleFileName": "20170603090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc.md5",
+        "bucket": "public",
+        "type": "metadata"
+      }
+    ]
+  }, async (t, output) => {
+    await validateOutput(t, output);
+    t.is(output.granules.length, 2);
+    output.granules.forEach(({ files }) => t.is(files.length, 3));
+  }));
+
+test('discover granules with allFilesPresent set to true with files missing',
+  discoverGranulesUsingS3(({ context: { event: { config } } }) => {
+    config.provider = {
+      id: 'MODAPS',
+      protocol: 's3',
+      host: config.sourceBucketName,
+    };
+    // Adds cmr.json files to collection config
+    config.collection.granuleIdExtraction = "^(.*)\\.(nc|nc\\.md5|nc\\.cmr\\.json|nc\\.png)$"
+    config.collection.meta =  {
+      "allFilesPresent": true
+    }
+    config.collection.files = [
+      {
+        "regex": ".*.nc.cmr.json$",
+        "sampleFileName": "20170603090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc.cmr.json",
+        "bucket": "protected",
+        "type": "metadata"
+      },
+      {
+        "regex": ".*.nc$",
+        "sampleFileName": "20170603090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc",
+        "bucket": "protected",
+        "type": "data"
+      },
+      {
+        "regex": ".*.nc.md5$",
+        "sampleFileName": "20170603090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc.md5",
+        "bucket": "public",
+        "type": "metadata"
+      },
+      {
+        "regex": ".*.nc.png$",
+        "sampleFileName": "20170603090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc.md5",
+        "bucket": "public",
+        "type": "metadata"
+      }
+    ]
+  }, async (t, output) => {
+    await validateOutput(t, output);
+    t.is(output.granules.length, 0);
+    output.granules.forEach(({ files }) => t.is(files.length, 0));
+  }));
+
+test('discover granules with allFilesPresent set to true with extra files for granule',
+  discoverGranulesUsingS3(({ context: { event: { config } } }) => {
+    config.provider = {
+      id: 'MODAPS',
+      protocol: 's3',
+      host: config.sourceBucketName,
+    };
+    // Adds cmr.json and .xml granuleId
+    config.collection.granuleIdExtraction = "^(.*)\\.(nc|nc\\.md5|nc\\.cmr\\.json|nc\\.xml)$"
+    config.collection.meta =  {
+      "allFilesPresent": true
+    }
+    config.collection.files = [
+      {
+        "regex": ".*.nc.cmr.json$",
+        "sampleFileName": "20170603090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc.cmr.json",
+        "bucket": "protected",
+        "type": "metadata"
+      },
+      {
+        "regex": ".*.nc$",
+        "sampleFileName": "20170603090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc",
+        "bucket": "protected",
+        "type": "data"
+      },
+      {
+        "regex": ".*.nc.md5$",
+        "sampleFileName": "20170603090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.nc.md5",
+        "bucket": "public",
+        "type": "metadata"
+      }
+    ]
+  }, async (t, output) => {
+    await validateOutput(t, output);
+    t.is(output.granules.length, 2);
+    output.granules.forEach(({ files }) => t.is(files.length, 3));
+  }));
 
 test('discover granules using S3',
   discoverGranulesUsingS3(({ context: { event: { config } } }) => {


### PR DESCRIPTION
**Summary:** Introducing allFilesPresent metadata field for Cumulus Collections

Addresses [CUMULUS-3193: Introducing allFilesPresent metadata field for Cumulus Collections](https://bugs.earthdata.nasa.gov/browse/CUMULUS-XXX](https://github.com/nasa/cumulus/issues/3193))(https://github.com/nasa/cumulus/issues/3193)

## Changes
Change allows Cumulus Collections to enforce that all files specified in Collections list to be present before ingesting Granules.

## Build and Tests

Successful Build
```
webpack 5.75.0 compiled with 9 warnings in 19512 ms
lerna success run Ran npm script 'build' in 28 packages in 107.9s:
lerna success - @cumulus/ftp-populate-test-lambda
lerna success - @cumulus/python-process-activity
lerna success - @cumulus/python-reference-activity
lerna success - @cumulus/python-reference-task
lerna success - @cumulus/example-lib
lerna success - @cumulus/postgres-migration-async-operation
lerna success - @cumulus/api
lerna success - @cumulus/ingest
lerna success - @cumulus/integration-tests
lerna success - @cumulus/s3-credentials-endpoint
lerna success - @cumulus/discover-granules
lerna success - @cumulus/discover-pdrs
lerna success - @cumulus/files-to-granules
lerna success - @cumulus/hello-world
lerna success - @cumulus/hyrax-metadata-updates
lerna success - @cumulus/move-granules
lerna success - @cumulus/parse-pdr
lerna success - @cumulus/pdr-status-check
lerna success - @cumulus/post-to-cmr
lerna success - @cumulus/queue-granules
lerna success - @cumulus/queue-pdrs
lerna success - @cumulus/queue-workflow
lerna success - @cumulus/sf-sqs-report
lerna success - @cumulus/sync-granule
lerna success - @cumulus/test-processing
lerna success - @cumulus/update-cmr-access-constraints
lerna success - @cumulus/update-granules-cmr-metadata-file-links
lerna success - @cumulus/cumulus-test-cleanup
```

Successful Tests
```
lerna info run Ran npm script 'test' in '@cumulus/discover-granules' in 8.8s:
> @cumulus/discover-granules@13.4.0 test
> ../../node_modules/.bin/ava
  ✔ discover granules uses default concurrency of 3
  ✔ discover granules uses configured concurrency
  ✔ discover granules sets the GRANULES environment variable and logs the granules
  ✔ handleDuplicates throws Error on duplicateHandling set to "error"
  ✔ handleDuplicates filters on duplicateHandling set to "skip"
  ✔ handleDuplicates does not filter when duplicateHandling is set to "replace"
  ✔ handleDuplicates throws Error on an invalid duplicateHandling configuration
  ✔ filterDuplicates returns a set of filtered keys
  ✔ handleDuplicates does not filter when duplicateHandling is set to "version"
  ✔ checkGranuleHasNoDuplicate returns false when API lambda returns a granule
  ✔ checkGranuleHasNoDuplicate returns a granuleId string when the API lambda returns a 404/Not Found error
  ✔ checkGranuleHasNoDuplicate throws an error if the API lambda throws an error other than 404/Not Found
  ✔ checkGranuleHasNoDuplicate throws an error when API lambda returns a granule and duplicateHandling is set to "error"
  ✔ checkGranuleHasNoDuplicate throws an error on an unexpected API lambda return
  ✔ discover granules sets the correct dataType for granules (229ms)
  ✔ discover granules using HTTP (233ms)
  ✔ discover granules using FTP (475ms)
  ✔ discover granules using SFTP (1.2s)
  ✔ discover granules without collection files config using S3 (5.3s)
  ✔ discover granules with allFilesPresent set to true with files missing (5.4s)
  ✔ discover granules with allFilesPresent set to true (5.4s)
  ✔ discover granules with allFilesPresent set to true with extra files for granule (5.4s)
  ✔ discover granules without collection files config, but configuring task to ignore it and overriding collection config not to ignore it, using S3 (5.5s)
  ✔ discover granules using S3 (5.5s)
  ✔ discover granules without collection files config, but configuring collection to ignore it, using S3 (5.5s)
  ✔ discover granules without collection files config, but configuring task to ignore it, using S3 (5.5s)
  ✔ discover granules without collection files config for .nc files using S3 (5.6s)
  ✔ discover granules using S3 throws error when discovery fails (5.6s)
  ─
  28 tests passed
```

## PR Checklist

- [ ] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [x] Integration tests
