### PR TITLE
Fix race condition in CloudFormation tests

### DIFF
--- a/packages/aws-client/tests/test-CloudFormation.js
+++ b/packages/aws-client/tests/test-CloudFormation.js
@@ -5,6 +5,25 @@ const cryptoRandomString = require('crypto-random-string');
 const CloudFormation = require('../CloudFormation');
 const { cf } = require('../services');
 
+/**
+ * Delete a stack but don't fail the test if stack deletion fails.
+ *
+ * There are times in these tests where the bucket created in the test can still be in the
+ * `UPDATE_IN_PROGRESS` state when we try to delete the stack, which results in a `NoSuchBucket`
+ * error. Since these are just being created in LocalStack, a couple extra buckets don't make a
+ * difference, so there's no reason to fail the test. Just log that the error happened and move on.
+ *
+ * @param {string} StackName
+ * @returns {Promise<void>}
+ */
+const deleteStack = async (StackName) => {
+  try {
+    await cf().deleteStack({ StackName }).promise();
+  } catch (error) {
+    console.log(`Failed to delete stack ${StackName}: ${error}`);
+  }
+};
+
 test('describeCfStack() returns the stack information', async (t) => {
   const StackName = cryptoRandomString({ length: 10 });
 
@@ -23,7 +42,7 @@ test('describeCfStack() returns the stack information', async (t) => {
 
   t.is(actualStack.StackName, StackName);
 
-  await cf().deleteStack({ StackName }).promise();
+  await deleteStack(StackName);
 });
 
 test('describeCfStack() throws an exception for stack that does not exist', (t) =>
@@ -49,7 +68,7 @@ test('describeCfStackResources() returns resources for stack', async (t) => {
   t.is(actualStackResources[0].StackName, StackName);
   t.is(actualStackResources[0].ResourceType, 'AWS::S3::Bucket');
 
-  await cf().deleteStack({ StackName }).promise();
+  await deleteStack(StackName);
 });
 
 test('getCfStackParameterValues() returns empty object if no stack is found', async (t) => {
@@ -76,7 +95,7 @@ test('getCfStackParameterValues() returns object excluding keys for missing para
 
   t.deepEqual(parameters, {});
 
-  await cf().deleteStack({ StackName }).promise();
+  await deleteStack(StackName);
 });
 
 test('getCfStackParameterValues() returns requested stack parameters', async (t) => {
@@ -111,5 +130,5 @@ test('getCfStackParameterValues() returns requested stack parameters', async (t)
     }
   );
 
-  await cf().deleteStack({ StackName }).promise();
+  await deleteStack(StackName);
 });


### PR DESCRIPTION
There are times in these tests where the bucket created in the test can still be in the `UPDATE_IN_PROGRESS` state when we try to delete the stack, which results in a `NoSuchBucket` error. Since these are just being created in LocalStack, a couple extra buckets don't make a difference, so there's no reason to fail the test. Just log that the error happened and move on.