### PR TITLE
Upgrade LocalStack version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     across all API granule writes.
   - Updated granule write code to validate written createdAt is synced between
     datastores in cases where granule.createdAt is not provided for a new granule.
-
+- **No Ticket**
+  - Updated version of LocalStack used in testing.
 
 ## [v13.4.0] 10/31/2022
 

--- a/bamboo/docker-compose-local.yml
+++ b/bamboo/docker-compose-local.yml
@@ -24,7 +24,7 @@ services:
       - 8080:8080
       - 9200:9200
   localstack:
-    image: localstack/localstack:0.12.13
+    image: localstack/localstack:1.3.1
   elasticsearch:
     image: elasticsearch:5.3
   http:

--- a/bamboo/docker-compose.yml
+++ b/bamboo/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     environment:
       ES_JAVA_OPTS: "-Xms750m -Xmx750m"
   localstack:
-    image: localstack/localstack:0.12.13
+    image: localstack/localstack:1.3.1
     network_mode: "service:build_env"
     environment:
       SERVICES: "cloudformation,cloudwatch,cloudwatchlogs,dynamodb,iam,kinesis,kms,lambda,s3,secretsmanager,sns,sqs,stepfunctions,ssm,logs"


### PR DESCRIPTION
LocalStack was failing to start on my M1 Mac. I saw that the version we were using was fairly far behind. I updated to the newer version, which fixed the issues that I was seeing locally.