### PR TITLE
CUMULUS-3144: Increased the memory of API lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,9 +83,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     across all API granule writes.
   - Updated granule write code to validate written createdAt is synced between
     datastores in cases where granule.createdAt is not provided for a new granule.
-
-
-## [v13.4.0] 10/31/2022
+- **CUMULUS-3144**
+  - Increased the memory of API lambda to 1280MB
 
 - **CUMULUS-3075**
   - Changed the API endpoint return value for a granule with no files. When a granule has no files, the return value beforehand for

--- a/tf-modules/archive/api.tf
+++ b/tf-modules/archive/api.tf
@@ -168,7 +168,7 @@ resource "aws_lambda_function" "private_api" {
   environment {
     variables = merge(local.api_env_variables, {"auth_mode"="private"})
   }
-  memory_size = 960
+  memory_size = 1280
   tags        = var.tags
 
   dynamic "vpc_config" {
@@ -193,7 +193,7 @@ resource "aws_lambda_function" "api" {
   environment {
     variables = merge(local.api_env_variables, {"auth_mode"="public"})
   }
-  memory_size = 960
+  memory_size = 1280
   tags        = var.tags
 
   reserved_concurrent_executions = var.api_reserved_concurrency


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3144: Cumulus API lambda erroring/timing out](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3144)

## Changes

* Increased the memory of API lambda to 1280MB

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
