### PR TITLE
Jk/cumulus 3148

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- **CUMULUS-3148**
+  - Update IngestGranuleSuccessSpec as test was dependant on file ordering and
+    PG 11 upgrade exposed dependency on DB results in the API return
+  - Update unit test container to utilize postgres 11.13 container
+
 - **CUMULUS-3121**
   - Added a map of variables for the cloud_watch_log retention_in_days for the various cloudwatch_log_groups, as opposed to keeping them hardcoded at 30 days. Can be configured by adding the <module>_<cloudwatch_log_group_name>_log_retention value in days to the cloudwatch_log_retention_groups map variable
 

--- a/bamboo/docker-compose.yml
+++ b/bamboo/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   postgres:
-    image: postgres:10.7-alpine
+    image: postgres:11.13-alpine
     environment:
       - POSTGRES_PASSWORD=password
     network_mode: "service:build_env"

--- a/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
@@ -1181,7 +1181,7 @@ describe('The S3 Ingest Granules workflow', () => {
           try {
             failOnSetupError([beforeAllError]);
 
-            file = granule.files[0];
+            file = granule.files.sort((a, b) => (a.key > b.key ? 1 : -1))[0];
 
             destinationKey = `${testDataFolder}/${file.key}`;
 


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3148](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3148)

## Changes

### Fixed

- **CUMULUS-3148**
  - Update IngestGranuleSuccessSpec as test was dependant on file ordering and
    PG 11 upgrade exposed dependency on DB results in the API return
  - Update unit test container to utilize postgres 11.13 container
  
## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
