### PR TITLE
CUMULUS-3181:Fixed sqsMessageRemover to correctly retrieve ENABLE sqs rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - **CUMULUS-3142**
   - Fix issue from CUMULUS-3070 where undefined values for status results in
     unexpected insertion failure on PATCH.
+- **CUMULUS-3181**
+  - Fixed `sqsMessageRemover` lambda to correctly retrieve ENABLED sqs rules.
     
 ### Changed
 

--- a/packages/api/lambdas/sqs-message-consumer.js
+++ b/packages/api/lambdas/sqs-message-consumer.js
@@ -22,8 +22,10 @@ const log = new Logger({ sender: '@cumulus/sqs-message-consumer' });
  */
 async function processQueues(event, dispatchFn) {
   const rules = await rulesHelpers.fetchRules({
-    type: 'sqs',
-    state: 'ENABLED',
+    queryParams: {
+      type: 'sqs',
+      state: 'ENABLED',
+    },
   });
 
   const messageLimit = event.messageLimit || 1;

--- a/packages/api/lambdas/sqs-message-consumer.js
+++ b/packages/api/lambdas/sqs-message-consumer.js
@@ -23,10 +23,11 @@ const log = new Logger({ sender: '@cumulus/sqs-message-consumer' });
 async function processQueues(event, dispatchFn) {
   const rules = await rulesHelpers.fetchRules({
     queryParams: {
-      type: 'sqs',
+      'rule.type': 'sqs',
       state: 'ENABLED',
     },
   });
+  log.info(`processQueues found ${rules.length} active sqs rules`);
 
   const messageLimit = event.messageLimit || 1;
   const timeLimit = event.timeLimit || 240;

--- a/packages/api/tests/endpoints/test-rules.js
+++ b/packages/api/tests/endpoints/test-rules.js
@@ -298,7 +298,7 @@ test('CUMULUS-912 DELETE with pathParameters and with an invalid access token re
 
 test.todo('CUMULUS-912 DELETE with pathParameters and with an unauthorized user returns an unauthorized response');
 
-test.serial.only('default returns list of rules', async (t) => {
+test.serial('default returns list of rules', async (t) => {
   const response = await request(app)
     .get('/rules')
     .set('Accept', 'application/json')

--- a/packages/api/tests/endpoints/test-rules.js
+++ b/packages/api/tests/endpoints/test-rules.js
@@ -298,7 +298,7 @@ test('CUMULUS-912 DELETE with pathParameters and with an invalid access token re
 
 test.todo('CUMULUS-912 DELETE with pathParameters and with an unauthorized user returns an unauthorized response');
 
-test.serial('default returns list of rules', async (t) => {
+test.serial.only('default returns list of rules', async (t) => {
   const response = await request(app)
     .get('/rules')
     .set('Accept', 'application/json')
@@ -307,6 +307,26 @@ test.serial('default returns list of rules', async (t) => {
 
   const { results } = response.body;
   t.is(results.length, 1);
+});
+
+test.serial('search returns correct list of rules', async (t) => {
+  const response = await request(app)
+    .get('/rules?page=1&rule.type=onetime&state=ENABLED')
+    .set('Accept', 'application/json')
+    .set('Authorization', `Bearer ${jwtAuthToken}`)
+    .expect(200);
+
+  const { results } = response.body;
+  t.is(results.length, 1);
+
+  const newResponse = await request(app)
+    .get('/rules?page=1&rule.type=sqs&state=ENABLED')
+    .set('Accept', 'application/json')
+    .set('Authorization', `Bearer ${jwtAuthToken}`)
+    .expect(200);
+
+  const { results: newResults } = newResponse.body;
+  t.is(newResults.length, 0);
 });
 
 test('GET gets a rule', async (t) => {

--- a/packages/api/tests/lambdas/test-sqs-message-consumer.js
+++ b/packages/api/tests/lambdas/test-sqs-message-consumer.js
@@ -167,7 +167,7 @@ test.serial('processQueues processes messages from the ENABLED sqs rule', async 
   const { queueMessageStub } = t.context;
   const { rules, queues } = await createRulesAndQueues();
   t.context.fetchRulesStub.callsFake((params) => {
-    t.deepEqual(params, { type: 'sqs', state: 'ENABLED' });
+    t.deepEqual(params, { queryParams: { type: 'sqs', state: 'ENABLED' } });
     return rules.filter((rule) => rule.state === 'ENABLED');
   });
   const queueMessageFromEnabledRuleStub = queueMessageStub
@@ -406,7 +406,7 @@ test.serial('processQueues archives messages from the ENABLED sqs rule only', as
   const { stackName } = process.env;
   const { rules, queues } = await createRulesAndQueues();
   t.context.fetchRulesStub.callsFake((params) => {
-    t.deepEqual(params, { type: 'sqs', state: 'ENABLED' });
+    t.deepEqual(params, { queryParams: { type: 'sqs', state: 'ENABLED' } });
     return rules.filter((rule) => rule.state === 'ENABLED');
   });
   const message = { testdata: randomString() };

--- a/packages/api/tests/lambdas/test-sqs-message-consumer.js
+++ b/packages/api/tests/lambdas/test-sqs-message-consumer.js
@@ -167,7 +167,7 @@ test.serial('processQueues processes messages from the ENABLED sqs rule', async 
   const { queueMessageStub } = t.context;
   const { rules, queues } = await createRulesAndQueues();
   t.context.fetchRulesStub.callsFake((params) => {
-    t.deepEqual(params, { queryParams: { type: 'sqs', state: 'ENABLED' } });
+    t.deepEqual(params, { queryParams: { 'rule.type': 'sqs', state: 'ENABLED' } });
     return rules.filter((rule) => rule.state === 'ENABLED');
   });
   const queueMessageFromEnabledRuleStub = queueMessageStub
@@ -406,7 +406,7 @@ test.serial('processQueues archives messages from the ENABLED sqs rule only', as
   const { stackName } = process.env;
   const { rules, queues } = await createRulesAndQueues();
   t.context.fetchRulesStub.callsFake((params) => {
-    t.deepEqual(params, { queryParams: { type: 'sqs', state: 'ENABLED' } });
+    t.deepEqual(params, { queryParams: { 'rule.type': 'sqs', state: 'ENABLED' } });
     return rules.filter((rule) => rule.state === 'ENABLED');
   });
   const message = { testdata: randomString() };


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3181: Rules in a disabled state triggers workflow](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3181)

## Changes

* Fixed sqsMessageRemover lambda to correctly retrieve ENABLE sqs rules
* The issue was introduced in v11.0.0
* fix test-granule-search-after test.
✖ endpoints › granules › default paginates correctly with search_after
The previous test adds data to es, and affects search_after test. Combines these two tests together.

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
