### PR TITLE
Jk/release 11.1.x/cumulus 3148 backport 3235

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,45 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### MIGRATION notes
+
+From this release forward Core will be tested against postgres 11   Existing
+release compatibility testing was done for release 11.1.8/14.0.0+.   Users
+should migrate their datastores to Aurora postgres11.13+ compatible data stores
+as soon as possible.
+
+Users utilizing the `cumulus-rds-tf` module will have upgraded/had their
+database clusters forcibly upgraded at the next maintenance window after 31 Jan
+2023.   Our guidance to mitigate this issue is to do a manual (outside of
+terraform) upgrade.   This will result in the cluster being upgraded with a
+manually set parameter group not managed by terraform.
+
+If you manually upgraded and the cluster is now on version 11.13, to continue using the `cumulus-rds-tf` module *once
+upgraded* update following module configuration values:
+
+```terraform
+parameter_group_family = "aurora-postgresql11"
+engine_version = 11.13
+```
+
+When you apply this update, the original postgresql v10 parameter group will be
+removed, and recreated using PG11 defaults/configured terraform values and
+update the database cluster to use the new configuration.
+
+
 ### Fixed
 
 - **CUMULUS-3148**
   - Update IngestGranuleSuccessSpec as test was dependant on file ordering and
     PostgreSQL v11 upgrade exposed dependency on database results in the API return
   - Update unit test container to utilize PostgreSQL 11.13 container
+
 ### Changed
 
 - **Snyk Security**-
   - Upgraded jsonwebtoken from 8.5.1 to 9.0.0
   - CUMULUS-3160: Upgrade knex from 0.95.15 to 2.4.1
-  
+
 ## [v11.1.8] 2022-11-07 [BACKPORT]
 
 ### Breaking Changes

--- a/docs/deployment/postgres-database-deployment.md
+++ b/docs/deployment/postgres-database-deployment.md
@@ -6,7 +6,7 @@ hide_title: false
 
 ## Overview
 
-Cumulus deployments require an Aurora [PostgreSQL 10.2](https://www.postgresql.org/) compatible database to be provided as the primary data store for Cumulus with Elasticsearch for non-authoritative querying/state data for the API and other applications that require more complex queries. Note that Cumulus is tested with an Aurora Postgres database.
+Cumulus deployments require an Aurora [PostgreSQL 11](https://www.postgresql.org/) compatible database to be provided as the primary data store for Cumulus with Elasticsearch for non-authoritative querying/state data for the API and other applications that require more complex queries. Note that Cumulus is tested with an Aurora Postgres database.
 
 Users are *strongly* encouraged to plan for and implement a database solution that scales to their use requirements, meets their security posture and maintenance needs and/or allows for multi-tenant cluster usage.
 
@@ -16,7 +16,7 @@ configured [Aurora Serverless](https://aws.amazon.com/rds/aurora/serverless/) cl
 
 To that end, Cumulus provides a terraform module
 [`cumulus-rds-tf`](https://github.com/nasa/cumulus/tree/master/tf-modules/cumulus-rds-tf)
-that will deploy an AWS RDS Aurora Serverless PostgreSQL 10.2 compatible [database cluster](https://aws.amazon.com/rds/aurora/postgresql-features/), and optionally provision a single deployment database with credentialed secrets for use with Cumulus.
+that will deploy an AWS RDS Aurora Serverless PostgreSQL 11 compatible [database cluster](https://aws.amazon.com/rds/aurora/postgresql-features/), and optionally provision a single deployment database with credentialed secrets for use with Cumulus.
 
 We have provided an example terraform deployment using this module in the [Cumulus template-deploy repository](https://github.com/nasa/cumulus-template-deploy/tree/master/rds-cluster-tf) on github.
 

--- a/example/rds-cluster-tf/variables.tf
+++ b/example/rds-cluster-tf/variables.tf
@@ -1,7 +1,3 @@
-variable "prefix" {
-  type = string
-}
-
 variable "aws_profile" {
   type    = string
   default = null

--- a/tf-modules/cumulus-rds-tf/variables.tf
+++ b/tf-modules/cumulus-rds-tf/variables.tf
@@ -88,13 +88,13 @@ variable "vpc_id" {
 variable "engine_version" {
   description = "Postgres engine version for serverless cluster"
   type        = string
-  default     = "10.14"
+  default     = "11.13"
 }
 
 variable "parameter_group_family" {
   description = "Database family to use for creating database parameter group"
   type = string
-  default = "aurora-postgresql10"
+  default = "aurora-postgresql11"
 }
 
 variable "max_capacity" {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3148](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3148)

## Changes

* Backport of #3235

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
