### PR TITLE
CUMULUS-3189: update CMA python versions to support pip 23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,9 @@ update the database cluster to use the new configuration.
   - Fixed `sqsMessageRemover` lambda to correctly retrieve ENABLED sqs rules.
 - The `getLambdaAliases` function has been removed from the `@cumulus/integration-tests` package
 - The `getLambdaVersions` function has been removed from the `@cumulus/integration-tests` package
+- **CUMULUS-3189**
+  - Upgraded `cumulus-proces`s and `cumulus-message-adapter-python` versions to
+    support pip 23.0
 
 ### Changed
 

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -2,5 +2,5 @@
     "high": true,
     "pass-enoaudit": true,
     "retry-count": 20,
-    "allowlist": ["knex", "jsonwebtoken", "http-cache-semantics"]
+    "allowlist": ["cacheable-request", "http-cache-semantics"]
 }

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -2,5 +2,5 @@
     "high": true,
     "pass-enoaudit": true,
     "retry-count": 20,
-    "allowlist": ["cacheable-request", "http-cache-semantics"]
+    "allowlist": ["knex", "jsonwebtoken", "cacheable-request", "http-cache-semantics"]
 }

--- a/example/lambdas/python-processing/Pipfile
+++ b/example/lambdas/python-processing/Pipfile
@@ -5,8 +5,8 @@ name = "pypi"
 
 [packages]
 boto3 = "~=1.18.40"
-cumulus-process = "==1.0.0"
-cumulus-message-adapter-python = "==2.0.0"
+cumulus-process = "==1.1.0"
+cumulus-message-adapter-python = "==2.1.0"
 six = "==1.12.0"
 
 [dev-packages]

--- a/example/lambdas/python-processing/Pipfile.lock
+++ b/example/lambdas/python-processing/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1ffb16f477d32df6bd461aeb35c5553c55b800cab6772da142b74c76c3cecca0"
+            "sha256": "e35e3edd19e0030eeef21c505048ef765ff67c803ce27a2c0beccaf78f693611"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -41,17 +41,17 @@
         },
         "cumulus-message-adapter-python": {
             "hashes": [
-                "sha256:eceb70a2811a2091d4310c9ac58211e70e3176bf895c5f15fba1f1b04d43bed1"
+                "sha256:8ce3dc55ef6471b82e5e93aa7e37c11520b3f3f18a7f68a91180e59dd748ed6f"
             ],
             "index": "pypi",
-            "version": "==2.0.0"
+            "version": "==2.1.0"
         },
         "cumulus-process": {
             "hashes": [
-                "sha256:c23ef7a7841292a6a8fd6e8386a9644f0fcb24f462cd345a6b16be949a138df0"
+                "sha256:590b66be84cd4ac61a10d2b2fc16f197c87f71ada848dc79ea6b1e1b77d836c5"
             ],
             "index": "pypi",
-            "version": "==1.0.0"
+            "version": "==1.1.0"
         },
         "decorator": {
             "hashes": [
@@ -171,11 +171,11 @@
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:14c1603c41cc61aae731cad1884a073c4645e26f126d13ac8346113c95577f3b",
-                "sha256:6afc22718a48a689ca24a97981ad377ba7fb78c133f40335dfd16772f29bcfb1"
+                "sha256:23c718921acab5f08cbbbe9293967f1f8fec40c336d19cd75dc12a9ea31d2eb2",
+                "sha256:bd1aa4f9915c98e8aaebcd4e71930154d4e8c9aaf05d35ac0a63d1956091ae3f"
             ],
             "markers": "python_full_version >= '3.7.2'",
-            "version": "==2.13.3"
+            "version": "==2.14.1"
         },
         "dill": {
             "hashes": [
@@ -187,11 +187,11 @@
         },
         "isort": {
             "hashes": [
-                "sha256:6db30c5ded9815d813932c04c2f85a360bcdd35fed496f4d8f35495ef0a261b6",
-                "sha256:c033fd0edb91000a7f09527fe5c75321878f98322a77ddcc81adbd83724afb7b"
+                "sha256:6be1f76a507cb2ecf16c7cf14a37e41609ca082330be4e3436a18ef74add55db",
+                "sha256:ba1d72fb2595a01c7895a5128f9585a5cc4b6d395f1c8d514989b9a7eb2a8746"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==5.11.4"
+            "markers": "python_full_version >= '3.7.0'",
+            "version": "==5.11.5"
         },
         "lazy-object-proxy": {
             "hashes": [
@@ -232,7 +232,7 @@
                 "sha256:f2457189d8257dd41ae9b434ba33298aec198e30adf2dcdaaa3a28b9994f6adb",
                 "sha256:f699ac1c768270c9e384e4cbd268d6e67aebcfae6cd623b4d7c3bfde5a35db59"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_full_version >= '3.7.0'",
             "version": "==1.9.0"
         },
         "mccabe": {
@@ -245,19 +245,19 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490",
-                "sha256:e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2"
+                "sha256:8a1228abb1ef82d788f74139988b137e78692984ec7b08eaa6c65f1723af28f9",
+                "sha256:b1d5eb14f221506f50d6604a561f4c5786d9e80355219694a1b244bcd96f4567"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.6.2"
+            "markers": "python_full_version >= '3.7.0'",
+            "version": "==3.0.0"
         },
         "pylint": {
             "hashes": [
-                "sha256:9df0d07e8948a1c3ffa3b6e2d7e6e63d9fb457c5da5b961ed63106594780cc7e",
-                "sha256:b3dc5ef7d33858f297ac0d06cc73862f01e4f2e74025ec3eff347ce0bc60baf5"
+                "sha256:bad9d7c36037f6043a1e848a43004dfd5ea5ceb05815d713ba56ca4503a9fe37",
+                "sha256:ffe7fa536bb38ba35006a7c8a6d2efbfdd3d95bbf21199cad31f76b1c50aaf30"
             ],
             "index": "pypi",
-            "version": "==2.15.10"
+            "version": "==2.16.1"
         },
         "tomli": {
             "hashes": [

--- a/example/lambdas/python-reference-activity/Pipfile
+++ b/example/lambdas/python-reference-activity/Pipfile
@@ -5,8 +5,8 @@ name = "pypi"
 
 [packages]
 boto3 = "~=1.18.40"
-cumulus-process = "==1.0.0"
-cumulus-message-adapter-python = "==2.0.0"
+cumulus-process = "==1.1.0"
+cumulus-message-adapter-python = "==2.1.0"
 six = "==1.12.0"
 
 [dev-packages]

--- a/example/lambdas/python-reference-activity/Pipfile.lock
+++ b/example/lambdas/python-reference-activity/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1ffb16f477d32df6bd461aeb35c5553c55b800cab6772da142b74c76c3cecca0"
+            "sha256": "e35e3edd19e0030eeef21c505048ef765ff67c803ce27a2c0beccaf78f693611"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -41,17 +41,17 @@
         },
         "cumulus-message-adapter-python": {
             "hashes": [
-                "sha256:eceb70a2811a2091d4310c9ac58211e70e3176bf895c5f15fba1f1b04d43bed1"
+                "sha256:8ce3dc55ef6471b82e5e93aa7e37c11520b3f3f18a7f68a91180e59dd748ed6f"
             ],
             "index": "pypi",
-            "version": "==2.0.0"
+            "version": "==2.1.0"
         },
         "cumulus-process": {
             "hashes": [
-                "sha256:c23ef7a7841292a6a8fd6e8386a9644f0fcb24f462cd345a6b16be949a138df0"
+                "sha256:590b66be84cd4ac61a10d2b2fc16f197c87f71ada848dc79ea6b1e1b77d836c5"
             ],
             "index": "pypi",
-            "version": "==1.0.0"
+            "version": "==1.1.0"
         },
         "decorator": {
             "hashes": [
@@ -171,11 +171,11 @@
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:14c1603c41cc61aae731cad1884a073c4645e26f126d13ac8346113c95577f3b",
-                "sha256:6afc22718a48a689ca24a97981ad377ba7fb78c133f40335dfd16772f29bcfb1"
+                "sha256:23c718921acab5f08cbbbe9293967f1f8fec40c336d19cd75dc12a9ea31d2eb2",
+                "sha256:bd1aa4f9915c98e8aaebcd4e71930154d4e8c9aaf05d35ac0a63d1956091ae3f"
             ],
             "markers": "python_full_version >= '3.7.2'",
-            "version": "==2.13.3"
+            "version": "==2.14.1"
         },
         "dill": {
             "hashes": [
@@ -187,11 +187,11 @@
         },
         "isort": {
             "hashes": [
-                "sha256:6db30c5ded9815d813932c04c2f85a360bcdd35fed496f4d8f35495ef0a261b6",
-                "sha256:c033fd0edb91000a7f09527fe5c75321878f98322a77ddcc81adbd83724afb7b"
+                "sha256:6be1f76a507cb2ecf16c7cf14a37e41609ca082330be4e3436a18ef74add55db",
+                "sha256:ba1d72fb2595a01c7895a5128f9585a5cc4b6d395f1c8d514989b9a7eb2a8746"
             ],
             "markers": "python_full_version >= '3.7.0'",
-            "version": "==5.11.4"
+            "version": "==5.11.5"
         },
         "lazy-object-proxy": {
             "hashes": [
@@ -245,19 +245,19 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490",
-                "sha256:e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2"
+                "sha256:8a1228abb1ef82d788f74139988b137e78692984ec7b08eaa6c65f1723af28f9",
+                "sha256:b1d5eb14f221506f50d6604a561f4c5786d9e80355219694a1b244bcd96f4567"
             ],
             "markers": "python_full_version >= '3.7.0'",
-            "version": "==2.6.2"
+            "version": "==3.0.0"
         },
         "pylint": {
             "hashes": [
-                "sha256:9df0d07e8948a1c3ffa3b6e2d7e6e63d9fb457c5da5b961ed63106594780cc7e",
-                "sha256:b3dc5ef7d33858f297ac0d06cc73862f01e4f2e74025ec3eff347ce0bc60baf5"
+                "sha256:bad9d7c36037f6043a1e848a43004dfd5ea5ceb05815d713ba56ca4503a9fe37",
+                "sha256:ffe7fa536bb38ba35006a7c8a6d2efbfdd3d95bbf21199cad31f76b1c50aaf30"
             ],
             "index": "pypi",
-            "version": "==2.15.10"
+            "version": "==2.16.1"
         },
         "tomli": {
             "hashes": [

--- a/example/lambdas/python-reference-task/Pipfile
+++ b/example/lambdas/python-reference-task/Pipfile
@@ -5,8 +5,8 @@ name = "pypi"
 
 [packages]
 boto3 = "~=1.18.40"
-cumulus-process = "==1.0.0"
-cumulus-message-adapter-python = "==2.0.0"
+cumulus-process = "==1.1.0"
+cumulus-message-adapter-python = "==2.1.0"
 six = "==1.12.0"
 
 [dev-packages]

--- a/example/lambdas/python-reference-task/Pipfile.lock
+++ b/example/lambdas/python-reference-task/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1ffb16f477d32df6bd461aeb35c5553c55b800cab6772da142b74c76c3cecca0"
+            "sha256": "e35e3edd19e0030eeef21c505048ef765ff67c803ce27a2c0beccaf78f693611"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -41,17 +41,17 @@
         },
         "cumulus-message-adapter-python": {
             "hashes": [
-                "sha256:eceb70a2811a2091d4310c9ac58211e70e3176bf895c5f15fba1f1b04d43bed1"
+                "sha256:8ce3dc55ef6471b82e5e93aa7e37c11520b3f3f18a7f68a91180e59dd748ed6f"
             ],
             "index": "pypi",
-            "version": "==2.0.0"
+            "version": "==2.1.0"
         },
         "cumulus-process": {
             "hashes": [
-                "sha256:c23ef7a7841292a6a8fd6e8386a9644f0fcb24f462cd345a6b16be949a138df0"
+                "sha256:590b66be84cd4ac61a10d2b2fc16f197c87f71ada848dc79ea6b1e1b77d836c5"
             ],
             "index": "pypi",
-            "version": "==1.0.0"
+            "version": "==1.1.0"
         },
         "decorator": {
             "hashes": [
@@ -171,11 +171,11 @@
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:14c1603c41cc61aae731cad1884a073c4645e26f126d13ac8346113c95577f3b",
-                "sha256:6afc22718a48a689ca24a97981ad377ba7fb78c133f40335dfd16772f29bcfb1"
+                "sha256:23c718921acab5f08cbbbe9293967f1f8fec40c336d19cd75dc12a9ea31d2eb2",
+                "sha256:bd1aa4f9915c98e8aaebcd4e71930154d4e8c9aaf05d35ac0a63d1956091ae3f"
             ],
             "markers": "python_full_version >= '3.7.2'",
-            "version": "==2.13.3"
+            "version": "==2.14.1"
         },
         "dill": {
             "hashes": [
@@ -187,11 +187,11 @@
         },
         "isort": {
             "hashes": [
-                "sha256:6db30c5ded9815d813932c04c2f85a360bcdd35fed496f4d8f35495ef0a261b6",
-                "sha256:c033fd0edb91000a7f09527fe5c75321878f98322a77ddcc81adbd83724afb7b"
+                "sha256:6be1f76a507cb2ecf16c7cf14a37e41609ca082330be4e3436a18ef74add55db",
+                "sha256:ba1d72fb2595a01c7895a5128f9585a5cc4b6d395f1c8d514989b9a7eb2a8746"
             ],
             "markers": "python_full_version >= '3.7.0'",
-            "version": "==5.11.4"
+            "version": "==5.11.5"
         },
         "lazy-object-proxy": {
             "hashes": [
@@ -245,19 +245,19 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490",
-                "sha256:e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2"
+                "sha256:8a1228abb1ef82d788f74139988b137e78692984ec7b08eaa6c65f1723af28f9",
+                "sha256:b1d5eb14f221506f50d6604a561f4c5786d9e80355219694a1b244bcd96f4567"
             ],
             "markers": "python_full_version >= '3.7.0'",
-            "version": "==2.6.2"
+            "version": "==3.0.0"
         },
         "pylint": {
             "hashes": [
-                "sha256:9df0d07e8948a1c3ffa3b6e2d7e6e63d9fb457c5da5b961ed63106594780cc7e",
-                "sha256:b3dc5ef7d33858f297ac0d06cc73862f01e4f2e74025ec3eff347ce0bc60baf5"
+                "sha256:bad9d7c36037f6043a1e848a43004dfd5ea5ceb05815d713ba56ca4503a9fe37",
+                "sha256:ffe7fa536bb38ba35006a7c8a6d2efbfdd3d95bbf21199cad31f76b1c50aaf30"
             ],
             "index": "pypi",
-            "version": "==2.15.10"
+            "version": "==2.16.1"
         },
         "tomli": {
             "hashes": [


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3189: Update Python CMA to support new pip3 syntax](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3189)

## Changes

* Detailed list or prose of changes
* ...

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
