### PR TITLE
Jk/cumulus 1/fix integration test bucket

### DIFF
--- a/example/spec/parallel/ingestGranule/IngestGranuleFailureSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleFailureSpec.js
@@ -77,7 +77,7 @@ describe('The Ingest Granule failure workflow', () => {
         {
           name: 'non-existent-file',
           key: 'non-existent-path/non-existent-file',
-          bucket: 'non-existent-bucket',
+          bucket: 'cumulus-test-sandbox-private',
         },
       ];
 

--- a/example/spec/parallel/ingestGranule/IngestGranuleFailureSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleFailureSpec.js
@@ -77,7 +77,7 @@ describe('The Ingest Granule failure workflow', () => {
         {
           name: 'non-existent-file',
           key: 'non-existent-path/non-existent-file',
-          bucket: 'cumulus-test-sandbox-private',
+          bucket: 'cumulus-test-sandbox-public',
         },
       ];
 


### PR DESCRIPTION
**Summary:** Fix integration test

Addresses [CUMULUS-1:](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1)

## Changes
Update IngestGranuleFailureSpec bucket name to use an existing bucket

Test was originally using           bucket: 'non-existent-bucket',
this is generally a bad practice as the bucket namespace is global, and
once someone else owns the bucket it will result access/IAM
errors *or* attempting a delete of an object from an unknown bucket.

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
