### PR TITLE
Use bucket associated with environment instead of static bucket

### DIFF
--- a/example/spec/parallel/ingestGranule/IngestGranuleFailureSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleFailureSpec.js
@@ -77,7 +77,7 @@ describe('The Ingest Granule failure workflow', () => {
         {
           name: 'non-existent-file',
           key: 'non-existent-path/non-existent-file',
-          bucket: 'cumulus-test-sandbox-public',
+          bucket: config.bucket,
         },
       ];
 


### PR DESCRIPTION
Previously we were using a static bucket for all environments. That's an issue for SIT because the previous `cumulus-test-sandbox-public` isn't accessible from that account. This switches the test to use the bucket configured for each account.