### PR TITLE
Add name to event_rule resource in throttle example

### DIFF
--- a/example/cumulus-tf/throttled-queue.tf
+++ b/example/cumulus-tf/throttled-queue.tf
@@ -6,6 +6,7 @@ resource "aws_sqs_queue" "throttled_queue" {
 
 
 resource "aws_cloudwatch_event_rule" "throttled_queue_watcher" {
+  name                = "${var.prefix}-throttled_queue_watcher"
   schedule_expression = "rate(1 minute)"
 }
 


### PR DESCRIPTION
**Summary:** Summary of changes

I noticed in our accounts that there are some untagged and unnamed cloudwatch event rules associated with our cumulus deploys. Ultimately, these come from our own terraform files, however, I suspect those were copied from this example and therefore have no name or tags. 

It might also be nice to add tags in this example as well. Thoughts?

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
