### PR TITLE
Update record factory to fix unit tests

### DIFF
--- a/packages/api/tests/endpoints/collections/delete-collection.js
+++ b/packages/api/tests/endpoints/collections/delete-collection.js
@@ -317,12 +317,12 @@ test.serial('Deleting a collection removes it from all data stores and publishes
   );
 });
 
-test.only('Attempting to delete a collection with an associated rule returns a 409 response', async (t) => {
+test.serial('Attempting to delete a collection with an associated rule returns a 409 response', async (t) => {
   const {
     testKnex,
     rulePgModel,
   } = t.context;
-  console.log('in test:::::');
+
   const {
     originalPgRecord,
   } = await createCollectionTestRecords(t.context);
@@ -334,21 +334,14 @@ test.only('Attempting to delete a collection with an associated rule returns a 4
     type: 'onetime',
   });
 
-  console.log('rule:::', rule);
-  console.log('stackname:::', process.env.stackName);
-
   // The workflow message template must exist in S3 before the rule can be created
-  const putResponse = await s3().putObject({
+  await s3().putObject({
     Bucket: process.env.system_bucket,
     Key: `${process.env.stackName}/workflows/${rule.workflow}.json`,
     Body: JSON.stringify({}),
   });
 
-  console.log('putResponse:::', putResponse);
-
-  const resultRule = await rulePgModel.create(testKnex, rule);
-
-  console.log('resultRule:::', resultRule);
+  await rulePgModel.create(testKnex, rule);
 
   const response = await request(app)
     .delete(`/collections/${originalPgRecord.name}/${originalPgRecord.version}`)
@@ -360,7 +353,7 @@ test.only('Attempting to delete a collection with an associated rule returns a 4
   t.true(response.body.message.includes('Cannot delete collection with associated rules'));
 });
 
-test.only('Attempting to delete a collection with an associated rule does not delete the collection', async (t) => {
+test.serial('Attempting to delete a collection with an associated rule does not delete the collection', async (t) => {
   const {
     collectionPgModel,
     rulePgModel,

--- a/packages/api/tests/endpoints/collections/delete-collection.js
+++ b/packages/api/tests/endpoints/collections/delete-collection.js
@@ -327,8 +327,6 @@ test.serial('Attempting to delete a collection with an associated rule returns a
     originalPgRecord,
   } = await createCollectionTestRecords(t.context);
 
-  console.log('originalPgRecord::::', originalPgRecord);
-
   const rule = fakeRuleRecordFactory({
     collection_cumulus_id: originalPgRecord.cumulus_id,
     type: 'onetime',

--- a/packages/api/tests/endpoints/collections/delete-collection.js
+++ b/packages/api/tests/endpoints/collections/delete-collection.js
@@ -322,24 +322,32 @@ test.serial('Attempting to delete a collection with an associated rule returns a
     testKnex,
     rulePgModel,
   } = t.context;
-
+  console.log('in test:::::');
   const {
     originalPgRecord,
   } = await createCollectionTestRecords(t.context);
+
+  console.log('originalPgRecord::::', originalPgRecord);
 
   const rule = fakeRuleRecordFactory({
     collection_cumulus_id: originalPgRecord.cumulus_id,
     type: 'onetime',
   });
 
+  console.log('rule:::', rule);
+
   // The workflow message template must exist in S3 before the rule can be created
-  await s3().putObject({
+  const putResponse = await s3().putObject({
     Bucket: process.env.system_bucket,
     Key: `${process.env.stackName}/workflows/${rule.workflow}.json`,
     Body: JSON.stringify({}),
   });
 
-  await rulePgModel.create(testKnex, rule);
+  console.log('putResponse:::', putResponse);
+
+  const resultRule = await rulePgModel.create(testKnex, rule);
+
+  console.log('resultRule:::', resultRule);
 
   const response = await request(app)
     .delete(`/collections/${originalPgRecord.name}/${originalPgRecord.version}`)

--- a/packages/api/tests/endpoints/collections/delete-collection.js
+++ b/packages/api/tests/endpoints/collections/delete-collection.js
@@ -317,7 +317,7 @@ test.serial('Deleting a collection removes it from all data stores and publishes
   );
 });
 
-test.serial('Attempting to delete a collection with an associated rule returns a 409 response', async (t) => {
+test.only('Attempting to delete a collection with an associated rule returns a 409 response', async (t) => {
   const {
     testKnex,
     rulePgModel,
@@ -335,6 +335,7 @@ test.serial('Attempting to delete a collection with an associated rule returns a
   });
 
   console.log('rule:::', rule);
+  console.log('stackname:::', process.env.stackName);
 
   // The workflow message template must exist in S3 before the rule can be created
   const putResponse = await s3().putObject({
@@ -359,7 +360,7 @@ test.serial('Attempting to delete a collection with an associated rule returns a
   t.true(response.body.message.includes('Cannot delete collection with associated rules'));
 });
 
-test.serial('Attempting to delete a collection with an associated rule does not delete the collection', async (t) => {
+test.only('Attempting to delete a collection with an associated rule does not delete the collection', async (t) => {
   const {
     collectionPgModel,
     rulePgModel,

--- a/packages/db/src/test-utils.ts
+++ b/packages/db/src/test-utils.ts
@@ -60,7 +60,7 @@ export const fakeRuleRecordFactory = (
   params: Partial<PostgresRule>
 ): PostgresRule => ({
   name: cryptoRandomString({ length: 8 }),
-  workflow: 'Random Workflow',
+  workflow: 'RandomWorkflow',
   type: 'onetime',
   enabled: false,
   created_at: new Date(),

--- a/packages/db/src/test-utils.ts
+++ b/packages/db/src/test-utils.ts
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import pRetry from 'p-retry';
 
 import { getExecutionUrlFromArn } from '@cumulus/message/Executions';
+import { randomId  } from '@cumulus/common/test-utils';
 
 import { getKnexClient } from './connection';
 import { localStackConnectionEnv } from './config';
@@ -60,7 +61,7 @@ export const fakeRuleRecordFactory = (
   params: Partial<PostgresRule>
 ): PostgresRule => ({
   name: cryptoRandomString({ length: 8 }),
-  workflow: 'RandomWorkflow',
+  workflow: randomId('workflow'),
   type: 'onetime',
   enabled: false,
   created_at: new Date(),

--- a/packages/db/src/test-utils.ts
+++ b/packages/db/src/test-utils.ts
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import pRetry from 'p-retry';
 
 import { getExecutionUrlFromArn } from '@cumulus/message/Executions';
-import { randomId  } from '@cumulus/common/test-utils';
+import { randomId } from '@cumulus/common/test-utils';
 
 import { getKnexClient } from './connection';
 import { localStackConnectionEnv } from './config';


### PR DESCRIPTION
This started causing failures in `aws-sdk` calls. In a couple unit tests we're putting an object in S3 with:

```
 await s3().putObject({
    Bucket: process.env.system_bucket,
    Key: `${process.env.stackName}/workflows/${rule.workflow}.json`,
    Body: JSON.stringify({}),
  });
```

The issue is `rule.workflow`. Previously that was set to "Random Workflow", which includes a space. A space is an invalid character for workflows and `putObject` started throwing an error. It's unclear what changed to make this pop up now. Possibly an implementation change in `s3().putObject` where previously it was URL-encoding and now isn't? In either case, a workflow name containing a space isn't valid (can't be created even from the AWS console) and the factory should reflect that.

Note that this is only a problem on `feature/rds-phase-3`. The main branch uses a different record factory in these tests.