### PR TITLE
CUMULUS-3285: Updated isAuthBearTokenRequest to handle non-Bearer authorization header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     `v0.5.0`
   - Added audit-ci CVE override until July 1 to allow for Core package releases
 
+## Fixed
+
+- **CUMULUS-3285**
+  - Updated `api/lib/distribution.js isAuthBearTokenRequest` to handle non-Bearer authorization header
+
 ## [v15.0.0] 2023-03-10
 
 ### Breaking Changes

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "babel-loader": "^8.2.2",
     "babel-plugin-source-map-support": "^2.1.1",
     "babel-preset-env": "^1.7.0",
+    "base-64": "^0.1.0",
     "cookie-parser": "^1.4.5",
     "copy-webpack-plugin": "^6.0.3",
     "coveralls": "^3.0.0",

--- a/packages/api/lib/distribution.js
+++ b/packages/api/lib/distribution.js
@@ -119,7 +119,7 @@ function isAuthBearTokenRequest(req) {
   const authHeader = req.headers.authorization;
   if (authHeader) {
     const match = authHeader.match(BEARER_TOKEN_REGEX);
-    if (match.length >= 2) return true;
+    if (match && match.length >= 2) return true;
   }
   return false;
 }


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3285: s3credentials endpoint fails when request has header 'Authorization: Basic'
](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3285)

## Changes

* Detailed list or prose of changes
* ...

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [x] Integration tests
