### PR TITLE
CUMULUS-3285: Updated isAuthBearTokenRequest to handle non-Bearer authorization header (merge to master)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,11 @@ Users/clients that do not make use of these endpoints will not be impacted.
 - **CUMULUS-3165**
   - Update example/cumulus-tf/orca.tf to use orca v6.0.3
 
+## Fixed
+
+- **CUMULUS-3285**
+  - Updated `api/lib/distribution.js isAuthBearTokenRequest` to handle non-Bearer authorization header
+
 ## [v15.0.0] 2023-03-10
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,16 @@ Users/clients that do not make use of these endpoints will not be impacted.
 - **CUMULUS-3165**
   - Update example/cumulus-tf/orca.tf to use orca v6.0.3
 
+## [v15.0.1] 2023-04-20
+
+### Changed
+
+- **CUMULUS-3279**
+  - Updated core dependencies on `xml2js` to `v0.5.0`
+  - Forcibly updated downstream dependency for `xml2js` in `saml2-js` to
+    `v0.5.0`
+  - Added audit-ci CVE override until July 1 to allow for Core package releases
+
 ## Fixed
 
 - **CUMULUS-3285**
@@ -7088,7 +7098,8 @@ Note: There was an issue publishing 1.12.0. Upgrade to 1.12.1.
 
 ## [v1.0.0] - 2018-02-23
 
-[unreleased]: https://github.com/nasa/cumulus/compare/v15.0.0...HEAD
+[unreleased]: https://github.com/nasa/cumulus/compare/v15.0.1...HEAD
+[v15.0.1]: https://github.com/nasa/cumulus/compare/v15.0.0...v15.0.1
 [v15.0.0]: https://github.com/nasa/cumulus/compare/v14.1.0...v15.0.0
 [v14.1.0]: https://github.com/nasa/cumulus/compare/v14.0.0...v14.1.0
 [v14.0.0]: https://github.com/nasa/cumulus/compare/v13.4.0...v14.0.0

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "babel-loader": "^8.2.2",
     "babel-plugin-source-map-support": "^2.1.1",
     "babel-preset-env": "^1.7.0",
+    "base-64": "^0.1.0",
     "cookie-parser": "^1.4.5",
     "copy-webpack-plugin": "^6.0.3",
     "coveralls": "^3.0.0",

--- a/packages/api/lib/distribution.js
+++ b/packages/api/lib/distribution.js
@@ -119,7 +119,7 @@ function isAuthBearTokenRequest(req) {
   const authHeader = req.headers.authorization;
   if (authHeader) {
     const match = authHeader.match(BEARER_TOKEN_REGEX);
-    if (match.length >= 2) return true;
+    if (match && match.length >= 2) return true;
   }
   return false;
 }


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3285: s3credentials endpoint fails when request has header 'Authorization: Basic'](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3285)

## Changes

* Detailed list or prose of changes
* ...

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
