### PR TITLE
Allows ECS task to have configurable health check

### DIFF
--- a/tf-modules/cumulus_ecs_service/main.tf
+++ b/tf-modules/cumulus_ecs_service/main.tf
@@ -32,6 +32,7 @@ resource "aws_ecs_task_definition" "default" {
       mountPoints       = [for k, v in var.volumes : { sourceVolume = v.name, containerPath = v.container_path }]
       privileged        = var.privileged
       environment       = [for k, v in var.environment : { name = k, value = v }]
+      healthCheck       = var.health_check
       image             = var.image
       memoryReservation = var.memory_reservation
       command           = var.command

--- a/tf-modules/cumulus_ecs_service/variables.tf
+++ b/tf-modules/cumulus_ecs_service/variables.tf
@@ -11,6 +11,18 @@ variable "default_log_retention_days" {
   description = "default value that user chooses for their log retention periods"
 }
 
+variable "health_check" {
+  description = "Health check used by AWS ECS to determine containers health status. See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definition_healthcheck"
+  type = object({
+    command = list(string)
+    interval = number
+    timeout = number
+    retries = number
+    startPeriod = number
+  })
+  default = null
+}
+
 variable "image" {
   description = "Image used to start the container. See https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDefinition.html#ECS-Type-ContainerDefinition-image"
   type = string


### PR DESCRIPTION
**Summary:** Summary of changes
 - Added variable to allow the aws_ecs_task_definition health check to be configurable.

Addresses 
 - https://bugs.earthdata.nasa.gov/browse/CUMULUS-3287
 - https://bugs.earthdata.nasa.gov/browse/GHRCCLOUD-4582

## Changes
 - The healthcheck is now configurable or will default to null if not provided

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
