### PR TITLE
Addresses #3382 move-granules documentation

### DIFF
--- a/tasks/move-granules/README.md
+++ b/tasks/move-granules/README.md
@@ -12,7 +12,7 @@ Config object fields:
 
 | field name | type | default | values | description
 | ---------- | ---- | ------- | ------ | -----------
-| bucket | string | (required) | | Bucket with public/private key for decrypting CMR password
+| bucket | string | (required) | | The name of source AWS S3 bucket that contains the granule files
 | buckets | object | (required) | | Object specifying AWS S3 buckets used by this task
 | collection | object | (required) | | The cumulus-api collection object
 | distribution_endpoint | string | (required) | | The API distribution endpoint

--- a/tasks/move-granules/index.js
+++ b/tasks/move-granules/index.js
@@ -241,7 +241,7 @@ async function moveFilesForAllGranules(
  *
  * @param {Object} event - Lambda function payload
  * @param {Object} event.config - the config object
- * @param {string} event.config.bucket - Bucket name where public/private keys are stored
+ * @param {string} event.config.bucket - Name of source aws s3 bucket that contains the granule files
  * @param {Object} event.config.buckets - Buckets config
  * @param {string} event.config.distribution_endpoint - distribution endpoint for the api
  * @param {Object} event.config.collection - collection configuration

--- a/tasks/move-granules/schemas/config.json
+++ b/tasks/move-granules/schemas/config.json
@@ -11,7 +11,7 @@
   "properties": {
     "bucket": {
       "type": "string",
-      "description": "the bucket the has the private/public key needed for decrypting cmr password"
+      "description": "the name of source aws s3 bucket that contains the granule files"
     },
     "buckets": {
       "type": "object",


### PR DESCRIPTION

**Summary:** Summary of changes
Add clarity to how the `bucket` field needs to be configured
closes #3382 
Update documentation for the corresponding files. 

## Changes

* Detailed list or prose of changes
* Update move-granules `Readme.md` to contain a clearer definition of `bucket` in `task_config`
* Update move-granules `index.js` to contain a clearer doc string for `bucket`
* Update move-granules `config.json` schema to be clearer how the field `bucket` should be configured.

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
