### PR TITLE
[CUMULUS-3172]: Update RDS migration docs

### DIFF
--- a/docs/upgrade-notes/upgrade-rds.md
+++ b/docs/upgrade-notes/upgrade-rds.md
@@ -124,7 +124,11 @@ Please read this entire section thoroughly before proceeding to run the second d
 
 :::note
 
-The data migration Lambda described here uses Cumulus' Granule `upsert` logic to write granules from DynamoDB to PostgreSQL. This is particularly notable because granules with a `running` or `queued` status will only migrate a subset of their fields. See the Granule `upsert` logic [here](https://github.com/nasa/cumulus/blob/release-15.0.x/packages/db/src/models/granule.ts#L128).
+The data-migration2 Lambda (which is invoked asynchronously using `${PREFIX}-postgres-migration-async-operation`) uses Cumulus' Granule `upsert` logic to write granules from DynamoDB to PostgreSQL. This is particularly notable because granules with a `running` or `queued` status will only migrate a subset of their fields:
+  - status
+  - timestamp
+  - updated_at
+  - created_at
 
 It is recommended that users ensure their granules are in the correct state before running this data migration. If there are Granules with an incorrect status, it will impact the data migration.
 

--- a/docs/upgrade-notes/upgrade-rds.md
+++ b/docs/upgrade-notes/upgrade-rds.md
@@ -134,6 +134,8 @@ It is recommended that users ensure their granules are in the correct state befo
 
 For example, if a Granule in the `running` status is updated by a workflow or API call (containing an updated status) and _fails_, that granule will have the original `running` status, not the intended/updated status. Failed Granule writes/updates should be evaluated and resolved prior to this data migration. These failures can be found in the [Cumulus Dead Letter Archive](https://nasa.github.io/cumulus/docs/features/dead_letter_archive/) which is populated by the Dead Letter Queue for the `sfEventSqsToDbRecords` Lambda, which is responsible for Cumulus message writes to PostgreSQL.
 
+If a Granule record is correct except for the `status`, Cumulus provides [an API to update specific granule fields](https://nasa.github.io/cumulus-api/v14.1.0/#update-or-replace-granule).
+
 :::
 
 This second data migration process can be run by invoking the provided `${PREFIX}-postgres-migration-async-operation` Lambda included in the Cumulus module deployment.

--- a/docs/upgrade-notes/upgrade-rds.md
+++ b/docs/upgrade-notes/upgrade-rds.md
@@ -132,7 +132,7 @@ The data-migration2 Lambda (which is invoked asynchronously using `${PREFIX}-pos
 
 It is recommended that users ensure their granules are in the correct state before running this data migration. If there are Granules with an incorrect status, it will impact the data migration.
 
-For example, if a Granule in the `running` status is updated by a workflow or API call (containing an updated status) and _fails_, that granule will have the original `running` status, not the intended/updated status. Failed Granule writes/updates should be evaluated and resolved prior to this data migration.
+For example, if a Granule in the `running` status is updated by a workflow or API call (containing an updated status) and _fails_, that granule will have the original `running` status, not the intended/updated status. Failed Granule writes/updates should be evaluated and resolved prior to this data migration. These failures can be found in the [Cumulus Dead Letter Archive](https://nasa.github.io/cumulus/docs/features/dead_letter_archive/) which is populated by the Dead Letter Queue for the `sfEventSqsToDbRecords` Lambda, which is responsible for Cumulus message writes to PostgreSQL.
 
 :::
 

--- a/docs/upgrade-notes/upgrade-rds.md
+++ b/docs/upgrade-notes/upgrade-rds.md
@@ -122,6 +122,16 @@ Please read this entire section thoroughly before proceeding to run the second d
 
 :::
 
+:::note
+
+The data migration Lambda described here uses Cumulus' Granule `upsert` logic to write granules from DynamoDB to PostgreSQL. This is particularly notable because granules with a `running` or `queued` status will only migrate a subset of their fields. See the Granule `upsert` logic [here](https://github.com/nasa/cumulus/blob/release-15.0.x/packages/db/src/models/granule.ts#L128).
+
+It is recommended that users ensure their granules are in the correct state before running this data migration. If there are Granules with an incorrect status, it will impact the data migration.
+
+For example, if a Granule in the `running` status is updated by a workflow or API call (containing an updated status) and _fails_, that granule will have the original `running` status, not the intended/updated status. Failed Granule writes/updates should be evaluated and resolved prior to this data migration.
+
+:::
+
 This second data migration process can be run by invoking the provided `${PREFIX}-postgres-migration-async-operation` Lambda included in the Cumulus module deployment.
 This Lambda starts an asynchronous operation which runs as an ECS task to run the migration.
 

--- a/docs/upgrade-notes/upgrade-rds.md
+++ b/docs/upgrade-notes/upgrade-rds.md
@@ -132,7 +132,9 @@ The data-migration2 Lambda (which is invoked asynchronously using `${PREFIX}-pos
 
 It is recommended that users ensure their granules are in the correct state before running this data migration. If there are Granules with an incorrect status, it will impact the data migration.
 
-For example, if a Granule in the `running` status is updated by a workflow or API call (containing an updated status) and _fails_, that granule will have the original `running` status, not the intended/updated status. Failed Granule writes/updates should be evaluated and resolved prior to this data migration. These failures can be found in the [Cumulus Dead Letter Archive](https://nasa.github.io/cumulus/docs/features/dead_letter_archive/) which is populated by the Dead Letter Queue for the `sfEventSqsToDbRecords` Lambda, which is responsible for Cumulus message writes to PostgreSQL.
+For example, if a Granule in the `running` status is updated by a workflow or API call (containing an updated status) and _fails_, that granule will have the original `running` status, not the intended/updated status. Failed Granule writes/updates should be evaluated and resolved prior to this data migration.
+
+Cumulus provides the [Cumulus Dead Letter Archive](https://nasa.github.io/cumulus/docs/features/dead_letter_archive/) which is populated by the Dead Letter Queue for the `sfEventSqsToDbRecords` Lambda, which is responsible for Cumulus message writes to PostgreSQL. This may not catch all write failures depending on where the failure happened and workflow configuration but may be a useful tool.
 
 If a Granule record is correct except for the `status`, Cumulus provides [an API to update specific granule fields](https://nasa.github.io/cumulus-api/v14.1.0/#update-or-replace-granule).
 


### PR DESCRIPTION
This adds a note to the data-migration2 documentation calling out the implication of a Granule's status and how it impacts migration.