### PR TITLE
CUMULUS-2625: Improve heap memory usage in queue-granules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -113,6 +113,7 @@ module.exports = {
     ],
     strict: 'off',
     'guard-for-in': 'off',
+    'no-restricted-syntax': ['error', 'ForInStatement', 'LabeledStatement', 'WithStatement'],
     'object-shorthand': 'off',
     'space-before-function-paren': [
       'error',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Update CI scripts to use shell logic/GNU timeout to bound test timeouts
     instead of NPM `parallel` package, as timeouts were not resulting in
     integration test failure
+- **CUMULUS-2625**
+  - Optimized heap memory and api load in queue-granules task to scale to larger workloads.
 
 ### Notable Changes
 

--- a/tasks/queue-granules/index.js
+++ b/tasks/queue-granules/index.js
@@ -93,6 +93,13 @@ class GroupedGranulesIterable {
     }
   }
 
+  /**
+   * This generator acts like a filter. It will yield all granules that match the
+   * `groupKey` param, starting at the `start` point passed in. The `start` index
+   * is an optimization to avoid reiterating through granules that can't possibly
+   * be in the same group because _groupedGranules is called the first time a
+   * group is seen from the [Symbol.iterator] generator.
+   */
   *_groupedGranules(groupKey, start) {
     for (let i = start; i < this._granules.length; i += 1) {
       const granule = this._granules[i];
@@ -103,6 +110,11 @@ class GroupedGranulesIterable {
     }
   }
 
+  /**
+   * [Symbol.iterator] implements the `Iterable` protocol. This generator iterates through
+   * all the granules finding unique groups. When a new group is found, it yields all the
+   * matching granules through `_groupedGranules` and chunked using `_chunk`.
+   */
   *[Symbol.iterator]() {
     const previouslySeen = new Set();
     for (let i = 0; i < this._granules.length; i += 1) {

--- a/tasks/queue-granules/tests/index.js
+++ b/tasks/queue-granules/tests/index.js
@@ -9,7 +9,7 @@ const {
 const { createQueue } = require('@cumulus/aws-client/SQS');
 const { recursivelyDeleteS3Bucket, s3PutObject } = require('@cumulus/aws-client/S3');
 const { buildExecutionArn } = require('@cumulus/message/Executions');
-const CollectionConfigStore = require('@cumulus/collection-config-store');
+const { constructCollectionId } = require('@cumulus/message/Collections');
 const {
   randomNumber,
   randomString,
@@ -22,8 +22,9 @@ const pMap = require('p-map');
 const noop = require('lodash/noop');
 
 const pMapSpy = sinon.spy(pMap);
+const { updateGranuleBatchCreatedAt } = require('..');
 const fakeProvidersApi = {};
-const { getCollectionIdFromGranule, groupAndBatchGranules, updateGranuleBatchCreatedAt } = require('..');
+const fetchCollectionStub = sinon.stub();
 const fakeGranulesApi = {
   updateGranule: noop,
 };
@@ -31,8 +32,9 @@ const fakeGranulesApi = {
 const { queueGranules } = proxyquire('..', {
   'p-map': pMapSpy,
   '@cumulus/api-client': {
-    providers: fakeProvidersApi,
+    collections: { getCollection: fetchCollectionStub },
     granules: fakeGranulesApi,
+    providers: fakeProvidersApi,
   },
 });
 
@@ -43,10 +45,8 @@ test.beforeEach(async (t) => {
   t.context.stackName = `stack-${randomString().slice(0, 6)}`;
   t.context.workflow = randomString();
   t.context.stateMachineArn = randomString();
-  t.context.collectionConfigStore = new CollectionConfigStore(
-    t.context.internalBucket,
-    t.context.stackName
-  );
+  fetchCollectionStub.resetBehavior();
+  t.context.getCollection = fetchCollectionStub;
 
   await s3().createBucket({ Bucket: t.context.internalBucket });
 
@@ -102,68 +102,15 @@ test.afterEach(async (t) => {
   ]);
 });
 
-test('groupAndBatchGranules uses default if batchSize is NaN', (t) => {
-  const granules = [
-    { granuleId: '1', dataType: 'ABC', version: '001' },
-    { granuleId: '2', dataType: 'ABC', version: '002' },
-    { granuleId: '3', dataType: 'XYZ', version: '001' },
-  ];
-  const expectedBatchGranules = granules.map((g) => [g]);
-  const actualGroupedAndBatchedGranules = groupAndBatchGranules(granules, undefined);
-  t.deepEqual(actualGroupedAndBatchedGranules, expectedBatchGranules);
-});
-
-test('groupAndBatchGranules batches granules by collection', (t) => {
-  const granules = [
-    { granuleId: '1', dataType: 'ABC', version: '001' },
-    { granuleId: '2', dataType: 'ABC', version: '002' },
-    { granuleId: '3', dataType: 'XYZ', version: '001' },
-  ];
-  const expectedBatchGranules = granules.map((g) => [g]);
-  const actualGroupedAndBatchedGranules = groupAndBatchGranules(granules);
-  t.deepEqual(actualGroupedAndBatchedGranules, expectedBatchGranules);
-});
-
-test('groupAndBatchGranules respects batchSize', (t) => {
-  const granules = [
-    { granuleId: '1', dataType: 'ABC', version: '001' },
-    { granuleId: '2', dataType: 'ABC', version: '001' },
-    { granuleId: '3', dataType: 'ABC', version: '001' },
-    { granuleId: '4', dataType: 'ABC', version: '002' },
-    { granuleId: '5', dataType: 'ABC', version: '002' },
-    { granuleId: '6', dataType: 'XYZ', version: '001' },
-  ];
-  const expectedBatchGranules = [
-    [granules[0], granules[1]],
-    [granules[2]],
-    [granules[3], granules[4]],
-    [granules[5]],
-  ];
-  const actualGroupedAndBatchedGranules = groupAndBatchGranules(granules, 2);
-  t.deepEqual(actualGroupedAndBatchedGranules, expectedBatchGranules);
-});
-
-test('groupAndBatchGranules further divides batches by provider if granules have one', (t) => {
-  const granules = [
-    { granuleId: '1', dataType: 'ABC', version: '001' },
-    { granuleId: '2', dataType: 'ABC', version: '001', provider: 'prov' },
-    { granuleId: '3', dataType: 'ABC', version: '001', provider: 'prov' },
-    { granuleId: '4', dataType: 'ABC', version: '002' },
-  ];
-  const expectedBatchGranules = [
-    [granules[0]],
-    [granules[1], granules[2]],
-    [granules[3]],
-  ];
-  const actualGroupedAndBatchedGranules = groupAndBatchGranules(granules, 3);
-  t.deepEqual(actualGroupedAndBatchedGranules, expectedBatchGranules);
-});
-
 test.serial('The correct output is returned when granules are queued without a PDR', async (t) => {
   const dataType = `data-type-${randomString().slice(0, 6)}`;
   const version = '6';
   const collectionConfig = { foo: 'bar' };
-  await t.context.collectionConfigStore.put(dataType, version, collectionConfig);
+  await t.context.getCollection.withArgs({
+    prefix: t.context.stackName,
+    collectionName: dataType,
+    collectionVersion: version,
+  }).returns(collectionConfig);
 
   const { event } = t.context;
   event.input.granules = [
@@ -189,7 +136,11 @@ test.serial('The correct output is returned when granules are queued with a PDR'
   const dataType = `data-type-${randomString().slice(0, 6)}`;
   const version = '6';
   const collectionConfig = { foo: 'bar' };
-  await t.context.collectionConfigStore.put(dataType, version, collectionConfig);
+  await t.context.getCollection.withArgs({
+    prefix: t.context.stackName,
+    collectionName: dataType,
+    collectionVersion: version,
+  }).returns(collectionConfig);
 
   const { event } = t.context;
   event.input.granules = [
@@ -216,7 +167,11 @@ test.serial('The correct output is returned when no granules are queued', async 
   const dataType = `data-type-${randomString().slice(0, 6)}`;
   const version = '6';
   const collectionConfig = { foo: 'bar' };
-  await t.context.collectionConfigStore.put(dataType, version, collectionConfig);
+  await t.context.getCollection.withArgs({
+    prefix: t.context.stackName,
+    collectionName: dataType,
+    collectionVersion: version,
+  }).returns(collectionConfig);
 
   const { event } = t.context;
   event.input.granules = [];
@@ -234,7 +189,11 @@ test.serial('Granules are added to the queue', async (t) => {
   const dataType = `data-type-${randomString().slice(0, 6)}`;
   const version = '6';
   const collectionConfig = { foo: 'bar' };
-  await t.context.collectionConfigStore.put(dataType, version, collectionConfig);
+  await t.context.getCollection.withArgs({
+    prefix: t.context.stackName,
+    collectionName: dataType,
+    collectionVersion: version,
+  }).returns(collectionConfig);
 
   const { event } = t.context;
   event.input.granules = [
@@ -266,7 +225,7 @@ test.serial('Granules are added to the queue', async (t) => {
 
 test.serial('The correct message is enqueued without a PDR', async (t) => {
   const {
-    collectionConfigStore,
+    getCollection,
     event,
     queueUrl,
     queueExecutionLimits,
@@ -297,8 +256,16 @@ test.serial('The correct message is enqueued without a PDR', async (t) => {
   event.input.granules = [granule1, granule2];
 
   await Promise.all([
-    collectionConfigStore.put(granule1.dataType, granule1.version, collectionConfig1),
-    collectionConfigStore.put(granule2.dataType, granule2.version, collectionConfig2),
+    getCollection.withArgs({
+      prefix: t.context.stackName,
+      collectionName: granule1.dataType,
+      collectionVersion: granule1.version,
+    }).returns(collectionConfig1),
+    getCollection.withArgs({
+      prefix: t.context.stackName,
+      collectionName: granule2.dataType,
+      collectionVersion: granule2.version,
+    }).returns(collectionConfig2),
   ]);
 
   await validateConfig(t, event.config);
@@ -386,7 +353,7 @@ test.serial('The correct message is enqueued without a PDR', async (t) => {
 
 test.serial('granules are enqueued with createdAt values added to granules that are missing them', async (t) => {
   const {
-    collectionConfigStore,
+    getCollection,
     event,
   } = t.context;
 
@@ -412,8 +379,16 @@ test.serial('granules are enqueued with createdAt values added to granules that 
   event.input.granules = [granule1, granule2];
 
   await Promise.all([
-    collectionConfigStore.put(granule1.dataType, granule1.version, collectionConfig1),
-    collectionConfigStore.put(granule2.dataType, granule2.version, collectionConfig2),
+    getCollection.withArgs({
+      prefix: t.context.stackName,
+      collectionName: granule1.dataType,
+      collectionVersion: granule1.version,
+    }).returns(collectionConfig1),
+    getCollection.withArgs({
+      prefix: t.context.stackName,
+      collectionName: granule2.dataType,
+      collectionVersion: granule2.version,
+    }).returns(collectionConfig2),
   ]);
 
   await validateConfig(t, event.config);
@@ -444,7 +419,7 @@ test.serial('granules are enqueued with createdAt values added to granules that 
 
 test.serial('The correct message is enqueued with a PDR', async (t) => {
   const {
-    collectionConfigStore,
+    getCollection,
     event,
     queueUrl,
     queueExecutionLimits,
@@ -487,8 +462,16 @@ test.serial('The correct message is enqueued with a PDR', async (t) => {
   event.input.granules = [granule1, granule2];
 
   await Promise.all([
-    collectionConfigStore.put(granule1.dataType, granule1.version, collectionConfig1),
-    collectionConfigStore.put(granule2.dataType, granule2.version, collectionConfig2),
+    getCollection.withArgs({
+      prefix: t.context.stackName,
+      collectionName: granule1.dataType,
+      collectionVersion: granule1.version,
+    }).returns(collectionConfig1),
+    getCollection.withArgs({
+      prefix: t.context.stackName,
+      collectionName: granule2.dataType,
+      collectionVersion: granule2.version,
+    }).returns(collectionConfig2),
   ]);
 
   await validateConfig(t, event.config);
@@ -582,7 +565,11 @@ test.serial('If a granule has a provider property, that provider is used', async
   const dataType = randomString();
   const version = randomString();
   const collectionConfig = { foo: 'bar' };
-  await t.context.collectionConfigStore.put(dataType, version, collectionConfig);
+  await t.context.getCollection.withArgs({
+    prefix: t.context.stackName,
+    collectionName: dataType,
+    collectionVersion: version,
+  }).returns(collectionConfig);
 
   const provider = { id: randomString(), host: randomString() };
 
@@ -632,7 +619,11 @@ test.serial('A default concurrency of 3 is used', async (t) => {
   const dataType = `data-type-${randomString().slice(0, 6)}`;
   const version = '6';
   const collectionConfig = { foo: 'bar' };
-  await t.context.collectionConfigStore.put(dataType, version, collectionConfig);
+  await t.context.getCollection.withArgs({
+    prefix: t.context.stackName,
+    collectionName: dataType,
+    collectionVersion: version,
+  }).returns(collectionConfig);
 
   const { event } = t.context;
   event.input.granules = [
@@ -646,8 +637,8 @@ test.serial('A default concurrency of 3 is used', async (t) => {
 
   await queueGranules(event);
 
-  t.true(pMapSpy.calledThrice);
-  pMapSpy.getCalls().forEach((call) => t.true(call.calledWithMatch(
+  t.is(pMapSpy.getCalls().length, 4);
+  pMapSpy.getCalls().slice(1).forEach((call) => t.true(call.calledWithMatch(
     sinon.match.any,
     sinon.match.any,
     sinon.match({ concurrency: 3 })
@@ -658,7 +649,11 @@ test.serial('A configured concurrency is used', async (t) => {
   const dataType = `data-type-${randomString().slice(0, 6)}`;
   const version = '6';
   const collectionConfig = { foo: 'bar' };
-  await t.context.collectionConfigStore.put(dataType, version, collectionConfig);
+  await t.context.getCollection.withArgs({
+    prefix: t.context.stackName,
+    collectionName: dataType,
+    collectionVersion: version,
+  }).returns(collectionConfig);
 
   const { event } = t.context;
 
@@ -675,8 +670,8 @@ test.serial('A configured concurrency is used', async (t) => {
 
   await queueGranules(event);
 
-  t.true(pMapSpy.calledThrice);
-  pMapSpy.getCalls().forEach((call) => t.true(call.calledWithMatch(
+  t.is(pMapSpy.getCalls().length, 4);
+  pMapSpy.getCalls().slice(1).forEach((call) => t.true(call.calledWithMatch(
     sinon.match.any,
     sinon.match.any,
     sinon.match({ concurrency: 99 })
@@ -689,7 +684,11 @@ test.serial('A config with executionNamePrefix is handled as expected', async (t
   const dataType = `data-type-${randomString().slice(0, 6)}`;
   const version = '6';
   const collectionConfig = { foo: 'bar' };
-  await t.context.collectionConfigStore.put(dataType, version, collectionConfig);
+  await t.context.getCollection.withArgs({
+    prefix: t.context.stackName,
+    collectionName: dataType,
+    collectionVersion: version,
+  }).returns(collectionConfig);
 
   const executionNamePrefix = randomString(3);
   event.config.executionNamePrefix = executionNamePrefix;
@@ -738,7 +737,11 @@ test.serial('If a childWorkflowMeta is provided, it is passed through to the mes
   const dataType = `data-type-${randomString().slice(0, 6)}`;
   const version = '6';
   const collectionConfig = { foo: 'bar' };
-  await t.context.collectionConfigStore.put(dataType, version, collectionConfig);
+  await t.context.getCollection.withArgs({
+    prefix: t.context.stackName,
+    collectionName: dataType,
+    collectionVersion: version,
+  }).returns(collectionConfig);
 
   const { event } = t.context;
   event.input.granules = [
@@ -785,7 +788,11 @@ test.serial('createdAt for queued granule is equal to enqueueGranuleIngestMessag
   const dataType = `data-type-${randomString().slice(0, 6)}`;
   const version = '6';
   const collectionConfig = { foo: 'bar' };
-  await t.context.collectionConfigStore.put(dataType, version, collectionConfig);
+  await t.context.getCollection.withArgs({
+    prefix: t.context.stackName,
+    collectionName: dataType,
+    collectionVersion: version,
+  }).returns(collectionConfig);
   event.input.granules = [
     {
       dataType, version, granuleId: randomString(), files: [],
@@ -805,11 +812,10 @@ test.serial('createdAt for queued granule is equal to enqueueGranuleIngestMessag
 
   await queueGranules(event, testMocks);
   const expectedCreatedAt = enqueueGranuleIngestMessageMock.returnValues[0].granules[0].createdAt;
-  t.deepEqual(dataType + '___' + version, getCollectionIdFromGranule(event.input.granules[0]));
-  t.assert(updateGranuleMock.returnValues[0] === expectedCreatedAt);
+  t.is(updateGranuleMock.returnValues[0], expectedCreatedAt);
 });
 
-test('updatedGranuleBatchCreatedAt updates batch granule object with correct createdAt values', (t) => {
+test.serial('updatedGranuleBatchCreatedAt updates batch granule object with correct createdAt values', (t) => {
   const testGranuleBatch = [
     {
       granuleId: 1,
@@ -832,35 +838,217 @@ test('updatedGranuleBatchCreatedAt updates batch granule object with correct cre
   t.deepEqual(actual, expected);
 });
 
-test.serial('queueGranules throws an error when no dataType, version, or collectionId are provided in input', async (t) => {
-  const { event } = t.context;
-  event.input.granules = [
-    {
-      granuleId: randomString(), files: [],
-    },
-    {
-      granuleId: randomString(), files: [],
-    },
-  ];
+test.serial('hitting defaults for branch coverage', async (t) => {
+  const dataType = `data-type-${randomString().slice(0, 6)}`;
+  const version = '6';
+  const collectionConfig = { foo: 'bar' };
+  await t.context.getCollection.withArgs({
+    prefix: t.context.stackName,
+    collectionName: dataType,
+    collectionVersion: version,
+  }).returns(collectionConfig);
 
-  await t.throwsAsync(queueGranules(event));
+  const { event } = t.context;
+
+  event.config.concurrency = 99;
+
+  event.input.granules = undefined;
+
+  await queueGranules(event);
+
+  t.is(pMapSpy.getCalls().length, 1);
 });
 
-test.serial('queueGranules does not throw an error when collectionId is provided in the task input', async (t) => {
-  const dataType = undefined;
-  const version = undefined;
-  const collectionConfig = { foo: 'bar' };
-  await t.context.collectionConfigStore.put(dataType, version, collectionConfig);
-
+test.serial('does not change collection id on granule', async (t) => {
   const { event } = t.context;
+
   event.input.granules = [
     {
-      collectionId: 'ABC___001', granuleId: randomString(), files: [],
+      granuleId: 'granule-1',
+      dataType: 'http_testcollection_test-stackName-DiscoverGranules-1686092642035',
+      version: '001',
+      files: [],
     },
     {
-      collectionId: 'ABC___001', granuleId: randomString(), files: [],
+      granuleId: 'granule-2',
+      dataType: 'http_testcollection_test-stackName-DiscoverGranules-1686092642035',
+      version: '001',
+      files: [],
+    },
+    {
+      granuleId: 'granule-3',
+      dataType: 'http_testcollection_test-stackName-DiscoverGranules-1686092642035',
+      version: '001',
+      files: [],
     },
   ];
-  await t.deepEqual('ABC___001', getCollectionIdFromGranule(event.input.granules[0]));
-  await t.notThrowsAsync(queueGranules(event));
+  const enqueueGranuleIngestMessageMock = sinon.spy((params) => params);
+
+  const testMocks = {
+    updateGranuleMock: sinon.spy(async () => { }),
+    enqueueGranuleIngestMessageMock,
+  };
+
+  await queueGranules(event, testMocks);
+
+  const createdMap = Object.fromEntries(
+    testMocks.updateGranuleMock.getCalls()
+      .map(({ args: [params] }) => [params.granuleId, params.body.createdAt])
+  );
+  t.deepEqual(
+    testMocks.updateGranuleMock.getCalls()
+      .map(({ args: [params] }) => params)
+      .sort(({ granuleId: a }, { granuleId: b }) => a.localeCompare(b)),
+    event.input.granules.map(
+      ({ granuleId, dataType, version }) => {
+        const collectionId = constructCollectionId(dataType, version);
+        return {
+          prefix: event.config.stackName,
+          collectionId,
+          granuleId,
+          body: {
+            collectionId,
+            granuleId,
+            status: 'queued',
+            createdAt: createdMap[granuleId],
+          },
+        };
+      }
+    )
+  );
+
+  t.deepEqual(
+    enqueueGranuleIngestMessageMock.getCalls().length,
+    event.input.granules.length
+  );
+});
+
+test.serial('handles different collections', async (t) => {
+  const { event } = t.context;
+
+  event.input.granules = [
+    {
+      granuleId: 'granule-1',
+      dataType: 'http_testcollection_test-stackName-DiscoverGranules-1686092642035',
+      version: '001',
+      files: [],
+    },
+    {
+      granuleId: 'granule-2',
+      dataType: 'http_testcollection_test-stackName-DiscoverGranules-1686092642035',
+      version: '001',
+      files: [],
+    },
+    {
+      granuleId: 'granule-3',
+      dataType: 'http_testcollection_test-stackName-DiscoverGranules-1686092642035',
+      version: '002',
+      files: [],
+    },
+  ];
+  const enqueueGranuleIngestMessageMock = sinon.spy((params) => params);
+
+  const testMocks = {
+    updateGranuleMock: sinon.spy(async () => { }),
+    enqueueGranuleIngestMessageMock,
+  };
+
+  await queueGranules(event, testMocks);
+
+  const createdMap = Object.fromEntries(
+    testMocks.updateGranuleMock.getCalls()
+      .map(({ args: [params] }) => [params.granuleId, params.body.createdAt])
+  );
+  t.deepEqual(
+    testMocks.updateGranuleMock.getCalls()
+      .map(({ args: [params] }) => params)
+      .sort(({ granuleId: a }, { granuleId: b }) => a.localeCompare(b)),
+    event.input.granules.map(
+      ({ granuleId, dataType, version }) => {
+        const collectionId = constructCollectionId(dataType, version);
+        return {
+          prefix: event.config.stackName,
+          collectionId,
+          granuleId,
+          body: {
+            collectionId,
+            granuleId,
+            status: 'queued',
+            createdAt: createdMap[granuleId],
+          },
+        };
+      }
+    )
+  );
+
+  t.deepEqual(
+    enqueueGranuleIngestMessageMock.getCalls().length,
+    event.input.granules.length
+  );
+});
+
+
+test.serial('handles different providers', async (t) => {
+  const { event } = t.context;
+
+  event.input.granules = [
+    {
+      granuleId: 'granule-1',
+      dataType: 'http_testcollection_test-stackName-DiscoverGranules-1686092642035',
+      version: '001',
+      provider: 'test-s3provider',
+      files: [],
+    },
+    {
+      granuleId: 'granule-2',
+      dataType: 'http_testcollection_test-stackName-DiscoverGranules-1686092642035',
+      version: '001',
+      files: [],
+    },
+    {
+      granuleId: 'granule-3',
+      dataType: 'http_testcollection_test-stackName-DiscoverGranules-1686092642035',
+      version: '002',
+      files: [],
+    },
+  ];
+  const enqueueGranuleIngestMessageMock = sinon.spy((params) => params);
+
+  const testMocks = {
+    updateGranuleMock: sinon.spy(async () => { }),
+    enqueueGranuleIngestMessageMock,
+  };
+
+  await queueGranules(event, testMocks);
+
+  const createdMap = Object.fromEntries(
+    testMocks.updateGranuleMock.getCalls()
+      .map(({ args: [params] }) => [params.granuleId, params.body.createdAt])
+  );
+  t.deepEqual(
+    testMocks.updateGranuleMock.getCalls()
+      .map(({ args: [params] }) => params)
+      .sort(({ granuleId: a }, { granuleId: b }) => a.localeCompare(b)),
+    event.input.granules.map(
+      ({ granuleId, dataType, version }) => {
+        const collectionId = constructCollectionId(dataType, version);
+        return {
+          prefix: event.config.stackName,
+          collectionId,
+          granuleId,
+          body: {
+            collectionId,
+            granuleId,
+            status: 'queued',
+            createdAt: createdMap[granuleId],
+          },
+        };
+      }
+    )
+  );
+
+  t.deepEqual(
+    enqueueGranuleIngestMessageMock.getCalls().length,
+    event.input.granules.length
+  );
 });

--- a/tasks/queue-granules/tests/index.js
+++ b/tasks/queue-granules/tests/index.js
@@ -1051,3 +1051,17 @@ test.serial('handles different providers', async (t) => {
     event.input.granules.length
   );
 });
+
+test.serial('queueGranules throws an error when no dataType, version, or collectionId are provided in input', async (t) => {
+  const { event } = t.context;
+  event.input.granules = [
+    {
+      granuleId: randomString(), files: [],
+    },
+    {
+      granuleId: randomString(), files: [],
+    },
+  ];
+
+  await t.throwsAsync(queueGranules(event));
+});

--- a/tasks/queue-granules/tests/index.js
+++ b/tasks/queue-granules/tests/index.js
@@ -987,7 +987,6 @@ test.serial('handles different collections', async (t) => {
   );
 });
 
-
 test.serial('handles different providers', async (t) => {
   const { event } = t.context;
 

--- a/tasks/queue-granules/tests/iterator.js
+++ b/tasks/queue-granules/tests/iterator.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const test = require('ava');
+const { constructCollectionId } = require('@cumulus/message/Collections');
 const { GroupedGranulesIterable } = require('..');
 
 function createGranule(granuleId, dataType, version, provider = undefined) {
@@ -13,10 +14,28 @@ function createGranule(granuleId, dataType, version, provider = undefined) {
   };
 }
 
+function createGranuleWithCollectionId(granuleId, dataType, version, provider = undefined) {
+  const collectionId = constructCollectionId(dataType, version);
+  return {
+    granuleId,
+    collectionId,
+    files: [],
+    ...(provider ? { provider } : {}),
+  };
+}
+
 test('GroupedGranulesIterable yields all granules', (t) => {
   const granule1 = createGranule('granule-1', 'collection-1', '001');
   const granule2 = createGranule('granule-2', 'collection-1', '001');
   const granule3 = createGranule('granule-3', 'collection-1', '001');
+  const iterable = new GroupedGranulesIterable([granule1, granule2, granule3], 3);
+  t.deepEqual([...iterable].flatMap(({ chunks }) => [...chunks]), [[granule1, granule2, granule3]]);
+});
+
+test('GroupedGranulesIterable yields all granules with collectionId', (t) => {
+  const granule1 = createGranuleWithCollectionId('granule-1', 'collection-1', '001');
+  const granule2 = createGranuleWithCollectionId('granule-2', 'collection-1', '001');
+  const granule3 = createGranuleWithCollectionId('granule-3', 'collection-1', '001');
   const iterable = new GroupedGranulesIterable([granule1, granule2, granule3], 3);
   t.deepEqual([...iterable].flatMap(({ chunks }) => [...chunks]), [[granule1, granule2, granule3]]);
 });
@@ -62,6 +81,17 @@ test('GroupedGranulesIterable batches granules by version', (t) => {
   );
 });
 
+test('GroupedGranulesIterable batches granules with collectionId', (t) => {
+  const granule1 = createGranuleWithCollectionId('granule-1', 'collection-1', '001');
+  const granule2 = createGranuleWithCollectionId('granule-2', 'collection-2', '001');
+  const granule3 = createGranuleWithCollectionId('granule-3', 'collection-1', '002');
+  const iterable = new GroupedGranulesIterable([granule1, granule2, granule3], 3);
+  t.deepEqual(
+    [...iterable].flatMap(({ chunks }) => [...chunks]),
+    [[granule1], [granule2], [granule3]]
+  );
+});
+
 test('GroupedGranulesIterable batches granules by collection and version', (t) => {
   const granule1 = createGranule('granule-1', 'collection-1', '001');
   const granule2 = createGranule('granule-2', 'collection-2', '001');
@@ -77,6 +107,17 @@ test('GroupedGranulesIterable batches granules by provider', (t) => {
   const granule1 = createGranule('granule-1', 'collection-1', '001', 'test_provider');
   const granule2 = createGranule('granule-2', 'collection-1', '001', 'test_provider');
   const granule3 = createGranule('granule-3', 'collection-1', '001');
+  const iterable = new GroupedGranulesIterable([granule1, granule2, granule3], 3);
+  t.deepEqual(
+    [...iterable].flatMap(({ chunks }) => [...chunks]),
+    [[granule1, granule2], [granule3]]
+  );
+});
+
+test('GroupedGranulesIterable batches granules by provider with collectionId', (t) => {
+  const granule1 = createGranuleWithCollectionId('granule-1', 'collection-1', '001', 'test_provider');
+  const granule2 = createGranuleWithCollectionId('granule-2', 'collection-1', '001', 'test_provider');
+  const granule3 = createGranuleWithCollectionId('granule-3', 'collection-1', '001');
   const iterable = new GroupedGranulesIterable([granule1, granule2, granule3], 3);
   t.deepEqual(
     [...iterable].flatMap(({ chunks }) => [...chunks]),

--- a/tasks/queue-granules/tests/iterator.js
+++ b/tasks/queue-granules/tests/iterator.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const test = require('ava');
+const { GroupedGranulesIterable } = require('..');
+
+function createGranule(granuleId, dataType, version, provider = undefined) {
+  return {
+    granuleId,
+    dataType,
+    version,
+    files: [],
+    ...(provider ? { provider } : {}),
+  };
+}
+
+test('GroupedGranulesIterable yields all granules', (t) => {
+  const granule1 = createGranule('granule-1', 'collection-1', '001');
+  const granule2 = createGranule('granule-2', 'collection-1', '001');
+  const granule3 = createGranule('granule-3', 'collection-1', '001');
+  const iterable = new GroupedGranulesIterable([granule1, granule2, granule3], 3);
+  t.deepEqual([...iterable].flatMap(({ chunks }) => [...chunks]), [[granule1, granule2, granule3]]);
+});
+
+test('GroupedGranulesIterable handles NaN chunkSize', (t) => {
+  const granule1 = createGranule('granule-1', 'collection-1', '001');
+  const granule2 = createGranule('granule-2', 'collection-1', '001');
+  const granule3 = createGranule('granule-3', 'collection-1', '001');
+  const iterable = new GroupedGranulesIterable([granule1, granule2, granule3], Number.NaN);
+  t.deepEqual([...iterable].flatMap(({ chunks }) => [...chunks]), [[granule1, granule2, granule3]]);
+});
+
+test('GroupedGranulesIterable batches granules by chunk size', (t) => {
+  const granule1 = createGranule('granule-1', 'collection-1', '001');
+  const granule2 = createGranule('granule-2', 'collection-1', '001');
+  const granule3 = createGranule('granule-3', 'collection-1', '001');
+  const iterable = new GroupedGranulesIterable([granule1, granule2, granule3], 1);
+  t.deepEqual(
+    [...iterable].flatMap(({ chunks }) => [...chunks]),
+    [[granule1], [granule2], [granule3]]
+  );
+});
+
+test('GroupedGranulesIterable batches granules by collection', (t) => {
+  const granule1 = createGranule('granule-1', 'collection-1', '001');
+  const granule2 = createGranule('granule-2', 'collection-2', '001');
+  const granule3 = createGranule('granule-3', 'collection-1', '001');
+  const iterable = new GroupedGranulesIterable([granule1, granule2, granule3], 3);
+  t.deepEqual(
+    [...iterable].flatMap(({ chunks }) => [...chunks]),
+    [[granule1, granule3], [granule2]]
+  );
+});
+
+test('GroupedGranulesIterable batches granules by version', (t) => {
+  const granule1 = createGranule('granule-1', 'collection-1', '002');
+  const granule2 = createGranule('granule-2', 'collection-1', '001');
+  const granule3 = createGranule('granule-3', 'collection-1', '001');
+  const iterable = new GroupedGranulesIterable([granule1, granule2, granule3], 3);
+  t.deepEqual(
+    [...iterable].flatMap(({ chunks }) => [...chunks]),
+    [[granule1], [granule2, granule3]]
+  );
+});
+
+test('GroupedGranulesIterable batches granules by collection and version', (t) => {
+  const granule1 = createGranule('granule-1', 'collection-1', '001');
+  const granule2 = createGranule('granule-2', 'collection-2', '001');
+  const granule3 = createGranule('granule-3', 'collection-1', '002');
+  const iterable = new GroupedGranulesIterable([granule1, granule2, granule3], 3);
+  t.deepEqual(
+    [...iterable].flatMap(({ chunks }) => [...chunks]),
+    [[granule1], [granule2], [granule3]]
+  );
+});
+
+test('GroupedGranulesIterable batches granules by provider', (t) => {
+  const granule1 = createGranule('granule-1', 'collection-1', '001', 'test_provider');
+  const granule2 = createGranule('granule-2', 'collection-1', '001', 'test_provider');
+  const granule3 = createGranule('granule-3', 'collection-1', '001');
+  const iterable = new GroupedGranulesIterable([granule1, granule2, granule3], 3);
+  t.deepEqual(
+    [...iterable].flatMap(({ chunks }) => [...chunks]),
+    [[granule1, granule2], [granule3]]
+  );
+});


### PR DESCRIPTION
**Summary:** Improve heap memory usage in queue-granules

Addresses [CUMULUS-2625](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2625). 

## Changes

* Change `groupAndBatchGranules` to be an Iterator, yielding chunks of granules at a time instead of the entire collection of chunks at once. 
* Optimize calls to the api by memoizing the responses and moving the calls out of the inner loops.

## Notes

* `groupAndBatchGranules` goes `groupby collection -> chunk -> groupby provider`. It would be more performant to do `groupby collection + provider -> chunk` but that does technically change the chunks. I'm assuming that's not intentional as I can't think of a reason to chunk before grouping by provider. 
* 800k granules in a single workflow call is pretty close to what you could expect Node to allocate on the heap to begin with (1.4 GB of heap space by default). I tested my changes up to 100k successfully in ECS. The current master can't do 10k in ECS, but this has alot more to do with api calls can memory.

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [x] Integration tests

### Ad-hoc Testing
The following is from manually testing memory using ```node --inspect``` and then connecting the Chrome Devtools to the process to record allocations while running `index.js` with fake granules and the api calls mocked out.

Memory before:
<img width="918" alt="Screenshot 2023-05-23 at 4 54 45 PM" src="https://github.com/nasa/cumulus/assets/1011062/f80021e4-4507-450e-8546-ec0190194bc3">

Memory after:
![Screenshot 2023-06-05 at 9 30 08 PM](https://github.com/nasa/cumulus/assets/1011062/e7990fb2-13e3-4577-9064-afae14f6e1b8)

### Ad-hoc Load Testing

Please see https://github.com/nasa/cumulus/tree/test/CUMULUS-2625 for the task `GenerateGranules` and the associated workflow I used to load test these changes.