### PR TITLE
CUMULUS-3223: Fix failed granule stuck in queued (#3373) merge to release 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,14 @@ Users/clients that do not make use of these endpoints will not be impacted.
 - **CUMULUS-3165**
   - Update example/cumulus-tf/orca.tf to use orca v6.0.3
 
+### Fixed
+
+- **CUMULUS-3223**
+  - Update `@cumulus/cmrjs/cmr-utils.getGranuleTemporalInfo` to handle the error when the cmr file s3url is not available
+  - Update `sfEventSqsToDbRecords` lambda to return [partial batch failure](https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting),
+    and only reprocess messages when cumulus message can't be retrieved from the execution events.
+  - Update `@cumulus/cumulus-message-adapter-js` to `2.0.5` for all cumulus tasks
+
 ## [v15.0.3] 2023-04-28
 
 ### Fixed

--- a/example/spec/parallel/ingestGranule/IngestGranuleFailureSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleFailureSpec.js
@@ -70,15 +70,22 @@ describe('The Ingest Granule failure workflow', () => {
       inputPayload = await setupTestGranuleForIngest(config.bucket, inputPayloadJson, granuleRegex, testSuffix, testDataFolder);
       pdrFilename = inputPayload.pdr.name;
 
-      // add a non-existent file to input payload to cause lambda error
+      // add a file with invalid schema (missing path field), and a non-existent file to input payload.
+      // .cmr.json is for testing retrieving cmr information when granule is failed
       inputPayload.granules[0].files = [
         {
-          name: 'non-existent-file',
-          key: 'non-existent-path/non-existent-file',
+          key: 'no-path-field/no-path-field-file',
           bucket: config.bucket,
+          name: 'no-path-field-file',
         },
+        {
+          name: 'non-existent-file.cmr.json',
+          path: 'non-existent-path',
+        },
+        ...inputPayload.granules[0].files,
       ];
 
+      console.log(`testSuffix: ${testSuffix}, granuleId: ${inputPayload.granules[0].granuleId}`);
       workflowExecution = await buildAndExecuteWorkflow(
         config.stackName,
         config.bucket,
@@ -89,6 +96,7 @@ describe('The Ingest Granule failure workflow', () => {
       );
     } catch (error) {
       beforeAllFailed = true;
+      console.log('IngestGranuleFailure beforeAll caught error', error);
       throw error;
     }
   });
@@ -217,7 +225,7 @@ describe('The Ingest Granule failure workflow', () => {
       expect(JSON.parse(execution.error.Cause)).toEqual(JSON.parse(syncGranFailedDetail.cause));
     });
 
-    it('fails the granule with an error object', async () => {
+    it('fails the granule with a list of errors', async () => {
       await waitForApiStatus(
         getGranule,
         {
@@ -233,8 +241,16 @@ describe('The Ingest Granule failure workflow', () => {
       });
 
       expect(granule.status).toBe('failed');
-      expect(granule.error.Error).toBeDefined();
-      expect(granule.error.Cause).toBeDefined();
+      console.log('IngestGranuleFailure granule.error', granule.error);
+      const errors = JSON.parse(granule.error.errors || []);
+      expect(errors.length).toBeGreaterThanOrEqual(2);
+      errors.forEach((error) => {
+        const isSchemaValidationError = (error.Error === 'CumulusMessageAdapterExecutionError') &&
+          error.Cause.includes('jsonschema.exceptions.ValidationError');
+        const isPostgresWriteError = error.Error.includes('Failed writing files to PostgreSQL') &&
+          error.Cause.includes('null value in column "bucket" violates not-null constraint');
+        expect(isSchemaValidationError || isPostgresWriteError).toBeTrue();
+      });
     });
   });
 });

--- a/packages/api/tests/lambdas/sf-event-sqs-to-db-records/test-index.js
+++ b/packages/api/tests/lambdas/sf-event-sqs-to-db-records/test-index.js
@@ -40,6 +40,7 @@ const {
 const {
   getMessageExecutionParentArn,
 } = require('@cumulus/message/Executions');
+const { createSqsQueues, getSqsQueueMessageCounts } = require('../../../lib/testUtils');
 const {
   writeRecords,
 } = require('../../../lambdas/sf-event-sqs-to-db-records');
@@ -47,9 +48,6 @@ const {
 const {
   handler,
 } = proxyquire('../../../lambdas/sf-event-sqs-to-db-records', {
-  '@cumulus/aws-client/SQS': {
-    sendSQSMessage: (queue, message) => Promise.resolve([queue, message]),
-  },
   '@cumulus/message/Executions': {
     getMessageExecutionParentArn: (cumulusMessage) => {
       if (cumulusMessage.fail === true) {
@@ -73,29 +71,32 @@ const loadFixture = (filename) =>
     )
   );
 
-let fixture;
-
 const runHandler = async ({
-  cumulusMessage = {},
+  fixture,
+  cumulusMessages = [{}],
   stateMachineArn,
   executionArn,
   executionName,
   testDbName,
   ...additionalParams
 }) => {
-  fixture.resources = [executionArn];
-  fixture.detail.executionArn = executionArn;
-  fixture.detail.stateMachineArn = stateMachineArn;
-  fixture.detail.name = executionName;
-
-  fixture.detail.input = JSON.stringify(cumulusMessage);
+  const eventRecords = cumulusMessages.map((cumulusMessage) => {
+    const eventFixture = { ...fixture };
+    eventFixture.resources = [executionArn];
+    eventFixture.detail.executionArn = executionArn;
+    eventFixture.detail.stateMachineArn = stateMachineArn;
+    eventFixture.detail.name = executionName;
+    eventFixture.detail.input = JSON.stringify(cumulusMessage);
+    return {
+      messageId: cryptoRandomString({ length: 10 }),
+      eventSource: 'aws:sqs',
+      body: JSON.stringify(eventFixture),
+    };
+  });
 
   const sqsEvent = {
     ...additionalParams,
-    Records: [{
-      eventSource: 'aws:sqs',
-      body: JSON.stringify(fixture),
-    }],
+    Records: eventRecords,
     env: {
       ...localStackConnectionEnv,
       PG_DATABASE: testDbName,
@@ -163,7 +164,7 @@ test.before(async (t) => {
   t.context.pdrPgModel = new PdrPgModel();
   t.context.providerPgModel = new ProviderPgModel();
 
-  fixture = await loadFixture('execution-running-event.json');
+  t.context.fixture = await loadFixture('execution-running-event.json');
 
   const executionsTopicName = cryptoRandomString({ length: 10 });
   const pdrsTopicName = cryptoRandomString({ length: 10 });
@@ -191,11 +192,9 @@ test.beforeEach(async (t) => {
   process.env.granule_sns_topic_arn = TopicArn;
   t.context.TopicArn = TopicArn;
 
-  const QueueName = cryptoRandomString({ length: 10 });
-  const { QueueUrl } = await sqs().createQueue({ QueueName }).promise();
-  t.context.QueueUrl = QueueUrl;
+  t.context.queues = await createSqsQueues(cryptoRandomString({ length: 10 }));
   const getQueueAttributesResponse = await sqs().getQueueAttributes({
-    QueueUrl,
+    QueueUrl: t.context.queues.queueUrl,
     AttributeNames: ['QueueArn'],
   }).promise();
   const QueueArn = getQueueAttributesResponse.Attributes.QueueArn;
@@ -211,11 +210,13 @@ test.beforeEach(async (t) => {
     Token: SubscriptionArn,
   }).promise();
 
+  process.env.DeadLetterQueue = t.context.queues.deadLetterQueueUrl;
+
   const stateMachineName = cryptoRandomString({ length: 5 });
-  t.context.stateMachineArn = `arn:aws:states:${fixture.region}:${fixture.account}:stateMachine:${stateMachineName}`;
+  t.context.stateMachineArn = `arn:aws:states:${t.context.fixture.region}:${t.context.fixture.account}:stateMachine:${stateMachineName}`;
 
   t.context.executionName = cryptoRandomString({ length: 5 });
-  t.context.executionArn = `arn:aws:states:${fixture.region}:${fixture.account}:execution:${stateMachineName}:${t.context.executionName}`;
+  t.context.executionArn = `arn:aws:states:${t.context.fixture.region}:${t.context.fixture.account}:execution:${stateMachineName}:${t.context.executionName}`;
 
   t.context.provider = {
     id: `provider${cryptoRandomString({ length: 5 })}`,
@@ -266,6 +267,11 @@ test.beforeEach(async (t) => {
       host: t.context.provider.host,
       protocol: t.context.provider.protocol,
     });
+});
+
+test.afterEach.always(async (t) => {
+  await sqs().deleteQueue({ QueueUrl: t.context.queues.queueUrl }).promise();
+  await sqs().deleteQueue({ QueueUrl: t.context.queues.deadLetterQueueUrl }).promise();
 });
 
 test.after.always(async (t) => {
@@ -361,16 +367,60 @@ test.serial('writeRecords() writes records to Dynamo and PostgreSQL', async (t) 
   );
 });
 
-test('Lambda sends message to DLQ when writeRecords() throws an error', async (t) => {
+test.serial('Lambda sends message to DLQ when writeRecords() throws an error', async (t) => {
   const {
     handlerResponse,
     sqsEvent,
   } = await runHandler({
     ...t.context,
-    cumulusMessage: { fail: true },
+    cumulusMessages: [{ fail: true }],
   });
 
-  t.is(handlerResponse[0][1].body, sqsEvent.Records[0].body);
+  t.is(handlerResponse.batchItemFailures.length, 0);
+  const {
+    numberOfMessagesAvailable,
+    numberOfMessagesNotVisible,
+  } = await getSqsQueueMessageCounts(t.context.queues.deadLetterQueueUrl);
+  t.is(numberOfMessagesAvailable, 1);
+  t.is(numberOfMessagesNotVisible, 0);
+  const { Messages } = await sqs()
+    .receiveMessage({
+      QueueUrl: t.context.queues.deadLetterQueueUrl,
+      WaitTimeSeconds: 10,
+    })
+    .promise();
+  const dlqMessage = JSON.parse(Messages[0].Body);
+  t.deepEqual(dlqMessage, sqsEvent.Records[0]);
+});
+
+test.serial('Lambda returns partial batch response to reprocess messages when getCumulusMessageFromExecutionEvent() throws an error', async (t) => {
+  const {
+    handlerResponse,
+    sqsEvent,
+  } = await runHandler({
+    ...t.context,
+    cumulusMessages: [null],
+  });
+
+  t.is(handlerResponse.batchItemFailures.length, 1);
+  t.is(handlerResponse.batchItemFailures[0].itemIdentifier, sqsEvent.Records[0].messageId);
+});
+
+test.serial('Lambda processes multiple messages', async (t) => {
+  const {
+    handlerResponse,
+  } = await runHandler({
+    ...t.context,
+    cumulusMessages: [{ fail: true }, null, t.context.cumulusMessage, null, { fail: true }],
+  });
+
+  const {
+    numberOfMessagesAvailable,
+    numberOfMessagesNotVisible,
+  } = await getSqsQueueMessageCounts(t.context.queues.deadLetterQueueUrl);
+  t.is(numberOfMessagesAvailable, 2);
+  t.is(numberOfMessagesNotVisible, 0);
+  t.is(handlerResponse.batchItemFailures.length, 2);
 });
 
 test.serial('writeRecords() discards an out of order message that is older than an existing message without error or write', async (t) => {

--- a/packages/cmrjs/src/cmr-utils.js
+++ b/packages/cmrjs/src/cmr-utils.js
@@ -1090,8 +1090,13 @@ async function getUserAccessibleBuckets(edlUser, cmrProvider = process.env.cmr_p
  *    available.
  */
 async function getGranuleTemporalInfo(granule) {
-  const cmrFile = granuleToCmrFileObject(granule);
-  if (cmrFile.length === 0) return {};
+  let cmrFile = [];
+  try {
+    cmrFile = granuleToCmrFileObject(granule);
+  } catch (error) {
+    log.debug(`getGranuleTemporalInfo failed to granuleToCmrFileObject ${JSON.stringify(granule)}, ${error.message}`);
+  }
+  if (cmrFile === undefined || cmrFile.length === 0) return {};
 
   const cmrFilename = getS3UrlOfFile(cmrFile[0]);
 

--- a/packages/cmrjs/tests/cmr-utils/test-cmr-utils.js
+++ b/packages/cmrjs/tests/cmr-utils/test-cmr-utils.js
@@ -941,6 +941,18 @@ test.serial('getGranuleTemporalInfo returns temporal information from granule CM
   }
 });
 
+test.serial('getGranuleTemporalInfo returns empty object if cmr file s3 url is not available', async (t) => {
+  const temporalInfo = await getGranuleTemporalInfo({
+    granuleId: 'testGranuleId',
+    files: [{
+      path: 'path',
+      name: 'test.cmr_iso.xml',
+    }],
+  });
+
+  t.deepEqual(temporalInfo, {});
+});
+
 test.serial('generateFileUrl generates correct url for cmrGranuleUrlType distribution', (t) => {
   const filename = 's3://fake-bucket/folder/key.txt';
   const distEndpoint = 'www.example.com/';

--- a/packages/ingest/src/granule.ts
+++ b/packages/ingest/src/granule.ts
@@ -344,7 +344,7 @@ export function generateMoveFileParams(
     } else if (file.filename) {
       source = S3.parseS3Uri(file.filename);
     } else {
-      throw new Error(`Unable to determine location of file: ${JSON.stringify(file)}`);
+      throw new Error(`granule.generateMoveFileParams unable to determine location of file: ${JSON.stringify(file)}`);
     }
 
     const targetKey = destination.filepath

--- a/packages/message/src/Granules.ts
+++ b/packages/message/src/Granules.ts
@@ -275,7 +275,7 @@ export const generateGranuleApiRecord = async ({
 
   // Get CMR temporalInfo
   const temporalInfo = await getGranuleCmrTemporalInfo({
-    granule,
+    granule: { ...granule, status },
     cmrTemporalInfo,
     cmrUtils,
   });

--- a/tasks/add-missing-file-checksums/package.json
+++ b/tasks/add-missing-file-checksums/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@cumulus/aws-client": "16.0.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.4"
+    "@cumulus/cumulus-message-adapter-js": "2.0.5"
   },
   "devDependencies": {
     "@cumulus/schemas": "16.0.0",

--- a/tasks/discover-granules/package.json
+++ b/tasks/discover-granules/package.json
@@ -36,7 +36,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cumulus/api-client": "16.0.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.4",
+    "@cumulus/cumulus-message-adapter-js": "2.0.5",
     "@cumulus/ingest": "16.0.0",
     "@cumulus/logger": "16.0.0",
     "got": "^11.8.5",

--- a/tasks/discover-pdrs/package.json
+++ b/tasks/discover-pdrs/package.json
@@ -35,7 +35,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cumulus/aws-client": "16.0.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.4",
+    "@cumulus/cumulus-message-adapter-js": "2.0.5",
     "@cumulus/ingest": "16.0.0",
     "lodash": "^4.17.21",
     "p-filter": "^2.1.0"

--- a/tasks/files-to-granules/package.json
+++ b/tasks/files-to-granules/package.json
@@ -33,7 +33,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cumulus/aws-client": "16.0.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.4",
+    "@cumulus/cumulus-message-adapter-js": "2.0.5",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/tasks/hello-world/package.json
+++ b/tasks/hello-world/package.json
@@ -34,6 +34,6 @@
   "dependencies": {
     "@cumulus/aws-client": "16.0.0",
     "@cumulus/common": "16.0.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.4"
+    "@cumulus/cumulus-message-adapter-js": "2.0.5"
   }
 }

--- a/tasks/hyrax-metadata-updates/package.json
+++ b/tasks/hyrax-metadata-updates/package.json
@@ -42,7 +42,7 @@
     "@cumulus/cmr-client": "16.0.0",
     "@cumulus/cmrjs": "16.0.0",
     "@cumulus/common": "16.0.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.4",
+    "@cumulus/cumulus-message-adapter-js": "2.0.5",
     "@cumulus/errors": "16.0.0",
     "libxmljs": "^0.19.7",
     "lodash": "^4.17.21",

--- a/tasks/lzards-backup/package.json
+++ b/tasks/lzards-backup/package.json
@@ -45,7 +45,7 @@
     "@cumulus/api-client": "16.0.0",
     "@cumulus/aws-client": "16.0.0",
     "@cumulus/common": "16.0.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.4",
+    "@cumulus/cumulus-message-adapter-js": "2.0.5",
     "@cumulus/db": "16.0.0",
     "@cumulus/distribution-utils": "16.0.0",
     "@cumulus/launchpad-auth": "16.0.0",

--- a/tasks/move-granules/package.json
+++ b/tasks/move-granules/package.json
@@ -41,7 +41,7 @@
     "@cumulus/aws-client": "16.0.0",
     "@cumulus/cmrjs": "16.0.0",
     "@cumulus/common": "16.0.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.4",
+    "@cumulus/cumulus-message-adapter-js": "2.0.5",
     "@cumulus/distribution-utils": "16.0.0",
     "@cumulus/errors": "16.0.0",
     "@cumulus/ingest": "16.0.0",

--- a/tasks/parse-pdr/package.json
+++ b/tasks/parse-pdr/package.json
@@ -34,7 +34,7 @@
     "@cumulus/aws-client": "16.0.0",
     "@cumulus/collection-config-store": "16.0.0",
     "@cumulus/common": "16.0.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.4",
+    "@cumulus/cumulus-message-adapter-js": "2.0.5",
     "@cumulus/errors": "16.0.0",
     "@cumulus/ingest": "16.0.0",
     "@cumulus/pvl": "16.0.0",

--- a/tasks/pdr-status-check/package.json
+++ b/tasks/pdr-status-check/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@cumulus/aws-client": "16.0.0",
     "@cumulus/common": "16.0.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.4",
+    "@cumulus/cumulus-message-adapter-js": "2.0.5",
     "@cumulus/errors": "16.0.0"
   }
 }

--- a/tasks/post-to-cmr/package.json
+++ b/tasks/post-to-cmr/package.json
@@ -36,7 +36,7 @@
     "@cumulus/aws-client": "16.0.0",
     "@cumulus/cmrjs": "16.0.0",
     "@cumulus/common": "16.0.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.4",
+    "@cumulus/cumulus-message-adapter-js": "2.0.5",
     "@cumulus/errors": "16.0.0",
     "@cumulus/launchpad-auth": "16.0.0",
     "lodash": "^4.17.21"

--- a/tasks/queue-granules/package.json
+++ b/tasks/queue-granules/package.json
@@ -35,7 +35,7 @@
     "@cumulus/aws-client": "16.0.0",
     "@cumulus/collection-config-store": "16.0.0",
     "@cumulus/common": "16.0.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.4",
+    "@cumulus/cumulus-message-adapter-js": "2.0.5",
     "@cumulus/ingest": "16.0.0",
     "@cumulus/message": "16.0.0",
     "lodash": "^4.17.21",

--- a/tasks/queue-pdrs/package.json
+++ b/tasks/queue-pdrs/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@cumulus/aws-client": "16.0.0",
     "@cumulus/common": "16.0.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.4",
+    "@cumulus/cumulus-message-adapter-js": "2.0.5",
     "@cumulus/ingest": "16.0.0",
     "@cumulus/message": "16.0.0",
     "lodash": "^4.17.21"

--- a/tasks/queue-workflow/package.json
+++ b/tasks/queue-workflow/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@cumulus/aws-client": "16.0.0",
     "@cumulus/common": "16.0.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.4",
+    "@cumulus/cumulus-message-adapter-js": "2.0.5",
     "@cumulus/ingest": "16.0.0",
     "@cumulus/message": "16.0.0",
     "lodash": "^4.17.21"

--- a/tasks/sf-sqs-report/package.json
+++ b/tasks/sf-sqs-report/package.json
@@ -33,7 +33,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cumulus/aws-client": "16.0.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.4",
+    "@cumulus/cumulus-message-adapter-js": "2.0.5",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/tasks/sync-granule/package.json
+++ b/tasks/sync-granule/package.json
@@ -40,7 +40,7 @@
     "@cumulus/aws-client": "16.0.0",
     "@cumulus/collection-config-store": "16.0.0",
     "@cumulus/common": "16.0.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.4",
+    "@cumulus/cumulus-message-adapter-js": "2.0.5",
     "@cumulus/errors": "16.0.0",
     "@cumulus/ingest": "16.0.0",
     "@cumulus/message": "16.0.0",

--- a/tasks/test-processing/package.json
+++ b/tasks/test-processing/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cumulus/aws-client": "16.0.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.4",
+    "@cumulus/cumulus-message-adapter-js": "2.0.5",
     "@cumulus/integration-tests": "16.0.0"
   }
 }

--- a/tasks/update-cmr-access-constraints/package.json
+++ b/tasks/update-cmr-access-constraints/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@cumulus/aws-client": "16.0.0",
     "@cumulus/cmrjs": "16.0.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.4",
+    "@cumulus/cumulus-message-adapter-js": "2.0.5",
     "lodash": "^4.17.5"
   },
   "devDependencies": {

--- a/tasks/update-granules-cmr-metadata-file-links/package.json
+++ b/tasks/update-granules-cmr-metadata-file-links/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@cumulus/cmrjs": "16.0.0",
     "@cumulus/common": "16.0.0",
-    "@cumulus/cumulus-message-adapter-js": "2.0.4",
+    "@cumulus/cumulus-message-adapter-js": "2.0.5",
     "@cumulus/distribution-utils": "16.0.0",
     "lodash": "^4.17.15"
   },

--- a/tf-modules/archive/sf_event_sqs_to_db_records.tf
+++ b/tf-modules/archive/sf_event_sqs_to_db_records.tf
@@ -147,6 +147,7 @@ resource "aws_sqs_queue_policy" "sf_event_sqs_to_db_records_input_queue_policy" 
 resource "aws_lambda_event_source_mapping" "sf_event_sqs_to_db_records_mapping" {
   event_source_arn = aws_sqs_queue.sf_event_sqs_to_db_records_input_queue.arn
   function_name    = aws_lambda_function.sf_event_sqs_to_db_records.arn
+  function_response_types = ["ReportBatchItemFailures"]
 }
 
 resource "aws_sqs_queue" "sf_event_sqs_to_db_records_dead_letter_queue" {


### PR DESCRIPTION
* CUMULUS-3223:Fix failed granule stuck in queued

* skip sqsQueueExists test

* update getGranuleTemporalInfo

* update test match schema

* update getGranuleTemporalInfo

* remove extra await

* remove skip sqsQueueExists

* update `@cumulus/cumulus-message-adapter-js` to `2.0.5`

* update sfEventSqsToDbRecords to return partial batch failure

* fix typo

* handle process error seperately, multiple message test

* update test to process multiple messages

**Summary:** Summary of changes

Addresses [CUMULUS-XX: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-XXX)

## Changes

* Detailed list or prose of changes
* ...

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
