### PR TITLE
Jk/cumulus 3135 fix integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 ### Changed
-  - **CUMULUS-2985**
-    - Changed `onetime` rules RuleTrigger to only execute when the state is `ENABLED` and updated documentation to reflect the change
-    - Changed the `invokeRerun` function to only re-run enabled rules
+
+- **CUMULUS-2985**
+  - Changed `onetime` rules RuleTrigger to only execute when the state is `ENABLED` and updated documentation to reflect the change
+  - Changed the `invokeRerun` function to only re-run enabled rules
+
+### Fixed
+
+- **CUMULUS-3315**
+  - Update CI scripts to use shell logic/GNU timeout to bound test timeouts
+    instead of NPM `parallel` package, as timeouts were not resulting in
+    integration test failue
 
 ### Notable Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - **CUMULUS-2985**
   - Changed `onetime` rules RuleTrigger to only execute when the state is `ENABLED` and updated documentation to reflect the change
   - Changed the `invokeRerun` function to only re-run enabled rules
+- **CUMULUS-3315**
+  - Updated `@cumulus/api-client/granules.bulkOperation` to remove `ids`
+    parameter in favor of `granules` parameter, in the form of a
+    `@cumulus/types/ApiGranule` that requires the following keys: `[granuleId, collectionId]`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - **CUMULUS-3315**
   - Update CI scripts to use shell logic/GNU timeout to bound test timeouts
     instead of NPM `parallel` package, as timeouts were not resulting in
-    integration test failue
+    integration test failure
 
 ### Notable Changes
 

--- a/example/package.json
+++ b/example/package.json
@@ -24,7 +24,7 @@
     "load-test": "../node_modules/.bin/jasmine ./spec/loadTest/runScaledtest.js",
     "package": "for x in lambdas/*; do (echo \"packaging $x\" && cd $x && test -e package.json && npm run package); done",
     "package-deployment": "for x in lambdas/*; do (echo \"packaging $x\" && cd $x && test -e package.json && npm install && npm run package); done",
-    "parallel-tests": "sh scripts/tests-parallel.sh",
+    "parallel-tests": "bash scripts/tests-parallel.sh",
     "test": "npm run test:ava && for x in lambdas/*; do cd $x && npm test && cd -; done",
     "test:ava": "../node_modules/.bin/ava",
     "test:coverage": "../node_modules/.bin/nyc npm run test:ava"

--- a/example/package.json
+++ b/example/package.json
@@ -24,7 +24,7 @@
     "load-test": "../node_modules/.bin/jasmine ./spec/loadTest/runScaledtest.js",
     "package": "for x in lambdas/*; do (echo \"packaging $x\" && cd $x && test -e package.json && npm run package); done",
     "package-deployment": "for x in lambdas/*; do (echo \"packaging $x\" && cd $x && test -e package.json && npm install && npm run package); done",
-    "parallel-tests": "bash scripts/tests-parallel.sh",
+    "parallel-tests": "sh scripts/tests-parallel.sh",
     "test": "npm run test:ava && for x in lambdas/*; do cd $x && npm test && cd -; done",
     "test:ava": "../node_modules/.bin/ava",
     "test:coverage": "../node_modules/.bin/nyc npm run test:ava"

--- a/example/scripts/run_test.sh
+++ b/example/scripts/run_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set +e
 
@@ -12,10 +12,10 @@ timeout "$testTimeout" ../node_modules/.bin/jasmine --no-color "$3" > "$outputPa
 result=$?
 
 TIMESTAMP=$(date "+%Y-%m-%dT%H:%M:%S")
-if [[ "$result" -eq "0" ]]; then
+if [ "$result" -eq "0" ]; then
   echo "$TIMESTAMP ../node_modules/.bin/jasmine $3 PASSED"
   mv "$outputPath" "$1/${specName}-passed.txt"
-elif [[ "$result" -gt "124" && "$result" -lt "128" ]] || [[ "$result" -eq "137" ]]; then
+elif { [ "$result" -gt "124" ] && [ "$result" -lt "128" ] ;} || [ "$result" -eq "137" ]; then
   echo "$TIMESTAMP ../node_modules/.bin/jasmine $3 PASSED"
   mv "$outputPath" "$1/${specName}-passed.txt"
   result=1

--- a/example/scripts/run_test.sh
+++ b/example/scripts/run_test.sh
@@ -1,22 +1,26 @@
-#!/bin/sh
+#!/bin/bash
 
 set +e
 
-specName=$(echo "$2" | rev | cut -d'/' -f 1 | cut -d'.' -f 2 | rev)
+specName=$(echo "$3" | rev | cut -d'/' -f 1 | cut -d'.' -f 2 | rev)
 outputPath="${1}/${specName}-running.txt"
+testTimeout=$2
 
 TIMESTAMP=$(date "+%Y-%m-%dT%H:%M:%S")
-echo "$TIMESTAMP ../node_modules/.bin/jasmine $2 STARTED"
-
-../node_modules/.bin/jasmine --no-color "$2" > "$outputPath" 2>&1
+echo "$TIMESTAMP ../node_modules/.bin/jasmine $3 STARTED"
+timeout "$testTimeout" ../node_modules/.bin/jasmine --no-color "$3" > "$outputPath" 2>&1
 result=$?
 
 TIMESTAMP=$(date "+%Y-%m-%dT%H:%M:%S")
 if [ "$result" -eq "0" ]; then
-  echo "$TIMESTAMP ../node_modules/.bin/jasmine $2 PASSED"
+  echo "$TIMESTAMP ../node_modules/.bin/jasmine $3 PASSED"
   mv "$outputPath" "$1/${specName}-passed.txt"
+elif [[ ( "$result" -gt 124 && "$result" -lt 128 ) || "$result" -eq "137" ]]; then
+  echo "$TIMESTAMP ../node_modules/.bin/jasmine $3 PASSED"
+  mv "$outputPath" "$1/${specName}-passed.txt"
+  result=1
 else
-  echo "$TIMESTAMP ../node_modules/.bin/jasmine $2 FAILED"
+  echo "$TIMESTAMP ../node_modules/.bin/jasmine $3 FAILED"
   mv "$outputPath" "$1/${specName}-failed.txt"
 fi
 

--- a/example/scripts/run_test.sh
+++ b/example/scripts/run_test.sh
@@ -12,10 +12,10 @@ timeout "$testTimeout" ../node_modules/.bin/jasmine --no-color "$3" > "$outputPa
 result=$?
 
 TIMESTAMP=$(date "+%Y-%m-%dT%H:%M:%S")
-if [ "$result" -eq "0" ]; then
+if [[ "$result" -eq "0" ]]; then
   echo "$TIMESTAMP ../node_modules/.bin/jasmine $3 PASSED"
   mv "$outputPath" "$1/${specName}-passed.txt"
-elif [[ ( "$result" -gt 124 && "$result" -lt 128 ) || "$result" -eq "137" ]]; then
+elif [[ ( "$result" -gt "124" && "$result" -lt "128" ) || "$result" -eq "137" ]]; then
   echo "$TIMESTAMP ../node_modules/.bin/jasmine $3 PASSED"
   mv "$outputPath" "$1/${specName}-passed.txt"
   result=1

--- a/example/scripts/run_test.sh
+++ b/example/scripts/run_test.sh
@@ -15,7 +15,7 @@ TIMESTAMP=$(date "+%Y-%m-%dT%H:%M:%S")
 if [[ "$result" -eq "0" ]]; then
   echo "$TIMESTAMP ../node_modules/.bin/jasmine $3 PASSED"
   mv "$outputPath" "$1/${specName}-passed.txt"
-elif [[ ( "$result" -gt "124" && "$result" -lt "128" ) || "$result" -eq "137" ]]; then
+elif [[ "$result" -gt "124" && "$result" -lt "128" ]] || [[ "$result" -eq "137" ]]; then
   echo "$TIMESTAMP ../node_modules/.bin/jasmine $3 PASSED"
   mv "$outputPath" "$1/${specName}-passed.txt"
   result=1

--- a/example/scripts/tests-parallel.sh
+++ b/example/scripts/tests-parallel.sh
@@ -8,7 +8,7 @@ echo Running parallel integration tests
 (while true; do sleep 60; echo .; done) &
 DOT_PID="$!"
 
-TESTS=$(find spec/parallel -type f -name '*IngestGranuleSuccessSpec*.js' -or -name '*OrcaBackupAndRecoverySpec*.js')
+TESTS=$(find spec/parallel -type f -name '*spec.js' -or -name '*Spec.js')
 testOutputDir=scripts/test_output
 testTimeout=1200
 

--- a/example/scripts/tests-parallel.sh
+++ b/example/scripts/tests-parallel.sh
@@ -8,13 +8,14 @@ echo Running parallel integration tests
 (while true; do sleep 60; echo .; done) &
 DOT_PID="$!"
 
-TESTS=$(find spec/parallel -type f -name '*spec.js' -or -name '*Spec.js')
+TESTS=$(find spec/parallel -type f -name '*IngestGranuleSuccessSpec*.js' -or -name '*OrcaBackupAndRecoverySpec*.js')
 testOutputDir=scripts/test_output
+testTimeout=1200
 
 rm -r -f $testOutputDir
 mkdir -p $testOutputDir
 
-echo "" | ../node_modules/.bin/parallel -j "${INTEGRATION_CONCURRENCY:=0}" --timeout 1200 sh scripts/run_test.sh  $testOutputDir ::: $TESTS
+echo "" | ../node_modules/.bin/parallel -j "${INTEGRATION_CONCURRENCY:=0}" sh scripts/run_test.sh  $testOutputDir $testTimeout ::: $TESTS
 result=$?
 echo parallel tests complete: $result suite failures
 

--- a/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
+++ b/example/spec/parallel/ingestGranule/IngestGranuleSuccessSpec.js
@@ -114,6 +114,7 @@ describe('The S3 Ingest Granules workflow', () => {
 
   let beforeAllError;
   let collection;
+  let collectionId;
   let config;
   let expectedPayload;
   let expectedS3TagSet;
@@ -140,7 +141,7 @@ describe('The S3 Ingest Granules workflow', () => {
       testDataFolder = createTestDataPath(testId);
 
       collection = { name: `MOD09GQ${testSuffix}`, version: '006' };
-      const newCollectionId = constructCollectionId(collection.name, collection.version);
+      collectionId = constructCollectionId(collection.name, collection.version);
       provider = { id: `s3_provider${testSuffix}` };
 
       process.env.system_bucket = config.bucket;
@@ -193,7 +194,7 @@ describe('The S3 Ingest Granules workflow', () => {
         },
       });
 
-      expectedSyncGranulePayload = loadFileWithUpdatedGranuleIdPathAndCollection(templatedSyncGranuleFilename, granuleId, testDataFolder, newCollectionId, config.stackName);
+      expectedSyncGranulePayload = loadFileWithUpdatedGranuleIdPathAndCollection(templatedSyncGranuleFilename, granuleId, testDataFolder, collectionId, config.stackName);
 
       expectedSyncGranulePayload.granules[0].dataType += testSuffix;
       expectedSyncGranulePayload.granules[0].files[0].checksumType = inputPayload.granules[0].files[0].checksumType;
@@ -231,7 +232,7 @@ describe('The S3 Ingest Granules workflow', () => {
         },
       });
 
-      expectedPayload = loadFileWithUpdatedGranuleIdPathAndCollection(templatedOutputPayloadFilename, granuleId, testDataFolder, newCollectionId);
+      expectedPayload = loadFileWithUpdatedGranuleIdPathAndCollection(templatedOutputPayloadFilename, granuleId, testDataFolder, collectionId);
       expectedPayload.granules[0].dataType += testSuffix;
 
       // process.env.DISTRIBUTION_ENDPOINT needs to be set for below
@@ -932,7 +933,16 @@ describe('The S3 Ingest Granules workflow', () => {
             bulkReingestResponse = await bulkReingestGranules({
               prefix: config.stackName,
               body: {
-                ids: [reingestGranuleId, fakeGranuleId],
+                granules: [
+                  {
+                    collectionId,
+                    granuleId: reingestGranuleId,
+                  },
+                  {
+                    collectionId,
+                    granuleId: fakeGranuleId,
+                  },
+                ],
               },
             });
           } catch (error) {

--- a/example/spec/parallel/orca/OrcaBackupAndRecoverySpec.js
+++ b/example/spec/parallel/orca/OrcaBackupAndRecoverySpec.js
@@ -20,6 +20,8 @@ const {
   waitForCompletedExecution,
 } = require('@cumulus/integration-tests');
 const { LambdaStep } = require('@cumulus/integration-tests/sfnStep');
+const { constructCollectionId } = require('@cumulus/message/Collections');
+
 
 const { removeCollectionAndAllDependencies } = require('../../helpers/Collections');
 const { buildAndStartWorkflow } = require('../../helpers/workflowUtils');
@@ -163,7 +165,10 @@ describe('The S3 Ingest Granules workflow', () => {
 
       const response = await bulkOperation({
         prefix: config.stackName,
-        ids: [granuleId],
+        granules: [{
+          granuleId,
+          collectionId: constructCollectionId(collection.name, collection.version),
+        }],
         workflowName: recoveryWorkflowName,
       });
 

--- a/packages/api-client/src/granules.ts
+++ b/packages/api-client/src/granules.ts
@@ -1,6 +1,6 @@
 import pRetry from 'p-retry';
 
-import { ApiGranuleRecord, GranuleId, GranuleStatus } from '@cumulus/types/api/granules';
+import { ApiGranuleRecord, ApiGranule, GranuleId, GranuleStatus } from '@cumulus/types/api/granules';
 import { CollectionId } from '@cumulus/types/api/collections';
 import Logger from '@cumulus/logger';
 
@@ -612,7 +612,7 @@ export const associateExecutionWithGranule = async (params: {
  */
 export const bulkGranules = async (params: {
   prefix: string,
-  body: object,
+  body: unknown,
   callback?: InvokeApiFunction
 }): Promise<ApiGatewayLambdaHttpProxyResponse> => {
   const { prefix, body, callback = invokeApi } = params;
@@ -693,7 +693,7 @@ export const bulkReingestGranules = async (params: {
  *
  * @param {Object} params - params
  * @param {string} params.prefix - the prefix configured for the stack
- * @param {Array<string>} params.ids - the granules to have bulk operation on
+ * @param {Array<ApiGranuleRecord>} params.granules - the granules to have bulk operation on
  * @param {string} params.workflowName - workflowName for the bulk operation execution
  * @param {Function} params.callback  - async function to invoke the api lambda
  *                                      that takes a prefix / user payload.  Defaults
@@ -703,11 +703,11 @@ export const bulkReingestGranules = async (params: {
  */
 export const bulkOperation = async (params: {
   prefix: string,
-  ids: string[],
+  granules: ApiGranule[],
   workflowName: string,
   callback?: InvokeApiFunction
 }): Promise<ApiGatewayLambdaHttpProxyResponse> => {
-  const { prefix, ids, workflowName, callback = invokeApi } = params;
+  const { prefix, granules, workflowName, callback = invokeApi } = params;3
   return await callback({
     prefix: prefix,
     payload: {
@@ -717,7 +717,7 @@ export const bulkOperation = async (params: {
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ ids, workflowName }),
+      body: JSON.stringify({ granules, workflowName }),
     },
     expectedStatusCodes: 202,
   });

--- a/packages/api-client/tests/test-granules.js
+++ b/packages/api-client/tests/test-granules.js
@@ -531,3 +531,38 @@ test('associateExecutionWithGranule calls the callback with the expected object'
     body,
   }));
 });
+
+test('bulkOperation calls the callback with the expected object', async (t) => {
+  const workflowName = randomId('workflowName');
+  const granuleId = t.context.granuleId;
+  const collectionId = randomId('collectionId');
+  const granules = [{ granuleId, collectionId }];
+
+  const expected = {
+    prefix: t.context.testPrefix,
+    payload: {
+      httpMethod: 'POST',
+      resource: '/{proxy+}',
+      path: `/granules/bulk/`,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        granules,
+        workflowName,
+      }),
+    },
+    expectedStatusCodes: 202,
+  };
+
+  const callback = (configObject) => {
+    t.deepEqual(configObject, expected);
+  };
+
+  await t.notThrowsAsync(
+    granulesApi.bulkOperation({
+      callback,
+      prefix: t.context.testPrefix,
+      granules,
+      workflowName,
+    })
+  );
+});


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3135](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3135)

This PR can be merged with or after https://github.com/nasa/cumulus/pull/3401

## Changes

- **CUMULUS-3315**
  - Updated `@cumulus/api-client/granules.bulkOperation` to remove `ids`
    parameter in favor of `granules` parameter, in the form of a
    `@cumulus/types/ApiGranule` that requires the following keys: `[granuleId, collectionId]`

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
