### PR TITLE
Add missing method for erasing PG tables

### DIFF
--- a/packages/api/bin/serve.js
+++ b/packages/api/bin/serve.js
@@ -4,14 +4,9 @@ const { promiseS3Upload } = require('@cumulus/aws-client/S3');
 const { s3, sns } = require('@cumulus/aws-client/services');
 const { randomId, inTestMode } = require('@cumulus/common/test-utils');
 const {
-  AsyncOperationPgModel,
   CollectionPgModel,
-  ExecutionPgModel,
-  FilePgModel,
   getKnexClient,
   GranulePgModel,
-  GranulesExecutionsPgModel,
-  PdrPgModel,
   localStackConnectionEnv,
   ProviderPgModel,
   RulePgModel,
@@ -337,34 +332,6 @@ function eraseDataStack(
 }
 
 /**
-* Remove all records from api-related postgres tables
-* @param {Object} knex - knex/knex transaction object
-* @returns {[Promise]} - Array of promises with deletion results
-*/
-async function erasePostgresTables(knex) {
-  const asyncOperationPgModel = new AsyncOperationPgModel();
-  const collectionPgModel = new CollectionPgModel();
-  const executionPgModel = new ExecutionPgModel();
-  const filePgModel = new FilePgModel();
-  const granulePgModel = new GranulePgModel();
-  const granulesExecutionsPgModel = new GranulesExecutionsPgModel();
-  const pdrPgModel = new PdrPgModel();
-  const providerPgModel = new ProviderPgModel();
-  const rulePgModel = new RulePgModel();
-
-  await granulesExecutionsPgModel.delete(knex, {});
-  await granulePgModel.delete(knex, {});
-  await pdrPgModel.delete(knex, {});
-  await executionPgModel.delete(knex, {});
-  await asyncOperationPgModel.delete(knex, {});
-  await filePgModel.delete(knex, {});
-  await granulePgModel.delete(knex, {});
-  await rulePgModel.delete(knex, {});
-  await collectionPgModel.delete(knex, {});
-  await providerPgModel.delete(knex, {});
-}
-
-/**
  * Removes all additional data from tables and repopulates with original data.
  *
  * @param {string} user - defaults to local user, testUser
@@ -379,14 +346,13 @@ async function resetTables(
 ) {
   if (inTestMode() || runIt) {
     const knex = await getKnexClient({ env: { ...localStackConnectionEnv, ...process.env } });
-    await erasePostgresTables(knex);
+    await serveUtils.erasePostgresTables(knex);
     await createDBRecords(stackName, user, knex);
   }
 }
 
 module.exports = {
   eraseDataStack,
-  erasePostgresTables,
   serveApi,
   serveDistributionApi,
   resetTables,

--- a/packages/api/bin/serve.js
+++ b/packages/api/bin/serve.js
@@ -4,9 +4,14 @@ const { promiseS3Upload } = require('@cumulus/aws-client/S3');
 const { s3, sns } = require('@cumulus/aws-client/services');
 const { randomId, inTestMode } = require('@cumulus/common/test-utils');
 const {
+  AsyncOperationPgModel,
   CollectionPgModel,
+  ExecutionPgModel,
+  FilePgModel,
   getKnexClient,
   GranulePgModel,
+  GranulesExecutionsPgModel,
+  PdrPgModel,
   localStackConnectionEnv,
   ProviderPgModel,
   RulePgModel,
@@ -332,6 +337,34 @@ function eraseDataStack(
 }
 
 /**
+* Remove all records from api-related postgres tables
+* @param {Object} knex - knex/knex transaction object
+* @returns {[Promise]} - Array of promises with deletion results
+*/
+async function erasePostgresTables(knex) {
+  const asyncOperationPgModel = new AsyncOperationPgModel();
+  const collectionPgModel = new CollectionPgModel();
+  const executionPgModel = new ExecutionPgModel();
+  const filePgModel = new FilePgModel();
+  const granulePgModel = new GranulePgModel();
+  const granulesExecutionsPgModel = new GranulesExecutionsPgModel();
+  const pdrPgModel = new PdrPgModel();
+  const providerPgModel = new ProviderPgModel();
+  const rulePgModel = new RulePgModel();
+
+  await granulesExecutionsPgModel.delete(knex, {});
+  await granulePgModel.delete(knex, {});
+  await pdrPgModel.delete(knex, {});
+  await executionPgModel.delete(knex, {});
+  await asyncOperationPgModel.delete(knex, {});
+  await filePgModel.delete(knex, {});
+  await granulePgModel.delete(knex, {});
+  await rulePgModel.delete(knex, {});
+  await collectionPgModel.delete(knex, {});
+  await providerPgModel.delete(knex, {});
+}
+
+/**
  * Removes all additional data from tables and repopulates with original data.
  *
  * @param {string} user - defaults to local user, testUser
@@ -346,13 +379,14 @@ async function resetTables(
 ) {
   if (inTestMode() || runIt) {
     const knex = await getKnexClient({ env: { ...localStackConnectionEnv, ...process.env } });
-    await serveUtils.erasePostgresTables(knex);
+    await erasePostgresTables(knex);
     await createDBRecords(stackName, user, knex);
   }
 }
 
 module.exports = {
   eraseDataStack,
+  erasePostgresTables,
   serveApi,
   serveDistributionApi,
   resetTables,

--- a/packages/api/bin/serveUtils.js
+++ b/packages/api/bin/serveUtils.js
@@ -11,7 +11,6 @@ const {
   GranulePgModel,
   GranulesExecutionsPgModel,
   CollectionPgModel,
-  PdrPgModel,
   ProviderPgModel,
   RulePgModel,
   translateApiCollectionToPostgresCollection,

--- a/packages/api/bin/serveUtils.js
+++ b/packages/api/bin/serveUtils.js
@@ -3,11 +3,17 @@
 const pEachSeries = require('p-each-series');
 const indexer = require('@cumulus/es-client/indexer');
 const {
+  AsyncOperationPgModel,
   RulePgModel,
   PdrPgModel,
   ExecutionPgModel,
+  FilePgModel,
+  GranulePgModel,
+  GranulesExecutionsPgModel,
   CollectionPgModel,
+  PdrPgModel,
   ProviderPgModel,
+  RulePgModel,
   translateApiCollectionToPostgresCollection,
   translateApiProviderToPostgresProvider,
   translateApiExecutionToPostgresExecution,
@@ -26,9 +32,29 @@ const models = require('../models');
 const { createRuleTrigger } = require('../lib/rulesHelpers');
 const { fakeGranuleFactoryV2 } = require('../lib/testUtils');
 const { getESClientAndIndex } = require('./local-test-defaults');
-const {
-  erasePostgresTables,
-} = require('./serve');
+
+async function erasePostgresTables(knex) {
+  const asyncOperationPgModel = new AsyncOperationPgModel();
+  const collectionPgModel = new CollectionPgModel();
+  const executionPgModel = new ExecutionPgModel();
+  const filePgModel = new FilePgModel();
+  const granulePgModel = new GranulePgModel();
+  const granulesExecutionsPgModel = new GranulesExecutionsPgModel();
+  const pdrPgModel = new PdrPgModel();
+  const providerPgModel = new ProviderPgModel();
+  const rulePgModel = new RulePgModel();
+
+  await granulesExecutionsPgModel.delete(knex, {});
+  await granulePgModel.delete(knex, {});
+  await pdrPgModel.delete(knex, {});
+  await executionPgModel.delete(knex, {});
+  await asyncOperationPgModel.delete(knex, {});
+  await filePgModel.delete(knex, {});
+  await granulePgModel.delete(knex, {});
+  await rulePgModel.delete(knex, {});
+  await collectionPgModel.delete(knex, {});
+  await providerPgModel.delete(knex, {});
+}
 
 async function resetPostgresDb() {
   const knexAdmin = await getKnexClient({ env: localStackConnectionEnv });
@@ -218,4 +244,5 @@ module.exports = {
   addPdrs,
   addReconciliationReports,
   addRules,
+  erasePostgresTables,
 };

--- a/packages/api/bin/serveUtils.js
+++ b/packages/api/bin/serveUtils.js
@@ -4,7 +4,6 @@ const pEachSeries = require('p-each-series');
 const indexer = require('@cumulus/es-client/indexer');
 const {
   AsyncOperationPgModel,
-  RulePgModel,
   PdrPgModel,
   ExecutionPgModel,
   FilePgModel,

--- a/packages/api/endpoints/schemas.js
+++ b/packages/api/endpoints/schemas.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const router = require('express-promise-router')();
-const schemas = require('../models/schemas');
+const schemas = require('../lib/schemas');
 
 /**
  * get a particular schema


### PR DESCRIPTION
This should add a missing method from our serve tools. This needs to be tested locally by a developer with an Intel mac.

The sure-fire way to test this is to set up your local dashboard, start your local API, and run the Cypress tests. 