### PR TITLE
CUMULUS-3265: Fix getGranulesForPayload function to query es

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Notable Changes
+
+- The async_operation_image property of cumulus module should be updated to pull
+  the ECR image for cumuluss/async-operation:47
+
 ### Added
 
 - **CUMULUS-3220**
@@ -66,13 +71,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - **CUMULUS-2625**
   - Optimized heap memory and api load in queue-granules task to scale to larger workloads.
+- **CUMULUS-3265**
+  - Fixed `@cumulus/api` `getGranulesForPayload` function to query cloud metrics es when needed.
+
+## [v16.0.0] 2023-05-09
 
 ### Notable Changes
 
 - The async_operation_image property of cumulus module should be updated to pull
-  the ECR image for cumuluss/async-operation:47
-
-## [v16.0.0] 2023-05-09
+  the ECR image for cumuluss/async-operation:46
 
 ### MIGRATION notes
 

--- a/packages/api/lambdas/bulk-operation.js
+++ b/packages/api/lambdas/bulk-operation.js
@@ -261,7 +261,7 @@ function setEnvVarsForOperation(event) {
 
 async function handler(event) {
   setEnvVarsForOperation(event);
-  log.info(`bulkOperation asyncOperationId ${process.env.asyncOperationId} event type ${event.type}`);
+  log.info(`bulkOperation asyncOperationId ${process.env.asyncOperationId} event type ${event.type}, payload: ${JSON.stringify(event.payload)}`);
   if (event.type === 'BULK_GRANULE') {
     return await bulkGranule(event.payload, event.applyWorkflowHandler);
   }

--- a/packages/api/lib/granules.js
+++ b/packages/api/lib/granules.js
@@ -347,7 +347,7 @@ async function getGranulesForPayload(payload) {
   const queryGranules = granules || [];
 
   // query ElasticSearch if needed
-  if (!granules && query) {
+  if (queryGranules.length === 0 && query) {
     log.info('No granules detected. Searching for granules in ElasticSearch.');
 
     const esGranules = await granuleEsQuery({

--- a/packages/api/tests/lib/test-granules.js
+++ b/packages/api/tests/lib/test-granules.js
@@ -438,6 +438,7 @@ test.serial('getGranulesForPayload returns unique granules from query', async (t
     },
   });
   const returnedGranules = await getGranulesForPayload({
+    granules: [],
     query: 'fake-query',
     index: 'fake-index',
   });


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3265: Bulk Delete not working from Cumulus dashboard](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3265)

## Changes

* Detailed list or prose of changes
* ...

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
