### PR TITLE
switch to docker compose from docker-compose

### DIFF
--- a/bamboo/bootstrap-unit-tests.sh
+++ b/bamboo/bootstrap-unit-tests.sh
@@ -9,15 +9,15 @@ set -ex
 export SSH_USERS=user:$(id -u):$(id -u)
 export COMPOSE_FILE=./bamboo/docker-compose.yml
 
-## Set container_id for docker-compose to use to identify the compose stack per planKey
+## Set container_id for docker compose to use to identify the compose stack per planKey
 docker_command="docker exec -t ${container_id}_build_env_1 /bin/bash -c"
 
 docker ps -a
 
 ## Setup the compose stack
-docker-compose -p ${container_id} down
-docker-compose -p ${container_id} rm -f
-docker-compose -p ${container_id} up -d
+docker compose -p ${container_id} down
+docker compose -p ${container_id} rm -f
+docker compose -p ${container_id} up -d
 
 docker ps -a
 

--- a/bamboo/bootstrap-unit-tests.sh
+++ b/bamboo/bootstrap-unit-tests.sh
@@ -10,7 +10,7 @@ export SSH_USERS=user:$(id -u):$(id -u)
 export COMPOSE_FILE=./bamboo/docker-compose.yml
 
 ## Set container_id for docker compose to use to identify the compose stack per planKey
-docker_command="docker exec -t ${container_id}_build_env_1 /bin/bash -c"
+docker_command="docker exec -t ${container_id}-build_env-1 /bin/bash -c"
 
 docker ps -a
 
@@ -20,8 +20,7 @@ docker compose -p ${container_id} rm -f
 docker compose -p ${container_id} up -d
 
 docker ps -a
-
-while ! docker container inspect ${container_id}\_build_env_1; do
+while ! docker container inspect ${container_id}-build_env-1; do
   echo 'Waiting for build env to be available';
   docker ps -a
   sleep 5;
@@ -30,8 +29,8 @@ done
 ## Setup the build env container once it's started
 $docker_command "npm install --error --no-progress -g nyc; cd $UNIT_TEST_BUILD_DIR; git fetch --all; git checkout $GIT_SHA"
 # Copy build cache of compiled TS code into cached bootstrap dir, if necessary
-docker cp $TS_BUILD_CACHE_FILE "${container_id}_build_env_1:$UNIT_TEST_BUILD_DIR"
-docker cp bamboo/extract-ts-build-cache.sh "${container_id}_build_env_1:$UNIT_TEST_BUILD_DIR/bamboo"
+docker cp $TS_BUILD_CACHE_FILE "${container_id}-build_env-1:$UNIT_TEST_BUILD_DIR"
+docker cp bamboo/extract-ts-build-cache.sh "${container_id}-build_env-1:$UNIT_TEST_BUILD_DIR/bamboo"
 
 # Extract build cache of compiled TS files
 $docker_command "cd $UNIT_TEST_BUILD_DIR; TS_BUILD_CACHE_FILE=$TS_BUILD_CACHE_FILE ./bamboo/extract-ts-build-cache.sh"

--- a/bamboo/cleanup-unit-tests.sh
+++ b/bamboo/cleanup-unit-tests.sh
@@ -10,5 +10,5 @@ container_id=${container_id/-/}
 export COMPOSE_FILE=./bamboo/docker-compose.yml
 
 docker ps -a
-docker-compose -p ${container_id} down
-docker-compose -p ${container_id} rm -f
+docker compose -p ${container_id} down
+docker compose -p ${container_id} rm -f

--- a/bamboo/unit-tests.sh
+++ b/bamboo/unit-tests.sh
@@ -7,6 +7,6 @@ set -ex
 
 docker ps -a ## Show running containers for output logs
 
-docker exec -i ${container_id}\_build_env_1 /bin/bash -c "cd $UNIT_TEST_BUILD_DIR && npm run db:local:reset"
-docker exec -i ${container_id}\_build_env_1 /bin/bash -c "cd $UNIT_TEST_BUILD_DIR && npm run test:coverage"
-docker exec -i ${container_id}\_build_env_1 /bin/bash -c "cd $UNIT_TEST_BUILD_DIR && npm run coverage -- --noRerun"
+docker exec -i ${container_id}-build_env-1 /bin/bash -c "cd $UNIT_TEST_BUILD_DIR && npm run db:local:reset"
+docker exec -i ${container_id}-build_env-1 /bin/bash -c "cd $UNIT_TEST_BUILD_DIR && npm run test:coverage"
+docker exec -i ${container_id}-build_env-1 /bin/bash -c "cd $UNIT_TEST_BUILD_DIR && npm run coverage -- --noRerun"

--- a/docs/workflows/docker.md
+++ b/docs/workflows/docker.md
@@ -8,12 +8,12 @@ The software used for processing data amongst DAAC's is developed in a variety o
 
 ## Using Docker
 
-Docker images are run using the `docker` command and can be used to build a Docker image from a Dockerfile, fetch an existing image from a remote repository, or run an existing image. In Cumulus, `docker-compose` is used to help developers by making it easy to build images locally and test them.
+Docker images are run using the `docker` command and can be used to build a Docker image from a Dockerfile, fetch an existing image from a remote repository, or run an existing image. In Cumulus, `docker compose` is used to help developers by making it easy to build images locally and test them.
 
-To run a command using docker-compose use:
+To run a command using docker compose use:
 
 ```bash
-docker-compose run *command*
+docker compose run *command*
 ```
 
 where *command* is one of
@@ -34,13 +34,13 @@ pip install awscli
 aws ecr get-login --region us-east-1 | source /dev/stdin
 ```
 
-As long as you have permissions to access the NASA Cumulus AWS account, this will allow you to pull images from AWS ECR, and push rebuilt or new images there as well. Docker-compose may also be used to push images.
+As long as you have permissions to access the NASA Cumulus AWS account, this will allow you to pull images from AWS ECR, and push rebuilt or new images there as well. docker compose may also be used to push images.
 
 ```bash
-docker-compose push
+docker compose push
 ```
 
-Which will push the built image to AWS ECR. Note that the image built by docker-compose will have is the `:latest` tag, and will overwrite the `:latest` tagged docker image on the registry.  This file should be updated to push to a different tag if overwriting is not desired.
+Which will push the built image to AWS ECR. Note that the image built by docker compose will have is the `:latest` tag, and will overwrite the `:latest` tagged docker image on the registry.  This file should be updated to push to a different tag if overwriting is not desired.
 
 In normal use-cases for most production images on either repository,  CircleCI takes care of this building and deploying process
 
@@ -194,10 +194,10 @@ The docker image for a process can be used on the retrieved test data. First cre
 mkdir data/test-output
 ```
 
-Then run the docker image using docker-compose.
+Then run the docker image using docker compose.
 
 ```bash
-docker-compose run test
+docker compose run test
 ```
 
 This will process the data in the data/input directory and put the output into data/test-output. Repositories also include Python based tests which will validate this newly created output to the contents of data/output. Use Python's Nose tool to run the included tests.

--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
     "serve-dist-oauth": "lerna run --stream serve-dist-oauth --scope @cumulus/api",
     "serve-dist-remote": "lerna run --stream serve-dist-remote --scope @cumulus/api",
     "coveralls": "nyc report --reporter=text-lcov --temp-directory=\"./.final_nyc_output\" | coveralls",
-    "start-unit-test-stack": "export SSH_USERS=user:$(id -u):$(id -u) && docker-compose -f ./bamboo/docker-compose.yml -f ./bamboo/docker-compose-local.yml -p cumulusstack up -d",
-    "stop-unit-test-stack": "docker-compose -f ./bamboo/docker-compose.yml -f ./bamboo/docker-compose-local.yml -p cumulusstack down",
-    "view-unit-test-stack-logs": "export SSH_USERS=user:$(id -u):$(id -u) && docker-compose -f ./bamboo/docker-compose.yml -f ./bamboo/docker-compose-local.yml -p cumulusstack logs --follow"
+    "start-unit-test-stack": "export SSH_USERS=user:$(id -u):$(id -u) && docker compose -f ./bamboo/docker-compose.yml -f ./bamboo/docker-compose-local.yml -p cumulusstack up -d",
+    "stop-unit-test-stack": "docker compose -f ./bamboo/docker-compose.yml -f ./bamboo/docker-compose-local.yml -p cumulusstack down",
+    "view-unit-test-stack-logs": "export SSH_USERS=user:$(id -u):$(id -u) && docker compose -f ./bamboo/docker-compose.yml -f ./bamboo/docker-compose-local.yml -p cumulusstack logs --follow"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Summary:** Summary of changes

updates unit tests to call docker compose instead of docker-compose

## Changes

* bootstrap_unit_tests.sh and cleanup_unit_tests.sh changed to use docker compose syntax
* ...

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
