### PR TITLE
CUMULUS-3351: Group CMR online access URLs by link type

### DIFF
--- a/packages/cmrjs/src/cmr-utils.js
+++ b/packages/cmrjs/src/cmr-utils.js
@@ -512,8 +512,7 @@ function constructOnlineAccessUrls({
     throw new Error(`cmrGranuleUrlType is ${cmrGranuleUrlType}, but no distribution endpoint is configured.`);
   }
 
-  const urlListCalls = files.map((file) => {
-    const urls = [];
+  const [distributionUrls, s3Urls] = files.reduce(([distributionAcc, s3Acc], file) => {
     if (['both', 'distribution'].includes(cmrGranuleUrlType)) {
       const url = constructOnlineAccessUrl({
         file,
@@ -523,7 +522,7 @@ function constructOnlineAccessUrls({
         distributionBucketMap,
         useDirectS3Type,
       });
-      urls.push(url);
+      distributionAcc.push(url);
     }
     if (['both', 's3'].includes(cmrGranuleUrlType)) {
       const url = constructOnlineAccessUrl({
@@ -534,11 +533,11 @@ function constructOnlineAccessUrls({
         distributionBucketMap,
         useDirectS3Type,
       });
-      urls.push(url);
+      s3Acc.push(url);
     }
-    return urls;
-  });
-  const urlList = flatten(urlListCalls);
+    return [distributionAcc, s3Acc];
+  }, [[], []]);
+  const urlList = distributionUrls.concat(s3Urls);
   return urlList.filter((urlObj) => urlObj);
 }
 

--- a/packages/cmrjs/tests/cmr-utils/test-constructurls.js
+++ b/packages/cmrjs/tests/cmr-utils/test-constructurls.js
@@ -281,6 +281,79 @@ test('constructOnlineAccessUrls throws error if URL type is distribution and dis
   }));
 });
 
+test('constructOnlineAccessUrls returns expected array grouped by URL type starting with distribution files', (t) => {
+  const movedFiles = [
+    {
+      key: 'another/path/protected.hdf',
+      bucket: t.context.bucketConfig.protected.name,
+      type: 'data',
+    },
+    {
+      key: 'hidden/secretfile.gpg',
+      bucket: t.context.bucketConfig.private.name,
+      type: 'data',
+    },
+    {
+      key: 'another/path/public.dmrpp',
+      bucket: t.context.bucketConfig.public.name,
+      type: 'metadata',
+    },
+    {
+      key: 'path/publicfile.jpg',
+      bucket: t.context.bucketConfig.public.name,
+      type: 'browse',
+    },
+  ];
+
+  const expected = [
+    {
+      URL: `${distEndpoint}/${t.context.bucketConfig.protected.name}/another/path/protected.hdf`,
+      Description: 'Download protected.hdf',
+      URLDescription: 'Download protected.hdf',
+      Type: 'GET DATA',
+    },
+    {
+      URL: `${distEndpoint}/${t.context.bucketConfig.public.name}/another/path/public.dmrpp`,
+      Description: 'Download public.dmrpp',
+      URLDescription: 'Download public.dmrpp',
+      Type: 'EXTENDED METADATA',
+    },
+    {
+      URL: `${distEndpoint}/${t.context.bucketConfig.public.name}/path/publicfile.jpg`,
+      Description: 'Download publicfile.jpg',
+      URLDescription: 'Download publicfile.jpg',
+      Type: 'GET RELATED VISUALIZATION',
+    },
+    {
+      URL: `s3://${t.context.bucketConfig.protected.name}/another/path/protected.hdf`,
+      Description: 'This link provides direct download access via S3 to the granule',
+      URLDescription: 'This link provides direct download access via S3 to the granule',
+      Type: 'GET DATA',
+    },
+    {
+      URL: `s3://${t.context.bucketConfig.public.name}/another/path/public.dmrpp`,
+      Description: 'This link provides direct download access via S3 to the granule',
+      URLDescription: 'This link provides direct download access via S3 to the granule',
+      Type: 'EXTENDED METADATA',
+    },
+    {
+      URL: `s3://${t.context.bucketConfig.public.name}/path/publicfile.jpg`,
+      Description: 'This link provides direct download access via S3 to the granule',
+      URLDescription: 'This link provides direct download access via S3 to the granule',
+      Type: 'GET RELATED VISUALIZATION',
+    },
+  ];
+
+  const actual = constructOnlineAccessUrls({
+    files: movedFiles,
+    distEndpoint,
+    bucketTypes: t.context.bucketTypes,
+    distributionBucketMap: t.context.distributionBucketMap,
+  });
+
+  t.deepEqual(actual, expected);
+});
+
 test('constructRelatedUrls returns expected array when called with file list and cmrGranuleUrlType is not set and useDirectS3Type is not set', (t) => {
   const movedFiles = [
     {


### PR DESCRIPTION
**Summary:** Group online access URLs so that all HTTP links come first followed by all S3 links, without any other changes in ordering. This grouping helps to ensure that links are ordered in a manner consistent with EDSC expectations.

This PR replaces #3412, which was not generated against the master branch and didn't include a unit test.

Addresses [CUMULUS-3351: Group CMR online access URLs by link type](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3351)

## Changes

* Modified `constructOnlineAccessUrls` in `cmrjs` package to group links by type with no other change in ordering.
* Added unit test for new grouping.

## PR Checklist

- [ ] Update CHANGELOG
- [x] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
