### PR TITLE
CUMULUS-3393: Fix PUT collection endpoint to update collection in s3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,18 +42,20 @@ Users/clients that do not make use of these endpoints will not be impacted.
   - Updated mapping for rule Elasticsearch records to prevent dynamic field for keys under
     `meta` and `payload`, and fixed `rule` field mapping.
 
-### Fixed
-
-- **CUMULUS-3095**
-  - Added back `rule` schema validation which is missing after RDS phase 3.
-  - Fixed a bug for creating rule with tags.
-
 ### Changed
 
 - **CUMULUS-3351**
   - Updated `constructOnlineAccessUrls()` to group CMR online access URLs by link type.
 - **CUMULUS-3392**
   - Modify cloudwatch rule by deleting `custom`
+
+### Fixed
+
+- **CUMULUS-3095**
+  - Added back `rule` schema validation which is missing after RDS phase 3.
+  - Fixed a bug for creating rule with tags.
+- **CUMULUS-3393**
+  - Fixed `PUT` collection endpoint to update collection configuration in S3.
 
 ## [v18.0.0] 2023-08-28
 

--- a/packages/api/endpoints/collections.js
+++ b/packages/api/endpoints/collections.js
@@ -182,6 +182,10 @@ async function put(req, res) {
     collectionPgModel = new CollectionPgModel(),
     knex = await getKnexClient(),
     esClient = await Search.es(),
+    collectionConfigStore = new CollectionConfigStore(
+      process.env.system_bucket,
+      process.env.stackName
+    ),
   } = req.testContext || {};
 
   const { name, version } = req.params;
@@ -218,6 +222,7 @@ async function put(req, res) {
       apiPgCollection = translatePostgresCollectionToApiCollection(pgCollection);
       await indexCollection(esClient, apiPgCollection, process.env.ES_INDEX);
       await publishCollectionUpdateSnsMessage(apiPgCollection);
+      await collectionConfigStore.put(name, version, apiPgCollection);
     });
   } catch (error) {
     log.debug(`Failed to update collection with name ${name}, version ${version} and payload ${JSON.stringify(collection)} . Error: ${JSON.stringify(error)}`);

--- a/packages/api/tests/endpoints/collections/update-collection.js
+++ b/packages/api/tests/endpoints/collections/update-collection.js
@@ -28,6 +28,7 @@ const {
   createTestIndex,
   cleanupTestIndex,
 } = require('@cumulus/es-client/testUtils');
+const CollectionConfigStore = require('@cumulus/collection-config-store');
 const {
   InvalidRegexError,
   UnmatchedRegexError,
@@ -356,6 +357,41 @@ test.serial('PUT replaces an existing collection in all data stores with correct
   // PG and ES records have the same timestamps
   t.is(actualPgCollection.created_at.getTime(), updatedEsRecord.createdAt);
   t.is(actualPgCollection.updated_at.getTime(), updatedEsRecord.updatedAt);
+});
+
+test.serial('PUT updates collection configuration store via name and version', async (t) => {
+  const { originalCollection } = await createCollectionTestRecords(
+    t.context,
+    {
+      duplicateHandling: 'replace',
+      process: randomString(),
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    }
+  );
+
+  const updatedCollection = {
+    ...originalCollection,
+    updatedAt: Date.now(),
+    createdAt: Date.now(),
+    duplicateHandling: 'error',
+    meta: { foo: randomString() },
+  };
+
+  const res = await request(app)
+    .put(`/collections/${originalCollection.name}/${originalCollection.version}`)
+    .set('Accept', 'application/json')
+    .set('Authorization', `Bearer ${jwtAuthToken}`)
+    .send(updatedCollection)
+    .expect(200);
+
+  const collectionConfigStore = new CollectionConfigStore(
+    process.env.system_bucket,
+    process.env.stackName
+  );
+
+  t.deepEqual(await collectionConfigStore.get(originalCollection.name, originalCollection.version),
+    res.body);
 });
 
 test.serial('PUT returns 404 for non-existent collection', async (t) => {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3393: Cumulus collection does not update when editing in dashboard](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3393)

## Changes

* Detailed list or prose of changes
* ...

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
