### PR TITLE
CUMULUS-3467:Add childWorkflowMeta to QueueWorkflow task config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - **CUMULUS-3177**
   - changed `_removeGranuleFromCmr` function for granule `bulkDelete` to not throw an error and instead catch the error when the granule is not found in CMR
+- **CUMULUS-3467**
+  - Added `childWorkflowMeta` to `QueueWorkflow` task configuration
 
 ## [v18.1.0] 2023-10-25
 

--- a/docs/data-cookbooks/queue-post-to-cmr.md
+++ b/docs/data-cookbooks/queue-post-to-cmr.md
@@ -30,7 +30,8 @@ The last step should be the `QueuePublishWorkflow` step. It should be configured
           "workflow": "{$.meta.workflow}",
           "queueUrl": "${start_sf_queue_url}",
           "provider": "{$.meta.provider}",
-          "collection": "{$.meta.collection}"
+          "collection": "{$.meta.collection}",
+          "childWorkflowMeta": { "file_etags": "{$.meta.file_etags}", "staticValue": "aStaticValue" }
         }
       }
     },
@@ -97,7 +98,8 @@ Then, configure the `QueueWorkflow` task similarly to its configuration in the i
           "workflow": "PublishGranuleQueue",
           "queueUrl": "${start_sf_queue_url}",
           "provider": "{$.meta.provider}",
-          "collection": "{$.meta.collection}"
+          "collection": "{$.meta.collection}",
+          "childWorkflowMeta": { "file_etags": "{$.meta.file_etags}", "staticValue": "aStaticValue" }
         }
       }
     },

--- a/example/cumulus-tf/ingest_granule_with_queue_workflow.asl.json
+++ b/example/cumulus-tf/ingest_granule_with_queue_workflow.asl.json
@@ -234,7 +234,8 @@
             "workflow": "{$.meta.workflow}",
             "queueUrl": "${start_sf_queue_url}",
             "provider": "{$.meta.provider}",
-            "collection": "{$.meta.collection}"
+            "collection": "{$.meta.collection}",
+            "childWorkflowMeta": { "file_etags": "{$.meta.file_etags}", "staticValue": "aStaticValue" }
           }
         }
       },

--- a/example/cumulus-tf/publish_granule_with_requeue_workflow.asl.json
+++ b/example/cumulus-tf/publish_granule_with_requeue_workflow.asl.json
@@ -13,7 +13,8 @@
             "bucket": "{$.meta.buckets.internal.name}",
             "stack": "{$.meta.stack}",
             "cmr": "{$.meta.cmr}",
-            "launchpad": "{$.meta.launchpad}"
+            "launchpad": "{$.meta.launchpad}",
+            "etags": "{$.meta.file_etags}"
           }
         }
       },
@@ -58,7 +59,8 @@
             "workflow": "PublishGranuleQueue",
             "queueUrl": "${start_sf_queue_url}",
             "provider": "{$.meta.provider}",
-            "collection": "{$.meta.collection}"
+            "collection": "{$.meta.collection}",
+            "childWorkflowMeta": { "file_etags": "{$.meta.file_etags}", "staticValue": "aStaticValue" }
           }
         }
       },

--- a/example/spec/parallel/ingestGranule/ingestGranuleQueueSpec.js
+++ b/example/spec/parallel/ingestGranule/ingestGranuleQueueSpec.js
@@ -12,6 +12,7 @@ const { s3 } = require('@cumulus/aws-client/services');
 const { generateChecksumFromStream } = require('@cumulus/checksum');
 const {
   addCollections,
+  getExecutionInputObject,
   getOnlineResources,
   waitForCompletedExecution,
 } = require('@cumulus/integration-tests');
@@ -467,6 +468,12 @@ describe('The S3 Ingest Granules workflow', () => {
         publishGranuleExecutionArn
       );
       expect(publishGranuleExecutionStatus).toEqual('SUCCEEDED');
+    });
+
+    it('passes through childWorkflowMeta to the PublishGranuleQueue execution', async () => {
+      const executionInput = await getExecutionInputObject(publishGranuleExecutionArn);
+      expect(executionInput.meta.staticValue).toEqual('aStaticValue');
+      expect(executionInput.meta.file_tags).toEqual(lambdaOutput.meta.file_tags);
     });
   });
 

--- a/tasks/queue-workflow/schemas/config.json
+++ b/tasks/queue-workflow/schemas/config.json
@@ -17,6 +17,7 @@
     "stackName": { "type": "string" },
     "executionNamePrefix": { "type": "string" },
     "workflow": { "type": "string" },
-    "workflowInput": { "type": "object" }
+    "workflowInput": { "type": "object" },
+    "childWorkflowMeta": { "type": "object" }
   }
 }

--- a/tasks/queue-workflow/tests/index.js
+++ b/tasks/queue-workflow/tests/index.js
@@ -176,6 +176,7 @@ test.serial('The correct message is enqueued', async (t) => {
   );
   event.config.workflow = t.context.queuedWorkflow;
   event.config.workflowInput = { prop1: randomId('prop1'), prop2: randomId('prop2') };
+  event.config.childWorkflowMeta = { metakey1: randomId('metavalue1') };
 
   await validateConfig(t, event.config);
   await validateInput(t, event.input);
@@ -206,6 +207,7 @@ test.serial('The correct message is enqueued', async (t) => {
     },
     meta: {
       workflow_name: event.config.workflow,
+      ...event.config.childWorkflowMeta,
     },
     payload: {
       prop1: event.config.workflowInput.prop1,


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3467: Missing childWorkflowMeta in the config schema of queue_workflow](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3467)

## Changes

* Detailed list or prose of changes
* ...

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [x] Integration tests
