### PR TITLE
CUMULUS-3479: Fix typo in s3-replicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Fixed overriden changes to `rules.buildPayload' to restore changes from ticket `CUMULUS-2969` which limited the definition object to `name` and `arn` to
     account for AWS character limits.
 - **CUMULUS-3479**
-  - Fixed typo in s3-replicator resource declaration where `var.lambda_memory_size` is supposed to be `var.lmabda_memory_sizes`
+  - Fixed typo in s3-replicator resource declaration where `var.lambda_memory_size` is supposed to be `var.lambda_memory_sizes`
 
 ## [v18.1.0] 2023-10-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - **CUMULUS-3467**
   - Added `childWorkflowMeta` to `QueueWorkflow` task configuration
 - **CUMULUS-3474**
-  - Fixed overriden changes to `rules.buildPayload' to restore changes from
-    ticket `CUMULUS-2969` which limited the definition object to `name` and `arn` to
+  - Fixed overriden changes to `rules.buildPayload' to restore changes from ticket `CUMULUS-2969` which limited the definition object to `name` and `arn` to
     account for AWS character limits.
+- **CUMULUS-3479**
+  - Fixed typo in s3-replicator resource declaration where `var.lambda_memory_size` is supposed to be `var.lmabda_memory_sizes`
 
 ## [v18.1.0] 2023-10-25
 

--- a/tf-modules/s3-replicator/main.tf
+++ b/tf-modules/s3-replicator/main.tf
@@ -39,7 +39,7 @@ resource "aws_lambda_function" "s3_replicator" {
   handler       = "index.handler"
   runtime       = "nodejs16.x"
   timeout       = lookup(var.lambda_timeouts, "s3-replicator", 300)
-  memory_size   = lookup(var.lambda_memory_size, "s3-replicator", 512)
+  memory_size   = lookup(var.lambda_memory_sizes, "s3-replicator", 512)
 
   source_code_hash = data.archive_file.replicator_package.output_base64sha256
 


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3479: Typo in s3-replicator Terraform configuration](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3479)

## Changes

* Fixed typo in s3-replicator resource declaration where `var.lambda_memory_size` is supposed to be `var.lambda_memory_sizes`

Tested by configuring my dev Cumulus stack to deploy s3 replicator using these instructions. Verified that I saw the error:
```
│ Error: Reference to undeclared input variable
│ 
│   on .terraform/modules/s3-replicator/main.tf line 42, in resource "aws_lambda_function" "s3_replicator":
│   42:   memory_size   = lookup(var.lambda_memory_size, "s3-replicator", 512)
│ 
│ An input variable with the name "lambda_memory_size" has not been declared. Did you mean "lambda_memory_sizes"?
```
## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
