### PR TITLE
Jk/cumulus 3499

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **CUMULUS_3499
+  - Update AWS-SDK dependency pin to "2.1490" to prevent SQS issue.  Dependency
+    pin expected to be changed with the resolution to CUMULUS-2900
 - **CUMULUS-2894**
   - Update Lambda code to AWS SDK v3
 

--- a/example/lambdas/ftpPopulateTestLambda/package.json
+++ b/example/lambdas/ftpPopulateTestLambda/package.json
@@ -25,7 +25,7 @@
     "@cumulus/integration-tests": "18.1.0",
     "@cumulus/logger": "18.1.0",
     "@cumulus/test-data": "18.1.0",
-    "aws-sdk": "^2.585.0",
+    "aws-sdk": "2.1490.0",
     "fs-extra": "^9.0.0",
     "jsftp": "https://github.com/jkovarik/jsftp.git#add_288",
     "lodash": "^4.17.20"

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@typescript-eslint/parser": "^4.33.0",
     "audit-ci": "6.6.1",
     "ava": "^3.12.1",
-    "aws-sdk": "^2.585.0",
+    "aws-sdk": "2.1490.0",
     "babel-eslint": "^10.0.3",
     "babel-loader": "^8.2.2",
     "babel-plugin-source-map-support": "^2.1.1",

--- a/packages/api/ecs/async-operation/package.json
+++ b/packages/api/ecs/async-operation/package.json
@@ -25,7 +25,7 @@
     "@cumulus/db": "18.1.0",
     "@cumulus/es-client": "18.1.0",
     "@cumulus/logger": "18.1.0",
-    "aws-sdk": "^2.585.0",
+    "aws-sdk": "2.1490.0",
     "crypto-random-string": "^3.2.0",
     "got": "^11.8.5",
     "lodash": "^4.17.21",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -72,7 +72,7 @@
     "@mapbox/dyno": "^1.4.2",
     "aggregate-error": "^3.1.0",
     "ajv": "^6.12.3",
-    "aws-sdk": "^2.585.0",
+    "aws-sdk": "2.1490.0",
     "aws-serverless-express": "^3.3.5",
     "body-parser": "^1.18.3",
     "commander": "^2.15.0",

--- a/packages/aws-client/package.json
+++ b/packages/aws-client/package.json
@@ -57,7 +57,7 @@
     "@cumulus/checksum": "18.1.0",
     "@cumulus/errors": "18.1.0",
     "@cumulus/logger": "18.1.0",
-    "aws-sdk": "^2.585.0",
+    "aws-sdk": "2.1490.0",
     "jsonpath-plus": "^1.1.0",
     "lodash": "~4.17.21",
     "mem": "^8.0.2",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -48,7 +48,7 @@
     "@cumulus/errors": "18.1.0",
     "@cumulus/logger": "18.1.0",
     "ajv": "^6.12.3",
-    "aws-sdk": "^2.585.0",
+    "aws-sdk": "2.1490.0",
     "follow-redirects": "^1.2.4",
     "fs-extra": "^5.0.0",
     "is-ip": "^3.1.0",

--- a/packages/es-client/package.json
+++ b/packages/es-client/package.json
@@ -37,7 +37,7 @@
     "@cumulus/message": "18.1.0",
     "@elastic/elasticsearch": "^5.6.20",
     "aws-elasticsearch-connector": "8.2.0",
-    "aws-sdk": "^2.585.0",
+    "aws-sdk": "2.1490.0",
     "lodash": "~4.17.21",
     "moment": "2.29.4",
     "p-limit": "^1.2.0"

--- a/packages/ingest/package.json
+++ b/packages/ingest/package.json
@@ -46,7 +46,7 @@
     "@cumulus/logger": "18.1.0",
     "@cumulus/message": "18.1.0",
     "@cumulus/sftp-client": "18.1.0",
-    "aws-sdk": "^2.585.0",
+    "aws-sdk": "2.1490.0",
     "cksum": "^1.3.0",
     "encodeurl": "^1.0.2",
     "fs-extra": "^5.0.0",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -39,7 +39,7 @@
     "@cumulus/logger": "18.1.0",
     "@cumulus/message": "18.1.0",
     "@cumulus/oauth-client": "18.1.0",
-    "aws-sdk": "^2.585.0",
+    "aws-sdk": "2.1490.0",
     "base-64": "^0.1.0",
     "commander": "^2.15.0",
     "dotenv": "^8.2.0",

--- a/tf-modules/internal/cumulus-test-cleanup/package.json
+++ b/tf-modules/internal/cumulus-test-cleanup/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.58.0",
     "@aws-sdk/signature-v4-crt": "^3.58.0",
-    "aws-sdk": "^2.585.0",
+    "aws-sdk": "2.1490.0",
     "moment": "2.29.4"
   },
   "private": true

--- a/tf-modules/s3-replicator/package.json
+++ b/tf-modules/s3-replicator/package.json
@@ -18,7 +18,7 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "aws-sdk": "^2.585.0"
+    "aws-sdk": "2.1490.0"
   },
   "private": true
 }


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3499: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3499)

Pins aws-sdk to 2.1490 due to breaking change in later versions with the current version of localstack.    This change will need to be modified again once the work on CUMULUS-2900 is complete. 