### PR TITLE
Use the correct variable for lzards launchpad secret value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     account for AWS character limits.
 - **CUMULUS-3479**
   - Fixed typo in s3-replicator resource declaration where `var.lambda_memory_size` is supposed to be `var.lambda_memory_sizes`
+- **CUMULUS-????**
+  - Fixed secret value for `lzards_launchpad_passphrase` which was getting the value from `var.launchpad_passphrase` instead of `var.lzards_launchpad_passphrase`.
 
 ## [v18.1.0] 2023-10-25
 

--- a/tf-modules/ingest/lzards-backup-task.tf
+++ b/tf-modules/ingest/lzards-backup-task.tf
@@ -99,7 +99,7 @@ resource "aws_secretsmanager_secret" "lzards_launchpad_passphrase" {
 resource "aws_secretsmanager_secret_version" "lzards_launchpad_passphrase" {
   count         = length(var.lzards_launchpad_passphrase) == 0 ? 0 : 1
   secret_id     = aws_secretsmanager_secret.lzards_launchpad_passphrase[0].id
-  secret_string = var.launchpad_passphrase
+  secret_string = var.lzards_launchpad_passphrase
 }
 
 data "aws_iam_policy_document" "lzards_processing_role_get_secrets" {


### PR DESCRIPTION
**Summary:** Fix `lzards_launchpad_passphrase` secret value.

I was told there are known issues with LZARDS and launchpad, however I was unable to find any cumulus tickets associated with them. Could be my lack of familiarity with the ticketing system.

## Changes

* Fix the secret being populated with the value from the wrong variable.

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
