### PR TITLE
CUMULUS-3502-2:Update step function unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Update example deployment to deploy cnmToGranule lambda
     version 1.7.0-alpha.2-SNAPSHOT
 - **CUMULUS-3502**
-  - Upgraded localstack to v3.0.0 to support recent aws-sdk releases
+  - Upgraded localstack to v3.0.0 to support recent aws-sdk releases and update unit tests.
 
 ### Fixed
 

--- a/packages/aws-client/src/StepFunctions.ts
+++ b/packages/aws-client/src/StepFunctions.ts
@@ -4,6 +4,7 @@
 
 import { sfn } from './services';
 import { improveStackTrace, retryOnThrottlingException } from './utils';
+import { inTestMode } from './test-utils';
 
 // Utility functions
 
@@ -12,6 +13,7 @@ export const doesExecutionExist = (describeExecutionPromise: Promise<unknown>) =
     .then(() => true)
     .catch((error) => {
       if (error.code === 'ExecutionDoesNotExist') return false;
+      if (inTestMode() && error.code === 'InvalidName') return false;
       throw error;
     });
 

--- a/packages/aws-client/tests/test-StepFunctions.js
+++ b/packages/aws-client/tests/test-StepFunctions.js
@@ -159,3 +159,8 @@ test('doesExecutionExist throws any non-ExecutionDoesNotExist errors', async (t)
     t.pass();
   }
 });
+
+test('executionExists returns false if the execution does not exist', async (t) => {
+  const executionArn = 'arn:aws:states:us-east-1:123456789012:execution:MyStackIngestAndPublishGranuleStateMachine:c154d37a-98e5-4ca9-9653-35f4ae9b59d3';
+  t.false(await StepFunctions.executionExists(executionArn));
+});


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-XX: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-XXX)

## Changes

* This is to help with dashboard PR https://github.com/nasa/cumulus-dashboard/pull/1119
   There is an issue with localstack v3, it returns AWS stepfunctions.DescribeExecution => 400 (InvalidName) when execution doesn't exist, instead of ExecutionDoesNotExist.

https://github.com/localstack/localstack/blob/v3.0.0/localstack/services/stepfunctions/provider.py#L115

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
