### PR TITLE
Don't allow duplicate URLs in Hyrax metadata updates

### DIFF
--- a/tasks/hyrax-metadata-updates/index.js
+++ b/tasks/hyrax-metadata-updates/index.js
@@ -209,12 +209,20 @@ function addHyraxUrlToUmmG(metadata, hyraxUrl) {
   if (metadataCopy.RelatedUrls === undefined) {
     metadataCopy.RelatedUrls = [];
   }
+
   const url = {
     URL: hyraxUrl,
     Type: 'USE SERVICE API',
     Subtype: 'OPENDAP DATA',
     Description: 'OPeNDAP request URL',
   };
+
+  for (const relatedUrl of metadataCopy.RelatedUrls) {
+    if (isEqual(relatedUrl, url)) {
+      return JSON.stringify(metadataCopy, undefined, 2);
+    }
+  }
+
   metadataCopy.RelatedUrls.push(url);
 
   return JSON.stringify(metadataCopy, undefined, 2);
@@ -245,6 +253,13 @@ function addHyraxUrlToEcho10(metadata, hyraxUrl) {
     Description: 'OPeNDAP request URL',
     Type: 'GET DATA : OPENDAP DATA',
   };
+
+  for (const resourceUrl of resourceUrls) {
+    if (isEqual(resourceUrl, url)) {
+      return generateEcho10XMLString(metadata.Granule);
+    }
+  }
+
   resourceUrls.push(url);
 
   metadataCopy.Granule.OnlineResources = {

--- a/tasks/hyrax-metadata-updates/tests/test-index.js
+++ b/tasks/hyrax-metadata-updates/tests/test-index.js
@@ -97,6 +97,16 @@ test('Test adding OPeNDAP URL to UMM-G file with no related urls', (t) => {
   t.is(actual, JSON.stringify(expectedObject, undefined, 2));
 });
 
+test('Test adding duplicate OPeNDAP URL to UMM-G file', (t) => {
+  const data = fs.readFileSync('tests/data/umm-gin.json', 'utf8');
+  const metadata = JSON.parse(data);
+  const expected = fs.readFileSync('tests/data/umm-gout.json', 'utf8');
+  const expectedObject = JSON.parse(expected);
+  const newMetadata = JSON.parse(addHyraxUrl(metadata, true, 'https://opendap.earthdata.nasa.gov/collections/C1453188197-GES_DISC/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4'));
+  const actual = addHyraxUrl(newMetadata, true, 'https://opendap.earthdata.nasa.gov/collections/C1453188197-GES_DISC/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4');
+  t.is(actual, JSON.stringify(expectedObject, undefined, 2));
+});
+
 test('Test adding OPeNDAP URL to ECHO10 file', async (t) => {
   const data = fs.readFileSync('tests/data/echo10in.xml', 'utf8');
   const metadata = await (promisify(xml2js.parseString))(data, xmlParseOptions);
@@ -127,6 +137,15 @@ test('Test adding OPeNDAP URL to ECHO10 file with two OnlineResources', async (t
   const metadata = await (promisify(xml2js.parseString))(data, xmlParseOptions);
   const expected = fs.readFileSync('tests/data/echo10out-2-online-resource-urls.xml', 'utf8');
   const actual = addHyraxUrl(metadata, false, 'https://opendap.earthdata.nasa.gov/collections/C1453188197-GES_DISC/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4');
+  t.is(actual, expected.trim('\n'));
+});
+
+test('Test adding duplicate OPeNDAP URL to ECHO10 file', async (t) => {
+  const data = fs.readFileSync('tests/data/echo10in.xml', 'utf8');
+  const metadata = await (promisify(xml2js.parseString))(data, xmlParseOptions);
+  const expected = fs.readFileSync('tests/data/echo10out.xml', 'utf8');
+  const newMetadata = await (promisify(xml2js.parseString))(addHyraxUrl(metadata, false, 'https://opendap.earthdata.nasa.gov/collections/C1453188197-GES_DISC/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4'), xmlParseOptions);
+  const actual = addHyraxUrl(newMetadata, false, 'https://opendap.earthdata.nasa.gov/collections/C1453188197-GES_DISC/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4');
   t.is(actual, expected.trim('\n'));
 });
 


### PR DESCRIPTION
Test for OPeNDAP URL duplication on the ECHO-10 and UMM-G Hyrax paths before adding the URL. If it is a duplicate, return the provided metadata with no modifications.

**Summary:** Updated the `hyrax-metadata-updates` task to prevent duplicate OPeNDAP URLs.

Addresses [CUMULUS-3343: Update HyraxMetadataUpdates to be idempotent](https://bugs.earthdata.nasa.gov/projects/CUMULUS/issues/CUMULUS-3343)

## Changes

* Modified `addHyraxUrlToUmmG` to test whether the provide Hyrax URL is already included in the metadata, and if so return the metadata unaltered.
* Modified `addHyraxUrlToEcho10` to test whether the provide Hyrax URL is already included in the metadata, and if so return the metadata unaltered.
* Added unit tests for the cases of duplicate URLs in both of the above paths.

## PR Checklist

- [ ] Update CHANGELOG
- [x] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [x] Integration tests
