### PR TITLE
Update ECS Cluster EBS Volume Default Encryption Settings (CUMULUS-3547/NDCUM-1184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     version 1.7.0-alpha.2-SNAPSHOT
 - **CUMULUS-3502**
   - Upgraded localstack to v3.0.0 to support recent aws-sdk releases
+- **CUMULUS-3547**
+  - Updated ECS Cluster `/dev/xvdcz` EBS volumes so they're encrypted.
 
 ### Fixed
 

--- a/tf-modules/cumulus/ecs_cluster_instance_autoscaling_cf_template.yml.tmpl
+++ b/tf-modules/cumulus/ecs_cluster_instance_autoscaling_cf_template.yml.tmpl
@@ -13,6 +13,7 @@ Resources:
         - DeviceName: "/dev/xvdcz"
           Ebs:
             DeleteOnTermination: true
+            Encrypted: true
             VolumeSize: ${docker_volume_size}
 %{ if key_name != null ~}
       KeyName: ${key_name}


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [NDCUM-1184: DAR requirement: Update ECS Cluster EBS Volume Default Encryption Settings](https://bugs.earthdata.nasa.gov/browse/NDCUM-1184) (see also [CUMULUS-3547](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3547)).

## Changes

* Added "Encrypted: true" to the `/dev/xvdcz` EBS volume to enable encryption for this volume.

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
