### PR TITLE
Temp whitelist crypto js

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -12,6 +12,8 @@
     "knex",
     "jsonwebtoken",
     "cacheable-request",
-    "http-cache-semantics"
+    "http-cache-semantics",
+    "lodash.pick",
+    "crypto-js",
   ]
 }

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -14,6 +14,6 @@
     "cacheable-request",
     "http-cache-semantics",
     "lodash.pick",
-    "crypto-js",
+    "crypto-js"
   ]
 }


### PR DESCRIPTION
because fixes to the crypto-js vulnerability are proving a little time-consuming to fix, I don't want to hold up ci during these final hours of the sprint.

## Changes
- whitelist crypto-js
- whitelist lodash.pick (this is a high vulnerability but error reporting is tripping over it)
## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
