### PR TITLE
[CUMULUS-3527] Adds support for additional kex algorithms to sftp-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Removed unused CloudWatch AWS SDK client. This change removes the CloudWatch client
     from the `@cumulus/aws-client` package.
 
+### Changed
+
+- **CUMULUS-3527**
+  - Added suppport for additional kex algorithms in the sftp-client.
+
 ## [v18.2.0] 2023-02-02
 
 ### Migration Notes
@@ -30,6 +35,7 @@ upgrade
 instructions](https://nasa.github.io/cumulus/docs/upgrade-notes/upgrade-rds-cluster-tf-postgres-13).
 
 ### Changed
+
 - **CUMULUS-3492**
   - add teclark to select-stack.js
 - **CUMULUS-3444**

--- a/packages/sftp-client/src/index.ts
+++ b/packages/sftp-client/src/index.ts
@@ -41,6 +41,13 @@ export class SftpClient {
     this.clientOptions = {
       host: config.host,
       port: get(config, 'port', 22),
+      algorithms: {
+        kex: {
+          append: ['diffie-hellman-group14-sha1'],
+          prepend: [],
+          remove: [],
+        },
+      },
     };
 
     if (config.username) this.clientOptions.username = config.username;

--- a/packages/sftp-client/src/index.ts
+++ b/packages/sftp-client/src/index.ts
@@ -43,7 +43,11 @@ export class SftpClient {
       port: get(config, 'port', 22),
       algorithms: {
         kex: {
-          append: ['diffie-hellman-group14-sha1'],
+          append: [
+            'diffie-hellman-group-exchange-sha1',
+            'diffie-hellman-group14-sha1',
+            'diffie-hellman-group1-sha1',
+          ],
           prepend: [],
           remove: [],
         },


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3527: SyncGranule failing for SFTP provider](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3527)

After much discussion around this change it was agreed on to simply add specific support for the algorithm that was not by default supported. Our sftp client uses the [ssh2](https://www.npmjs.com/package/ssh2#api) library for ssh connections. By default the `diffie-hellman-group14-sha1` is not supported.

## Changes

* Adds `diffie-hellman-group14-sha1` to the list of supported kex algorithms in the sftp-client

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
