### PR TITLE
[CUMULUS-2897]: Removes unused Systems Manager AWS SDK from aws-client.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - **CUMULUS-2890**
   - Removed unused CloudWatch AWS SDK client. This change removes the CloudWatch client
     from the `@cumulus/aws-client` package.
+- **CUMULUS-2897**
+  - Removed unused Systems Manager AWS SDK client. This change removes the Systems Manager client
+    from the `@cumulus/aws-client` package.
     
 ### Changed
 

--- a/packages/aws-client/src/services.ts
+++ b/packages/aws-client/src/services.ts
@@ -34,7 +34,6 @@ export const sfn = awsClient(AWS.StepFunctions, '2016-11-23');
 export const cf = awsClient(CloudFormation, '2010-05-15');
 export const sns = awsClient(SNS, '2010-03-31');
 export const secretsManager = awsClient(AWS.SecretsManager, '2017-10-17');
-export const systemsManager = awsClient(AWS.SSM, '2017-10-17');
 export const kms = awsClient(KMS, '2014-11-01');
 export const es = awsClient(AWS.ES, '2015-01-01');
 export const sts = awsClient(AWS.STS, '2011-06-15');

--- a/packages/aws-client/tests/test-services.js
+++ b/packages/aws-client/tests/test-services.js
@@ -355,16 +355,3 @@ test('sts() service defaults to localstack in test mode', (t) => {
   );
   t.is(sts.config.endpoint, endpoint);
 });
-
-test('systemsManager() service defaults to localstack in test mode', (t) => {
-  const systemsManager = services.systemsManager();
-  const {
-    credentials,
-    endpoint,
-  } = localStackAwsClientOptions(AWS.SSM);
-  t.deepEqual(
-    systemsManager.config.credentials,
-    credentials
-  );
-  t.is(systemsManager.config.endpoint, endpoint);
-});


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2897: Update Systems Manager code to AWS SDK v3](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2897)

## Changes

* Removes Systems Manager from aws-client since it's not referenced anywhere.

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
