### PR TITLE
CUMULUS-3449-3: Add knex hook postProcessResponse to convert id fields to number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Minor refactor of `@cumulus/lzards-api-client` to:
     - Use proper ECMAScript import for `@cumulus/launchpad-auth`
     - Update incorrect docstring
+- **CUMULUS-3449**
+  - Updated `@cumulus/db` package and add knex hook postProcessResponse to convert postgres id fields in
+    query result to number.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,8 +63,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     - Use proper ECMAScript import for `@cumulus/launchpad-auth`
     - Update incorrect docstring
 - **CUMULUS-3449**
-  - Updated `@cumulus/db` package and add knex hook postProcessResponse to convert postgres id fields in
-    query result to number.
+  - Updated `@cumulus/db` package and configure knex hook postProcessResponse to convert the return string
+    from columns ending with "cumulus_id" to number.
 
 ### Changed
 

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -33,8 +33,8 @@ Typically, there are two TypeScript interfaces describing each Cumulus data type
 
 ### BigInt cumulus_id columns
 
-For the BigInt columns, knex returns postgres as "string" type. In order to use cumulus_id as a number,
-we are converting the return string from columns ending with "cumulus_id" to Number.
+For the BigInt columns, knex returns postgres as "string" type. In order to use cumulus_id as a number, knex hook
+postProcessResponse is configured to convert the return string from columns ending with "cumulus_id" to number.
 
 ## About Cumulus
 

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -31,6 +31,11 @@ Typically, there are two TypeScript interfaces describing each Cumulus data type
 - `PostgresProvider`: Describes the data structure ready for insertion into the Cumulus Postgres database
 - `PostgresProviderRecord`: Describes the data structure after retrieval from the Cumulus database. This data type usually includes extra required properties (such as the auto-incremented primary key field), since those properties will exist once a record has been created.
 
+### BigInt cumulus_id columns
+
+For the BigInt columns, knex returns postgres as "string" type. In order to use cumulus_id as a number,
+we are converting the return string from columns ending with "cumulus_id" to Number.
+
 ## About Cumulus
 
 Cumulus is a cloud-based data ingest, archive, distribution and management

--- a/packages/db/src/config.ts
+++ b/packages/db/src/config.ts
@@ -105,6 +105,21 @@ export const getConnectionConfig = async ({
   return await getConnectionConfigEnv(env);
 };
 
+const convertIdColumnsToNumber = (row: any): any => {
+  const convertedRow: any = {};
+  for (const key in row) {
+    if (row.hasOwnProperty(key)) {
+      const value = row[key];
+      if (typeof value === 'string' && key.endsWith('cumulud_id')) {
+        convertedRow[key] = Number(value);
+      } else {
+        convertedRow[key] = value;
+      }
+    }
+  }
+  return convertedRow;
+};
+
 /**
  * Given a NodeJS.ProcessEnv with configuration values, build and return Knex
  * configuration
@@ -170,6 +185,14 @@ export const getKnexConfig = async ({
       destroyTimeoutMillis: Number.parseInt(env.destroyTimeoutMillis ?? '5000', 10),
       reapIntervalMillis: Number.parseInt(env.reapIntervalMillis ?? '1000', 10),
       propagateCreateError: false,
+    },
+    postProcessResponse: (result: any, _queryContext: any) => {
+      if (result && Array.isArray(result)) {
+        return result.map((row) => convertIdColumnsToNumber(row));
+      } else if (result && typeof result === 'object') {
+        return convertIdColumnsToNumber(result);
+      }
+      else return result;
     },
   };
 

--- a/packages/db/src/config.ts
+++ b/packages/db/src/config.ts
@@ -116,7 +116,7 @@ export const getConnectionConfig = async ({
  * @returns true if the string can be converted
  * @throws - Throws error if the string can not be converted
  */
-export const safelyConvertBigInt = (bigIntValue: string): boolean => {
+export const canSafelyConvertBigInt = (bigIntValue: string): boolean => {
   if (BigInt(bigIntValue) > BigInt(Number.MAX_SAFE_INTEGER)) {
     throw new Error(`Failed to convert to number: ${bigIntValue} exceeds max safe integer ${Number.MAX_SAFE_INTEGER}`);
   }
@@ -138,7 +138,7 @@ export const convertIdColumnsToNumber = <T extends Record<string, any>>(record: 
     mapValues(
       record,
       (value, key) =>
-        ((key.endsWith('cumulus_id') && !isNull(value) && isString(value) && safelyConvertBigInt(value))
+        ((key.endsWith('cumulus_id') && !isNull(value) && isString(value) && canSafelyConvertBigInt(value))
           ? Number(value)
           : value)
     );

--- a/packages/db/src/config.ts
+++ b/packages/db/src/config.ts
@@ -106,18 +106,21 @@ export const getConnectionConfig = async ({
 };
 
 const convertIdColumnsToNumber = (row: any): any => {
-  const convertedRow: any = {};
-  for (const key in row) {
-    if (row.hasOwnProperty(key)) {
-      const value = row[key];
-      if (typeof value === 'string' && key.endsWith('cumulud_id')) {
-        convertedRow[key] = Number(value);
-      } else {
-        convertedRow[key] = value;
+  if (typeof row === 'object' && row !== null) {
+    const convertedRow: any = {};
+    for (const key in row) {
+      if (row.hasOwnProperty(key)) {
+        const value = row[key];
+        if (typeof value === 'string' && key.endsWith('cumulus_id')) {
+          convertedRow[key] = Number(value);
+        } else {
+          convertedRow[key] = value;
+        }
       }
     }
+    return convertedRow;
   }
-  return convertedRow;
+  return row;
 };
 
 /**
@@ -189,10 +192,8 @@ export const getKnexConfig = async ({
     postProcessResponse: (result: any, _queryContext: any) => {
       if (result && Array.isArray(result)) {
         return result.map((row) => convertIdColumnsToNumber(row));
-      } else if (result && typeof result === 'object') {
-        return convertIdColumnsToNumber(result);
       }
-      else return result;
+      return convertIdColumnsToNumber(result);
     },
   };
 

--- a/packages/db/src/config.ts
+++ b/packages/db/src/config.ts
@@ -116,9 +116,9 @@ export const getConnectionConfig = async ({
  * @returns true if the string can be converted
  * @throws - Throws error if the string can not be converted
  */
-const safelyConvertBigInt = (bigIntValue: string): boolean => {
-  if (BigInt(Number.MAX_SAFE_INTEGER) < BigInt(Number(bigIntValue))) {
-    throw new Error(`Failed to convert to number, ${bigIntValue} exceeds ${Number.MAX_SAFE_INTEGER}`);
+export const safelyConvertBigInt = (bigIntValue: string): boolean => {
+  if (BigInt(bigIntValue) > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error(`Failed to convert to number: ${bigIntValue} exceeds max safe integer ${Number.MAX_SAFE_INTEGER}`);
   }
   return true;
 };
@@ -133,7 +133,7 @@ type RecordTypeWithNumberIdField<T> = {
  * @param record - record to be converted
  * @returns the converted record
  */
-const convertIdColumnsToNumber = <T extends Record<string, any>>(record: T)
+export const convertIdColumnsToNumber = <T extends Record<string, any>>(record: T)
   : RecordTypeWithNumberIdField<T> =>
     mapValues(
       record,

--- a/packages/db/src/config.ts
+++ b/packages/db/src/config.ts
@@ -209,7 +209,7 @@ export const getKnexConfig = async ({
       reapIntervalMillis: Number.parseInt(env.reapIntervalMillis ?? '1000', 10),
       propagateCreateError: false,
     },
-    // modify the response to convert columns ending with "cumulus_id" from string to number
+    // modify any knex query response to convert columns ending with "cumulus_id" from string | number to number
     postProcessResponse: (result: any) => {
       if (result && Array.isArray(result)) {
         return result.map((row) => (isObject(row) ? convertIdColumnsToNumber(row) : row));

--- a/packages/db/src/config.ts
+++ b/packages/db/src/config.ts
@@ -209,7 +209,8 @@ export const getKnexConfig = async ({
       reapIntervalMillis: Number.parseInt(env.reapIntervalMillis ?? '1000', 10),
       propagateCreateError: false,
     },
-    // modify any knex query response to convert columns ending with "cumulus_id" from string | number to number
+    // modify any knex query response to convert columns ending with "cumulus_id" from
+    // string | number to number
     postProcessResponse: (result: any) => {
       if (result && Array.isArray(result)) {
         return result.map((row) => (isObject(row) ? convertIdColumnsToNumber(row) : row));

--- a/packages/db/tests/test-config.js
+++ b/packages/db/tests/test-config.js
@@ -10,7 +10,7 @@ const {
   getSecretConnectionConfig,
   getKnexConfig,
   isKnexDebugEnabled,
-  safelyConvertBigInt,
+  canSafelyConvertBigInt,
 } = require('../dist/config');
 
 const dbConnectionConfig = {
@@ -425,15 +425,15 @@ test('isKnexDebugEnabled() returns false if debugging is not enabled', (t) => {
   t.false(isKnexDebugEnabled());
 });
 
-test('safelyConvertBigInt() returns true if number is in safe range', (t) => {
-  t.true(safelyConvertBigInt(Number.MAX_SAFE_INTEGER.toString()));
-  t.true(safelyConvertBigInt((Number.MAX_SAFE_INTEGER - 1).toString()));
+test('canSafelyConvertBigInt() returns true if number is in safe range', (t) => {
+  t.true(canSafelyConvertBigInt(Number.MAX_SAFE_INTEGER.toString()));
+  t.true(canSafelyConvertBigInt((Number.MAX_SAFE_INTEGER - 1).toString()));
 });
 
-test('safelyConvertBigInt() throws exception if number exceeds safe range', (t) => {
+test('canSafelyConvertBigInt() throws exception if number exceeds safe range', (t) => {
   const bigIntString = (BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1)).toString();
   t.throws(
-    () => safelyConvertBigInt(bigIntString),
+    () => canSafelyConvertBigInt(bigIntString),
     {
       instanceOf: Error,
       message: `Failed to convert to number: ${bigIntString} exceeds max safe integer ${Number.MAX_SAFE_INTEGER}`,
@@ -441,10 +441,10 @@ test('safelyConvertBigInt() throws exception if number exceeds safe range', (t) 
   );
 });
 
-test('safelyConvertBigInt() throws exception for non-numeric string', (t) => {
+test('canSafelyConvertBigInt() throws exception for non-numeric string', (t) => {
   const nonNumericString = cryptoRandomString({ length: 10 });
   t.throws(
-    () => safelyConvertBigInt(nonNumericString),
+    () => canSafelyConvertBigInt(nonNumericString),
     {
       instanceOf: SyntaxError,
       message: `Cannot convert ${nonNumericString} to a BigInt`,

--- a/packages/db/tests/test-config.js
+++ b/packages/db/tests/test-config.js
@@ -1,4 +1,5 @@
 const test = require('ava');
+const isFunction = require('lodash/isFunction');
 const omit = require('lodash/omit');
 
 const {
@@ -82,6 +83,7 @@ test('getKnexConfig returns an expected default configuration object', async (t)
     },
   };
   t.deepEqual(omit(result, ['postProcessResponse']), expectedConfig);
+  t.true(isFunction(result.postProcessResponse));
 });
 
 test('getKnexConfig sets idleTimeoutMillis when env is set', async (t) => {

--- a/packages/db/tests/test-config.js
+++ b/packages/db/tests/test-config.js
@@ -1,4 +1,5 @@
 const test = require('ava');
+const omit = require('lodash/omit');
 
 const {
   getConnectionConfig,
@@ -80,7 +81,7 @@ test('getKnexConfig returns an expected default configuration object', async (t)
       reapIntervalMillis: 1000,
     },
   };
-  t.deepEqual(result, expectedConfig);
+  t.deepEqual(omit(result, ['postProcessResponse']), expectedConfig);
 });
 
 test('getKnexConfig sets idleTimeoutMillis when env is set', async (t) => {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3449: SPIKE: Improve performance for reconciliation query](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3449)

## Changes

* Updated `@cumulus/db` package and configure knex hook postProcessResponse to convert the return string
    from columns ending with "cumulus_id" to number

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
