### PR TITLE
CUMULUS-3610: Updates aws-client ES client to v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Updated `example/cumulus-tf/orca.tf` to use v9.0.4
 - **CUMULUS-3527**
   - Added suppport for additional kex algorithms in the sftp-client.
+- **CUMULUS-3610**
+  - WIP: Updating `aws-client` ES code to AWS SDK v3.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - **CUMULUS-3527**
   - Added suppport for additional kex algorithms in the sftp-client.
 - **CUMULUS-3610**
-  - WIP: Updating `aws-client` ES code to AWS SDK v3.
+  - Updated `aws-client`'s ES client to use AWS SDK v3.
 
 ### Fixed
 

--- a/packages/aws-client/package.json
+++ b/packages/aws-client/package.json
@@ -52,6 +52,7 @@
     "@aws-sdk/client-dynamodb-streams": "^3.447.0",
     "@aws-sdk/client-ec2": "^3.447.0",
     "@aws-sdk/client-ecs": "^3.447.0",
+    "@aws-sdk/client-elasticsearch-service": "^3.447.0",
     "@aws-sdk/client-kinesis": "^3.447.0",
     "@aws-sdk/client-kms": "^3.447.0",
     "@aws-sdk/client-lambda": "^3.447.0",

--- a/packages/aws-client/package.json
+++ b/packages/aws-client/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/client-dynamodb-streams": "^3.447.0",
     "@aws-sdk/client-ec2": "^3.447.0",
     "@aws-sdk/client-ecs": "^3.447.0",
-    "@aws-sdk/client-elasticsearch-service": "^3.447.0",
+    "@aws-sdk/client-elasticsearch-service": "^3.529.1",
     "@aws-sdk/client-kinesis": "^3.447.0",
     "@aws-sdk/client-kms": "^3.447.0",
     "@aws-sdk/client-lambda": "^3.447.0",

--- a/packages/aws-client/src/SQS.ts
+++ b/packages/aws-client/src/SQS.ts
@@ -9,13 +9,13 @@ import isObject from 'lodash/isObject';
 import isString from 'lodash/isString';
 import isNil from 'lodash/isNil';
 import { SQSRecord } from 'aws-lambda';
-import { QueueAttributeName } from '@aws-sdk/client-sqs';
+import { Message, QueueAttributeName } from '@aws-sdk/client-sqs';
 
 import { StepFunctionEventBridgeEvent } from './Lambda';
 import { sqs } from './services';
 
 const log = new Logger({ sender: '@cumulus/aws-client/SQS' });
-export interface SQSMessage extends AWS.SQS.Message {
+export interface SQSMessage extends Message {
   ReceiptHandle: string
 }
 

--- a/packages/aws-client/src/services.ts
+++ b/packages/aws-client/src/services.ts
@@ -15,7 +15,7 @@ import { SNS } from '@aws-sdk/client-sns';
 import { STS } from '@aws-sdk/client-sts';
 import { ECS } from '@aws-sdk/client-ecs';
 import { EC2 } from '@aws-sdk/client-ec2';
-import { ElasticsearchServiceClient } from '@aws-sdk/client-elasticsearch-service';
+import { ElasticsearchService } from '@aws-sdk/client-elasticsearch-service';
 
 import awsClient from './client';
 
@@ -31,7 +31,7 @@ export const dynamodbDocClient = (docClientOptions?: TranslateConfig, dynamoOpti
     docClientOptions
   );
 export const cf = awsClient(CloudFormation, '2010-05-15');
-export const es = awsClient(ElasticsearchServiceClient, '2015-01-01');
+export const es = awsClient(ElasticsearchService, '2015-01-01');
 export const kinesis = awsClient(Kinesis, '2013-12-02');
 export const kms = awsClient(KMS, '2014-11-01');
 export const lambda = awsClient(Lambda, '2015-03-31');

--- a/packages/aws-client/src/services.ts
+++ b/packages/aws-client/src/services.ts
@@ -15,7 +15,7 @@ import { SNS } from '@aws-sdk/client-sns';
 import { STS } from '@aws-sdk/client-sts';
 import { ECS } from '@aws-sdk/client-ecs';
 import { EC2 } from '@aws-sdk/client-ec2';
-import * as AWS from 'aws-sdk';
+import { ElasticsearchServiceClient } from '@aws-sdk/client-elasticsearch-service';
 
 import awsClient from './client';
 
@@ -31,7 +31,7 @@ export const dynamodbDocClient = (docClientOptions?: TranslateConfig, dynamoOpti
     docClientOptions
   );
 export const cf = awsClient(CloudFormation, '2010-05-15');
-export const es = awsClient(AWS.ES, '2015-01-01');
+export const es = awsClient(ElasticsearchServiceClient, '2015-01-01');
 export const kinesis = awsClient(Kinesis, '2013-12-02');
 export const kms = awsClient(KMS, '2014-11-01');
 export const lambda = awsClient(Lambda, '2015-03-31');

--- a/packages/aws-client/src/test-utils.ts
+++ b/packages/aws-client/src/test-utils.ts
@@ -16,7 +16,7 @@ const localStackPorts = {
   DynamoDBStreamsClient: 4566,
   EC2: 4566,
   ECS: 4566,
-  ElasticsearchServiceClient: 4566,
+  ElasticsearchService: 4566,
   firehose: 4566,
   iam: 4566,
   Kinesis: 4566,

--- a/packages/aws-client/src/test-utils.ts
+++ b/packages/aws-client/src/test-utils.ts
@@ -16,7 +16,7 @@ const localStackPorts = {
   DynamoDBStreamsClient: 4566,
   EC2: 4566,
   ECS: 4566,
-  es: 4566,
+  ElasticsearchServiceClient: 4566,
   firehose: 4566,
   iam: 4566,
   Kinesis: 4566,

--- a/packages/aws-client/src/types.ts
+++ b/packages/aws-client/src/types.ts
@@ -7,6 +7,7 @@ import { DynamoDBStreamsClient } from '@aws-sdk/client-dynamodb-streams';
 import { DynamoDB, DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { EC2 } from '@aws-sdk/client-ec2';
 import { ECS } from '@aws-sdk/client-ecs';
+import { ElasticsearchServiceClient } from '@aws-sdk/client-elasticsearch-service';
 import { Kinesis } from '@aws-sdk/client-kinesis';
 import { KMS } from '@aws-sdk/client-kms';
 import { Lambda } from '@aws-sdk/client-lambda';
@@ -25,6 +26,7 @@ export type AWSClientTypes =
     Lambda |
     ECS |
     EC2 |
+    ElasticsearchServiceClient |
     S3 |
     SecretsManager |
     SFN |

--- a/packages/aws-client/src/types.ts
+++ b/packages/aws-client/src/types.ts
@@ -7,7 +7,7 @@ import { DynamoDBStreamsClient } from '@aws-sdk/client-dynamodb-streams';
 import { DynamoDB, DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { EC2 } from '@aws-sdk/client-ec2';
 import { ECS } from '@aws-sdk/client-ecs';
-import { ElasticsearchServiceClient } from '@aws-sdk/client-elasticsearch-service';
+import { ElasticsearchService } from '@aws-sdk/client-elasticsearch-service';
 import { Kinesis } from '@aws-sdk/client-kinesis';
 import { KMS } from '@aws-sdk/client-kms';
 import { Lambda } from '@aws-sdk/client-lambda';
@@ -26,7 +26,7 @@ export type AWSClientTypes =
     Lambda |
     ECS |
     EC2 |
-    ElasticsearchServiceClient |
+    ElasticsearchService |
     S3 |
     SecretsManager |
     SFN |

--- a/packages/aws-client/tests/test-services.js
+++ b/packages/aws-client/tests/test-services.js
@@ -6,7 +6,7 @@ const { CloudFormation } = require('@aws-sdk/client-cloudformation');
 const { DynamoDB } = require('@aws-sdk/client-dynamodb');
 const { ECS } = require('@aws-sdk/client-ecs');
 const { EC2 } = require('@aws-sdk/client-ec2');
-const { ElasticsearchServiceClient } = require('@aws-sdk/client-elasticsearch-service');
+const { ElasticsearchService } = require('@aws-sdk/client-elasticsearch-service');
 const { Kinesis } = require('@aws-sdk/client-kinesis');
 const { Lambda } = require('@aws-sdk/client-lambda');
 const { S3 } = require('@aws-sdk/client-s3');
@@ -193,7 +193,7 @@ test('es() service defaults to localstack in test mode', async (t) => {
   const {
     credentials,
     endpoint,
-  } = localStackAwsClientOptions(ElasticsearchServiceClient);
+  } = localStackAwsClientOptions(ElasticsearchService);
   t.deepEqual(
     await es.config.credentials(),
     credentials

--- a/packages/aws-client/tests/test-services.js
+++ b/packages/aws-client/tests/test-services.js
@@ -1,12 +1,12 @@
 const test = require('ava');
 
-const AWS = require('aws-sdk');
 const { APIGatewayClient } = require('@aws-sdk/client-api-gateway');
 const { CloudWatchEvents } = require('@aws-sdk/client-cloudwatch-events');
 const { CloudFormation } = require('@aws-sdk/client-cloudformation');
 const { DynamoDB } = require('@aws-sdk/client-dynamodb');
 const { ECS } = require('@aws-sdk/client-ecs');
 const { EC2 } = require('@aws-sdk/client-ec2');
+const { ElasticsearchServiceClient } = require('@aws-sdk/client-elasticsearch-service');
 const { Kinesis } = require('@aws-sdk/client-kinesis');
 const { Lambda } = require('@aws-sdk/client-lambda');
 const { S3 } = require('@aws-sdk/client-s3');
@@ -188,17 +188,25 @@ test('ec2() service defaults to localstack in test mode', async (t) => {
   );
 });
 
-test('es() service defaults to localstack in test mode', (t) => {
+test('es() service defaults to localstack in test mode', async (t) => {
   const es = services.es();
   const {
     credentials,
     endpoint,
-  } = localStackAwsClientOptions(AWS.ES);
+  } = localStackAwsClientOptions(ElasticsearchServiceClient);
   t.deepEqual(
-    es.config.credentials,
+    await es.config.credentials(),
     credentials
   );
-  t.is(es.config.endpoint, endpoint);
+  const esEndpoint = await es.config.endpoint();
+  const localSatckEndpoint = new URL(endpoint);
+  t.like(
+    esEndpoint,
+    {
+      hostname: localSatckEndpoint.hostname,
+      port: Number.parseInt(localSatckEndpoint.port, 10),
+    }
+  );
 });
 
 test('kinesis() service defaults to localstack in test mode', async (t) => {

--- a/packages/tf-inventory/src/inventory.js
+++ b/packages/tf-inventory/src/inventory.js
@@ -81,7 +81,7 @@ async function listAwsResources() {
   ec2Instances = [].concat(...ec2Instances.Reservations.map((e) => e.Instances));
   ec2Instances = ec2Instances.map((inst) => inst.InstanceId);
 
-  let esDomainNames = await es().listDomainNames().promise();
+  let esDomainNames = await es().listDomainNames();
   esDomainNames = esDomainNames.DomainNames.map((e) => e.DomainName);
 
   return {

--- a/packages/tf-inventory/src/inventory.js
+++ b/packages/tf-inventory/src/inventory.js
@@ -81,7 +81,7 @@ async function listAwsResources() {
   ec2Instances = [].concat(...ec2Instances.Reservations.map((e) => e.Instances));
   ec2Instances = ec2Instances.map((inst) => inst.InstanceId);
 
-  let esDomainNames = await es().listDomainNames();
+  let esDomainNames = await es().listDomainNames().promise();
   esDomainNames = esDomainNames.DomainNames.map((e) => e.DomainName);
 
   return {

--- a/packages/tf-inventory/tests/inventory.js
+++ b/packages/tf-inventory/tests/inventory.js
@@ -83,15 +83,13 @@ test.before(() => {
 
   esStub = sinon.stub(es(), 'listDomainNames')
     .returns(
-      (
-        Promise.resolve({
-          DomainNames: [
-            { DomainName: 'cumulus-es5vpc' },
-            { DomainName: 'cumulus-1-es5vpc' },
-            { DomainName: 'cumulus-2-es5vpc' },
-          ],
-        })
-      )
+      Promise.resolve({
+        DomainNames: [
+          { DomainName: 'cumulus-es5vpc' },
+          { DomainName: 'cumulus-1-es5vpc' },
+          { DomainName: 'cumulus-2-es5vpc' },
+        ],
+      })
     );
 });
 

--- a/packages/tf-inventory/tests/inventory.js
+++ b/packages/tf-inventory/tests/inventory.js
@@ -82,17 +82,16 @@ test.before(() => {
     });
 
   esStub = sinon.stub(es(), 'listDomainNames')
-    .returns(
-      (
+    .returns({
+      promise: () =>
         Promise.resolve({
           DomainNames: [
             { DomainName: 'cumulus-es5vpc' },
             { DomainName: 'cumulus-1-es5vpc' },
             { DomainName: 'cumulus-2-es5vpc' },
           ],
-        })
-      )
-    );
+        }),
+    });
 });
 
 test.after.always(() => {

--- a/packages/tf-inventory/tests/inventory.js
+++ b/packages/tf-inventory/tests/inventory.js
@@ -82,16 +82,17 @@ test.before(() => {
     });
 
   esStub = sinon.stub(es(), 'listDomainNames')
-    .returns({
-      promise: () =>
+    .returns(
+      (
         Promise.resolve({
           DomainNames: [
             { DomainName: 'cumulus-es5vpc' },
             { DomainName: 'cumulus-1-es5vpc' },
             { DomainName: 'cumulus-2-es5vpc' },
           ],
-        }),
-    });
+        })
+      )
+    );
 });
 
 test.after.always(() => {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3610: B - Update ES code to AWS SDK v3](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3610)

## Changes

* Updates `aws-client` ES import to use v3 client. Fixes a few small tests that broke.
* This update does not impact `es-client` since that package does not use the `aws-client` elasticsearch module.

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
