### PR TITLE
[CUMULUS-2600]: Update messaging related to CloudFront and API Gateways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **CUMULUS-3600**
+  - Update docs to clarify CloudFront HTTPS DIT requirements.
 - **CUMULUS-2892**
   - Updates `aws-client`'s EC2 client to use AWS SDK v3.
 - **CUMULUS-2896**

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -336,7 +336,7 @@ Consider [the size of your Elasticsearch cluster](#elasticsearch) when configuri
 
 :::tip
 
-Elasticsearch is optional and can be disabled using `include_elasticsearch = false` in your `terraform.tfvars`. Your Cumulus Dashboard will not work without Elasticsearch.
+Elasticsearch is optional and can be disabled using `include_elasticsearch = false` in your `terraform.tfvars`. Your Cumulus Dashboard and endpoints querying Elasticsearch will not work without Elasticsearch.
 
 :::
 
@@ -492,9 +492,9 @@ distribution_redirect_uri = https://abc123.execute-api.us-east-1.amazonaws.com/D
 distribution_url = https://abc123.execute-api.us-east-1.amazonaws.com/DEV/
 ```
 
-:::note
+:::caution
 
-Be sure to copy the redirect URLs because you will need them to update your Earthdata application.
+Cumulus deploys API Gateways for the Archive and Distribution APIs. In production environments these must be behind CloudFront distributions.
 
 :::
 
@@ -511,6 +511,12 @@ Add the two redirect URLs to your EarthData login application by doing the follo
 5. You may delete the placeholder url you used to create the application
 
 If you've lost track of the needed redirect URIs, they can be located on the [API Gateway](https://console.aws.amazon.com/apigateway). Once there, select `<prefix>-archive` and/or `<prefix>-thin-egress-app-EgressGateway`, `Dashboard` and utilizing the base URL at the top of the page that is accompanied by the text `Invoke this API at:`. Make sure to append `/token` for the archive URL and `/login` to the thin egress app URL.
+
+:::caution
+
+In production environments, the API Gateway URLs must be replaced with CloudFront distributions to ensure Data In Transit compliance.
+
+:::
 
 ---
 
@@ -606,6 +612,12 @@ From the S3 Console:
 
 You should be able to visit the Dashboard website at `http://<prefix>-dashboard.s3-website-<region>.amazonaws.com` or find the url
 `<prefix>-dashboard` -> "Properties" -> "Static website hosting" -> "Endpoint" and log in with a user that you had previously configured for access.
+
+:::caution
+
+In production environments, the dashboard must be behind a CloudFront distribution to ensure Data In Transit compliance.
+
+:::
 
 ---
 

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -494,7 +494,7 @@ distribution_url = https://abc123.execute-api.us-east-1.amazonaws.com/DEV/
 
 :::caution
 
-Cumulus deploys API Gateways for the Archive and Distribution APIs. In production environments these must be behind CloudFront distributions.
+Cumulus deploys API Gateways for the Archive and Distribution APIs. In production environments these must be behind CloudFront distributions using HTTPS connections.
 
 :::
 
@@ -514,7 +514,7 @@ If you've lost track of the needed redirect URIs, they can be located on the [AP
 
 :::caution
 
-In production environments, the API Gateway URLs must be replaced with CloudFront distributions to ensure Data In Transit compliance.
+In production environments, the API Gateway URLs must be replaced with CloudFront distributions using HTTPS connections to ensure Data In Transit compliance.
 
 :::
 
@@ -615,7 +615,7 @@ You should be able to visit the Dashboard website at `http://<prefix>-dashboard.
 
 :::caution
 
-In production environments, the dashboard must be behind a CloudFront distribution to ensure Data In Transit compliance.
+In production environments, the dashboard must be behind a CloudFront distributions using an HTTPS connection to ensure Data In Transit compliance.
 
 :::
 

--- a/docs/deployment/cumulus-distribution.md
+++ b/docs/deployment/cumulus-distribution.md
@@ -43,14 +43,14 @@ Although you might have to wait a bit for your Cognito user credentials, the rem
 
 Your Cumulus Distribution URL is used by Cumulus to generate download URLs as part of the granule metadata generated and published to the CMR. For example, a granule download URL will be of the form `<distribution url>/<protected bucket>/<key>` (or `<distribution url>/path/to/file`, if using a custom bucket map, as explained further below).
 
-By default, the value of your distribution URL is the URL of your private Cumulus Distribution API Gateway (the API Gateway named `<prefix>-distribution`, once you deploy the Cumulus Distribution module). Therefore, by default, the generated download URLs are private, and thus inaccessible directly, but there are 2 ways to address this issue (both of which are detailed below): (a) use tunneling (only in development) or (b) put a CloudFront URL in front of your API Gateway (required in production, UAT, and SIT).
+By default, the value of your distribution URL is the URL of your private Cumulus Distribution API Gateway (the API Gateway named `<prefix>-distribution`, once you deploy the Cumulus Distribution module). Therefore, by default, the generated download URLs are private, and thus inaccessible directly, but there are 2 ways to address this issue (both of which are detailed below): (a) use tunneling (only in development) or (b) put an HTTPS CloudFront URL in front of your API Gateway (required in production, UAT, and SIT).
 
 In either case, you must first know the default URL (i.e., the URL for the private Cumulus Distribution API Gateway). In order to obtain this default URL, you must first deploy your `cumulus-tf` module with the new Cumulus Distribution module, and once your initial deployment is complete, one of the Terraform outputs will be `cumulus_distribution_api_uri`, which is the URL for the private API Gateway.
 
 You may override this default URL by adding a `cumulus_distribution_url` variable to your `cumulus-tf/terraform.tfvars` file and setting it to one of the following values (both are explained below):
 
 1. The default URL, but with a port added to it, in order to allow you to configure tunneling (only in development)
-2. A CloudFront URL placed in front of your Cumulus Distribution API Gateway (required in production environments)
+2. An HTTPS CloudFront URL placed in front of your Cumulus Distribution API Gateway (required in production environments)
 
 The following subsections explain these approaches in turn.
 

--- a/docs/deployment/cumulus-distribution.md
+++ b/docs/deployment/cumulus-distribution.md
@@ -43,14 +43,14 @@ Although you might have to wait a bit for your Cognito user credentials, the rem
 
 Your Cumulus Distribution URL is used by Cumulus to generate download URLs as part of the granule metadata generated and published to the CMR. For example, a granule download URL will be of the form `<distribution url>/<protected bucket>/<key>` (or `<distribution url>/path/to/file`, if using a custom bucket map, as explained further below).
 
-By default, the value of your distribution URL is the URL of your private Cumulus Distribution API Gateway (the API Gateway named `<prefix>-distribution`, once you deploy the Cumulus Distribution module). Therefore, by default, the generated download URLs are private, and thus inaccessible directly, but there are 2 ways to address this issue (both of which are detailed below): (a) use tunneling (typically in development) or (b) put a CloudFront URL in front of your API Gateway (typically in production, and perhaps UAT and/or SIT).
+By default, the value of your distribution URL is the URL of your private Cumulus Distribution API Gateway (the API Gateway named `<prefix>-distribution`, once you deploy the Cumulus Distribution module). Therefore, by default, the generated download URLs are private, and thus inaccessible directly, but there are 2 ways to address this issue (both of which are detailed below): (a) use tunneling (only in development) or (b) put a CloudFront URL in front of your API Gateway (required in production, UAT, and SIT).
 
 In either case, you must first know the default URL (i.e., the URL for the private Cumulus Distribution API Gateway). In order to obtain this default URL, you must first deploy your `cumulus-tf` module with the new Cumulus Distribution module, and once your initial deployment is complete, one of the Terraform outputs will be `cumulus_distribution_api_uri`, which is the URL for the private API Gateway.
 
 You may override this default URL by adding a `cumulus_distribution_url` variable to your `cumulus-tf/terraform.tfvars` file and setting it to one of the following values (both are explained below):
 
-1. The default URL, but with a port added to it, in order to allow you to configure tunneling (typically only in development)
-2. A CloudFront URL placed in front of your Cumulus Distribution API Gateway (typically only for Production, but perhaps also for a UAT or SIT environment)
+1. The default URL, but with a port added to it, in order to allow you to configure tunneling (only in development)
+2. A CloudFront URL placed in front of your Cumulus Distribution API Gateway (required in production environments)
 
 The following subsections explain these approaches in turn.
 
@@ -172,7 +172,7 @@ While this is a relatively lengthy process, things are much easier when using Cl
 
 ### Using a CloudFront URL as Your Distribution URL
 
-In Production (OPS), and perhaps in other environments, such as UAT and SIT, you'll need to provide a publicly accessible URL for users to use for downloading (distributing) granule files.
+In Production (OPS), and in other environments, such as UAT and SIT, you'll need to provide a publicly accessible URL for users to use for downloading (distributing) granule files.
 
 This is generally done by placing a CloudFront URL in front of your private Cumulus Distribution API Gateway. In order to create such a CloudFront URL, contact the person who helped you obtain your Cognito credentials, and request a CloudFront URL with the following details:
 

--- a/example/cumulus-tf/terraform.tfvars.example
+++ b/example/cumulus-tf/terraform.tfvars.example
@@ -77,6 +77,7 @@ deploy_cumulus_distribution = true
 
 # Optional. Uncomment if using Cumulus Distribution.
 # toggle this after deployed to put the correct port in. (and hosts and config)
+# Once tested with API Gateway, update to use a CloudFront distribution
 # cumulus_distribution_url = "cumulus distribution url"
 
 # Optional. Uncomment if using TEA.

--- a/example/cumulus-tf/terraform.tfvars.example
+++ b/example/cumulus-tf/terraform.tfvars.example
@@ -77,7 +77,7 @@ deploy_cumulus_distribution = true
 
 # Optional. Uncomment if using Cumulus Distribution.
 # toggle this after deployed to put the correct port in. (and hosts and config)
-# Once tested with API Gateway, update to use a CloudFront distribution
+# Once tested with API Gateway, update to use a CloudFront distribution with an HTTPS connection
 # cumulus_distribution_url = "cumulus distribution url"
 
 # Optional. Uncomment if using TEA.

--- a/tf-modules/distribution/README.md
+++ b/tf-modules/distribution/README.md
@@ -19,7 +19,7 @@ Credentials Endpoint with a configuration targeted at Cumulus and NGAP.
 - **api_gateway_stage** (string) - The API Gateway stage to create, defaults to `DEV`
 - **cmr_provider** (string) - The provider used to search CMR ACLs, defaults to `null`
 - **deploy_s3_credentials_endpoint** - (bool) Option to deploy the s3 credentials endpoint, defaults to `true`
-- **distribution_url** (string) - An alternative URL used for distribution
+- **distribution_url** (string) - An alternative URL (e.g. CloudFront URL) used for distribution
 - **permissions_boundary_arn** (string) - The ARN of an IAM permissions boundary to use when creating IAM policies
 - **protected_buckets** (list(string)) - A list of protected buckets
 - **public_buckets** (list(string)) - A list of public buckets


### PR DESCRIPTION
This is a doc-only update to ensure we're pointing users towards CloudFront distributions over API Gateways. 

https://bugs.earthdata.nasa.gov/browse/CUMULUS-3600