### PR TITLE
CUMULUS-3617: Add lambdas to migrate DLA messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - The updates in CUMULUS-3449 requires manual update to postgres database in production environment. Please follow
   [Update Cumulus_id Type and Indexes](https://nasa.github.io/cumulus/docs/next/upgrade-notes/update-cumulus_id-type-indexes-CUMULUS-3449)
 
+- CUMULUS-3617 Instructions for migrating old DLA (Dead Letter Archive) messages to `YYYY-MM-DD` subfolder of S3 dead letter archive:
+To invoke the Lambda and start the DLA migration, you can use the AWS Console or CLI:
+
+```bash
+aws lambda invoke --function-name $PREFIX-migrationHelperAsyncOperation \
+  --payload $(echo '{"operationType": "DLA Migration"}' | base64) $OUTFILE
+```
+- `PREFIX` is your Cumulus deployment prefix.
+- `OUTFILE` (**optional**) is the filepath where the Lambda output will be saved.
+
+The Lambda will trigger an Async Operation and return an `id` such as:
+
+```json
+{"id":"41c9fbbf-a031-4dd8-91cc-8ec2d8b5e31a","description":"Migrate Dead Letter Archive Messages",
+"operationType":"DLA Migration","status":"RUNNING",
+"taskArn":"arn:aws:ecs:us-east-1:AWSID:task/$PREFIX-CumulusECSCluster/123456789"}
+```
+
+which you can then query the Async Operations [API Endpoint](https://nasa.github.io/cumulus-api/#retrieve-async-operation) for
+the output or status of your request. If you want to directly observe the progress of the migration as it runs, you can view
+the CloudWatch logs for your async operations (e.g. `PREFIX-AsyncOperationEcsLogs`).
+
 ### Breaking Changes
 
 - **CUMULUS-2889**
@@ -93,6 +115,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Added suppport for additional kex algorithms in the sftp-client.
 - **CUMULUS-3610**
   - Updated `aws-client`'s ES client to use AWS SDK v3.
+- **CUMULUS-3617**
+  - Added lambdas to migrate DLA messages to `YYYY-MM-DD` subfolder
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,22 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Migration Notes
 
+#### CUMULUS-3449 Please follow instructions before upgrading Cumulus.
+
 - The updates in CUMULUS-3449 requires manual update to postgres database in production environment. Please follow
   [Update Cumulus_id Type and Indexes](https://nasa.github.io/cumulus/docs/next/upgrade-notes/update-cumulus_id-type-indexes-CUMULUS-3449)
 
-- CUMULUS-3617 Instructions for migrating old DLA (Dead Letter Archive) messages to `YYYY-MM-DD` subfolder of S3 dead letter archive:
+#### CUMULUS-3617 Migration of DLA messages should be performed after Cumulus is upgraded.
+
+Instructions for migrating old DLA (Dead Letter Archive) messages to `YYYY-MM-DD` subfolder of S3 dead letter archive:
+
 To invoke the Lambda and start the DLA migration, you can use the AWS Console or CLI:
 
 ```bash
 aws lambda invoke --function-name $PREFIX-migrationHelperAsyncOperation \
   --payload $(echo '{"operationType": "DLA Migration"}' | base64) $OUTFILE
 ```
+
 - `PREFIX` is your Cumulus deployment prefix.
 - `OUTFILE` (**optional**) is the filepath where the Lambda output will be saved.
 
@@ -117,6 +123,7 @@ the CloudWatch logs for your async operations (e.g. `PREFIX-AsyncOperationEcsLog
   - Updated `aws-client`'s ES client to use AWS SDK v3.
 - **CUMULUS-3617**
   - Added lambdas to migrate DLA messages to `YYYY-MM-DD` subfolder
+  - Updated `@cumulus/aws-client/S3/recursivelyDeleteS3Bucket` to handle bucket with more than 1000 objects.
 
 ### Fixed
 

--- a/lambdas/dla-migration/.nycrc.json
+++ b/lambdas/dla-migration/.nycrc.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../nyc.config.js",
   "lines": 98.0,
-  "branches": 98.0,
+  "branches": 84.0,
   "statements": 98.0,
   "functions": 98.0
 }

--- a/lambdas/dla-migration/.nycrc.json
+++ b/lambdas/dla-migration/.nycrc.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../nyc.config.js",
   "lines": 98.0,
-  "branches": 84.0,
+  "branches": 83.0,
   "statements": 98.0,
   "functions": 98.0
 }

--- a/lambdas/dla-migration/README.md
+++ b/lambdas/dla-migration/README.md
@@ -1,0 +1,3 @@
+# Dead Letter Archive Migration Lambda
+
+This lambda migrates DLA messages to <date> subfolder based on the event time.

--- a/lambdas/dla-migration/iam.tf
+++ b/lambdas/dla-migration/iam.tf
@@ -1,0 +1,68 @@
+data "aws_iam_policy_document" "dla_migration_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_security_group" "dla_migration" {
+  count = length(var.lambda_subnet_ids) == 0 ? 0 : 1
+
+  name   = "${var.prefix}-dla-migration"
+  vpc_id = var.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = var.tags
+}
+
+resource "aws_iam_role" "dla_migration_role" {
+  name                 = "${var.prefix}-dla-migration"
+  assume_role_policy   = data.aws_iam_policy_document.dla_migration_assume_role_policy.json
+  permissions_boundary = var.permissions_boundary_arn
+  tags                 = var.tags
+}
+
+data "aws_iam_policy_document" "dla_migration_policy" {
+  statement {
+    actions = [
+      "ec2:CreateNetworkInterface",
+      "ec2:DeleteNetworkInterface",
+      "ec2:DescribeNetworkInterfaces",
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:DescribeLogStreams",
+      "logs:PutLogEvents",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "s3:ListBucket*",
+    ]
+    resources = [ "arn:aws:s3:::${var.system_bucket}"]
+  }
+
+  statement {
+    actions = [
+      "s3:GetObject*",
+      "s3:PutObject*",
+    ]
+    resources = [ "arn:aws:s3:::${var.system_bucket}/*"]
+  }
+}
+
+resource "aws_iam_role_policy" "dla_migration" {
+  name   = "${var.prefix}_dla_migration"
+  role   = aws_iam_role.dla_migration_role.id
+  policy = data.aws_iam_policy_document.dla_migration_policy.json
+}

--- a/lambdas/dla-migration/main.tf
+++ b/lambdas/dla-migration/main.tf
@@ -1,0 +1,26 @@
+resource "aws_lambda_function" "dla_migration" {
+  function_name    = "${var.prefix}-dlaMigration"
+  filename         = "${path.module}/dist/lambda.zip"
+  source_code_hash = filebase64sha256("${path.module}/dist/lambda.zip")
+  handler          = "index.handler"
+  role             = var.lambda_processing_role_arn
+  runtime          = "nodejs16.x"
+  timeout          = lookup(var.lambda_timeouts, "dlaMigration", 900)
+  memory_size      = lookup(var.lambda_memory_sizes, "dlaMigration", 512)
+  environment {
+    variables = {
+      stackName        = var.prefix
+      system_bucket    = var.system_bucket
+    }
+  }
+  tags = var.tags
+
+  dynamic "vpc_config" {
+    for_each = length(var.lambda_subnet_ids) == 0 ? [] : [1]
+    content {
+      subnet_ids = var.lambda_subnet_ids
+      security_group_ids = var.security_group_ids
+    }
+  }
+}
+

--- a/lambdas/dla-migration/main.tf
+++ b/lambdas/dla-migration/main.tf
@@ -1,9 +1,12 @@
+locals {
+  lambda_path      = "${path.module}/dist/webpack/lambda.zip"
+}
 resource "aws_lambda_function" "dla_migration" {
   function_name    = "${var.prefix}-dlaMigration"
-  filename         = "${path.module}/dist/lambda.zip"
-  source_code_hash = filebase64sha256("${path.module}/dist/lambda.zip")
+  filename         = local.lambda_path
+  source_code_hash = filebase64sha256(local.lambda_path)
   handler          = "index.handler"
-  role             = var.lambda_processing_role_arn
+  role             = aws_iam_role.dla_migration_role.arn
   runtime          = "nodejs16.x"
   timeout          = lookup(var.lambda_timeouts, "dlaMigration", 900)
   memory_size      = lookup(var.lambda_memory_sizes, "dlaMigration", 512)
@@ -19,7 +22,7 @@ resource "aws_lambda_function" "dla_migration" {
     for_each = length(var.lambda_subnet_ids) == 0 ? [] : [1]
     content {
       subnet_ids = var.lambda_subnet_ids
-      security_group_ids = var.security_group_ids
+      security_group_ids = [aws_security_group.dla_migration[0].id]
     }
   }
 }

--- a/lambdas/dla-migration/outputs.tf
+++ b/lambdas/dla-migration/outputs.tf
@@ -1,0 +1,3 @@
+output "lambda_arn" {
+  value = aws_lambda_function.dla_migration.arn
+}

--- a/lambdas/dla-migration/package.json
+++ b/lambdas/dla-migration/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@cumulus/dla-migration-lambda",
+  "version": "18.2.0",
+  "description": "A Lambda function used for DLA migrations",
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=16.19.0"
+  },
+  "main": "./dist/lambda/index.js",
+  "types": "./dist/lambda/index.d.ts",
+  "private": true,
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "rm -rf dist && mkdir dist && npm run prepare && npm run webpack",
+    "build-lambda-zip": "cd dist/webpack && node ../../../../bin/zip.js lambda.zip index.js",
+    "package": "npm run clean && npm run prepare && npm run webpack && npm run build-lambda-zip",
+    "test": "../../node_modules/.bin/ava",
+    "test:coverage": "../../node_modules/.bin/nyc npm test",
+    "prepare": "npm run tsc",
+    "tsc": "../../node_modules/.bin/tsc",
+    "tsc:listEmittedFiles": "../../node_modules/.bin/tsc --listEmittedFiles",
+    "webpack": "../../node_modules/.bin/webpack"
+  },
+  "dependencies": {
+    "@cumulus/api": "18.2.0"
+  }
+}

--- a/lambdas/dla-migration/package.json
+++ b/lambdas/dla-migration/package.json
@@ -22,6 +22,8 @@
     "webpack": "../../node_modules/.bin/webpack"
   },
   "dependencies": {
-    "@cumulus/api": "18.2.0"
+    "@cumulus/aws-client": "18.2.0",
+    "@cumulus/logger": "18.2.0",
+    "moment": "^2.29.4"
   }
 }

--- a/lambdas/dla-migration/package.json
+++ b/lambdas/dla-migration/package.json
@@ -24,6 +24,8 @@
   "dependencies": {
     "@cumulus/aws-client": "18.2.0",
     "@cumulus/logger": "18.2.0",
-    "moment": "^2.29.4"
+    "lodash": "^4.17.21",
+    "moment": "^2.29.4",
+    "p-map": "^4.0.0"
   }
 }

--- a/lambdas/dla-migration/src/index.ts
+++ b/lambdas/dla-migration/src/index.ts
@@ -1,3 +1,5 @@
+const moment = require('moment');
+const { deleteS3Object, getJsonS3Object, putJsonS3Object, S3ListObjectsV2Queue } = require('@cumulus/aws-client');
 const Logger = require('@cumulus/logger');
 
 const logger = new Logger({ sender: '@cumulus/dla-migration-lambda' });
@@ -10,7 +12,38 @@ export const handler = async (event: HandlerEvent): Promise<void> => {
   const stackName = process.env.stackName;
 
   const dlaPath = event.dlaPath ? event.dlaPath : `${stackName}/dead-letter-archive/sqs/`;
-  logger.info(systemBucket);
-  logger.info(dlaPath);
-  logger.info(JSON.stringify(event));
+  const lastIndexOfDlaPathSeparator = dlaPath.lastIndexOf('/');
+
+  let fileCount = 0;
+  const s3ObjectsQueue = new S3ListObjectsV2Queue({
+    Bucket: systemBucket,
+    Prefix: dlaPath,
+  });
+  /* eslint-disable no-await-in-loop */
+  while (await s3ObjectsQueue.peek()) {
+    const s3Object = await s3ObjectsQueue.shift();
+    logger.info(`About to process ${s3Object}`);
+    // skip directories and files on subfolder
+    if (s3Object.endsWith('.json') && s3Object.lastIndex('/') === lastIndexOfDlaPathSeparator) {
+      const deadLetterMessage = await getJsonS3Object(systemBucket, s3Object);
+      const dateString = deadLetterMessage.time
+        ? moment.utc(deadLetterMessage.time).format('YYYY-MM-DD') : moment.utc().format('YYYY-MM-DD');
+      const destinationKey = `${dlaPath}${dateString}/${s3Object.split('/').pop()}`;
+      await putJsonS3Object(
+        systemBucket,
+        destinationKey,
+        deadLetterMessage
+      );
+      logger.info(`Migrated file from bucket ${systemBucket}/${s3Object} to ${destinationKey}`);
+      await deleteS3Object(
+        systemBucket,
+        s3Object
+      );
+      logger.info(`Deleted file ${systemBucket}/${s3Object}`);
+      fileCount += 1;
+    }
+  }
+  /* eslint-enable no-await-in-loop */
+
+  logger.info(`Completed DLA migration, migrated ${fileCount} files`);
 };

--- a/lambdas/dla-migration/src/index.ts
+++ b/lambdas/dla-migration/src/index.ts
@@ -1,17 +1,22 @@
-const moment = require('moment');
-const { deleteS3Object, getJsonS3Object, putJsonS3Object, S3ListObjectsV2Queue } = require('@cumulus/aws-client');
-const Logger = require('@cumulus/logger');
+import moment from 'moment';
+import { deleteS3Object, getJsonS3Object, putJsonS3Object } from '@cumulus/aws-client/S3';
+import S3ListObjectsV2Queue from '@cumulus/aws-client/S3ListObjectsV2Queue';
+import Logger from '@cumulus/logger';
 
 const logger = new Logger({ sender: '@cumulus/dla-migration-lambda' });
 export interface HandlerEvent {
   dlaPath?: string
 }
 
-export const handler = async (event: HandlerEvent): Promise<void> => {
-  const systemBucket = process.env.system_bucket;
-  const stackName = process.env.stackName;
+export interface HandlerOutput {
+  migrated: number
+}
 
-  const dlaPath = event.dlaPath ? event.dlaPath : `${stackName}/dead-letter-archive/sqs/`;
+export const handler = async (event: HandlerEvent): Promise<HandlerOutput> => {
+  const systemBucket = process.env.system_bucket || '';
+  const stackName = process.env.stackName || '';
+
+  const dlaPath = event.dlaPath ?? `${stackName}/dead-letter-archive/sqs/`;
   const lastIndexOfDlaPathSeparator = dlaPath.lastIndexOf('/');
 
   let fileCount = 0;
@@ -19,31 +24,37 @@ export const handler = async (event: HandlerEvent): Promise<void> => {
     Bucket: systemBucket,
     Prefix: dlaPath,
   });
+
   /* eslint-disable no-await-in-loop */
   while (await s3ObjectsQueue.peek()) {
     const s3Object = await s3ObjectsQueue.shift();
-    logger.info(`About to process ${s3Object}`);
+    const s3ObjectKey = s3Object?.Key;
+
+    logger.info(`About to process ${s3ObjectKey}`);
     // skip directories and files on subfolder
-    if (s3Object.endsWith('.json') && s3Object.lastIndex('/') === lastIndexOfDlaPathSeparator) {
-      const deadLetterMessage = await getJsonS3Object(systemBucket, s3Object);
-      const dateString = deadLetterMessage.time
-        ? moment.utc(deadLetterMessage.time).format('YYYY-MM-DD') : moment.utc().format('YYYY-MM-DD');
-      const destinationKey = `${dlaPath}${dateString}/${s3Object.split('/').pop()}`;
+    if (s3ObjectKey && s3ObjectKey.endsWith('.json') && s3ObjectKey.lastIndexOf('/') === lastIndexOfDlaPathSeparator) {
+      const deadLetterMessage = await getJsonS3Object(systemBucket, s3ObjectKey);
+      const dateString = moment.utc(deadLetterMessage.time).format('YYYY-MM-DD');
+      const destinationKey = `${dlaPath}${dateString}/${s3ObjectKey.split('/').pop()}`;
+
       await putJsonS3Object(
         systemBucket,
         destinationKey,
         deadLetterMessage
       );
-      logger.info(`Migrated file from bucket ${systemBucket}/${s3Object} to ${destinationKey}`);
+      logger.info(`Migrated file from bucket ${systemBucket}/${s3ObjectKey} to ${destinationKey}`);
+
       await deleteS3Object(
         systemBucket,
-        s3Object
+        s3ObjectKey
       );
-      logger.info(`Deleted file ${systemBucket}/${s3Object}`);
+      logger.info(`Deleted file ${systemBucket}/${s3ObjectKey}`);
+
       fileCount += 1;
     }
   }
   /* eslint-enable no-await-in-loop */
 
   logger.info(`Completed DLA migration, migrated ${fileCount} files`);
+  return { migrated: fileCount };
 };

--- a/lambdas/dla-migration/src/index.ts
+++ b/lambdas/dla-migration/src/index.ts
@@ -1,0 +1,16 @@
+const Logger = require('@cumulus/logger');
+
+const logger = new Logger({ sender: '@cumulus/dla-migration-lambda' });
+export interface HandlerEvent {
+  dlaPath?: string
+}
+
+export const handler = async (event: HandlerEvent): Promise<void> => {
+  const systemBucket = process.env.system_bucket;
+  const stackName = process.env.stackName;
+
+  const dlaPath = event.dlaPath ? event.dlaPath : `${stackName}/dead-letter-archive/sqs/`;
+  logger.info(systemBucket);
+  logger.info(dlaPath);
+  logger.info(JSON.stringify(event));
+};

--- a/lambdas/dla-migration/tests/test-index.js
+++ b/lambdas/dla-migration/tests/test-index.js
@@ -1,0 +1,88 @@
+const test = require('ava');
+const cryptoRandomString = require('crypto-random-string');
+const moment = require('moment');
+
+const pMap = require('p-map');
+const range = require('lodash/range');
+const { createBucket, putJsonS3Object, listS3ObjectsV2, recursivelyDeleteS3Bucket } = require('@cumulus/aws-client/S3');
+
+// eslint-disable-next-line unicorn/import-index
+const { handler } = require('../dist/lambda/index');
+
+test.before(async (t) => {
+  t.context.stackName = `stack${cryptoRandomString({ length: 5 })}`;
+  process.env.stackName = t.context.stackName;
+  t.context.systemBucket = `stack${cryptoRandomString({ length: 5 })}`;
+  process.env.system_bucket = t.context.systemBucket;
+  t.context.dlaPath = `${t.context.stackName}/dead-letter-archive/sqs/`;
+  t.context.dlaPath2 = `${t.context.stackName}/dead-letter-archive/sqs2/`;
+
+  await createBucket(process.env.system_bucket);
+  const jsonObjects = range(1005).map((i) => ({
+    key: `${t.context.dlaPath}${cryptoRandomString({ length: 10 })}.json`,
+    body: {
+      time: i % 10 === 0 ? moment.utc().subtract(i, 'days') : undefined,
+      foo: 'bar',
+    },
+  }));
+
+  t.context.expectedJsonObjectKeys = jsonObjects.map((jsonObject) => {
+    const dateString = moment.utc(jsonObject.body.time).format('YYYY-MM-DD');
+    return jsonObject.key.replace(t.context.dlaPath, `${t.context.dlaPath}${dateString}/`);
+  });
+
+  await pMap(
+    jsonObjects,
+    (jsonObject) => putJsonS3Object(t.context.systemBucket, jsonObject.key, jsonObject.body),
+    { concurrency: 10 }
+  );
+
+  const jsonObjects2 = range(15).map((i) => ({
+    key: `${t.context.dlaPath2}${cryptoRandomString({ length: 10 })}.json`,
+    body: {
+      time: i % 10 === 0 ? moment.utc().subtract(i, 'days') : undefined,
+      foo: 'bar',
+    },
+  }));
+
+  t.context.expectedJsonObjectKeys2 = jsonObjects2.map((jsonObject) => {
+    const dateString = moment.utc(jsonObject.body.time).format('YYYY-MM-DD');
+    return jsonObject.key.replace(t.context.dlaPath2, `${t.context.dlaPath2}${dateString}/`);
+  });
+
+  await pMap(
+    jsonObjects2,
+    (jsonObject) => putJsonS3Object(t.context.systemBucket, jsonObject.key, jsonObject.body),
+    { concurrency: 10 }
+  );
+});
+
+test.after.always(async (t) => {
+  await recursivelyDeleteS3Bucket(t.context.systemBucket);
+});
+
+test('handler successfully migrates files', async (t) => {
+  const handlerOutput = await handler({});
+  t.is(handlerOutput.migrated, 1005);
+  const s3list = await listS3ObjectsV2({
+    Bucket: t.context.systemBucket,
+    Prefix: t.context.dlaPath,
+  });
+  t.deepEqual(s3list.map((object) => object.Key).sort(), t.context.expectedJsonObjectKeys.sort());
+
+  const handlerOutput2 = await handler({});
+  t.is(handlerOutput2.migrated, 0);
+});
+
+test('handler successfully migrates files in non-default location when dlaPath is provided', async (t) => {
+  const handlerOutput = await handler({ dlaPath: t.context.dlaPath2 });
+  t.is(handlerOutput.migrated, 15);
+  const s3list = await listS3ObjectsV2({
+    Bucket: t.context.systemBucket,
+    Prefix: t.context.dlaPath2,
+  });
+  t.deepEqual(s3list.map((object) => object.Key).sort(), t.context.expectedJsonObjectKeys2.sort());
+
+  const handlerOutput2 = await handler({ dlaPath: t.context.dlaPath2 });
+  t.is(handlerOutput2.migrated, 0);
+});

--- a/lambdas/dla-migration/tsconfig.json
+++ b/lambdas/dla-migration/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/lambda",
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "removeComments": true
+  },
+  "include": ["src"]
+}

--- a/lambdas/dla-migration/variables.tf
+++ b/lambdas/dla-migration/variables.tf
@@ -10,11 +10,6 @@ variable "system_bucket" {
   type        = string
 }
 
-variable "lambda_processing_role_arn" {
-  description = "Name of IAM role assumed when executing Lambda"
-  type = string
-}
-
 # Optional
 
 variable "lambda_memory_sizes" {
@@ -35,14 +30,19 @@ variable "lambda_subnet_ids" {
   default     = null
 }
 
-variable "security_group_ids" {
-  description = "Security Group IDs for Lambdas"
-  type        = list(string)
-  default     = null
+variable "permissions_boundary_arn" {
+  type    = string
+  description = "Optional permissions boundary for lambda role bounds"
+  default = null
 }
 
 variable "tags" {
   description = "Tags to be applied to Cumulus resources that support tags"
   type        = map(string)
   default     = {}
+}
+
+variable "vpc_id" {
+  type    = string
+  default = null
 }

--- a/lambdas/dla-migration/variables.tf
+++ b/lambdas/dla-migration/variables.tf
@@ -1,0 +1,48 @@
+# Required
+
+variable "prefix" {
+  description = "The unique prefix for your deployment resources"
+  type        = string
+}
+
+variable "system_bucket" {
+  description = "The name of the S3 bucket to be used for staging deployment files"
+  type        = string
+}
+
+variable "lambda_processing_role_arn" {
+  description = "Name of IAM role assumed when executing Lambda"
+  type = string
+}
+
+# Optional
+
+variable "lambda_memory_sizes" {
+  description = "Configurable map of memory sizes for lambdas"
+  type = map(number)
+  default = {}
+}
+
+variable "lambda_timeouts" {
+  description = "Configurable map of timeouts for lambdas"
+  type = map(number)
+  default = {}
+}
+
+variable "lambda_subnet_ids" {
+  description = "Subnet IDs for Lambdas"
+  type        = list(string)
+  default     = null
+}
+
+variable "security_group_ids" {
+  description = "Security Group IDs for Lambdas"
+  type        = list(string)
+  default     = null
+}
+
+variable "tags" {
+  description = "Tags to be applied to Cumulus resources that support tags"
+  type        = map(string)
+  default     = {}
+}

--- a/lambdas/dla-migration/versions.tf
+++ b/lambdas/dla-migration/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+  required_version = ">= 1.5"
+}

--- a/lambdas/dla-migration/webpack.config.js
+++ b/lambdas/dla-migration/webpack.config.js
@@ -1,44 +1,19 @@
 const path = require('path');
-// path to module root
-const root = path.resolve(__dirname);
 
 module.exports = {
-  mode: process.env.PRODUCTION ? 'production' : 'development',
-  entry: './src/index.js',
+  mode: 'production',
+  entry: './dist/lambda/index.js',
   output: {
     chunkFormat: false,
     libraryTarget: 'commonjs2',
-    filename: 'index.js',
-    path: path.resolve(__dirname, 'dist'),
-    devtoolModuleFilenameTemplate: (info) => {
-      const relativePath = path.relative(root, info.absoluteResourcePath)
-      return `webpack://${relativePath}`;
-    }
+    path: path.resolve(__dirname, 'dist', 'webpack'),
+    filename: 'index.js'
   },
-  externals: [
-    'aws-sdk',
-    'electron',
-    {'formidable': 'url'}
-  ],
-  module: {
-    rules: [
-      {
-        test: /\.js$/,
-        exclude: /node_modules/,
-        use: [
-          {
-            loader: 'babel-loader',
-            options: {
-              cacheDirectory: true
-            },
-          },
-        ],
-      },
-    ],
-  },
-  devtool: 'inline-source-map',
+  externals: ['aws-sdk'],
   target: 'node',
+  devtool: 'eval-cheap-module-source-map',
   optimization: {
     nodeEnv: false
   }
 };
+

--- a/lambdas/dla-migration/webpack.config.js
+++ b/lambdas/dla-migration/webpack.config.js
@@ -1,0 +1,44 @@
+const path = require('path');
+// path to module root
+const root = path.resolve(__dirname);
+
+module.exports = {
+  mode: process.env.PRODUCTION ? 'production' : 'development',
+  entry: './src/index.js',
+  output: {
+    chunkFormat: false,
+    libraryTarget: 'commonjs2',
+    filename: 'index.js',
+    path: path.resolve(__dirname, 'dist'),
+    devtoolModuleFilenameTemplate: (info) => {
+      const relativePath = path.relative(root, info.absoluteResourcePath)
+      return `webpack://${relativePath}`;
+    }
+  },
+  externals: [
+    'aws-sdk',
+    'electron',
+    {'formidable': 'url'}
+  ],
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              cacheDirectory: true
+            },
+          },
+        ],
+      },
+    ],
+  },
+  devtool: 'inline-source-map',
+  target: 'node',
+  optimization: {
+    nodeEnv: false
+  }
+};

--- a/lambdas/migration-helper-async-operation/.nycrc.json
+++ b/lambdas/migration-helper-async-operation/.nycrc.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../nyc.config.js",
+  "lines": 97.0,
+  "branches": 85.0,
+  "statements": 97.0,
+  "functions": 97.0
+}

--- a/lambdas/migration-helper-async-operation/README.md
+++ b/lambdas/migration-helper-async-operation/README.md
@@ -1,0 +1,12 @@
+# Migration Helper Async Operation Lambda
+
+This lambda invokes an asynchronous operation which starts an ECS task to run the lambda
+based on the operationType.
+
+To invoke the lambda, you can use the AWS Console or CLI:
+
+```shell
+aws lambda invoke --function-name ${PREFIX}-migrationHelperAsyncOperation --payload $(echo '{"operationType": "DLA Migration"}' | base64) $OUTFILE
+```
+
+where `${PREFIX}` is your Cumulus deployment prefix.

--- a/lambdas/migration-helper-async-operation/iam.tf
+++ b/lambdas/migration-helper-async-operation/iam.tf
@@ -1,0 +1,90 @@
+data "aws_iam_policy_document" "migration_async_operation_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_security_group" "migration_helper_async_operation" {
+  count = length(var.lambda_subnet_ids) == 0 ? 0 : 1
+
+  name   = "${var.prefix}-migration-helper-async-operation"
+  vpc_id = var.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = var.tags
+}
+
+resource "aws_iam_role" "migration_helper_async_operation_role" {
+  name                 = "${var.prefix}-migration_helper_async_operation"
+  assume_role_policy   = data.aws_iam_policy_document.migration_async_operation_assume_role_policy.json
+  permissions_boundary = var.permissions_boundary_arn
+  tags                 = var.tags
+}
+
+data "aws_iam_policy_document" "migration_helper_async_operation_policy" {
+  statement {
+    actions = [
+      "ecs:RunTask",
+      "ec2:CreateNetworkInterface",
+      "ec2:DeleteNetworkInterface",
+      "ec2:DescribeNetworkInterfaces",
+      "lambda:GetFunctionConfiguration",
+      "lambda:invokeFunction",
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:DescribeLogStreams",
+      "logs:PutLogEvents",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "s3:GetBucket*",
+    ]
+    resources = [ "arn:aws:s3:::${var.system_bucket}/*"]
+  }
+
+  statement {
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:GetObject*",
+      "s3:PutObject*",
+      "s3:ListMultipartUploadParts",
+    ]
+    resources = [ "arn:aws:s3:::${var.system_bucket}/*"]
+  }
+
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
+      var.rds_user_access_secret_arn
+    ]
+  }
+
+  statement {
+    actions = [
+      "iam:PassRole"
+    ]
+    resources = [
+      var.ecs_execution_role_arn,
+      var.ecs_task_role_arn
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "migration_helper_async_operation" {
+  name   = "${var.prefix}_migration_helper_async_operation"
+  role   = aws_iam_role.migration_helper_async_operation_role.id
+  policy = data.aws_iam_policy_document.migration_helper_async_operation_policy.json
+}

--- a/lambdas/migration-helper-async-operation/main.tf
+++ b/lambdas/migration-helper-async-operation/main.tf
@@ -1,0 +1,43 @@
+locals {
+  lambda_path      = "${path.module}/dist/webpack/lambda.zip"
+  all_bucket_names = [for k, v in var.buckets : v.name]
+}
+resource "aws_lambda_function" "migration-helper-async-operation" {
+  function_name    = "${var.prefix}-migration-helper-async-operation"
+  role             = aws_iam_role.postgres_migration_async_operation_role.arn
+  filename         = local.lambda_path
+  source_code_hash = filebase64sha256(local.lambda_path)
+  handler          = "index.handler"
+  runtime          = "nodejs16.x"
+  timeout          = 300
+  memory_size      = 512
+
+  environment {
+    variables = {
+      acquireTimeoutMillis         = var.rds_connection_timing_configuration.acquireTimeoutMillis
+      AsyncOperationTaskDefinition = var.async_operation_task_definition_arn
+      createRetryIntervalMillis    = var.rds_connection_timing_configuration.createRetryIntervalMillis
+      createTimeoutMillis          = var.rds_connection_timing_configuration.createTimeoutMillis
+      databaseCredentialSecretArn  = var.rds_user_access_secret_arn
+      EcsCluster                   = var.ecs_cluster_name
+      ES_HOST                      = var.elasticsearch_hostname
+      idleTimeoutMillis            = var.rds_connection_timing_configuration.idleTimeoutMillis
+      DLAMigrationLambda           = var.dla_migration_function_arn
+      reapIntervalMillis           = var.rds_connection_timing_configuration.reapIntervalMillis
+      stackName                    = var.prefix
+      system_bucket                = var.system_bucket
+    }
+  }
+
+  dynamic "vpc_config" {
+    for_each = length(var.lambda_subnet_ids) == 0 ? [] : [1]
+    content {
+      subnet_ids = var.lambda_subnet_ids
+      security_group_ids = compact([
+        aws_security_group.migration_helper_async_operation[0].id,
+        var.rds_security_group_id,
+        var.elasticsearch_security_group_id
+      ])
+    }
+  }
+}

--- a/lambdas/migration-helper-async-operation/main.tf
+++ b/lambdas/migration-helper-async-operation/main.tf
@@ -1,10 +1,9 @@
 locals {
   lambda_path      = "${path.module}/dist/webpack/lambda.zip"
-  all_bucket_names = [for k, v in var.buckets : v.name]
 }
-resource "aws_lambda_function" "migration-helper-async-operation" {
-  function_name    = "${var.prefix}-migration-helper-async-operation"
-  role             = aws_iam_role.postgres_migration_async_operation_role.arn
+resource "aws_lambda_function" "migration_helper_async_operation" {
+  function_name    = "${var.prefix}-migrationHelperAsyncOperation"
+  role             = aws_iam_role.migration_helper_async_operation_role.arn
   filename         = local.lambda_path
   source_code_hash = filebase64sha256(local.lambda_path)
   handler          = "index.handler"
@@ -22,7 +21,7 @@ resource "aws_lambda_function" "migration-helper-async-operation" {
       EcsCluster                   = var.ecs_cluster_name
       ES_HOST                      = var.elasticsearch_hostname
       idleTimeoutMillis            = var.rds_connection_timing_configuration.idleTimeoutMillis
-      DLAMigrationLambda           = var.dla_migration_function_arn
+      DlaMigrationLambda           = var.dla_migration_function_arn
       reapIntervalMillis           = var.rds_connection_timing_configuration.reapIntervalMillis
       stackName                    = var.prefix
       system_bucket                = var.system_bucket

--- a/lambdas/migration-helper-async-operation/main.tf
+++ b/lambdas/migration-helper-async-operation/main.tf
@@ -8,8 +8,8 @@ resource "aws_lambda_function" "migration_helper_async_operation" {
   source_code_hash = filebase64sha256(local.lambda_path)
   handler          = "index.handler"
   runtime          = "nodejs16.x"
-  timeout          = 300
-  memory_size      = 512
+  timeout          = lookup(var.lambda_timeouts, "migrationHelperAsyncOperation", 300)
+  memory_size      = lookup(var.lambda_memory_sizes, "migrationHelperAsyncOperation", 512)
 
   environment {
     variables = {

--- a/lambdas/migration-helper-async-operation/outputs.tf
+++ b/lambdas/migration-helper-async-operation/outputs.tf
@@ -1,0 +1,3 @@
+output "lambda_arn" {
+  value = aws_lambda_function.migration_helper_async_operation.arn
+}

--- a/lambdas/migration-helper-async-operation/package.json
+++ b/lambdas/migration-helper-async-operation/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@cumulus/migration-helper-async-operation",
+  "version": "18.2.0",
+  "description": "Lambda function helps with various migrations",
+  "author": "Cumulus Authors",
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=16.19.0"
+  },
+  "private": true,
+  "main": "./dist/lambda/index.js",
+  "types": "./dist/lambda/index.d.ts",
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "rm -rf dist && mkdir dist && npm run prepare && npm run webpack",
+    "build-lambda-zip": "cd dist/webpack && node ../../../../bin/zip.js lambda.zip index.js",
+    "package": "npm run clean && npm run prepare && npm run webpack && npm run build-lambda-zip",
+    "test": "../../node_modules/.bin/ava",
+    "test:coverage": "../../node_modules/.bin/nyc npm test",
+    "prepare": "npm run tsc",
+    "tsc": "../../node_modules/.bin/tsc",
+    "tsc:listEmittedFiles": "../../node_modules/.bin/tsc --listEmittedFiles",
+    "webpack": "../../node_modules/.bin/webpack"
+  },
+  "ava": {
+    "files": [
+      "tests/**/*.js"
+    ],
+    "timeout": "15m",
+    "failFast": true
+  },
+  "dependencies": {
+    "@cumulus/api": "18.2.0",
+    "@cumulus/async-operations": "18.2.0",
+    "@cumulus/aws-client": "18.2.0",
+    "@cumulus/common": "18.2.0",
+    "@cumulus/logger": "18.2.0",
+    "@cumulus/types": "18.2.0",
+    "lodash": "^4.17.21"
+  }
+}
+

--- a/lambdas/migration-helper-async-operation/src/index.ts
+++ b/lambdas/migration-helper-async-operation/src/index.ts
@@ -1,0 +1,41 @@
+'use strict';
+
+import Logger from '@cumulus/logger';
+
+import { Context } from 'aws-lambda';
+
+const asyncOperations = require('@cumulus/async-operations');
+
+const logger = new Logger({ sender: '@cumulus/migration-helper-async-operation' });
+
+export interface HandlerEvent {
+  prefix: string,
+  operationType: string
+}
+
+exports.handler = async (event: HandlerEvent, context: Context) => {
+  const { operationType } = event;
+
+  if (!['DLA Migration'].includes(operationType)) {
+    const errorMessage = `${operationType} is not supported`;
+    throw new Error(errorMessage);
+  }
+
+  logger.info('About to start async operation for Migration');
+  const asyncOperation = await asyncOperations.startAsyncOperation({
+    asyncOperationTaskDefinition: process.env.AsyncOperationTaskDefinition,
+    cluster: process.env.EcsCluster,
+    callerLambdaName: context.functionName,
+    description: 'dead-letter-archive Migration',
+    knexConfig: process.env,
+    lambdaName: process.env.DLAMigrationLambda,
+    operationType: 'DLA Migration',
+    payload: event,
+    stackName: process.env.stackName,
+    systemBucket: process.env.system_bucket,
+    useLambdaEnvironmentVariables: true,
+  });
+
+  logger.info(`Started async operation ${asyncOperation.id} for DLA Migration`);
+  return asyncOperation;
+};

--- a/lambdas/migration-helper-async-operation/src/index.ts
+++ b/lambdas/migration-helper-async-operation/src/index.ts
@@ -21,21 +21,21 @@ exports.handler = async (event: HandlerEvent, context: Context) => {
     throw new Error(errorMessage);
   }
 
-  logger.info('About to start async operation for Migration');
+  logger.info(`About to start async operation for ${operationType}`);
   const asyncOperation = await asyncOperations.startAsyncOperation({
     asyncOperationTaskDefinition: process.env.AsyncOperationTaskDefinition,
     cluster: process.env.EcsCluster,
     callerLambdaName: context.functionName,
-    description: 'dead-letter-archive Migration',
+    description: 'Migrate Dead Letter Archive Messages',
     knexConfig: process.env,
-    lambdaName: process.env.DLAMigrationLambda,
-    operationType: 'DLA Migration',
+    lambdaName: process.env.DlaMigrationLambda,
+    operationType,
     payload: event,
     stackName: process.env.stackName,
     systemBucket: process.env.system_bucket,
     useLambdaEnvironmentVariables: true,
   });
 
-  logger.info(`Started async operation ${asyncOperation.id} for DLA Migration`);
+  logger.info(`Started async operation ${asyncOperation.id} for ${operationType}`);
   return asyncOperation;
 };

--- a/lambdas/migration-helper-async-operation/tests/test-index.js
+++ b/lambdas/migration-helper-async-operation/tests/test-index.js
@@ -1,0 +1,69 @@
+const test = require('ava');
+const sinon = require('sinon');
+const cryptoRandomString = require('crypto-random-string');
+const asyncOperations = require('@cumulus/async-operations');
+
+// eslint-disable-next-line unicorn/import-index
+const { handler } = require('../dist/lambda/index');
+
+test.before((t) => {
+  t.context.lambdaName = `lambda${cryptoRandomString({ length: 5 })}`;
+  process.env.DlaMigrationLambda = t.context.lambdaName;
+  t.context.callerLambdaName = `caller${cryptoRandomString({ length: 5 })}`;
+  t.context.cluster = `cluster${cryptoRandomString({ length: 5 })}`;
+  process.env.EcsCluster = t.context.cluster;
+  t.context.asyncOperationTaskDefinition = `async${cryptoRandomString({ length: 5 })}`;
+  process.env.AsyncOperationTaskDefinition = t.context.asyncOperationTaskDefinition;
+  t.context.stackName = `stack${cryptoRandomString({ length: 5 })}`;
+  process.env.stackName = t.context.stackName;
+  t.context.systemBucket = `stack${cryptoRandomString({ length: 5 })}`;
+  process.env.system_bucket = t.context.systemBucket;
+});
+
+test('handler calls startAsyncOperation with the expected parameters', async (t) => {
+  const {
+    asyncOperationTaskDefinition,
+    callerLambdaName,
+    lambdaName,
+    cluster,
+    stackName,
+    systemBucket,
+  } = t.context;
+  const stub = sinon.stub(asyncOperations, 'startAsyncOperation').resolves(1);
+  t.teardown(() => {
+    stub.restore();
+  });
+  const event = {
+    operationType: 'DLA Migration',
+    foo: 'bar',
+  };
+  t.is(await handler(event, { functionName: callerLambdaName }), 1);
+  t.deepEqual(stub.getCall(0).firstArg, {
+    cluster,
+    callerLambdaName,
+    lambdaName,
+    asyncOperationTaskDefinition,
+    description: 'Migrate Dead Letter Archive Messages',
+    operationType: 'DLA Migration',
+    payload: event,
+    stackName,
+    systemBucket,
+    knexConfig: process.env,
+    useLambdaEnvironmentVariables: true,
+  });
+});
+
+test('handler throws error if the operationType is not support', async (t) => {
+  const operationType = 'Unsupported Operation';
+  const {
+    callerLambdaName,
+  } = t.context;
+  const event = {
+    operationType,
+    foo: 'bar',
+  };
+  await t.throwsAsync(
+    handler(event, { functionName: callerLambdaName }),
+    { message: `${operationType} is not supported` }
+  );
+});

--- a/lambdas/migration-helper-async-operation/tsconfig.json
+++ b/lambdas/migration-helper-async-operation/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/lambda",
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": true,
+    "removeComments": true
+  },
+  "include": ["src"],
+}

--- a/lambdas/migration-helper-async-operation/variables.tf
+++ b/lambdas/migration-helper-async-operation/variables.tf
@@ -1,0 +1,83 @@
+variable "async_operation_task_definition_arn" {
+  type = string
+}
+
+variable "buckets" {
+  type    = map(object({ name = string, type = string }))
+  default = {}
+}
+variable "dla_migration_function_arn" {
+  type = string
+}
+
+variable "ecs_cluster_name" {
+  type = string
+}
+
+variable "elasticsearch_hostname" {
+  type = string
+}
+
+variable "elasticsearch_security_group_id" {
+  description = "Security Group ID For Elasticsearch (OpenSearch)"
+}
+
+variable "ecs_execution_role_arn" {
+  description = "ARN of IAM role for initializing ECS tasks"
+  type = string
+}
+
+variable "ecs_task_role_arn" {
+  description = "ARN of IAM role for running ECS tasks"
+  type = string
+}
+
+variable "lambda_subnet_ids" {
+  type    = list(string)
+  default = []
+}
+
+variable "permissions_boundary_arn" {
+  type = string
+}
+
+variable "prefix" {
+  type = string
+}
+variable "rds_connection_timing_configuration" {
+  description = "Cumulus rds connection timeout retry timing object -- these values map to knex.js's internal use of  https://github.com/vincit/tarn.js/ for connection acquisition"
+  type = map(number)
+  default = {
+      acquireTimeoutMillis: 60000
+      createRetryIntervalMillis: 30000,
+      createTimeoutMillis: 20000,
+      idleTimeoutMillis: 1000,
+      reapIntervalMillis: 1000,
+  }
+}
+
+variable "rds_security_group_id" {
+  type = string
+}
+
+variable "rds_user_access_secret_arn" {
+  description = "RDS User Database Login Credential Secret ID"
+  type        = string
+}
+
+variable "system_bucket" {
+  description = "The name of the S3 bucket to be used for staging deployment files"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to be applied to Cumulus resources that support tags"
+  type        = map(string)
+  default     = {}
+}
+
+variable "vpc_id" {
+  type    = string
+  default = null
+}
+

--- a/lambdas/migration-helper-async-operation/variables.tf
+++ b/lambdas/migration-helper-async-operation/variables.tf
@@ -37,6 +37,18 @@ variable "lambda_subnet_ids" {
   default = []
 }
 
+variable "lambda_memory_sizes" {
+  description = "Configurable map of memory sizes for lambdas"
+  type = map(number)
+  default = {}
+}
+
+variable "lambda_timeouts" {
+  description = "Configurable map of timeouts for lambdas"
+  type = map(number)
+  default = {}
+}
+
 variable "permissions_boundary_arn" {
   type = string
 }

--- a/lambdas/migration-helper-async-operation/versions.tf
+++ b/lambdas/migration-helper-async-operation/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+  required_version = ">= 1.5"
+}

--- a/lambdas/migration-helper-async-operation/webpack.config.js
+++ b/lambdas/migration-helper-async-operation/webpack.config.js
@@ -1,0 +1,50 @@
+
+const path = require('path');
+const { IgnorePlugin } = require('webpack');
+
+const ignoredPackages = [
+  'better-sqlite3',
+  'mssql',
+  'mssql/lib/base',
+  'mssql/package.json',
+  'mysql',
+  'mysql2',
+  'oracledb',
+  'pg-native',
+  'pg-query-stream',
+  'sqlite3',
+  'tedious'
+];
+
+module.exports = {
+  plugins: [
+    new IgnorePlugin({
+      resourceRegExp: new RegExp(`^(${ignoredPackages.join('|')})$`)
+    }),
+  ],
+  mode: 'production',
+  entry: './dist/lambda/index.js',
+  output: {
+    chunkFormat: false,
+    libraryTarget: 'commonjs2',
+    filename: 'index.js',
+    path: path.resolve(__dirname, 'dist', 'webpack')
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              cacheDirectory: true
+            },
+          },
+        ],
+      },
+    ],
+  },
+  target: 'node'
+};

--- a/packages/api/lib/schemas.js
+++ b/packages/api/lib/schemas.js
@@ -50,7 +50,7 @@ module.exports.asyncOperation = {
     description: { type: 'string' },
     operationType: {
       type: 'string',
-      enum: ['Data Migration', 'Dead-Letter Processing', 'Migration Count Report', 'ES Index', 'Bulk Granules', 'Bulk Granule Delete', 'Bulk Granule Reingest', 'Kinesis Replay', 'Reconciliation Report', 'SQS Replay'],
+      enum: ['Data Migration', 'Dead-Letter Processing', 'DLA Migration', 'Migration Count Report', 'ES Index', 'Bulk Granules', 'Bulk Granule Delete', 'Bulk Granule Reingest', 'Kinesis Replay', 'Reconciliation Report', 'SQS Replay'],
     },
     output: {
       description: 'The result of the operation, stored as JSON',

--- a/packages/db/src/migrations/20240322161147_alter_async_operations_table_operation_type.ts
+++ b/packages/db/src/migrations/20240322161147_alter_async_operations_table_operation_type.ts
@@ -1,0 +1,47 @@
+import { Knex } from 'knex';
+
+const formatAlterTableEnumSql = (
+  tableName: string,
+  columnName: string,
+  enums: Array<string>
+) => {
+  const constraintName = `${tableName}_${columnName}_check`;
+  return [
+    `ALTER TABLE ${tableName}`,
+    `DROP CONSTRAINT IF EXISTS ${constraintName};`,
+    `ALTER TABLE ${tableName} ADD CONSTRAINT ${constraintName} CHECK (${columnName} = ANY (ARRAY['${enums.join(
+      "'::text, '"
+    )}'::text]));`,
+  ].join('\n');
+};
+
+export const up = async (knex: Knex): Promise<void> => {
+  await knex.raw(formatAlterTableEnumSql('async_operations', 'operation_type', [
+    'ES Index',
+    'Bulk Granules',
+    'Bulk Granule Reingest',
+    'Bulk Granule Delete',
+    'Dead-Letter Processing',
+    'DLA Migration',
+    'Kinesis Replay',
+    'Reconciliation Report',
+    'Data Migration',
+    'SQS Replay',
+  ]));
+};
+
+export const down = async (knex: Knex): Promise<void> => {
+  await knex.raw(
+    formatAlterTableEnumSql('async_operations', 'operation_type', [
+      'ES Index',
+      'Bulk Granules',
+      'Bulk Granule Reingest',
+      'Bulk Granule Delete',
+      'Dead-Letter Processing',
+      'Kinesis Replay',
+      'Reconciliation Report',
+      'Data Migration',
+      'SQS Replay',
+    ])
+  );
+};

--- a/tf-modules/cumulus/dla_migration.tf
+++ b/tf-modules/cumulus/dla_migration.tf
@@ -1,19 +1,14 @@
-module "dla-migration-lambda" {
+module "dla_migration_lambda" {
   source = "../../lambdas/dla-migration"
 
-  prefix = var.prefix
+  prefix              = var.prefix
+  system_bucket       = var.system_bucket
 
-  system_bucket = var.system_bucket
+  lambda_subnet_ids   = var.lambda_subnet_ids
+  lambda_timeouts     = var.lambda_timeouts
+  lambda_memory_sizes = var.lambda_memory_sizes
 
-  lambda_subnet_ids = var.lambda_subnet_ids
-  security_group_ids = [
-    aws_security_group.no_ingress_all_egress[0].id
-  ]
-
-  tags = var.tags
-
-  lambda_processing_role_arn = var.lambda_processing_role_arn
-  lambda_timeouts       = var.lambda_timeouts
-  lambda_memory_sizes   = var.lambda_memory_sizes
+  tags                = var.tags
+  vpc_id              = var.vpc_id
 }
 

--- a/tf-modules/cumulus/dla_migration.tf
+++ b/tf-modules/cumulus/dla_migration.tf
@@ -1,0 +1,19 @@
+module "dla-migration-lambda" {
+  source = "../../lambdas/dla-migration"
+
+  prefix = var.prefix
+
+  system_bucket = var.system_bucket
+
+  lambda_subnet_ids = var.lambda_subnet_ids
+  security_group_ids = [
+    aws_security_group.no_ingress_all_egress[0].id
+  ]
+
+  tags = var.tags
+
+  lambda_processing_role_arn = var.lambda_processing_role_arn
+  lambda_timeouts       = var.lambda_timeouts
+  lambda_memory_sizes   = var.lambda_memory_sizes
+}
+

--- a/tf-modules/cumulus/migration_helper_async_operation.tf
+++ b/tf-modules/cumulus/migration_helper_async_operation.tf
@@ -1,0 +1,31 @@
+module "migration_helper_async_operation" {
+  source = "../../lambdas/migration-helper-async-operation"
+
+  async_operation_task_definition_arn = module.archive.async_operation_task_definition_arn
+
+  buckets                    = var.buckets
+
+  dla_migration_function_arn = module.dla_migration_lambda.lambda_arn
+
+  ecs_cluster_name      = aws_ecs_cluster.default.name
+
+  ecs_execution_role_arn = aws_iam_role.ecs_execution_role.arn
+  ecs_task_role_arn = aws_iam_role.ecs_task_role.arn
+
+  elasticsearch_hostname              = var.elasticsearch_hostname
+  elasticsearch_security_group_id     = var.elasticsearch_security_group_id
+
+  lambda_subnet_ids          = var.lambda_subnet_ids
+
+  prefix                     = var.prefix
+  permissions_boundary_arn   = var.permissions_boundary_arn
+
+  rds_connection_timing_configuration    = var.rds_connection_timing_configuration
+  rds_security_group_id                  = var.rds_security_group
+  rds_user_access_secret_arn             = var.rds_user_access_secret_arn
+
+  system_bucket              = var.system_bucket
+  tags                       = var.tags
+  vpc_id                     = var.vpc_id
+}
+


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3617: Migration for DLA organization by timestamp](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3617)

## Changes

* Added lambdas to migrate DLA messages to `YYYY-MM-DD` subfolder
* Updated `@cumulus/aws-client/S3/recursivelyDeleteS3Bucket` to handle bucket with more than 1000 objects.

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
