### PR TITLE
Limited sqs size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,8 @@ the CloudWatch logs for your async operations (e.g. `PREFIX-AsyncOperationEcsLog
     to granules table
 
 ### Add
-
+- **UnticketedForNow**
+  - sqs messages truncated to max sqs length if necessary
 - **CUMULUS-3614**
   - `tf-modules/monitoring` module now deploys Glue table for querying dead-letter-archive messages.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ the CloudWatch logs for your async operations (e.g. `PREFIX-AsyncOperationEcsLog
     to granules table
 
 ### Add
-- **UnticketedForNow**
+- **CUMULUS-3678**
   - sqs messages truncated to max sqs length if necessary
 - **CUMULUS-3614**
   - `tf-modules/monitoring` module now deploys Glue table for querying dead-letter-archive messages.

--- a/packages/aws-client/tests/test-SQS.js
+++ b/packages/aws-client/tests/test-SQS.js
@@ -102,21 +102,21 @@ test('isSQSRecordLike filters correctly for sqs record shape', (t) => {
   but strictly checking is not compatible with the current use-case*/
 });
 
-test.only('sendSQSMessage truncates oversized messages safely', async (t) => {
+test('sendSQSMessage truncates oversized messages safely', async (t) => {
   const queueName = randomString();
   const queueUrl = await createQueue(queueName);
   const maxLength = 262144;
   const overflowMessage = '0'.repeat(maxLength + 2);
   await sendSQSMessage(queueUrl, overflowMessage);
 
-  let recievedMessage = await receiveSQSMessages(queueUrl, {});
+  let recievedMessage = await receiveSQSMessages(queueUrl);
   let messageBody = recievedMessage[0].Body;
   t.true(messageBody.endsWith('...TruncatedForLength'));
   t.is(messageBody.length, maxLength);
 
   const underflowMessage = '0'.repeat(maxLength);
   await sendSQSMessage(queueUrl, underflowMessage);
-  recievedMessage = await receiveSQSMessages(queueUrl, {});
+  recievedMessage = await receiveSQSMessages(queueUrl);
   messageBody = recievedMessage[0].Body;
 
   t.deepEqual(messageBody, underflowMessage);

--- a/packages/aws-client/tests/test-SQS.js
+++ b/packages/aws-client/tests/test-SQS.js
@@ -12,6 +12,7 @@ const {
   sqsQueueExists,
   sendSQSMessage,
   isSQSRecordLike,
+  receiveSQSMessages,
 } = require('../SQS');
 
 const randomString = () => cryptoRandomString({ length: 10 });
@@ -99,4 +100,16 @@ test('isSQSRecordLike filters correctly for sqs record shape', (t) => {
   /* this is a bare check for body in object.
   body *should* be a string form json object,
   but strictly checking is not compatible with the current use-case*/
+});
+
+test.only('sendSQSMessage truncates oversized messages safely', async (t) => {
+  const queueName = randomString();
+  const queueUrl = await createQueue(queueName);
+  const maxLength = 262144;
+  const overflowMessage = '0'.repeat(maxLength + 2);
+  const a = await sendSQSMessage(queueUrl, overflowMessage);
+  console.log(a);
+  const b = await receiveSQSMessages(queueUrl, {});
+  console.log(b);
+  t.true(true);
 });


### PR DESCRIPTION
prevent possibility of sqs message overflow causing messages to fail. 

Addresses [CUMULUS-3678: limit sqs message size](https://bugs.earthdata.nasa.gov/browse/CUMULUS-XXX)

## Changes

* sqs messages over documented maximum size are truncated to 256kb

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
