### PR TITLE
Add support for configuring EBS volume type for Elasticsearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ the CloudWatch logs for your async operations (e.g. `PREFIX-AsyncOperationEcsLog
   - `tf-modules/monitoring` module now deploys Glue table for querying dead-letter-archive messages.
 - **CUMULUS-3616**
   - Added user guide on querying dead-letter-archive messages using AWS Athena.
+- **CUMULUS-3700**
+  - Added option to configure EBS volume type for Elasticsearch; default remains `gp2`.
 
 ### Changed
 - **CUMULUS-3570**

--- a/tf-modules/data-persistence/elasticsearch.tf
+++ b/tf-modules/data-persistence/elasticsearch.tf
@@ -19,7 +19,7 @@ resource "aws_elasticsearch_domain" "es" {
 
   ebs_options {
     ebs_enabled = true
-    volume_type = "gp2"
+    volume_type = var.elasticsearch_config.volume_type
     volume_size = var.elasticsearch_config.volume_size
   }
 
@@ -94,7 +94,7 @@ resource "aws_elasticsearch_domain" "es_vpc" {
 
   ebs_options {
     ebs_enabled = true
-    volume_type = "gp2"
+    volume_type = var.elasticsearch_config.volume_type
     volume_size = var.elasticsearch_config.volume_size
   }
 

--- a/tf-modules/data-persistence/variables.tf
+++ b/tf-modules/data-persistence/variables.tf
@@ -24,6 +24,7 @@ variable "elasticsearch_config" {
     instance_count = number
     instance_type  = string
     version        = string
+    volume_type    = string
     volume_size    = number
   })
   default = {
@@ -31,6 +32,7 @@ variable "elasticsearch_config" {
     instance_count = 1
     instance_type  = "t2.small.elasticsearch"
     version        = "5.3"
+    volume_type    = "gp2"
     volume_size    = 10
   }
 }


### PR DESCRIPTION
**Summary:** Creation of an Elasticsearch instance in AWS offers an option for specifying the EBS volume type (e.g. `gp2`, `gp3`). Currently Cumulus hard-codes the type to gp2. This PR adds the ability to configure `volume_type`.

Addresses [CUMULUS-3700: Add support for configuring the EBS volume type for Elasticsearch](https://bugs.earthdata.nasa.gov/projects/CUMULUS/issues/CUMULUS-3700)

## Changes

* Updated `elasticsearch.tf` Terraform to support a new `volume_type` variable.

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
