### PR TITLE
Jk/cumulus 3717

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,9 @@ operations (e.g. `PREFIX-AsyncOperationEcsLogs`).
     CommmonJS typescript/webpack clients.
 
 ### Changed
+- **CUMULUS-3717**
+  - Updated dynamic import added in CUMULUS-3433 to be memoized in the ingest
+    pacakge to defend against repeat imports resulting in node errors
 - **CUMULUS-3433**
   - Updated all node.js lambda dependencies to node 20.x/20.12.2
   - Modified `@cumulus/ingest` unit test HTTPs server to accept localhost POST
@@ -204,7 +207,7 @@ operations (e.g. `PREFIX-AsyncOperationEcsLogs`).
     API/etc wholesale
   - Addresses [CVE-2020-36604](https://github.com/advisories/GHSA-c429-5p7v-vgjp)
 - **CUMULUS-3673**
-  - Fixes Granules API so that paths containing a granule and/or collection ID properly URI encode the ID.  
+  - Fixes Granules API so that paths containing a granule and/or collection ID properly URI encode the ID.
 - **Audit Issues**
   - Addressed [CVE-2023-45133](https://github.com/advisories/GHSA-67hx-6x53-jw92) by
     updating babel packages and .babelrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,7 +117,7 @@ operations (e.g. `PREFIX-AsyncOperationEcsLogs`).
 ### Changed
 - **CUMULUS-3717**
   - Updated dynamic import added in CUMULUS-3433 to be memoized in the ingest
-    pacakge to defend against repeat imports resulting in node errors
+    package to defend against repeat imports resulting in node errors
 - **CUMULUS-3433**
   - Updated all node.js lambda dependencies to node 20.x/20.12.2
   - Modified `@cumulus/ingest` unit test HTTPs server to accept localhost POST

--- a/packages/common/importEsm.js
+++ b/packages/common/importEsm.js
@@ -7,6 +7,10 @@ const memoize = require('lodash/memoize');
  * This should be used for importing the non-compat module in to CommonJS TS/webpacked
  * modules.
  *
+ * The method currently memoizes the import as under certain load conditions
+ * this import results in a segfault.   See https://github.com/nodejs/node/issues/35889 and the entire
+ * tree of related isseus for more detials.
+ *
  * @returns {Promise<Function>} A promise that resolves to the 'got' function.
  * @throws {Error} If an error occurs while importing the module.
  */

--- a/packages/common/importEsm.js
+++ b/packages/common/importEsm.js
@@ -1,3 +1,5 @@
+const memoize = require('lodash/memoize');
+
 /**
  * Asynchronously imports the 'got' module.
  *
@@ -8,9 +10,9 @@
  * @returns {Promise<Function>} A promise that resolves to the 'got' function.
  * @throws {Error} If an error occurs while importing the module.
  */
-const importGot = async () => {
+const importGot = memoize(async () => {
   const { default: got } = await import('got');
   return got;
-};
+});
 
 module.exports = { importGot };


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3717](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3717)

- **CUMULUS-3717**
  - Updated dynamic import added in CUMULUS-3433 to be memoized in the ingest
    package to defend against repeat imports resulting in node errors

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
