### PR TITLE
CUMULUS-3670 Develop upgrade/migration process Aurora Serverless v1 to v2

### DIFF
--- a/tf-modules/cumulus-rds-tf/main.tf
+++ b/tf-modules/cumulus-rds-tf/main.tf
@@ -96,7 +96,6 @@ resource "aws_rds_cluster" "cumulus" {
 
   lifecycle {
     ignore_changes = [engine_version]
-    # prevent_destroy = true
   }
 }
 
@@ -107,8 +106,4 @@ resource "aws_rds_cluster_instance" "cumulus" {
   instance_class     = "db.serverless"
   engine             = aws_rds_cluster.cumulus.engine
   engine_version     = aws_rds_cluster.cumulus.engine_version
-
-  lifecycle {
-    # prevent_destroy = true
-  }
 }

--- a/tf-modules/cumulus-rds-tf/main.tf
+++ b/tf-modules/cumulus-rds-tf/main.tf
@@ -96,7 +96,7 @@ resource "aws_rds_cluster" "cumulus" {
 
   lifecycle {
     ignore_changes = [engine_version]
-    prevent_destroy = true
+    # prevent_destroy = true
   }
 }
 
@@ -109,6 +109,6 @@ resource "aws_rds_cluster_instance" "cumulus" {
   engine_version     = aws_rds_cluster.cumulus.engine_version
 
   lifecycle {
-    prevent_destroy = true
+    # prevent_destroy = true
   }
 }


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3670: Develop upgrade/migration process Aurora Serverless v1 to v2](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3670)

## Changes

* remove prevent_destroy to allow automated CI migrations

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
