### PR TITLE
CUMULUS-3717 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,9 @@ operations (e.g. `PREFIX-AsyncOperationEcsLogs`).
     CommmonJS typescript/webpack clients.
 
 ### Changed
+- **CUMULUS-3717**
+  - Updated dynamic import added in CUMULUS-3433 to be memoized in the ingest
+    pacakge to defend against repeat imports resulting in node errors
 - **CUMULUS-3433**
   - Updated all node.js lambda dependencies to node 20.x/20.12.2
   - Modified `@cumulus/ingest` unit test HTTPs server to accept localhost POST
@@ -204,7 +207,7 @@ operations (e.g. `PREFIX-AsyncOperationEcsLogs`).
     API/etc wholesale
   - Addresses [CVE-2020-36604](https://github.com/advisories/GHSA-c429-5p7v-vgjp)
 - **CUMULUS-3673**
-  - Fixes Granules API so that paths containing a granule and/or collection ID properly URI encode the ID.  
+  - Fixes Granules API so that paths containing a granule and/or collection ID properly URI encode the ID.
 - **Audit Issues**
   - Addressed [CVE-2023-45133](https://github.com/advisories/GHSA-67hx-6x53-jw92) by
     updating babel packages and .babelrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,9 +116,7 @@ operations (e.g. `PREFIX-AsyncOperationEcsLogs`).
 
 ### Changed
 - **CUMULUS-3717**
-  - Updated dynamic import added in CUMULUS-3433 to be memoized in the ingest
-    package to defend against repeat imports resulting in node errors
-  - Update `@cumulus/ingest/HttpProviderClient` to use direct-injection test mocks, and remove rewire from unit tests
+  - Update `@cumulus/ingest/HttpProviderClient` to use direct injection test mocks, and remove rewire from unit tests
 - **CUMULUS-3433**
   - Updated all node.js lambda dependencies to node 20.x/20.12.2
   - Modified `@cumulus/ingest` unit test HTTPs server to accept localhost POST

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ operations (e.g. `PREFIX-AsyncOperationEcsLogs`).
 - **CUMULUS-3717**
   - Updated dynamic import added in CUMULUS-3433 to be memoized in the ingest
     package to defend against repeat imports resulting in node errors
+  - Update `@cumulus/ingest/HttpProviderClient` to use direct-injection test mocks, and remove rewire from unit tests
 - **CUMULUS-3433**
   - Updated all node.js lambda dependencies to node 20.x/20.12.2
   - Modified `@cumulus/ingest` unit test HTTPs server to accept localhost POST

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,7 +117,7 @@ operations (e.g. `PREFIX-AsyncOperationEcsLogs`).
 ### Changed
 - **CUMULUS-3717**
   - Updated dynamic import added in CUMULUS-3433 to be memoized in the ingest
-    pacakge to defend against repeat imports resulting in node errors
+    package to defend against repeat imports resulting in node errors
 - **CUMULUS-3433**
   - Updated all node.js lambda dependencies to node 20.x/20.12.2
   - Modified `@cumulus/ingest` unit test HTTPs server to accept localhost POST

--- a/packages/common/importEsm.js
+++ b/packages/common/importEsm.js
@@ -5,10 +5,6 @@
  * This should be used for importing the non-compat module in to CommonJS TS/webpacked
  * modules.
  *
- * The method currently memoizes the import as under certain load conditions
- * this import results in a segfault.   See https://github.com/nodejs/node/issues/35889 and the entire
- * tree of related isseus for more detials.
- *
  * @returns {Promise<Function>} A promise that resolves to the 'got' function.
  * @throws {Error} If an error occurs while importing the module.
  */

--- a/packages/common/importEsm.js
+++ b/packages/common/importEsm.js
@@ -7,6 +7,10 @@ const memoize = require('lodash/memoize');
  * This should be used for importing the non-compat module in to CommonJS TS/webpacked
  * modules.
  *
+ * The method currently memoizes the import as under certain load conditions
+ * this import results in a segfault.   See https://github.com/nodejs/node/issues/35889 and the entire
+ * tree of related isseus for more detials.
+ *
  * @returns {Promise<Function>} A promise that resolves to the 'got' function.
  * @throws {Error} If an error occurs while importing the module.
  */

--- a/packages/common/importEsm.js
+++ b/packages/common/importEsm.js
@@ -1,5 +1,3 @@
-const memoize = require('lodash/memoize');
-
 /**
  * Asynchronously imports the 'got' module.
  *
@@ -14,9 +12,9 @@ const memoize = require('lodash/memoize');
  * @returns {Promise<Function>} A promise that resolves to the 'got' function.
  * @throws {Error} If an error occurs while importing the module.
  */
-const importGot = memoize(async () => {
+const importGot = async () => {
   const { default: got } = await import('got');
   return got;
-});
+};
 
 module.exports = { importGot };

--- a/packages/common/importEsm.js
+++ b/packages/common/importEsm.js
@@ -1,3 +1,5 @@
+const memoize = require('lodash/memoize');
+
 /**
  * Asynchronously imports the 'got' module.
  *
@@ -8,9 +10,9 @@
  * @returns {Promise<Function>} A promise that resolves to the 'got' function.
  * @throws {Error} If an error occurs while importing the module.
  */
-const importGot = async () => {
+const importGot = memoize(async () => {
   const { default: got } = await import('got');
   return got;
-};
+});
 
 module.exports = { importGot };

--- a/packages/ingest/test/test-HttpProviderClient.js
+++ b/packages/ingest/test/test-HttpProviderClient.js
@@ -1,4 +1,4 @@
-/* 'use strict';
+'use strict';
 
 const EventEmitter = require('events');
 const fs = require('fs');
@@ -326,4 +326,4 @@ test.serial('upload() attempts to upload a file', async (t) => {
   readStream.push(null);
   await httpProviderClient.upload({ localPath, uploadPath });
   t.true(nock.isDone());
-}); */
+});

--- a/packages/ingest/test/test-HttpProviderClient.js
+++ b/packages/ingest/test/test-HttpProviderClient.js
@@ -1,4 +1,4 @@
-'use strict';
+/* 'use strict';
 
 const EventEmitter = require('events');
 const fs = require('fs');
@@ -326,4 +326,4 @@ test.serial('upload() attempts to upload a file', async (t) => {
   readStream.push(null);
   await httpProviderClient.upload({ localPath, uploadPath });
   t.true(nock.isDone());
-});
+}); */

--- a/packages/ingest/test/test-HttpProviderClient.js
+++ b/packages/ingest/test/test-HttpProviderClient.js
@@ -4,7 +4,6 @@ const EventEmitter = require('events');
 const fs = require('fs');
 const nock = require('nock');
 const path = require('path');
-const rewire = require('rewire');
 const test = require('ava');
 const { promisify } = require('util');
 const { tmpdir } = require('os');
@@ -18,7 +17,7 @@ const {
 } = require('@cumulus/aws-client/S3');
 const { s3 } = require('@cumulus/aws-client/services');
 const { randomString } = require('@cumulus/common/test-utils');
-const HttpProviderClient = rewire('../HttpProviderClient');
+const HttpProviderClient = require('../HttpProviderClient');
 
 const testListWith = (discoverer, event, ...args) => {
   class Crawler extends EventEmitter {
@@ -26,10 +25,9 @@ const testListWith = (discoverer, event, ...args) => {
       this.emit(event, ...args);
     }
   }
+  const crawler = new Crawler();
 
-  return HttpProviderClient.__with__({
-    Crawler,
-  })(() => discoverer.list(''));
+  return discoverer.list('', { crawler });
 };
 
 test.before((t) => {
@@ -163,13 +161,9 @@ test.serial('list() strips path from file names', async (t) => {
       this.emit('fetchcomplete', {}, Buffer.from(responseBody));
     }
   }
-
-  const actualFiles = await HttpProviderClient.__with__({
-    Crawler,
-  })(() => t.context.httpProviderClient.list('/path/to/file/'));
-
+  const crawler = new Crawler();
+  const actualFiles = await t.context.httpProviderClient.list('/path/to/file/', { crawler });
   const expectedFiles = [{ name: 'test.txt', path: '/path/to/file/' }];
-
   t.deepEqual(actualFiles, expectedFiles);
 });
 


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3717(https://bugs.earthdata.nasa.gov/browse/CUMULUS-3717)

- **CUMULUS-3717**
  - Update `@cumulus/ingest/HttpProviderClient` to use direct injection test mocks, and remove rewire from unit tests

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
