### PR TITLE
CUMULUS-3951 - Deploy all SNS topics with encrypted storage 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,9 @@ operations (e.g. `PREFIX-AsyncOperationEcsLogs`).
     CommmonJS typescript/webpack clients.
 
 ### Changed
+- **CUMULUS-3951**
+  - Enable server-side encryption for all SNS topcis deployed by Cumulus Core
+  - Update all integration/unit tests to use encrypted SNS topics
 - **CUMULUS-3433**
   - Updated all node.js lambda dependencies to node 20.x/20.12.2
   - Modified `@cumulus/ingest` unit test HTTPs server to accept localhost POST

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,13 @@ output or status of your request. If you want to directly observe the progress
 of the migration as it runs, you can view the CloudWatch logs for your async
 operations (e.g. `PREFIX-AsyncOperationEcsLogs`).
 
+#### CUMULUS-3951 - SNS topics set to use encrypted storage
+
+As part of the requirements for this ticket Cumulus Core created SNS topics are
+being updated to use server-side encryption with an AWS managed key.    No user
+action is required, this note is being added to increase visibility re: this
+modification.
+
 ### Breaking Changes
 
 - **CUMULUS-3618**

--- a/example/spec/parallel/cnmWorkflow/CnmWorkflowFromSqsSpec.js
+++ b/example/spec/parallel/cnmWorkflow/CnmWorkflowFromSqsSpec.js
@@ -185,7 +185,7 @@ describe('The Cloud Notification Mechanism SQS workflow', () => {
 
       // create SNS topic for cnm response
       const snsTopicName = timestampedName(`${config.stackName}_CnmSqsTestTopic`);
-      const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: snsTopicName }));
+      const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: snsTopicName, KmsMasterKeyId: 'alias/aws/sns' }));
       cnmResponseStream = TopicArn;
       config.cnmResponseStream = cnmResponseStream;
 

--- a/example/spec/parallel/cnmWorkflow/CnmWorkflowFromSqsSpec.js
+++ b/example/spec/parallel/cnmWorkflow/CnmWorkflowFromSqsSpec.js
@@ -7,7 +7,6 @@ const pWaitFor = require('p-wait-for');
 const { createSqsQueues, getSqsQueueMessageCounts } = require('@cumulus/api/lib/testUtils');
 const { sns } = require('@cumulus/aws-client/services');
 const {
-  CreateTopicCommand,
   DeleteTopicCommand,
 } = require('@aws-sdk/client-sns');
 const { getJsonS3Object } = require('@cumulus/aws-client/S3');
@@ -16,6 +15,7 @@ const {
   getQueueUrlByName,
   sendSQSMessage,
 } = require('@cumulus/aws-client/SQS');
+const { createSnsTopic } = require('@cumulus/aws-client/SNS');
 const { deleteExecution } = require('@cumulus/api-client/executions');
 const { getGranule, removePublishedGranule } = require('@cumulus/api-client/granules');
 const { randomId } = require('@cumulus/common/test-utils');
@@ -185,7 +185,7 @@ describe('The Cloud Notification Mechanism SQS workflow', () => {
 
       // create SNS topic for cnm response
       const snsTopicName = timestampedName(`${config.stackName}_CnmSqsTestTopic`);
-      const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: snsTopicName, KmsMasterKeyId: 'alias/aws/sns' }));
+      const { TopicArn } = await createSnsTopic(snsTopicName);
       cnmResponseStream = TopicArn;
       config.cnmResponseStream = cnmResponseStream;
 

--- a/example/spec/parallel/testAPI/snsRuleSpec.js
+++ b/example/spec/parallel/testAPI/snsRuleSpec.js
@@ -118,7 +118,7 @@ describe('The SNS-type rule', () => {
 
       await addCollections(config.stackName, config.bucket, collectionsDir,
         testSuffix, testId);
-      const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: snsTopicName }));
+      const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: snsTopicName, KmsMasterKeyId: 'alias/aws/sns' }));
       snsTopicArn = TopicArn;
       snsRuleDefinition.rule.value = TopicArn;
       const postRuleResponse = await postRule({
@@ -308,7 +308,7 @@ describe('The SNS-type rule', () => {
     beforeAll(async () => {
       if (beforeAllFailed) return;
       try {
-        const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: newValueTopicName }));
+        const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: newValueTopicName, KmsMasterKeyId: 'alias/aws/sns' }));
         newTopicArn = TopicArn;
         const updateParams = {
           rule: {
@@ -366,7 +366,7 @@ describe('The SNS-type rule', () => {
     beforeAll(async () => {
       if (beforeAllFailed) return;
       try {
-        const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: newValueTopicName }));
+        const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: newValueTopicName, KmsMasterKeyId: 'alias/aws/sns' }));
         newTopicArn = TopicArn;
         const subscriptionParams = {
           TopicArn,

--- a/example/spec/parallel/testAPI/snsRuleSpec.js
+++ b/example/spec/parallel/testAPI/snsRuleSpec.js
@@ -24,10 +24,10 @@ const {
   updateRule,
   listRules,
 } = require('@cumulus/api-client/rules');
+const { createSnsTopic } = require('@cumulus/aws-client/SNS');
 const { lambda, sns } = require('@cumulus/aws-client/services');
 const {
   ListSubscriptionsByTopicCommand,
-  CreateTopicCommand,
   DeleteTopicCommand,
   PublishCommand,
   SubscribeCommand,
@@ -118,7 +118,7 @@ describe('The SNS-type rule', () => {
 
       await addCollections(config.stackName, config.bucket, collectionsDir,
         testSuffix, testId);
-      const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: snsTopicName, KmsMasterKeyId: 'alias/aws/sns' }));
+      const { TopicArn } = await createSnsTopic(snsTopicName);
       snsTopicArn = TopicArn;
       snsRuleDefinition.rule.value = TopicArn;
       const postRuleResponse = await postRule({
@@ -308,7 +308,7 @@ describe('The SNS-type rule', () => {
     beforeAll(async () => {
       if (beforeAllFailed) return;
       try {
-        const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: newValueTopicName, KmsMasterKeyId: 'alias/aws/sns' }));
+        const { TopicArn } = createSnsTopic(newValueTopicName);
         newTopicArn = TopicArn;
         const updateParams = {
           rule: {
@@ -366,8 +366,7 @@ describe('The SNS-type rule', () => {
     beforeAll(async () => {
       if (beforeAllFailed) return;
       try {
-        const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: newValueTopicName, KmsMasterKeyId: 'alias/aws/sns' }));
-        newTopicArn = TopicArn;
+        const { TopicArn } = await createSnsTopic(newValueTopicName);
         const subscriptionParams = {
           TopicArn,
           Protocol: 'lambda',

--- a/example/spec/parallel/testAPI/snsRuleSpec.js
+++ b/example/spec/parallel/testAPI/snsRuleSpec.js
@@ -308,7 +308,7 @@ describe('The SNS-type rule', () => {
     beforeAll(async () => {
       if (beforeAllFailed) return;
       try {
-        const { TopicArn } = createSnsTopic(newValueTopicName);
+        const { TopicArn } = await createSnsTopic(newValueTopicName);
         newTopicArn = TopicArn;
         const updateParams = {
           rule: {

--- a/packages/api/bin/serve.js
+++ b/packages/api/bin/serve.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const { promiseS3Upload } = require('@cumulus/aws-client/S3');
-const { s3, sns } = require('@cumulus/aws-client/services');
-const { CreateTopicCommand } = require('@aws-sdk/client-sns');
+const { s3 } = require('@cumulus/aws-client/services');
+const { createSnsTopic } = require('@cumulus/aws-client/SNS');
 const { randomId, inTestMode } = require('@cumulus/common/test-utils');
 const {
   CollectionPgModel,
@@ -66,7 +66,7 @@ async function prepareServices(stackName, bucket) {
   });
   await s3().createBucket({ Bucket: bucket });
 
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: randomId('topicName'), KmsMasterKeyId: 'alias/aws/sns' }));
+  const { TopicArn } = await createSnsTopic(randomId('topicName'));
   process.env.collection_sns_topic_arn = TopicArn;
 }
 

--- a/packages/api/bin/serve.js
+++ b/packages/api/bin/serve.js
@@ -66,7 +66,7 @@ async function prepareServices(stackName, bucket) {
   });
   await s3().createBucket({ Bucket: bucket });
 
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: randomId('topicName') }));
+  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: randomId('topicName'), KmsMasterKeyId: 'alias/aws/sns' }));
   process.env.collection_sns_topic_arn = TopicArn;
 }
 

--- a/packages/api/tests/endpoints/collections/create-collection.js
+++ b/packages/api/tests/endpoints/collections/create-collection.js
@@ -93,7 +93,7 @@ test.before(async (t) => {
 
 test.beforeEach(async (t) => {
   const topicName = randomString();
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName }));
+  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName, KmsMasterKeyId: 'alias/aws/sns' }));
   process.env.collection_sns_topic_arn = TopicArn;
   t.context.TopicArn = TopicArn;
 

--- a/packages/api/tests/endpoints/collections/create-collection.js
+++ b/packages/api/tests/endpoints/collections/create-collection.js
@@ -19,8 +19,8 @@ const {
   translatePostgresCollectionToApiCollection,
 } = require('@cumulus/db');
 const { sns, sqs } = require('@cumulus/aws-client/services');
+const { createSnsTopic } = require('@cumulus/aws-client/SNS');
 const {
-  CreateTopicCommand,
   SubscribeCommand,
   DeleteTopicCommand,
 } = require('@aws-sdk/client-sns');
@@ -93,7 +93,7 @@ test.before(async (t) => {
 
 test.beforeEach(async (t) => {
   const topicName = randomString();
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName, KmsMasterKeyId: 'alias/aws/sns' }));
+  const { TopicArn } = await createSnsTopic(topicName);
   process.env.collection_sns_topic_arn = TopicArn;
   t.context.TopicArn = TopicArn;
 

--- a/packages/api/tests/endpoints/collections/delete-collection.js
+++ b/packages/api/tests/endpoints/collections/delete-collection.js
@@ -4,10 +4,10 @@ const test = require('ava');
 const request = require('supertest');
 const { s3, sns, sqs } = require('@cumulus/aws-client/services');
 const {
-  CreateTopicCommand,
   SubscribeCommand,
   DeleteTopicCommand,
 } = require('@aws-sdk/client-sns');
+const { createSnsTopic } = require('@cumulus/aws-client/SNS');
 const {
   recursivelyDeleteS3Bucket,
 } = require('@cumulus/aws-client/S3');
@@ -103,7 +103,7 @@ test.beforeEach(async (t) => {
   await t.context.collectionPgModel.create(t.context.testKnex, t.context.testCollection);
 
   const topicName = randomString();
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName, KmsMasterKeyId: 'alias/aws/sns' }));
+  const { TopicArn } = await createSnsTopic(topicName);
   process.env.collection_sns_topic_arn = TopicArn;
   t.context.TopicArn = TopicArn;
 

--- a/packages/api/tests/endpoints/collections/delete-collection.js
+++ b/packages/api/tests/endpoints/collections/delete-collection.js
@@ -103,7 +103,7 @@ test.beforeEach(async (t) => {
   await t.context.collectionPgModel.create(t.context.testKnex, t.context.testCollection);
 
   const topicName = randomString();
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName }));
+  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName, KmsMasterKeyId: 'alias/aws/sns' }));
   process.env.collection_sns_topic_arn = TopicArn;
   t.context.TopicArn = TopicArn;
 

--- a/packages/api/tests/endpoints/collections/update-collection.js
+++ b/packages/api/tests/endpoints/collections/update-collection.js
@@ -91,7 +91,7 @@ test.before(async (t) => {
 });
 test.beforeEach(async (t) => {
   const topicName = randomString();
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName }));
+  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName, KmsMasterKeyId: 'alias/aws/sns' }));
   process.env.collection_sns_topic_arn = TopicArn;
   t.context.TopicArn = TopicArn;
 

--- a/packages/api/tests/endpoints/collections/update-collection.js
+++ b/packages/api/tests/endpoints/collections/update-collection.js
@@ -4,10 +4,10 @@ const test = require('ava');
 const request = require('supertest');
 const { s3, sns, sqs } = require('@cumulus/aws-client/services');
 const {
-  CreateTopicCommand,
   SubscribeCommand,
   DeleteTopicCommand,
 } = require('@aws-sdk/client-sns');
+const { createSnsTopic } = require('@cumulus/aws-client/SNS');
 const {
   recursivelyDeleteS3Bucket,
 } = require('@cumulus/aws-client/S3');
@@ -91,7 +91,7 @@ test.before(async (t) => {
 });
 test.beforeEach(async (t) => {
   const topicName = randomString();
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName, KmsMasterKeyId: 'alias/aws/sns' }));
+  const { TopicArn } = await createSnsTopic(topicName);
   process.env.collection_sns_topic_arn = TopicArn;
   t.context.TopicArn = TopicArn;
 

--- a/packages/api/tests/endpoints/test-executions.js
+++ b/packages/api/tests/endpoints/test-executions.js
@@ -206,7 +206,7 @@ test.before(async (t) => {
 
 test.beforeEach(async (t) => {
   const topicName = cryptoRandomString({ length: 10 });
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName }));
+  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName, KmsMasterKeyId: 'alias/aws/sns' }));
   process.env.execution_sns_topic_arn = TopicArn;
   t.context.TopicArn = TopicArn;
 

--- a/packages/api/tests/endpoints/test-executions.js
+++ b/packages/api/tests/endpoints/test-executions.js
@@ -15,9 +15,9 @@ const {
 } = require('@cumulus/aws-client/S3');
 const { sns, sqs } = require('@cumulus/aws-client/services');
 const {
-  CreateTopicCommand,
   SubscribeCommand,
 } = require('@aws-sdk/client-sns');
+const { createSnsTopic } = require('@cumulus/aws-client/SNS');
 const { randomId, randomString } = require('@cumulus/common/test-utils');
 const {
   AsyncOperationPgModel,
@@ -206,7 +206,7 @@ test.before(async (t) => {
 
 test.beforeEach(async (t) => {
   const topicName = cryptoRandomString({ length: 10 });
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName, KmsMasterKeyId: 'alias/aws/sns' }));
+  const { TopicArn } = await createSnsTopic(topicName);
   process.env.execution_sns_topic_arn = TopicArn;
   t.context.TopicArn = TopicArn;
 

--- a/packages/api/tests/endpoints/test-granules.js
+++ b/packages/api/tests/endpoints/test-granules.js
@@ -35,7 +35,6 @@ const {
 } = require('@cumulus/db');
 
 const { createTestIndex, cleanupTestIndex } = require('@cumulus/es-client/testUtils');
-
 const {
   buildS3Uri,
   createBucket,
@@ -45,10 +44,9 @@ const {
   s3ObjectExists,
   s3PutObject,
 } = require('@cumulus/aws-client/S3');
-
+const { createSnsTopic } = require('@cumulus/aws-client/SNS');
 const { secretsManager, sfn, s3, sns, sqs } = require('@cumulus/aws-client/services');
 const {
-  CreateTopicCommand,
   SubscribeCommand,
   DeleteTopicCommand,
 } = require('@aws-sdk/client-sns');
@@ -351,7 +349,7 @@ test.beforeEach(async (t) => {
   );
 
   const topicName = randomString();
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName, KmsMasterKeyId: 'alias/aws/sns' }));
+  const { TopicArn } = await createSnsTopic(topicName);
   process.env.granule_sns_topic_arn = TopicArn;
   t.context.TopicArn = TopicArn;
 

--- a/packages/api/tests/endpoints/test-granules.js
+++ b/packages/api/tests/endpoints/test-granules.js
@@ -351,7 +351,7 @@ test.beforeEach(async (t) => {
   );
 
   const topicName = randomString();
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName }));
+  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName, KmsMasterKeyId: 'alias/aws/sns' }));
   process.env.granule_sns_topic_arn = TopicArn;
   t.context.TopicArn = TopicArn;
 

--- a/packages/api/tests/endpoints/test-rules.js
+++ b/packages/api/tests/endpoints/test-rules.js
@@ -543,7 +543,7 @@ test.serial('post() creates SNS rule with same trigger information in PostgreSQL
     pgCollection,
   } = t.context;
 
-  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_') }));
+  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_'), KmsMasterKeyId: 'alias/aws/sns' }));
 
   const rule = fakeRuleFactoryV2({
     state: 'ENABLED',
@@ -1560,8 +1560,8 @@ test.serial('PATCH creates the same updated SNS rule in PostgreSQL/Elasticsearch
     pgCollection,
   } = t.context;
 
-  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_') }));
-  const topic2 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic2_') }));
+  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_'), KmsMasterKeyId: 'alias/aws/sns' }));
+  const topic2 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic2_'), KmsMasterKeyId: 'alias/aws/sns' }));
 
   const {
     originalPgRecord,
@@ -1824,8 +1824,8 @@ test.serial('PATCH keeps initial trigger information if writing to PostgreSQL fa
     pgCollection,
   } = t.context;
 
-  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_') }));
-  const topic2 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic2_') }));
+  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_'), KmsMasterKeyId: 'alias/aws/sns' }));
+  const topic2 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic2_'), KmsMasterKeyId: 'alias/aws/sns' }));
 
   const {
     originalPgRecord,
@@ -1915,8 +1915,8 @@ test.serial('PATCH keeps initial trigger information if writing to Elasticsearch
     pgCollection,
   } = t.context;
 
-  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_') }));
-  const topic2 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic2_') }));
+  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_'), KmsMasterKeyId: 'alias/aws/sns' }));
+  const topic2 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic2_'), KmsMasterKeyId: 'alias/aws/sns' }));
 
   const {
     originalPgRecord,
@@ -2515,8 +2515,8 @@ test.serial('PUT creates the same updated SNS rule in PostgreSQL/Elasticsearch',
     pgCollection,
   } = t.context;
 
-  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_') }));
-  const topic2 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic2_') }));
+  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_'), KmsMasterKeyId: 'alias/aws/sns' }));
+  const topic2 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic2_'), KmsMasterKeyId: 'alias/aws/sns' }));
 
   const {
     originalApiRule,
@@ -2779,8 +2779,8 @@ test.serial('PUT keeps initial trigger information if writing to PostgreSQL fail
     pgCollection,
   } = t.context;
 
-  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_') }));
-  const topic2 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic2_') }));
+  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_'), KmsMasterKeyId: 'alias/aws/sns' }));
+  const topic2 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic2_'), KmsMasterKeyId: 'alias/aws/sns' }));
 
   const {
     originalApiRule,
@@ -2871,8 +2871,8 @@ test.serial('PUT keeps initial trigger information if writing to Elasticsearch f
     pgCollection,
   } = t.context;
 
-  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_') }));
-  const topic2 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic2_') }));
+  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_'), KmsMasterKeyId: 'alias/aws/sns' }));
+  const topic2 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic2_'), KmsMasterKeyId: 'alias/aws/sns' }));
 
   const {
     originalApiRule,

--- a/packages/api/tests/endpoints/test-rules.js
+++ b/packages/api/tests/endpoints/test-rules.js
@@ -14,6 +14,7 @@ const {
 } = require('@aws-sdk/client-lambda');
 const { mockClient } = require('aws-sdk-client-mock');
 
+const { createSnsTopic } = require('@cumulus/aws-client/SNS');
 const { randomString, randomId } = require('@cumulus/common/test-utils');
 const workflows = require('@cumulus/common/workflows');
 const {
@@ -43,7 +44,6 @@ const indexer = require('@cumulus/es-client/indexer');
 const { constructCollectionId } = require('@cumulus/message/Collections');
 
 const {
-  CreateTopicCommand,
   ListSubscriptionsByTopicCommand,
   UnsubscribeCommand,
 } = require('@aws-sdk/client-sns');
@@ -543,7 +543,7 @@ test.serial('post() creates SNS rule with same trigger information in PostgreSQL
     pgCollection,
   } = t.context;
 
-  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_'), KmsMasterKeyId: 'alias/aws/sns' }));
+  const topic1 = await createSnsTopic(randomId('topic1_'));
 
   const rule = fakeRuleFactoryV2({
     state: 'ENABLED',
@@ -1560,8 +1560,8 @@ test.serial('PATCH creates the same updated SNS rule in PostgreSQL/Elasticsearch
     pgCollection,
   } = t.context;
 
-  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_'), KmsMasterKeyId: 'alias/aws/sns' }));
-  const topic2 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic2_'), KmsMasterKeyId: 'alias/aws/sns' }));
+  const topic1 = await createSnsTopic(randomId('topic1_'));
+  const topic2 = await createSnsTopic(randomId('topic2_'));
 
   const {
     originalPgRecord,
@@ -1824,8 +1824,8 @@ test.serial('PATCH keeps initial trigger information if writing to PostgreSQL fa
     pgCollection,
   } = t.context;
 
-  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_'), KmsMasterKeyId: 'alias/aws/sns' }));
-  const topic2 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic2_'), KmsMasterKeyId: 'alias/aws/sns' }));
+  const topic1 = await createSnsTopic(randomId('topic1_'));
+  const topic2 = await createSnsTopic(randomId('topic2_'));
 
   const {
     originalPgRecord,
@@ -1915,8 +1915,8 @@ test.serial('PATCH keeps initial trigger information if writing to Elasticsearch
     pgCollection,
   } = t.context;
 
-  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_'), KmsMasterKeyId: 'alias/aws/sns' }));
-  const topic2 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic2_'), KmsMasterKeyId: 'alias/aws/sns' }));
+  const topic1 = await createSnsTopic(randomId('topic1_'));
+  const topic2 = await createSnsTopic(randomId('topic2_'));
 
   const {
     originalPgRecord,
@@ -2515,8 +2515,8 @@ test.serial('PUT creates the same updated SNS rule in PostgreSQL/Elasticsearch',
     pgCollection,
   } = t.context;
 
-  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_'), KmsMasterKeyId: 'alias/aws/sns' }));
-  const topic2 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic2_'), KmsMasterKeyId: 'alias/aws/sns' }));
+  const topic1 = await createSnsTopic(randomId('topic1_'));
+  const topic2 = await createSnsTopic(randomId('topic2_'));
 
   const {
     originalApiRule,
@@ -2779,8 +2779,8 @@ test.serial('PUT keeps initial trigger information if writing to PostgreSQL fail
     pgCollection,
   } = t.context;
 
-  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_'), KmsMasterKeyId: 'alias/aws/sns' }));
-  const topic2 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic2_'), KmsMasterKeyId: 'alias/aws/sns' }));
+  const topic1 = await createSnsTopic(randomId('topic1_'));
+  const topic2 = await createSnsTopic(randomId('topic2_'));
 
   const {
     originalApiRule,
@@ -2871,8 +2871,8 @@ test.serial('PUT keeps initial trigger information if writing to Elasticsearch f
     pgCollection,
   } = t.context;
 
-  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_'), KmsMasterKeyId: 'alias/aws/sns' }));
-  const topic2 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic2_'), KmsMasterKeyId: 'alias/aws/sns' }));
+  const topic1 = await createSnsTopic(randomId('topic1_'));
+  const topic2 = await createSnsTopic(randomId('topic2_'));
 
   const {
     originalApiRule,

--- a/packages/api/tests/lambdas/sf-event-sqs-to-db-records/test-index.js
+++ b/packages/api/tests/lambdas/sf-event-sqs-to-db-records/test-index.js
@@ -170,8 +170,8 @@ test.before(async (t) => {
 
   const executionsTopicName = cryptoRandomString({ length: 10 });
   const pdrsTopicName = cryptoRandomString({ length: 10 });
-  const executionsTopic = await sns().send(new CreateTopicCommand({ Name: executionsTopicName }));
-  const pdrsTopic = await sns().send(new CreateTopicCommand({ Name: pdrsTopicName }));
+  const executionsTopic = await sns().send(new CreateTopicCommand({ Name: executionsTopicName, KmsMasterKeyId: 'alias/aws/sns' }));
+  const pdrsTopic = await sns().send(new CreateTopicCommand({ Name: pdrsTopicName, KmsMasterKeyId: 'alias/aws/sns' }));
   process.env.execution_sns_topic_arn = executionsTopic.TopicArn;
   process.env.pdr_sns_topic_arn = pdrsTopic.TopicArn;
   t.context.ExecutionsTopicArn = executionsTopic.TopicArn;
@@ -190,7 +190,7 @@ test.beforeEach(async (t) => {
   );
 
   const topicName = cryptoRandomString({ length: 10 });
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName }));
+  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName, KmsMasterKeyId: 'alias/aws/sns' }));
   process.env.granule_sns_topic_arn = TopicArn;
   t.context.TopicArn = TopicArn;
 

--- a/packages/api/tests/lambdas/sf-event-sqs-to-db-records/test-index.js
+++ b/packages/api/tests/lambdas/sf-event-sqs-to-db-records/test-index.js
@@ -10,8 +10,8 @@ const proxyquire = require('proxyquire');
 
 const StepFunctions = require('@cumulus/aws-client/StepFunctions');
 const { sns, sqs } = require('@cumulus/aws-client/services');
+const { createSnsTopic } = require('@cumulus/aws-client/SNS');
 const {
-  CreateTopicCommand,
   SubscribeCommand,
   DeleteTopicCommand,
 } = require('@aws-sdk/client-sns');
@@ -170,8 +170,8 @@ test.before(async (t) => {
 
   const executionsTopicName = cryptoRandomString({ length: 10 });
   const pdrsTopicName = cryptoRandomString({ length: 10 });
-  const executionsTopic = await sns().send(new CreateTopicCommand({ Name: executionsTopicName, KmsMasterKeyId: 'alias/aws/sns' }));
-  const pdrsTopic = await sns().send(new CreateTopicCommand({ Name: pdrsTopicName, KmsMasterKeyId: 'alias/aws/sns' }));
+  const executionsTopic = await createSnsTopic(executionsTopicName);
+  const pdrsTopic = await createSnsTopic(pdrsTopicName);
   process.env.execution_sns_topic_arn = executionsTopic.TopicArn;
   process.env.pdr_sns_topic_arn = pdrsTopic.TopicArn;
   t.context.ExecutionsTopicArn = executionsTopic.TopicArn;
@@ -190,7 +190,7 @@ test.beforeEach(async (t) => {
   );
 
   const topicName = cryptoRandomString({ length: 10 });
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName, KmsMasterKeyId: 'alias/aws/sns' }));
+  const { TopicArn } = await createSnsTopic(topicName);
   process.env.granule_sns_topic_arn = TopicArn;
   t.context.TopicArn = TopicArn;
 

--- a/packages/api/tests/lambdas/sf-event-sqs-to-db-records/test-write-pdr.js
+++ b/packages/api/tests/lambdas/sf-event-sqs-to-db-records/test-write-pdr.js
@@ -18,9 +18,9 @@ const {
   migrationDir,
 } = require('@cumulus/db');
 const { Search } = require('@cumulus/es-client/search');
+const { createSnsTopic } = require('@cumulus/aws-client/SNS');
 const { sns, sqs } = require('@cumulus/aws-client/services');
 const {
-  CreateTopicCommand,
   SubscribeCommand,
   DeleteTopicCommand,
 } = require('@aws-sdk/client-sns');
@@ -134,7 +134,7 @@ test.beforeEach(async (t) => {
 
 test.beforeEach(async (t) => {
   const topicName = cryptoRandomString({ length: 10 });
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName, KmsMasterKeyId: 'alias/aws/sns' }));
+  const { TopicArn } = await createSnsTopic(topicName);
   process.env.pdr_sns_topic_arn = TopicArn;
   t.context.TopicArn = TopicArn;
 

--- a/packages/api/tests/lambdas/sf-event-sqs-to-db-records/test-write-pdr.js
+++ b/packages/api/tests/lambdas/sf-event-sqs-to-db-records/test-write-pdr.js
@@ -134,7 +134,7 @@ test.beforeEach(async (t) => {
 
 test.beforeEach(async (t) => {
   const topicName = cryptoRandomString({ length: 10 });
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName }));
+  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName, KmsMasterKeyId: 'alias/aws/sns' }));
   process.env.pdr_sns_topic_arn = TopicArn;
   t.context.TopicArn = TopicArn;
 

--- a/packages/api/tests/lambdas/test-bulk-granule-delete.js
+++ b/packages/api/tests/lambdas/test-bulk-granule-delete.js
@@ -20,10 +20,10 @@ const {
 } = require('@cumulus/es-client/testUtils');
 const { sns, sqs } = require('@cumulus/aws-client/services');
 const {
-  CreateTopicCommand,
   SubscribeCommand,
   DeleteTopicCommand,
 } = require('@aws-sdk/client-sns');
+const { createSnsTopic } = require('@cumulus/aws-client/SNS');
 
 const { bulkGranuleDelete } = require('../../lambdas/bulk-operation');
 const { createGranuleAndFiles } = require('../helpers/create-test-data');
@@ -53,7 +53,7 @@ test.before(async (t) => {
 
 test.beforeEach(async (t) => {
   const topicName = randomString();
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName, KmsMasterKeyId: 'alias/aws/sns' }));
+  const { TopicArn } = await createSnsTopic(topicName);
   process.env.granule_sns_topic_arn = TopicArn;
   t.context.TopicArn = TopicArn;
 

--- a/packages/api/tests/lambdas/test-bulk-granule-delete.js
+++ b/packages/api/tests/lambdas/test-bulk-granule-delete.js
@@ -53,7 +53,7 @@ test.before(async (t) => {
 
 test.beforeEach(async (t) => {
   const topicName = randomString();
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName }));
+  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName, KmsMasterKeyId: 'alias/aws/sns' }));
   process.env.granule_sns_topic_arn = TopicArn;
   t.context.TopicArn = TopicArn;
 

--- a/packages/api/tests/lambdas/test-bulk-operation.js
+++ b/packages/api/tests/lambdas/test-bulk-operation.js
@@ -216,7 +216,7 @@ test.before(async (t) => {
 
 test.beforeEach(async (t) => {
   const topicName = randomString();
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName }));
+  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName, KmsMasterKeyId: 'alias/aws/sns' }));
   process.env.granule_sns_topic_arn = TopicArn;
   t.context.TopicArn = TopicArn;
 

--- a/packages/api/tests/lambdas/test-bulk-operation.js
+++ b/packages/api/tests/lambdas/test-bulk-operation.js
@@ -6,11 +6,11 @@ const omit = require('lodash/omit');
 
 const { sns, sqs } = require('@cumulus/aws-client/services');
 const {
-  CreateTopicCommand,
   SubscribeCommand,
   DeleteTopicCommand,
 } = require('@aws-sdk/client-sns');
 
+const { createSnsTopic } = require('@cumulus/aws-client/SNS');
 const awsServices = require('@cumulus/aws-client/services');
 const {
   CollectionPgModel,
@@ -216,7 +216,7 @@ test.before(async (t) => {
 
 test.beforeEach(async (t) => {
   const topicName = randomString();
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName, KmsMasterKeyId: 'alias/aws/sns' }));
+  const { TopicArn } = await createSnsTopic(topicName);
   process.env.granule_sns_topic_arn = TopicArn;
   t.context.TopicArn = TopicArn;
 

--- a/packages/api/tests/lib/rules/test-rulesHelpers.js
+++ b/packages/api/tests/lib/rules/test-rulesHelpers.js
@@ -168,7 +168,7 @@ test.before(async (t) => {
 
 test.beforeEach(async (t) => {
   t.context.sandbox = sinon.createSandbox();
-  const topic = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('sns') }));
+  const topic = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('sns'), KmsMasterKeyId: 'alias/aws/sns' }));
   t.context.snsTopicArn = topic.TopicArn;
   await deleteKinesisEventSourceMappings();
 });
@@ -986,7 +986,7 @@ test.serial('deleteRuleResources() removes SNS source mappings and permissions',
     testKnex,
   } = t.context;
 
-  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_') }));
+  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_'), KmsMasterKeyId: 'alias/aws/sns' }));
 
   // create rule trigger and rule
   const snsRule = fakeRuleFactoryV2({
@@ -1032,7 +1032,7 @@ test.serial('deleteRuleResources() does not throw if a rule is passed in without
     testKnex,
   } = t.context;
 
-  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_') }));
+  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_'), KmsMasterKeyId: 'alias/aws/sns' }));
 
   // create rule trigger and rule
   const snsRule = fakeRuleFactoryV2({
@@ -1111,7 +1111,7 @@ test.serial('checkForSnsSubscriptions returns the correct status of a Rule\'s su
     testKnex,
   } = t.context;
 
-  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_') }));
+  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_'), KmsMasterKeyId: 'alias/aws/sns' }));
 
   const snsRule = fakeRuleFactoryV2({
     workflow,

--- a/packages/api/tests/lib/rules/test-rulesHelpers.js
+++ b/packages/api/tests/lib/rules/test-rulesHelpers.js
@@ -17,9 +17,8 @@ const {
   AddPermissionCommand,
   RemovePermissionCommand,
 } = require('@aws-sdk/client-lambda');
-
 const { mockClient } = require('aws-sdk-client-mock');
-
+const { createSnsTopic } = require('@cumulus/aws-client/SNS');
 const awsServices = require('@cumulus/aws-client/services');
 const workflows = require('@cumulus/common/workflows');
 const Logger = require('@cumulus/logger');
@@ -28,7 +27,6 @@ const SQS = require('@cumulus/aws-client/SQS');
 const { recursivelyDeleteS3Bucket } = require('@cumulus/aws-client/S3');
 const { sqsQueueExists } = require('@cumulus/aws-client/SQS');
 const {
-  CreateTopicCommand,
   UnsubscribeCommand,
   DeleteTopicCommand,
   ListSubscriptionsByTopicCommand,
@@ -168,7 +166,7 @@ test.before(async (t) => {
 
 test.beforeEach(async (t) => {
   t.context.sandbox = sinon.createSandbox();
-  const topic = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('sns'), KmsMasterKeyId: 'alias/aws/sns' }));
+  const topic = await createSnsTopic(randomId('sns'));
   t.context.snsTopicArn = topic.TopicArn;
   await deleteKinesisEventSourceMappings();
 });
@@ -986,7 +984,7 @@ test.serial('deleteRuleResources() removes SNS source mappings and permissions',
     testKnex,
   } = t.context;
 
-  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_'), KmsMasterKeyId: 'alias/aws/sns' }));
+  const topic1 = await createSnsTopic(randomId('topic1_'));
 
   // create rule trigger and rule
   const snsRule = fakeRuleFactoryV2({
@@ -1032,7 +1030,7 @@ test.serial('deleteRuleResources() does not throw if a rule is passed in without
     testKnex,
   } = t.context;
 
-  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_'), KmsMasterKeyId: 'alias/aws/sns' }));
+  const topic1 = await createSnsTopic(randomId('topic1_'));
 
   // create rule trigger and rule
   const snsRule = fakeRuleFactoryV2({
@@ -1111,7 +1109,7 @@ test.serial('checkForSnsSubscriptions returns the correct status of a Rule\'s su
     testKnex,
   } = t.context;
 
-  const topic1 = await awsServices.sns().send(new CreateTopicCommand({ Name: randomId('topic1_'), KmsMasterKeyId: 'alias/aws/sns' }));
+  const topic1 = await createSnsTopic(randomId('topic1_'));
 
   const snsRule = fakeRuleFactoryV2({
     workflow,
@@ -1238,9 +1236,7 @@ test.serial('Multiple rules using same SNS topic can be created and deleted', as
     ),
   ]);
   const sendSpy = sinon.spy(awsServices.sns(), 'send');
-  const { TopicArn } = await awsServices.sns().send(new CreateTopicCommand({
-    Name: randomId('topic'),
-  }));
+  const { TopicArn } = await createSnsTopic('topic');
 
   const ruleWithTrigger = await rulesHelpers.createRuleTrigger(fakeRuleFactoryV2({
     name: randomId('rule1'),
@@ -1677,9 +1673,7 @@ test('Creating a disabled SNS rule creates no event source mapping', async (t) =
 });
 
 test.serial('Creating an enabled SNS rule creates an event source mapping', async (t) => {
-  const { TopicArn } = await awsServices.sns().send(new CreateTopicCommand({
-    Name: randomId('topic'),
-  }));
+  const { TopicArn } = await createSnsTopic(randomId('topic'));
 
   const snsMock = mockClient(awsServices.sns());
 
@@ -2180,12 +2174,8 @@ test.serial('Updating the queue for an SQS rule succeeds and allows 0 retries an
 test.serial('Updating an SNS rule updates the event source mapping', async (t) => {
   const snsTopicArn = randomString();
   const newSnsTopicArn = randomString();
-  const { TopicArn } = await awsServices.sns().send(new CreateTopicCommand({
-    Name: snsTopicArn,
-  }));
-  const { TopicArn: TopicArn2 } = await awsServices.sns().send(new CreateTopicCommand({
-    Name: newSnsTopicArn,
-  }));
+  const { TopicArn } = await createSnsTopic(snsTopicArn);
+  const { TopicArn: TopicArn2 } = await createSnsTopic(newSnsTopicArn);
   const snsMock = mockClient(awsServices.sns());
 
   const lambdaStub = sinon.stub(awsServices, 'lambda')
@@ -2249,9 +2239,7 @@ test.serial('Updating an SNS rule updates the event source mapping', async (t) =
 
 test.serial('Updating an SNS rule to "disabled" removes the event source mapping ARN', async (t) => {
   const snsTopicArn = randomString();
-  const { TopicArn } = await awsServices.sns().send(new CreateTopicCommand({
-    Name: snsTopicArn,
-  }));
+  const { TopicArn } = await createSnsTopic(snsTopicArn);
   const snsMock = mockClient(awsServices.sns());
 
   const lambdaStub = sinon.stub(awsServices, 'lambda')

--- a/packages/api/tests/lib/test-granule-delete.js
+++ b/packages/api/tests/lib/test-granule-delete.js
@@ -103,7 +103,7 @@ test.before(async (t) => {
 
 test.beforeEach(async (t) => {
   const topicName = randomString();
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName }));
+  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName, KmsMasterKeyId: 'alias/aws/sns' }));
   process.env.granule_sns_topic_arn = TopicArn;
   t.context.TopicArn = TopicArn;
 

--- a/packages/api/tests/lib/test-granule-delete.js
+++ b/packages/api/tests/lib/test-granule-delete.js
@@ -3,10 +3,10 @@ const cryptoRandomString = require('crypto-random-string');
 
 const { sns, sqs } = require('@cumulus/aws-client/services');
 const {
-  CreateTopicCommand,
   SubscribeCommand,
   DeleteTopicCommand,
 } = require('@aws-sdk/client-sns');
+const { createSnsTopic } = require('@cumulus/aws-client/SNS');
 
 const { recordNotFoundString } = require('@cumulus/es-client/search');
 
@@ -103,7 +103,7 @@ test.before(async (t) => {
 
 test.beforeEach(async (t) => {
   const topicName = randomString();
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName, KmsMasterKeyId: 'alias/aws/sns' }));
+  const { TopicArn } = await createSnsTopic(topicName);
   process.env.granule_sns_topic_arn = TopicArn;
   t.context.TopicArn = TopicArn;
 

--- a/packages/api/tests/lib/test-ingest.js
+++ b/packages/api/tests/lib/test-ingest.js
@@ -5,9 +5,9 @@ const { randomString } = require('@cumulus/common/test-utils');
 const Lambda = require('@cumulus/aws-client/Lambda');
 const { sns } = require('@cumulus/aws-client/services');
 const {
-  CreateTopicCommand,
   DeleteTopicCommand,
 } = require('@aws-sdk/client-sns');
+const { createSnsTopic } = require('@cumulus/aws-client/SNS');
 const { createBucket } = require('@cumulus/aws-client/S3');
 const StepFunctions = require('@cumulus/aws-client/StepFunctions');
 const { constructCollectionId } = require('@cumulus/message/Collections');
@@ -68,7 +68,7 @@ test.before(async (t) => {
   t.context.esIndex = esIndex;
   t.context.esClient = esClient;
 
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: randomString(), KmsMasterKeyId: 'alias/aws/sns' }));
+  const { TopicArn } = await createSnsTopic(randomString());
   t.context.granules_sns_topic_arn = TopicArn;
   process.env.granule_sns_topic_arn = t.context.granules_sns_topic_arn;
 

--- a/packages/api/tests/lib/test-ingest.js
+++ b/packages/api/tests/lib/test-ingest.js
@@ -68,7 +68,7 @@ test.before(async (t) => {
   t.context.esIndex = esIndex;
   t.context.esClient = esClient;
 
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: randomString() }));
+  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: randomString(), KmsMasterKeyId: 'alias/aws/sns' }));
   t.context.granules_sns_topic_arn = TopicArn;
   process.env.granule_sns_topic_arn = t.context.granules_sns_topic_arn;
 

--- a/packages/api/tests/lib/test-publishSnsMessageUtils.js
+++ b/packages/api/tests/lib/test-publishSnsMessageUtils.js
@@ -28,7 +28,7 @@ test.before((t) => {
 
 test.beforeEach(async (t) => {
   const topicName = cryptoRandomString({ length: 10 });
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName }));
+  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName, KmsMasterKeyId: 'alias/aws/sns' }));
   t.context.TopicArn = TopicArn;
 
   const QueueName = cryptoRandomString({ length: 10 });

--- a/packages/api/tests/lib/test-publishSnsMessageUtils.js
+++ b/packages/api/tests/lib/test-publishSnsMessageUtils.js
@@ -4,8 +4,8 @@ const test = require('ava');
 const cryptoRandomString = require('crypto-random-string');
 
 const { sns, sqs } = require('@cumulus/aws-client/services');
+const { createSnsTopic } = require('@cumulus/aws-client/SNS');
 const {
-  CreateTopicCommand,
   SubscribeCommand,
   DeleteTopicCommand,
 } = require('@aws-sdk/client-sns');
@@ -28,7 +28,7 @@ test.before((t) => {
 
 test.beforeEach(async (t) => {
   const topicName = cryptoRandomString({ length: 10 });
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName, KmsMasterKeyId: 'alias/aws/sns' }));
+  const { TopicArn } = await createSnsTopic(topicName);
   t.context.TopicArn = TopicArn;
 
   const QueueName = cryptoRandomString({ length: 10 });

--- a/packages/api/tests/lib/writeRecords/test-write-execution.js
+++ b/packages/api/tests/lib/writeRecords/test-write-execution.js
@@ -58,7 +58,7 @@ test.before(async (t) => {
 
 test.beforeEach(async (t) => {
   const topicName = cryptoRandomString({ length: 10 });
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName }));
+  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName, KmsMasterKeyId: 'alias/aws/sns' }));
   process.env.execution_sns_topic_arn = TopicArn;
   t.context.TopicArn = TopicArn;
 

--- a/packages/api/tests/lib/writeRecords/test-write-execution.js
+++ b/packages/api/tests/lib/writeRecords/test-write-execution.js
@@ -18,9 +18,9 @@ const {
   createTestIndex,
   cleanupTestIndex,
 } = require('@cumulus/es-client/testUtils');
+const { createSnsTopic } = require('@cumulus/aws-client/SNS');
 const { sns, sqs } = require('@cumulus/aws-client/services');
 const {
-  CreateTopicCommand,
   SubscribeCommand,
   DeleteTopicCommand,
 } = require('@aws-sdk/client-sns');
@@ -58,7 +58,7 @@ test.before(async (t) => {
 
 test.beforeEach(async (t) => {
   const topicName = cryptoRandomString({ length: 10 });
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName, KmsMasterKeyId: 'alias/aws/sns' }));
+  const { TopicArn } = await createSnsTopic(topicName);
   process.env.execution_sns_topic_arn = TopicArn;
   t.context.TopicArn = TopicArn;
 

--- a/packages/api/tests/lib/writeRecords/test-write-granules.js
+++ b/packages/api/tests/lib/writeRecords/test-write-granules.js
@@ -8,6 +8,8 @@ const sortBy = require('lodash/sortBy');
 const omit = require('lodash/omit');
 
 const StepFunctions = require('@cumulus/aws-client/StepFunctions');
+const { createSnsTopic } = require('@cumulus/aws-client/SNS');
+
 const { randomId } = require('@cumulus/common/test-utils');
 const { removeNilProperties } = require('@cumulus/common/util');
 const { constructCollectionId } = require('@cumulus/message/Collections');
@@ -36,7 +38,6 @@ const {
 } = require('@cumulus/db');
 const { sns, sqs } = require('@cumulus/aws-client/services');
 const {
-  CreateTopicCommand,
   SubscribeCommand,
   DeleteTopicCommand,
 } = require('@aws-sdk/client-sns');
@@ -223,7 +224,7 @@ test.before(async (t) => {
 
 test.beforeEach(async (t) => {
   const topicName = cryptoRandomString({ length: 10 });
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName, KmsMasterKeyId: 'alias/aws/sns' }));
+  const { TopicArn } = await createSnsTopic(topicName);
   process.env.granule_sns_topic_arn = TopicArn;
   t.context.TopicArn = TopicArn;
 

--- a/packages/api/tests/lib/writeRecords/test-write-granules.js
+++ b/packages/api/tests/lib/writeRecords/test-write-granules.js
@@ -223,7 +223,7 @@ test.before(async (t) => {
 
 test.beforeEach(async (t) => {
   const topicName = cryptoRandomString({ length: 10 });
-  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName }));
+  const { TopicArn } = await sns().send(new CreateTopicCommand({ Name: topicName, KmsMasterKeyId: 'alias/aws/sns' }));
   process.env.granule_sns_topic_arn = TopicArn;
   t.context.TopicArn = TopicArn;
 

--- a/packages/aws-client/src/SNS.ts
+++ b/packages/aws-client/src/SNS.ts
@@ -4,7 +4,7 @@
 
 import pRetry from 'p-retry';
 import Logger from '@cumulus/logger';
-import { PublishCommand } from '@aws-sdk/client-sns';
+import { PublishCommand, CreateTopicCommand } from '@aws-sdk/client-sns';
 
 import { sns } from './services';
 
@@ -42,3 +42,21 @@ export const publishSnsMessageWithRetry = async (
       ...retryOptions,
     }
   );
+
+/**
+ * Create an SNS topic with a given name.
+ *
+ * @param snsTopicName - Name of the SNS topic
+ * @returns - ARN of the created SNS topic
+ */
+export const createSnsTopic = async (
+  snsTopicName: string
+): Promise<{ TopicArn: string | undefined }> => {
+  const createTopicInput = {
+    Name: snsTopicName,
+    KmsMasterKeyId: 'alias/aws/sns',
+  };
+  const createTopicCommand = new CreateTopicCommand(createTopicInput);
+  const createTopicResponse = await sns().send(createTopicCommand);
+  return { TopicArn: createTopicResponse.TopicArn };
+};

--- a/packages/aws-client/tests/test-SNS.js
+++ b/packages/aws-client/tests/test-SNS.js
@@ -1,0 +1,22 @@
+const test = require('ava');
+const sinon = require('sinon');
+
+const { createSnsTopic } = require('../SNS'); // replace with the actual path
+const { sns } = require('../services');
+
+test('createSnsTopic creates a topic and returns its ARN', async (t) => {
+  // Arrange
+  const snsTopicName = 'testTopic';
+  const mockTopicArn = 'arn:aws:sns:us-east-1:123456789012:testTopic';
+
+  // Mock the sns function and the send method
+  const sendMock = sinon.stub().returns({ TopicArn: mockTopicArn });
+  sinon.stub(sns(), 'send').callsFake(sendMock);
+
+  // Act
+  const result = await createSnsTopic(snsTopicName);
+
+  // Assert
+  t.is(result.TopicArn, mockTopicArn);
+  t.like(sendMock.getCalls()[0].args[0].input, { Name: snsTopicName, KmsMasterKeyId: 'alias/aws/sns' });
+});

--- a/tf-modules/archive/ingest-reporting.tf
+++ b/tf-modules/archive/ingest-reporting.tf
@@ -1,5 +1,6 @@
 # Report executions
 resource "aws_sns_topic" "report_executions_topic" {
+  kms_master_key_id = "alias/aws/sns"
   name = "${var.prefix}-report-executions-topic"
   tags = var.tags
 }
@@ -65,6 +66,7 @@ data "aws_iam_policy_document" "report_execution_sns_topic_policy" {
 
 # Report granules
 resource "aws_sns_topic" "report_granules_topic" {
+  kms_master_key_id = "alias/aws/sns"
   name = "${var.prefix}-report-granules-topic"
   tags = var.tags
 }
@@ -130,6 +132,7 @@ data "aws_iam_policy_document" "report_granules_sns_topic_policy" {
 
 # Report PDRs
 resource "aws_sns_topic" "report_pdrs_topic" {
+  kms_master_key_id = "alias/aws/sns"
   name = "${var.prefix}-report-pdrs-topic"
   tags = var.tags
 }
@@ -195,6 +198,7 @@ data "aws_iam_policy_document" "report_pdrs_sns_topic_policy" {
 }
 # Report collections
 resource "aws_sns_topic" "report_collections_topic" {
+  kms_master_key_id = "alias/aws/sns"
   name = "${var.prefix}-report-collections-topic"
   tags = var.tags
 }

--- a/tf-modules/ingest/sns.tf
+++ b/tf-modules/ingest/sns.tf
@@ -1,6 +1,7 @@
 # Kinesis fallback
 
 resource "aws_sns_topic" "kinesis_fallback" {
+  kms_master_key_id = "alias/aws/sns"
   name = "${var.prefix}-kinesisFallback"
   tags = var.tags
 }


### PR DESCRIPTION
**Summary:** 

Adds server-side encryption to deployed SNS topics, updates unit/integration tests to match. 

Addresses [CUMULUS-3951](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3951)


## Changes
- **CUMULUS-3951**
  - Enable server-side encryption for all SNS topcis deployed by Cumulus Core
  - Update all integration/unit tests to use encrypted SNS topics

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
