### PR TITLE
CUMULUS-3715 - Update db provisioning lambda to properly pass knex debug flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,7 +189,7 @@ operations (e.g. `PREFIX-AsyncOperationEcsLogs`).
 
 ### Fixed
 
-- **CUMULUS-3175**
+- **CUMULUS-3715**
   - Update `ProvisionUserDatabase` lambda to correctly pass in knex/node debug
     flags to knex custom code
 - **CUMULUS-3701**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,9 @@ operations (e.g. `PREFIX-AsyncOperationEcsLogs`).
 
 ### Fixed
 
+- **CUMULUS-3175**
+  - Update `ProvisionUserDatabase` lambda to correctly pass in knex/node debug
+    flags to knex custom code
 - **CUMULUS-3701**
   - Updated `@cumulus/api` to no longer improperly pass PATCH/PUT null values to Eventbridge rules
 - **CUMULUS-3618**

--- a/lambdas/db-provision-user-database/src/index.ts
+++ b/lambdas/db-provision-user-database/src/index.ts
@@ -42,6 +42,7 @@ export const handler = async (event: HandlerEvent): Promise<void> => {
     knex = await getKnexClient({
       env: {
         databaseCredentialSecretArn: event.rootLoginSecret,
+        KNEX_DEBUG: process.env.KNEX_DEBUG,
       },
       secretsManager,
     });


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3715](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3715)

## Changes
- **CUMULUS-3175**
  - Update `ProvisionUserDatabase` lambda to correctly pass in knex/node debug
    flags to knex custom code

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
