### PR TITLE
CUMULUS-3712 - Release 18.2.1 CHANGELOG updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,7 +223,7 @@ modification.
   - Addressed [CVE-2023-45133](https://github.com/advisories/GHSA-67hx-6x53-jw92) by
     updating babel packages and .babelrc
 
-## [v18.2.1] 2023-05-08
+## [v18.2.1] 2024-05-08
 
 **Please note** changes in 18.2.1 may not yet be released in future versions, as this
 is a backport/patch release on the 18.2.x series of releases.  Updates that are
@@ -236,7 +236,7 @@ included in the future will have a corresponding CHANGELOG entry in future relea
 - **CUMULUS-3701**
   - Updated `@cumulus/api` to no longer improperly pass PATCH/PUT null values to Eventbridge rules
 
-## [v18.2.0] 2023-02-02
+## [v18.2.0] 2024-02-02
 
 ### Migration Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,6 +223,19 @@ modification.
   - Addressed [CVE-2023-45133](https://github.com/advisories/GHSA-67hx-6x53-jw92) by
     updating babel packages and .babelrc
 
+## [v18.2.1] 2023-05-08
+
+**Please note** changes in 18.2.1 may not yet be released in future versions, as this
+is a backport/patch release on the 18.2.x series of releases.  Updates that are
+included in the future will have a corresponding CHANGELOG entry in future releases.
+
+### Fixed
+
+- **CUMULUS-3721**
+  - Update lambda:GetFunctionConfiguration policy statement to fix error related to resource naming
+- **CUMULUS-3701**
+  - Updated `@cumulus/api` to no longer improperly pass PATCH/PUT null values to Eventbridge rules
+
 ## [v18.2.0] 2023-02-02
 
 ### Migration Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7804,6 +7804,7 @@ Note: There was an issue publishing 1.12.0. Upgrade to 1.12.1.
 ## [v1.0.0] - 2018-02-23
 
 [unreleased]: https://github.com/nasa/cumulus/compare/v18.2.0...HEAD
+[v18.2.1]: https://github.com/nasa/cumulus/compare/v18.2.0...v18.2.1
 [v18.2.0]: https://github.com/nasa/cumulus/compare/v18.1.0...v18.2.0
 [v18.1.0]: https://github.com/nasa/cumulus/compare/v18.0.0...v18.1.0
 [v18.0.0]: https://github.com/nasa/cumulus/compare/v17.0.0...v18.0.0


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3712](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3712)

- Backport PR update for Release 18.2.1 CHANGELOG

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
