### PR TITLE
CUMULUS-3527 - Merge #3582 back to 16.1.x baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+## Fixed
+
+ **CUMULUS-3527**
+  - Added suppport for additional kex algorithms in the sftp-client.
+
 ## [v16.1.4] 2024-4-23
 
 ### Migration Notes
@@ -23,6 +30,7 @@ upgrade
 instructions](https://nasa.github.io/cumulus/docs/upgrade-notes/upgrade-rds-cluster-tf-postgres-13).
 
 ## Changed
+
 - **CUMULUS-3564**
   - Update webpack configuration to explicitly disable chunking
 - **CUMULUS-3444**

--- a/packages/sftp-client/src/index.ts
+++ b/packages/sftp-client/src/index.ts
@@ -41,6 +41,17 @@ export class SftpClient {
     this.clientOptions = {
       host: config.host,
       port: get(config, 'port', 22),
+      algorithms: {
+        kex: {
+          append: [
+            'diffie-hellman-group-exchange-sha1',
+            'diffie-hellman-group14-sha1',
+            'diffie-hellman-group1-sha1',
+          ],
+          prepend: [],
+          remove: [],
+        },
+      },
     };
 
     if (config.username) this.clientOptions.username = config.username;


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3527](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3527)

This is a backport of #3582 to the 16.1.x baseline

## Changes

 **CUMULUS-3527**
  - Added suppport for additional kex algorithms in the sftp-client.

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
