### PR TITLE
CUMULUS-3725: Ensure force_ssl is false by default in RDS Serverless v2 deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,12 @@ modification.
     CommmonJS typescript/webpack clients.
 
 ### Changed
+- **CUMULUS-3725**
+  - Updated the default parameter group for `cumulus-rds-tf` to set `force_ssl`
+    to 0. This setting for the Aurora Serverless v2 database allows non-SSL
+    connections to the database, and is intended to be a temporary solution
+    until Cumulus has been updated to import the RDS rds-ca-rsa2048-g1 CA bundles in Lambda environments.
+    See [CUMULUS-3724](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3724).
 - **CUMULUS-3951**
   - Enable server-side encryption for all SNS topcis deployed by Cumulus Core
   - Update all integration/unit tests to use encrypted SNS topics

--- a/tf-modules/cumulus-rds-tf/variables.tf
+++ b/tf-modules/cumulus-rds-tf/variables.tf
@@ -169,7 +169,7 @@ variable "db_parameters" {
     },
     {
       name         = "rds.force_ssl"
-      value        = 1
+      value        = 0
       apply_method = "pending-reboot"
     }
   ]


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3725: Ensure force_ssl is false by default in RDS Serverless v2 deployments.](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3725)

## Changes

* set force_ssl = 0

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
