### PR TITLE
CUMULUS-3689: Update Stats/Summary and Stats/Aggregate endpoints to use psql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Replace ElasticSearch Phase 1
 
+- **CUMULUS-3688**
+ - Updated `stats` api endpoint to query postgres instead of elasticsearch
 - **CUMULUS-3689**
  - Updated `stats/aggregate` api endpoint to query postgres instead of elasticsearch
  - Created a new StatsSearch class for querying postgres with the stats endpoint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Replace ElasticSearch Phase 1
 
+- **CUMULUS-3689**
+ - Updated `stats/aggregate` api endpoint to query postgres instead of elasticsearch
+ - Created a new StatsSearch class for querying postgres with the stats endpoint
 - **CUMULUS-3692**
   - Added `@cumulus/db/src/search` `BaseSearch` and `GranuleSearch` classes to
     support basic queries for granules

--- a/packages/api/endpoints/stats.js
+++ b/packages/api/endpoints/stats.js
@@ -3,6 +3,7 @@
 const router = require('express-promise-router')();
 const get = require('lodash/get');
 const { StatsSearch } = require('@cumulus/db');
+const omit = require('lodash/omit');
 
 /**
  * Map requested stats types to supported types
@@ -35,7 +36,7 @@ function getType(req) {
  */
 async function summary(req, res) {
   const stats = new StatsSearch({
-    queryStringParameters: req.query,
+    queryStringParameters: omit(req.query, 'type'),
   }, 'granule');
   const r = await stats.summary();
   return res.send(r);
@@ -50,7 +51,7 @@ async function summary(req, res) {
  */
 async function aggregate(req, res) {
   if (getType(req)) {
-    const stats = new StatsSearch({ queryStringParameters: req.query }, getType(req));
+    const stats = new StatsSearch({ queryStringParameters: omit(req.query, 'type') }, getType(req));
     const r = await stats.aggregate();
     return res.send(r);
   }

--- a/packages/api/tests/endpoints/stats.js
+++ b/packages/api/tests/endpoints/stats.js
@@ -55,7 +55,6 @@ process.env = {
 };
 
 test.before(async (t) => {
-  // create buckets
   await awsServices.s3().createBucket({ Bucket: process.env.system_bucket });
   const username = randomId();
   await setAuthorizedOAuthUsers([username]);
@@ -82,7 +81,6 @@ test.before(async (t) => {
   const collections = [];
 
   range(20).map((num) => (
-    // collections is never aggregate queried
     collections.push(fakeCollectionRecordFactory({
       name: `testCollection${num}`,
       cumulus_id: num,
@@ -90,7 +88,6 @@ test.before(async (t) => {
   ));
 
   range(100).map((num) => (
-    // granules can be queried by timestampto/from, collectionid, providerid, status,
     granules.push(fakeGranuleRecordFactory({
       collection_cumulus_id: num % 20,
       status: statuses[num % 4],

--- a/packages/api/tests/endpoints/stats.js
+++ b/packages/api/tests/endpoints/stats.js
@@ -244,9 +244,9 @@ test('GET /stats/aggregate returns correct response', async (t) => {
 
   const expectedCount = [
     { key: 'completed', count: 25 },
-    { key: 'running', count: 25 },
-    { key: 'queued', count: 25 },
     { key: 'failed', count: 25 },
+    { key: 'queued', count: 25 },
+    { key: 'running', count: 25 },
   ];
   t.is(response.body.meta.count, 100);
   t.deepEqual(response.body.count, expectedCount);

--- a/packages/api/tests/endpoints/stats.js
+++ b/packages/api/tests/endpoints/stats.js
@@ -246,10 +246,10 @@ test('GET /stats/aggregate returns correct response', async (t) => {
     .expect(200);
 
   t.is(response.body.meta.count, 100);
-  t.is(response.body.results.count.find((item) => item.key === 'completed').count, 25);
-  t.is(response.body.results.count.find((item) => item.key === 'queued').count, 25);
-  t.is(response.body.results.count.find((item) => item.key === 'queued').count, 25);
-  t.is(response.body.results.count.find((item) => item.key === 'queued').count, 25);
+  t.is(response.body.count.find((item) => item.key === 'completed').count, 25);
+  t.is(response.body.count.find((item) => item.key === 'queued').count, 25);
+  t.is(response.body.count.find((item) => item.key === 'queued').count, 25);
+  t.is(response.body.count.find((item) => item.key === 'queued').count, 25);
 });
 
 test('GET /stats/aggregate filters correctly by date', async (t) => {
@@ -259,8 +259,8 @@ test('GET /stats/aggregate filters correctly by date', async (t) => {
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .expect(200);
   t.is(response.body.meta.count, 41);
-  t.is(response.body.results.count.find((item) => item.key === 'completed').count, 8);
-  t.is(response.body.results.count.find((item) => item.key === 'queued').count, 8);
-  t.is(response.body.results.count.find((item) => item.key === 'queued').count, 8);
-  t.is(response.body.results.count.find((item) => item.key === 'queued').count, 8);
+  t.is(response.body.count.find((item) => item.key === 'completed').count, 8);
+  t.is(response.body.count.find((item) => item.key === 'queued').count, 8);
+  t.is(response.body.count.find((item) => item.key === 'queued').count, 8);
+  t.is(response.body.count.find((item) => item.key === 'queued').count, 8);
 });

--- a/packages/api/tests/endpoints/stats.js
+++ b/packages/api/tests/endpoints/stats.js
@@ -76,7 +76,7 @@ test.before(async (t) => {
   t.context.granulePgModel = new GranulePgModel();
 
   const statuses = ['queued', 'failed', 'completed', 'running'];
-  const errors = [{ Error: { keyword: 'UnknownError' } }, { Error: { keyword: 'CumulusMessageAdapterError' } }, { Error: { keyword: 'IngestFailure' } }, { Error: { keyword: 'CmrFailure' } }, { Error: {} }];
+  const errors = [{ Error: 'UnknownError' }, { Error: 'CumulusMessageAdapterError' }, { Error: 'IngestFailure' }, { Error: 'CmrFailure' }, { Error: {} }];
   const granules = [];
   const collections = [];
 

--- a/packages/api/tests/endpoints/stats.js
+++ b/packages/api/tests/endpoints/stats.js
@@ -76,7 +76,7 @@ test.before(async (t) => {
   t.context.granulePgModel = new GranulePgModel();
 
   const statuses = ['queued', 'failed', 'completed', 'running'];
-  const errors = [{ Error: 'UnknownError' }, { Error: 'CumulusMessageAdapterError' }, { Error: 'IngestFailure' }, { Error: 'CmrFailure' }, { Error: {} }];
+  const errors = [{ Error: 'UnknownError' }, { Error: 'CumulusMessageAdapterError' }, { Error: 'IngestFailure' }, { Error: 'CmrFailure' }, {}];
   const granules = [];
   const collections = [];
 

--- a/packages/api/tests/endpoints/stats.js
+++ b/packages/api/tests/endpoints/stats.js
@@ -242,11 +242,14 @@ test('GET /stats/aggregate returns correct response', async (t) => {
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .expect(200);
 
+  const expectedCount = [
+    { key: 'completed', count: 25 },
+    { key: 'running', count: 25 },
+    { key: 'queued', count: 25 },
+    { key: 'failed', count: 25 },
+  ];
   t.is(response.body.meta.count, 100);
-  t.is(response.body.count.find((item) => item.key === 'completed').count, 25);
-  t.is(response.body.count.find((item) => item.key === 'queued').count, 25);
-  t.is(response.body.count.find((item) => item.key === 'queued').count, 25);
-  t.is(response.body.count.find((item) => item.key === 'queued').count, 25);
+  t.deepEqual(response.body.count, expectedCount);
 });
 
 test('GET /stats/aggregate filters correctly by date', async (t) => {
@@ -255,9 +258,13 @@ test('GET /stats/aggregate filters correctly by date', async (t) => {
     .set('Accept', 'application/json')
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .expect(200);
+
+  const expectedCount = [
+    { key: 'failed', count: 16 },
+    { key: 'running', count: 9 },
+    { key: 'completed', count: 8 },
+    { key: 'queued', count: 8 },
+  ];
   t.is(response.body.meta.count, 41);
-  t.is(response.body.count.find((item) => item.key === 'completed').count, 8);
-  t.is(response.body.count.find((item) => item.key === 'queued').count, 8);
-  t.is(response.body.count.find((item) => item.key === 'queued').count, 8);
-  t.is(response.body.count.find((item) => item.key === 'queued').count, 8);
+  t.deepEqual(response.body.count, expectedCount);
 });

--- a/packages/api/tests/endpoints/stats.js
+++ b/packages/api/tests/endpoints/stats.js
@@ -3,40 +3,35 @@
 const test = require('ava');
 const request = require('supertest');
 const rewire = require('rewire');
-const sinon = require('sinon');
+const range = require('lodash/range');
 
 const awsServices = require('@cumulus/aws-client/services');
 const s3 = require('@cumulus/aws-client/S3');
 const { randomId } = require('@cumulus/common/test-utils');
-const { bootstrapElasticSearch } = require('@cumulus/es-client/bootstrap');
-const indexer = rewire('@cumulus/es-client/indexer');
-const { getEsClient } = require('@cumulus/es-client/search');
 
 const models = require('../../models');
 const {
-  fakeGranuleFactoryV2,
-  fakeCollectionFactory,
   createFakeJwtAuthToken,
   setAuthorizedOAuthUsers,
 } = require('../../lib/testUtils');
+
+const {
+  destroyLocalTestDb,
+  generateLocalTestDb,
+  GranulePgModel,
+  CollectionPgModel,
+  fakeCollectionRecordFactory,
+  fakeGranuleRecordFactory,
+  migrationDir,
+  localStackConnectionEnv,
+} = require('../../../db/dist');
+
+const testDbName = randomId('collection');
 
 const assertions = require('../../lib/assertions');
 
 const stats = rewire('../../endpoints/stats');
 const getType = stats.__get__('getType');
-
-let esClient;
-
-process.env.AccessTokensTable = randomId('accessTokenTable');
-
-process.env.system_bucket = randomId('bucket');
-process.env.stackName = randomId('stackName');
-
-const esIndex = randomId('esindex');
-const esAlias = randomId('esAlias');
-
-process.env.ES_INDEX = esAlias;
-process.env.TOKEN_SECRET = randomId('tokensecret');
 
 // import the express app after setting the env variables
 const { app } = require('../../app');
@@ -44,10 +39,24 @@ const { app } = require('../../app');
 let accessTokenModel;
 let jwtAuthToken;
 
-test.before(async () => {
+process.env.PG_HOST = randomId('hostname');
+process.env.PG_USER = randomId('user');
+process.env.PG_PASSWORD = randomId('password');
+process.env.stackName = randomId('userstack');
+process.env.AccessTokensTable = randomId('tokentable');
+process.env.system_bucket = randomId('bucket');
+process.env.stackName = randomId('stackName');
+process.env.TOKEN_SECRET = randomId('tokensecret');
+
+process.env = {
+  ...process.env,
+  ...localStackConnectionEnv,
+  PG_DATABASE: testDbName,
+};
+
+test.before(async (t) => {
   // create buckets
   await awsServices.s3().createBucket({ Bucket: process.env.system_bucket });
-  esClient = await getEsClient();
   const username = randomId();
   await setAuthorizedOAuthUsers([username]);
 
@@ -56,48 +65,63 @@ test.before(async () => {
 
   jwtAuthToken = await createFakeJwtAuthToken({ accessTokenModel, username });
 
-  // create the elasticsearch index and add mapping
-  await bootstrapElasticSearch({
-    host: 'fakehost',
-    index: esIndex,
-    alias: esAlias,
-  });
-  // Index test data - 2 collections, 3 granules
-  await Promise.all([
-    indexer.indexCollection(esClient, fakeCollectionFactory(), esAlias),
-    indexer.indexCollection(esClient, fakeCollectionFactory(), esAlias),
-    indexer.indexGranule(esClient, fakeGranuleFactoryV2({ collectionId: 'coll1' }), esAlias),
-    indexer.indexGranule(esClient, fakeGranuleFactoryV2({ collectionId: 'coll1' }), esAlias),
-    indexer.indexGranule(esClient, fakeGranuleFactoryV2({ status: 'failed', duration: 3 }), esAlias),
-  ]);
+  const { knexAdmin, knex } = await generateLocalTestDb(
+    testDbName,
+    migrationDir
+  );
 
-  // Indexing using Date.now() to generate the timestamp
-  const stub = sinon.stub(Date, 'now').returns((new Date(2020, 0, 29)).getTime());
+  t.context.knexAdmin = knexAdmin;
+  t.context.knex = knex;
 
-  await Promise.all([
-    indexer.indexCollection(esClient, fakeCollectionFactory({
-      updatedAt: new Date(2020, 0, 29),
-    }), esAlias),
-    indexer.indexGranule(esClient, fakeGranuleFactoryV2({
-      status: 'failed',
-      updatedAt: new Date(2020, 0, 29),
-      duration: 4,
-    }), esAlias),
-    indexer.indexGranule(esClient, fakeGranuleFactoryV2({
-      updatedAt: new Date(2020, 0, 29),
-      duration: 4,
-    }), esAlias),
-  ]);
+  t.context.collectionPgModel = new CollectionPgModel();
+  t.context.granulePgModel = new GranulePgModel();
 
-  stub.restore();
+  const statuses = ['queued', 'failed', 'completed', 'running'];
+  const errors = [{ Error: { keyword: 'UnknownError' } }, { Error: { keyword: 'CumulusMessageAdapterError' } }, { Error: { keyword: 'IngestFailure' } }, { Error: { keyword: 'CmrFailure' } }, { Error: {} }];
+  const granules = [];
+  const collections = [];
+
+  range(20).map((num) => (
+    // collections is never aggregate queried
+    collections.push(fakeCollectionRecordFactory({
+      name: `testCollection${num}`,
+      cumulus_id: num,
+    }))
+  ));
+
+  range(100).map((num) => (
+    // granules can be queried by timestampto/from, collectionid, providerid, status,
+    granules.push(fakeGranuleRecordFactory({
+      collection_cumulus_id: num % 20,
+      status: statuses[num % 4],
+      created_at: (new Date(2018 + (num % 6), (num % 12), (num % 30))).toISOString(),
+      updated_at: (new Date(2018 + (num % 6), (num % 12), ((num + 1) % 29))).toISOString(),
+      error: errors[num % 5],
+      duration: num + (num / 10),
+    }))
+  ));
+
+  await t.context.collectionPgModel.insert(
+    t.context.knex,
+    collections
+  );
+
+  await t.context.granulePgModel.insert(
+    t.context.knex,
+    granules
+  );
 });
 
-test.after.always(async () => {
+test.after.always(async (t) => {
   await Promise.all([
-    esClient.client.indices.delete({ index: esIndex }),
     await accessTokenModel.deleteTable(),
     s3.recursivelyDeleteS3Bucket(process.env.system_bucket),
   ]);
+
+  await destroyLocalTestDb({
+    ...t.context,
+    testDbName,
+  });
 });
 
 test('GET without pathParameters and without an Authorization header returns an Authorization Missing response', async (t) => {
@@ -121,18 +145,6 @@ test('GET /stats/aggregate without an Authorization header returns an Authorizat
 test('GET without pathParameters and with an invalid access token returns an unauthorized response', async (t) => {
   const response = await request(app)
     .get('/stats/')
-    .set('Accept', 'application/json')
-    .set('Authorization', 'Bearer ThisIsAnInvalidAuthorizationToken')
-    .expect(401);
-
-  assertions.isInvalidAccessTokenResponse(t, response);
-});
-
-test.todo('GET without pathParameters and with an unauthorized user returns an unauthorized response');
-
-test('GET /stats/aggregate with an invalid access token returns an unauthorized response', async (t) => {
-  const response = await request(app)
-    .get('/stats/aggregate')
     .set('Accept', 'application/json')
     .set('Authorization', 'Bearer ThisIsAnInvalidAuthorizationToken')
     .expect(401);
@@ -188,6 +200,18 @@ test('getType returns correct type from query params', (t) => {
   t.is(type, 'provider');
 });
 
+test.todo('GET without pathParameters and with an unauthorized user returns an unauthorized response');
+
+test('GET /stats/aggregate with an invalid access token returns an unauthorized response', async (t) => {
+  const response = await request(app)
+    .get('/stats/aggregate')
+    .set('Accept', 'application/json')
+    .set('Authorization', 'Bearer ThisIsAnInvalidAuthorizationToken')
+    .expect(401);
+
+  assertions.isInvalidAccessTokenResponse(t, response);
+});
+
 test('GET /stats returns correct response, defaulted to all', async (t) => {
   const response = await request(app)
     .get('/stats')
@@ -195,23 +219,23 @@ test('GET /stats returns correct response, defaulted to all', async (t) => {
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .expect(200);
 
-  t.is(response.body.errors.value, 2);
-  t.is(response.body.collections.value, 2);
-  t.is(response.body.processingTime.value, 2.2);
-  t.is(response.body.granules.value, 5);
+  t.is(response.body.errors.value, 80);
+  t.is(response.body.processingTime.value, 54.44999999642372);
+  t.is(response.body.granules.value, 100);
+  t.is(response.body.collections.value, 20);
 });
 
 test('GET /stats returns correct response with date params filters values correctly', async (t) => {
   const response = await request(app)
-    .get(`/stats?timestamp__from=${(new Date(2020, 0, 28)).getTime()}&timestamp__to=${(new Date(2020, 0, 30)).getTime()}`)
+    .get(`/stats?timestamp__from=${(new Date(2018, 1, 28)).getTime()}&timestamp__to=${(new Date(2019, 1, 30)).getTime()}`)
     .set('Accept', 'application/json')
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .expect(200);
 
-  t.is(response.body.errors.value, 1);
-  t.is(response.body.collections.value, 1);
-  t.is(response.body.processingTime.value, 4);
-  t.is(response.body.granules.value, 2);
+  t.is(response.body.errors.value, 15);
+  t.is(response.body.collections.value, 10);
+  t.is(response.body.processingTime.value, 53.38235317258274);
+  t.is(response.body.granules.value, 17);
 });
 
 test('GET /stats/aggregate returns correct response', async (t) => {
@@ -221,21 +245,22 @@ test('GET /stats/aggregate returns correct response', async (t) => {
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .expect(200);
 
-  t.is(response.body.meta.count, 5);
-  t.deepEqual(response.body.count, [
-    { key: 'completed', count: 3 }, { key: 'failed', count: 2 },
-  ]);
+  t.is(response.body.meta.count, 100);
+  t.is(response.body.results.count.find((item) => item.key === 'completed').count, 25);
+  t.is(response.body.results.count.find((item) => item.key === 'queued').count, 25);
+  t.is(response.body.results.count.find((item) => item.key === 'queued').count, 25);
+  t.is(response.body.results.count.find((item) => item.key === 'queued').count, 25);
 });
 
 test('GET /stats/aggregate filters correctly by date', async (t) => {
   const response = await request(app)
-    .get(`/stats/aggregate?type=granules&timestamp__from=${(new Date(2020, 0, 28)).getTime()}&timestamp__to=${(new Date(2020, 0, 30)).getTime()}`)
+    .get(`/stats/aggregate?type=granules&timestamp__from=${(new Date(2020, 11, 28)).getTime()}&timestamp__to=${(new Date(2023, 8, 30)).getTime()}`)
     .set('Accept', 'application/json')
     .set('Authorization', `Bearer ${jwtAuthToken}`)
     .expect(200);
-
-  t.is(response.body.meta.count, 2);
-  t.deepEqual(response.body.count, [
-    { key: 'completed', count: 1 }, { key: 'failed', count: 1 },
-  ]);
+  t.is(response.body.meta.count, 41);
+  t.is(response.body.results.count.find((item) => item.key === 'completed').count, 8);
+  t.is(response.body.results.count.find((item) => item.key === 'queued').count, 8);
+  t.is(response.body.results.count.find((item) => item.key === 'queued').count, 8);
+  t.is(response.body.results.count.find((item) => item.key === 'queued').count, 8);
 });

--- a/packages/db/.nycrc.json
+++ b/packages/db/.nycrc.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../nyc.config.js",
   "statements": 89.0,
-  "functions": 75.0,
-  "branches": 71.0,
+  "functions": 77.0,
+  "branches": 75.0,
   "lines": 90.0
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -142,6 +142,9 @@ export {
 export {
   GranuleSearch,
 } from './search/GranuleSearch';
+export {
+  StatsSearch,
+} from './search/StatsSearch';
 
 export { AsyncOperationPgModel } from './models/async_operation';
 export { BasePgModel } from './models/base';

--- a/packages/db/src/search/BaseSearch.ts
+++ b/packages/db/src/search/BaseSearch.ts
@@ -18,7 +18,7 @@ export type Meta = {
   count?: number,
 };
 
-const typeToTable: { [key: string]: string } = {
+export const typeToTable: { [key: string]: string } = {
   asyncOperation: TableNames.asyncOperations,
   collection: TableNames.collections,
   execution: TableNames.executions,
@@ -51,9 +51,9 @@ class BaseSearch {
    * @param knex - DB client
    * @returns queries for getting count and search result
    */
-  private _buildSearch(knex: Knex)
+  protected buildSearch(knex: Knex)
     : {
-      countQuery: Knex.QueryBuilder,
+      countQuery?: Knex.QueryBuilder,
       searchQuery: Knex.QueryBuilder,
     } {
     const { countQuery, searchQuery } = this.buildBasicQuery(knex);
@@ -64,7 +64,7 @@ class BaseSearch {
     if (limit) searchQuery.limit(limit);
     if (offset) searchQuery.offset(offset);
 
-    log.debug(`_buildSearch returns countQuery: ${countQuery.toSQL().sql}, searchQuery: ${searchQuery.toSQL().sql}`);
+    log.debug(`buildSearch returns countQuery: ${countQuery?.toSQL().sql}, searchQuery: ${searchQuery.toSQL().sql}`);
     return { countQuery, searchQuery };
   }
 
@@ -88,7 +88,7 @@ class BaseSearch {
    * @throws - function is not implemented
    */
   protected buildBasicQuery(knex: Knex): {
-    countQuery: Knex.QueryBuilder,
+    countQuery?: Knex.QueryBuilder,
     searchQuery: Knex.QueryBuilder,
   } {
     log.debug(`buildBasicQuery is not implemented ${knex.constructor.name}`);
@@ -99,12 +99,12 @@ class BaseSearch {
    * Build queries for infix and prefix
    *
    * @param params
-   * @param params.countQuery - query builder for getting count
+   * @param [params.countQuery] - query builder for getting count
    * @param params.searchQuery - query builder for search
    * @param [params.dbQueryParameters] - db query parameters
    */
   protected buildInfixPrefixQuery(params: {
-    countQuery: Knex.QueryBuilder,
+    countQuery?: Knex.QueryBuilder,
     searchQuery: Knex.QueryBuilder,
     dbQueryParameters?: DbQueryParameters,
   }) {
@@ -116,12 +116,12 @@ class BaseSearch {
    * Build queries for term fields
    *
    * @param params
-   * @param params.countQuery - query builder for getting count
+   * @param [params.countQuery] - query builder for getting count
    * @param params.searchQuery - query builder for search
    * @param [params.dbQueryParameters] - db query parameters
    */
   protected buildTermQuery(params: {
-    countQuery: Knex.QueryBuilder,
+    countQuery?: Knex.QueryBuilder,
     searchQuery: Knex.QueryBuilder,
     dbQueryParameters?: DbQueryParameters,
   }) {
@@ -130,7 +130,7 @@ class BaseSearch {
     const { term = {} } = dbQueryParameters || this.dbQueryParameters;
 
     Object.entries(term).forEach(([name, value]) => {
-      countQuery.where(`${table}.${name}`, value);
+      countQuery?.where(`${table}.${name}`, value);
       searchQuery.where(`${table}.${name}`, value);
     });
   }
@@ -154,7 +154,7 @@ class BaseSearch {
    */
   async query(testKnex: Knex | undefined) {
     const knex = testKnex ?? await getKnexClient();
-    const { countQuery, searchQuery } = this._buildSearch(knex);
+    const { countQuery, searchQuery } = this.buildSearch(knex);
     try {
       const countResult = await countQuery;
       const meta = this._metaTemplate();

--- a/packages/db/src/search/StatsSearch.ts
+++ b/packages/db/src/search/StatsSearch.ts
@@ -107,10 +107,10 @@ class StatsSearch extends BaseSearch {
   private formatSummaryResult(result: TotalSummary): SummaryResult {
     const timestampTo = Number.parseInt(this.queryStringParameters.timestamp__to as string, 10);
     const timestampFrom = Number.parseInt(this.queryStringParameters.timestamp__from as string, 10);
-    const dateto = this.queryStringParameters.timestamp__to ?
-      new Date(timestampTo).toISOString() : new Date().toISOString();
-    const datefrom = this.queryStringParameters.timestamp__from ?
-      new Date(timestampFrom).toISOString() : '1970-01-01T12:00:00+00:00';
+    const dateto = this.queryStringParameters.timestamp__to
+      ? new Date(timestampTo).toISOString() : new Date().toISOString();
+    const datefrom = this.queryStringParameters.timestamp__from
+      ? new Date(timestampFrom).toISOString() : '1970-01-01T12:00:00+00:00';
     return {
       errors: {
         dateFrom: datefrom,
@@ -149,8 +149,8 @@ class StatsSearch extends BaseSearch {
    * @param {Knex} sendKnex - the knex client to be used
    * @returns {Promise<SummaryResult>} the postgres aggregations based on query
    */
-  public async summary(sendknex: Knex): Promise<SummaryResult> {
-    const knex = sendknex ?? await getKnexClient();
+  public async summary(sendKnex: Knex): Promise<SummaryResult> {
+    const knex = sendKnex ?? await getKnexClient();
     const aggregateQuery:Knex.QueryBuilder = knex(this.tableName);
     if (this.queryStringParameters.timestamp__from) {
       aggregateQuery.where(`${TableNames.granules}.updated_at`, '>=', new Date(Number.parseInt(this.queryStringParameters.timestamp__from as string, 10)));

--- a/packages/db/src/search/StatsSearch.ts
+++ b/packages/db/src/search/StatsSearch.ts
@@ -202,7 +202,7 @@ class StatsSearch extends BaseSearch {
   /**
    * Builds basic query
    *
-   * @param knex - the knex client
+   * @param {Knex} knex - the knex client
    * @returns the search query
    */
   protected buildBasicQuery(knex: Knex)
@@ -219,6 +219,7 @@ class StatsSearch extends BaseSearch {
    *
    * @param params
    * @param {Knex.QueryBuilder} params.searchQuery - the search query
+   * @param [params.dbQueryParameters] - the db query parameters
    */
   protected buildInfixPrefixQuery(params: {
     searchQuery: Knex.QueryBuilder,
@@ -271,8 +272,7 @@ class StatsSearch extends BaseSearch {
    * Executes the aggregate search query
    *
    * @param {Knex | undefined} testKnex - the knex client to be used
-   * @param [params.dbQueryParameters] - the db query parameters
-   * @returns {ApiAggregateResult} - the aggregate query results in api format
+   * @returns {Promise<ApiAggregateResult>} - the aggregate query results in api format
    */
   async aggregate(testKnex: Knex | undefined): Promise<ApiAggregateResult> {
     const knex = testKnex ?? await getKnexClient();

--- a/packages/db/src/search/StatsSearch.ts
+++ b/packages/db/src/search/StatsSearch.ts
@@ -181,9 +181,9 @@ class StatsSearch extends BaseSearch {
     let groupStrings = '';
     this.queryStringParameters.field = this.queryStringParameters.field ? this.queryStringParameters.field : 'status';
     if (this.queryStringParameters.field.includes('error.Error')) {
-      groupStrings = `${groupStrings}*` + (knex.raw("error ->>'Error'->>'keyword' as error"), knex.raw('COUNT(*) as count'));
+      groupStrings += (knex.raw("error #>> '{Error, keyword}' as error"));
     } else {
-      groupStrings += (` ${this.queryStringParameters.type}.${this.queryStringParameters.field}`);
+      groupStrings += (`${this.queryStringParameters.type}.${this.queryStringParameters.field}`);
     }
     return groupStrings;
   }
@@ -197,7 +197,7 @@ class StatsSearch extends BaseSearch {
   private aggregateQueryField(query: Knex.QueryBuilder, knex: Knex): Knex.QueryBuilder {
     this.queryStringParameters.field = this.queryStringParameters.field ? this.queryStringParameters.field : 'status';
     if (this.queryStringParameters.field.includes('error.Error')) {
-      query.select(knex.raw("error #>> '{Error, keyword}' as error"), knex.raw('COUNT(*) as count')).groupByRaw("error #>> '{Error, keyword}'").orderByRaw('count DESC');
+      query.select(knex.raw("error #>> '{Error, keyword}' as error")).count('* as count').groupByRaw("error #>> '{Error, keyword}'").orderBy('count', 'desc');
     } else {
       query.select(`${this.queryStringParameters.type}.${this.queryStringParameters.field}`).count('* as count').groupBy(`${this.queryStringParameters.type}.${this.queryStringParameters.field}`)
         .orderBy('count', 'desc');

--- a/packages/db/src/search/StatsSearch.ts
+++ b/packages/db/src/search/StatsSearch.ts
@@ -1,0 +1,284 @@
+import { Knex } from 'knex';
+import { getKnexClient } from '../connection';
+import { TableNames } from '../tables';
+import { DbQueryParameters } from '../types/search';
+import { BaseSearch } from './BaseSearch';
+
+type TotalSummaryObject = {
+  count_errors: number,
+  count_collections: number,
+  count_granules: number,
+  avg_processing_time: number,
+};
+
+type AggregateObject = {
+  count: string,
+  status?: string,
+  error?: string,
+};
+
+type SummaryObject = {
+  dateFrom: string | Date,
+  dateTo: string | Date,
+  value: number,
+  aggregation: string,
+  unit: string,
+};
+
+type SummaryResultObject = {
+  errors: SummaryObject,
+  granules: SummaryObject,
+  collections: SummaryObject,
+  processingTime: SummaryObject,
+};
+
+type MetaObject = {
+  name: string,
+  count: number,
+  field: string,
+};
+
+type AggregateResObject = {
+  key: string,
+  count: number,
+};
+
+type ApiAggregateResult = {
+  meta: MetaObject,
+  count: AggregateResObject[]
+};
+
+const infixMapping = new Map([
+  ['granules', 'granule_id'],
+  ['collections', 'name'],
+  ['providers', 'name'],
+  ['executions', 'arn'],
+  ['pdrs', 'name'],
+]);
+
+class StatsSearch extends BaseSearch {
+  /** Formats the knex results into an API aggregate search response
+   *
+   * @param {Record<string, aggregateObject>} result - the knex query results
+   * @returns {apiAggregateResult} An api Object with the aggregate statistics
+   */
+  private formatAggregateResult(result: Record<string, AggregateObject>): ApiAggregateResult {
+    let totalCount = 0;
+    const responses = [];
+    for (const row of Object.keys(result)) {
+      responses.push(
+        {
+          key: this.queryStringParameters.field === 'status' ? `${result[row].status}` : `${result[row].error}`,
+          count: Number.parseInt(result[row].count, 10),
+        }
+      );
+      totalCount += Number(result[row].count);
+    }
+    return {
+      meta: {
+        name: 'cumulus-api',
+        count: totalCount,
+        field: `${this.queryStringParameters.field}`,
+      },
+      count: responses,
+    };
+  }
+
+  /** Formats the knex results into an API aggregate search response
+   *
+   * @param {totalSummaryObject} result - the knex summary query results
+   * @returns {SummaryResultObject} An api Object with the summary statistics
+   */
+  private formatSummaryResult(result: TotalSummaryObject): SummaryResultObject {
+    const dateto = this.queryStringParameters.timestamp__to ?
+      new Date(Number.parseInt(this.queryStringParameters.timestamp__to, 10)) : new Date();
+    const datefrom = this.queryStringParameters.timestamp__from ?
+      new Date(Number.parseInt(this.queryStringParameters.timestamp__from, 10)) : '1970-01-01T12:00:00+00:00';
+    return {
+      errors: {
+        dateFrom: datefrom,
+        dateTo: dateto,
+        value: Number(result.count_errors),
+        aggregation: 'count',
+        unit: 'error',
+      },
+      collections: {
+        dateFrom: datefrom,
+        dateTo: dateto,
+        value: Number(result.count_collections),
+        aggregation: 'count',
+        unit: 'collection',
+      },
+      processingTime: {
+        dateFrom: datefrom,
+        dateTo: dateto,
+        value: Number(result.avg_processing_time),
+        aggregation: 'average',
+        unit: 'second',
+      },
+      granules: {
+        dateFrom: datefrom,
+        dateTo: dateto,
+        value: Number(result.count_granules),
+        aggregation: 'count',
+        unit: 'granule',
+      },
+    };
+  }
+
+  /** Provides a summary of statistics around the granules in the system
+   *
+   * @param {Knex} sendKnex - the knex client to be used
+   * @returns {Promis<SummaryResultObject>} An Object with the summary statistics
+   */
+  public async summary(sendknex: Knex): Promise<SummaryResultObject> {
+    const knex = sendknex ?? await getKnexClient();
+    const aggregateQuery:Knex.QueryBuilder = knex(`${TableNames.granules}`);
+    if (this.queryStringParameters.timestamp__from) {
+      aggregateQuery.where(`${TableNames.granules}.updated_at`, '>=', new Date(Number.parseInt(this.queryStringParameters.timestamp__from, 10)));
+    }
+    if (this.queryStringParameters.timestamp__to) {
+      aggregateQuery.where(`${TableNames.granules}.updated_at`, '<=', new Date(Number.parseInt(this.queryStringParameters.timestamp__to, 10)));
+    }
+    const aggregateQueryRes: TotalSummaryObject[] = await aggregateQuery.select(
+      knex.raw(`COUNT(CASE WHEN ${TableNames.granules}.error ->> 'Error' != '{}' THEN 1 END) AS count_errors`),
+      knex.raw(`COUNT(${TableNames.granules}.cumulus_id) AS count_granules`),
+      knex.raw(`AVG(${TableNames.granules}.duration) AS avg_processing_time`),
+      knex.raw(`COUNT(DISTINCT ${TableNames.granules}.collection_cumulus_id) AS count_collections`)
+    );
+    return this.formatSummaryResult(aggregateQueryRes[0]);
+  }
+
+  /** Performs joins on the provider/collection table if neccessary
+   *
+   * @param {Knex} knex - the knex client to be used
+   * @returns {Knex.QueryBuilder} the knex query of a joined table or not based on queryStringParams
+   */
+  private providerAndCollectionIdBuilder(knex: Knex, type: string): Knex.QueryBuilder {
+    let aggregateQuery = knex(`${this.queryStringParameters.type}`);
+    if (type === 'search') {
+      aggregateQuery = knex.select(
+        this.whatToGroupBy(knex)
+      ).from(`${this.queryStringParameters.type}`);
+    }
+
+    if (this.queryStringParameters.collectionId) {
+      aggregateQuery.join(`${TableNames.collections}`, `${this.queryStringParameters.type}.collection_cumulus_id`, 'collections.cumulus_id');
+    }
+
+    if (this.queryStringParameters.provider) {
+      aggregateQuery.join(`${TableNames.providers}`, `${this.queryStringParameters.type}.provider_cumulus_id`, 'providers.cumulus_id');
+    }
+    return aggregateQuery;
+  }
+
+  /** Provides a knex raw string to group the query based on queryStringParameters
+   *
+   * @param {Knex} knex - the knex client to be used
+   * @returns {string} The elements to GroupBy
+   */
+  private whatToGroupBy(knex: Knex): string {
+    let groupStrings = '';
+    this.queryStringParameters.field = this.queryStringParameters.field ? this.queryStringParameters.field : 'status';
+    if (this.queryStringParameters.field.includes('error.Error')) {
+      groupStrings = `${groupStrings}*` + (knex.raw("error ->>'Error'->>'keyword' as error"), knex.raw('COUNT(*) as count'));
+    } else {
+      groupStrings += (` ${this.queryStringParameters.type}.${this.queryStringParameters.field}`);
+    }
+    return groupStrings;
+  }
+
+  /** Provides a knex raw string to aggregate the query based on queryStringParameters
+   *
+   * @param {query} Knex.QueryBuilder - the current knex query to be aggregated
+   * @param {Knex} knex - the knex client to be used
+   * @returns {Knex.QueryBuilder} The query with its new Aggregatation string
+   */
+  private aggregateQueryField(query: Knex.QueryBuilder, knex: Knex): Knex.QueryBuilder {
+    this.queryStringParameters.field = this.queryStringParameters.field ? this.queryStringParameters.field : 'status';
+    if (this.queryStringParameters.field.includes('error.Error')) {
+      query.select(knex.raw("error #>> '{Error, keyword}' as error"), knex.raw('COUNT(*) as count')).groupByRaw("error #>> '{Error, keyword}'").orderByRaw('count DESC');
+    } else {
+      query.select(`${this.queryStringParameters.type}.${this.queryStringParameters.field}`).count('* as count').groupBy(`${this.queryStringParameters.type}.${this.queryStringParameters.field}`)
+        .orderBy('count', 'desc');
+    }
+    return query;
+  }
+
+  protected buildBasicQuery(knex: Knex)
+    : {
+      countQuery: Knex.QueryBuilder,
+      searchQuery: Knex.QueryBuilder,
+    } {
+    let countQuery:Knex.QueryBuilder;
+    let searchQuery:Knex.QueryBuilder;
+    if (this.queryStringParameters.provider || this.queryStringParameters.collectionId) {
+      countQuery = this.providerAndCollectionIdBuilder(knex, 'count');
+      searchQuery = this.providerAndCollectionIdBuilder(knex, 'search');
+    } else {
+      countQuery = knex(`${this.queryStringParameters.type}`);
+      searchQuery = knex(`${this.queryStringParameters.type}`);
+    }
+    searchQuery = this.aggregateQueryField(searchQuery, knex);
+    return { countQuery, searchQuery };
+  }
+
+  protected buildInfixPrefixQuery(params: {
+    countQuery: Knex.QueryBuilder,
+    searchQuery: Knex.QueryBuilder,
+    dbQueryParameters?: DbQueryParameters,
+  }) {
+    const { countQuery, searchQuery, dbQueryParameters } = params;
+    const { infix, prefix } = dbQueryParameters || this.dbQueryParameters;
+    const fieldName = this.queryStringParameters.type ? infixMapping.get(this.queryStringParameters.type) : 'granuleId';
+    if (infix) {
+      countQuery.whereLike(`${this.queryStringParameters.type}.${fieldName}`, `%${infix}%`);
+      searchQuery.whereLike(`${this.queryStringParameters.type}.${fieldName}`, `%${infix}%`);
+    }
+    if (prefix) {
+      countQuery.whereLike(`${this.queryStringParameters.type}.${fieldName}`, `%${prefix}%`);
+      searchQuery.whereLike(`${this.queryStringParameters.type}.${fieldName}`, `%${prefix}%`);
+    }
+  }
+
+  protected buildTermQuery(params: {
+    countQuery: Knex.QueryBuilder,
+    searchQuery: Knex.QueryBuilder,
+    dbQueryParameters?: DbQueryParameters,
+  }) {
+    const { countQuery, searchQuery } = params;
+    if (this.queryStringParameters.collectionId) {
+      countQuery.where(`${TableNames.collections}.name`, '=', this.queryStringParameters.collectionId);
+      searchQuery.where(`${TableNames.collections}.name`, '=', this.queryStringParameters.collectionId);
+    }
+    if (this.queryStringParameters.provider) {
+      countQuery.where(`${TableNames.providers}.name`, '=', this.queryStringParameters.provider);
+      searchQuery.where(`${TableNames.providers}.name`, '=', this.queryStringParameters.provider);
+    }
+    if (this.queryStringParameters.timestamp__from) {
+      countQuery.where(`${this.queryStringParameters.type}.updated_at`, '>=', new Date(Number.parseInt(this.queryStringParameters.timestamp__from, 10)));
+      searchQuery.where(`${this.queryStringParameters.type}.updated_at`, '>=', new Date(Number.parseInt(this.queryStringParameters.timestamp__from, 10)));
+    }
+    if (this.queryStringParameters.timestamp__to) {
+      countQuery.where(`${this.queryStringParameters.type}.updated_at`, '<=', new Date(Number.parseInt(this.queryStringParameters.timestamp__to, 10)));
+      searchQuery.where(`${this.queryStringParameters.type}.updated_at`, '<=', new Date(Number.parseInt(this.queryStringParameters.timestamp__to, 10)));
+    }
+    if (this.queryStringParameters.status) {
+      countQuery.where(`${this.queryStringParameters.type}.status`, '=', this.queryStringParameters.status);
+      searchQuery.where(`${this.queryStringParameters.type}.status`, '=', this.queryStringParameters.status);
+    }
+    countQuery.count('* as count');
+    return { countQuery, searchQuery };
+  }
+
+  // @ts-ignore
+  protected translatePostgresRecordsToApiRecords(pgRecords: Record<string, AggregateObject>
+  | TotalSummaryObject): SummaryResultObject | ApiAggregateResult {
+    if (this.type === 'summary') {
+      return this.formatSummaryResult(pgRecords as TotalSummaryObject);
+    }
+    return this.formatAggregateResult(pgRecords as Record<string, AggregateObject>);
+  }
+}
+
+export { StatsSearch };

--- a/packages/db/src/search/StatsSearch.ts
+++ b/packages/db/src/search/StatsSearch.ts
@@ -196,7 +196,7 @@ class StatsSearch extends BaseSearch {
       query.select(`${this.tableName}.${this.queryStringParameters.field} as aggregatedfield`);
     }
     query.modify((queryBuilder) => this.joinTables(queryBuilder));
-    query.count(`${this.tableName}.cumulus_id as count`).groupBy('aggregatedfield').orderBy('count', 'desc');
+    query.count(`${this.tableName}.cumulus_id as count`).groupBy('aggregatedfield').orderBy([{ column: 'count', order: 'desc' }, { column: 'aggregatedfield' }]);
   }
 
   /**

--- a/packages/db/src/search/StatsSearch.ts
+++ b/packages/db/src/search/StatsSearch.ts
@@ -158,7 +158,7 @@ class StatsSearch extends BaseSearch {
       aggregateQuery.where(`${this.tableName}.updated_at`, '<=', new Date(Number.parseInt(this.queryStringParameters.timestamp__to as string, 10)));
     }
     aggregateQuery.select(
-      knex.raw(`COUNT(CASE WHEN ${this.tableName}.error ->> 'Error' != '{}' THEN 1 END) AS count_errors`),
+      knex.raw(`COUNT(CASE WHEN ${this.tableName}.error ->> 'Error' is not null THEN 1 END) AS count_errors`),
       knex.raw(`COUNT(${this.tableName}.cumulus_id) AS count_granules`),
       knex.raw(`AVG(${this.tableName}.duration) AS avg_processing_time`),
       knex.raw(`COUNT(DISTINCT ${this.tableName}.collection_cumulus_id) AS count_collections`)
@@ -261,6 +261,9 @@ class StatsSearch extends BaseSearch {
     }
     if (this.queryStringParameters.timestamp__to) {
       searchQuery.where(`${this.tableName}.updated_at`, '<=', new Date(Number.parseInt(this.queryStringParameters.timestamp__to as string, 10)));
+    }
+    if (this.queryStringParameters.field?.includes('error.Error')) {
+      searchQuery.whereRaw(`${this.tableName}.error ->> 'Error' is not null`);
     }
     const { term = {} } = this.dbQueryParameters;
     return super.buildTermQuery({

--- a/packages/db/src/search/StatsSearch.ts
+++ b/packages/db/src/search/StatsSearch.ts
@@ -195,8 +195,10 @@ class StatsSearch extends BaseSearch {
     } else {
       query.select(`${this.tableName}.${this.queryStringParameters.field} as aggregatedfield`);
     }
-    query.modify((queryBuilder) => this.joinTables(queryBuilder));
-    query.count(`${this.tableName}.cumulus_id as count`).groupBy('aggregatedfield').orderBy([{ column: 'count', order: 'desc' }, { column: 'aggregatedfield' }]);
+    query.modify((queryBuilder) => this.joinTables(queryBuilder))
+      .count(`${this.tableName}.cumulus_id as count`)
+      .groupBy('aggregatedfield')
+      .orderBy([{ column: 'count', order: 'desc' }, { column: 'aggregatedfield' }]);
   }
 
   /**

--- a/packages/db/src/search/StatsSearch.ts
+++ b/packages/db/src/search/StatsSearch.ts
@@ -149,7 +149,7 @@ class StatsSearch extends BaseSearch {
       aggregateQuery.where(`${TableNames.granules}.updated_at`, '<=', new Date(Number.parseInt(this.queryStringParameters.timestamp__to as string, 10)));
     }
     aggregateQuery.select(
-      knex.raw(`COUNT(CASE WHEN ${TableNames.granules}.error ->> 'Error' != '{}' THEN 1 ELSE 0 END) AS count_errors`),
+      knex.raw(`COUNT(CASE WHEN ${TableNames.granules}.error ->> 'Error' != '{}' THEN 1 END) AS count_errors`),
       knex.raw(`COUNT(${TableNames.granules}.cumulus_id) AS count_granules`),
       knex.raw(`AVG(${TableNames.granules}.duration) AS avg_processing_time`),
       knex.raw(`COUNT(DISTINCT ${TableNames.granules}.collection_cumulus_id) AS count_collections`)

--- a/packages/db/src/types/search.ts
+++ b/packages/db/src/types/search.ts
@@ -7,6 +7,12 @@ export type QueryStringParameters = {
   prefix?: string,
   sort_by?: string,
   sort_key?: string,
+  type?: string,
+  field?: string,
+  provider?: string,
+  collectionId?: string,
+  timestamp__to?: string,
+  timestamp__from?: string,
   [key: string]: string | string[] | undefined,
 };
 

--- a/packages/db/src/types/search.ts
+++ b/packages/db/src/types/search.ts
@@ -1,4 +1,5 @@
 export type QueryStringParameters = {
+  field?: string,
   fields?: string,
   infix?: string,
   limit?: string,
@@ -7,12 +8,6 @@ export type QueryStringParameters = {
   prefix?: string,
   sort_by?: string,
   sort_key?: string,
-  type?: string,
-  field?: string,
-  provider?: string,
-  collectionId?: string,
-  timestamp__to?: string,
-  timestamp__from?: string,
   [key: string]: string | string[] | undefined,
 };
 

--- a/packages/db/tests/search/test-StatsSearch.js
+++ b/packages/db/tests/search/test-StatsSearch.js
@@ -317,6 +317,7 @@ test('StatsSearch returns correct response when queried by error', async (t) => 
   };
   const AggregateSearch = new StatsSearch({ queryStringParameters }, 'granule');
   const results = await AggregateSearch.aggregate(knex);
+  console.log("RESULTS", results);
   t.is(results.meta.count, 100);
   t.is(results.count.find((item) => item.key === 'CmrFailure').count, 20);
   t.is(results.count.find((item) => item.key === 'UnknownError').count, 20);

--- a/packages/db/tests/search/test-StatsSearch.js
+++ b/packages/db/tests/search/test-StatsSearch.js
@@ -39,7 +39,7 @@ test.before(async (t) => {
   t.context.ExecutionPgModel = new ExecutionPgModel();
 
   const statuses = ['queued', 'failed', 'completed', 'running'];
-  const errors = [{ Error: { keyword: 'UnknownError' } }, { Error: { keyword: 'CumulusMessageAdapterError' } }, { Error: { keyword: 'IngestFailure' } }, { Error: { keyword: 'CmrFailure' } }, { Error: {} }];
+  const errors = [{ Error: 'UnknownError' }, { Error: 'CumulusMessageAdapterError' }, { Error: 'IngestFailure' }, { Error: 'CmrFailure' }, { Error: {} }];
   const granules = [];
   const collections = [];
   const executions = [];

--- a/packages/db/tests/search/test-StatsSearch.js
+++ b/packages/db/tests/search/test-StatsSearch.js
@@ -39,7 +39,7 @@ test.before(async (t) => {
   t.context.ExecutionPgModel = new ExecutionPgModel();
 
   const statuses = ['queued', 'failed', 'completed', 'running'];
-  const errors = [{ Error: 'UnknownError' }, { Error: 'CumulusMessageAdapterError' }, { Error: 'IngestFailure' }, { Error: 'CmrFailure' }, { Error: {} }];
+  const errors = [{ Error: 'UnknownError' }, { Error: 'CumulusMessageAdapterError' }, { Error: 'IngestFailure' }, { Error: 'CmrFailure' }, {}];
   const granules = [];
   const collections = [];
   const executions = [];
@@ -345,9 +345,8 @@ test('StatsSearch returns correct response when queried by error', async (t) => 
     { key: 'CumulusMessageAdapterError', count: 20 },
     { key: 'IngestFailure', count: 20 },
     { key: 'UnknownError', count: 20 },
-    { key: '{}', count: 20 },
   ];
-  t.is(results.meta.count, 100);
+  t.is(results.meta.count, 80);
   t.deepEqual(results.count, expectedResponse1);
 
   queryStringParameters = {
@@ -361,11 +360,10 @@ test('StatsSearch returns correct response when queried by error', async (t) => 
   const expectedResponse2 = [
     { key: 'CmrFailure', count: 8 },
     { key: 'IngestFailure', count: 7 },
-    { key: '{}', count: 7 },
     { key: 'CumulusMessageAdapterError', count: 6 },
     { key: 'UnknownError', count: 6 },
   ];
-  t.is(results2.meta.count, 34);
+  t.is(results2.meta.count, 27);
   t.deepEqual(results2.count, expectedResponse2);
 
   queryStringParameters = {

--- a/packages/db/tests/search/test-StatsSearch.js
+++ b/packages/db/tests/search/test-StatsSearch.js
@@ -317,12 +317,12 @@ test('StatsSearch returns correct response when queried by error', async (t) => 
   };
   const AggregateSearch = new StatsSearch({ queryStringParameters }, 'granule');
   const results = await AggregateSearch.aggregate(knex);
-  console.log("RESULTS", results);
   t.is(results.meta.count, 100);
   t.is(results.count.find((item) => item.key === 'CmrFailure').count, 20);
   t.is(results.count.find((item) => item.key === 'UnknownError').count, 20);
   t.is(results.count.find((item) => item.key === 'IngestFailure').count, 20);
   t.is(results.count.find((item) => item.key === 'CumulusMessageAdapterError').count, 20);
+
   queryStringParameters = {
     type: 'granules',
     field: 'error.Error.keyword',
@@ -336,6 +336,19 @@ test('StatsSearch returns correct response when queried by error', async (t) => 
   t.is(results2.count.find((item) => item.key === 'UnknownError').count, 6);
   t.is(results2.count.find((item) => item.key === 'IngestFailure').count, 7);
   t.is(results2.count.find((item) => item.key === 'CumulusMessageAdapterError').count, 6);
+
+  queryStringParameters = {
+    type: 'granules',
+    collectionId: 'testCollection___1',
+    providerId: 'testProvider1',
+    field: 'error.Error.keyword',
+    timestamp__to: `${(new Date(2019, 12, 9)).getTime()}`,
+    timestamp__from: `${(new Date(2018, 1, 28)).getTime()}`,
+  };
+  const AggregateSearch3 = new StatsSearch({ queryStringParameters }, 'granule');
+  const results3 = await AggregateSearch3.aggregate(knex);
+  t.is(results3.meta.count, 2);
+  t.is(results3.count.find((item) => item.key === 'CumulusMessageAdapterError').count, 2);
 });
 
 test('StatsSearch can query by infix and prefix when type is defined', async (t) => {

--- a/packages/db/tests/search/test-StatsSearch.js
+++ b/packages/db/tests/search/test-StatsSearch.js
@@ -131,11 +131,14 @@ test('StatsSearch returns correct response for basic granules query', async (t) 
   };
   const AggregateSearch = new StatsSearch({ queryStringParameters }, 'granule');
   const results = await AggregateSearch.aggregate(knex);
-  t.is(results.count.find((item) => item.key === 'completed')?.count, 25);
-  t.is(results.count.find((item) => item.key === 'failed')?.count, 25);
-  t.is(results.count.find((item) => item.key === 'queued')?.count, 25);
-  t.is(results.count.find((item) => item.key === 'running')?.count, 25);
+  const expectedResponse = [
+    { key: 'completed', count: 25 },
+    { key: 'failed', count: 25 },
+    { key: 'queued', count: 25 },
+    { key: 'running', count: 25 },
+  ];
   t.is(results.meta.count, 100);
+  t.deepEqual(results.count, expectedResponse);
 });
 
 test('StatsSearch filters correctly by date', async (t) => {
@@ -148,11 +151,14 @@ test('StatsSearch filters correctly by date', async (t) => {
 
   const AggregateSearch = new StatsSearch({ queryStringParameters }, 'granule');
   const results = await AggregateSearch.aggregate(knex);
-  t.is(results.count.find((item) => item.key === 'completed').count, 9);
-  t.is(results.count.find((item) => item.key === 'failed')?.count, 8);
-  t.is(results.count.find((item) => item.key === 'queued')?.count, 8);
-  t.is(results.count.find((item) => item.key === 'running')?.count, 9);
+  const expectedResponse = [
+    { key: 'completed', count: 9 },
+    { key: 'running', count: 9 },
+    { key: 'failed', count: 8 },
+    { key: 'queued', count: 8 },
+  ];
   t.is(results.meta.count, 34);
+  t.deepEqual(results.count, expectedResponse);
 });
 
 test('StatsSearch filters executions correctly', async (t) => {
@@ -164,10 +170,13 @@ test('StatsSearch filters executions correctly', async (t) => {
 
   const AggregateSearch = new StatsSearch({ queryStringParameters }, 'execution');
   const results = await AggregateSearch.aggregate(knex);
-  t.is(results.count.find((item) => item.key === 'completed').count, 7);
-  t.is(results.count.find((item) => item.key === 'failed').count, 7);
-  t.is(results.count.find((item) => item.key === 'running').count, 6);
+  const expectedResponse1 = [
+    { key: 'completed', count: 7 },
+    { key: 'failed', count: 7 },
+    { key: 'running', count: 6 },
+  ];
   t.is(results.meta.count, 20);
+  t.deepEqual(results.count, expectedResponse1);
 
   queryStringParameters = {
     type: 'executions',
@@ -178,10 +187,13 @@ test('StatsSearch filters executions correctly', async (t) => {
 
   const AggregateSearch2 = new StatsSearch({ queryStringParameters }, 'execution');
   const results2 = await AggregateSearch2.aggregate(knex);
-  t.is(results2.count.find((item) => item.key === 'completed').count, 3);
-  t.is(results2.count.find((item) => item.key === 'failed').count, 3);
-  t.is(results2.count.find((item) => item.key === 'running').count, 3);
+  const expectedResponse2 = [
+    { key: 'completed', count: 3 },
+    { key: 'failed', count: 3 },
+    { key: 'running', count: 3 },
+  ];
   t.is(results2.meta.count, 9);
+  t.deepEqual(results2.count, expectedResponse2);
 
   queryStringParameters = {
     type: 'executions',
@@ -194,7 +206,8 @@ test('StatsSearch filters executions correctly', async (t) => {
 
   const AggregateSearch3 = new StatsSearch({ queryStringParameters }, 'execution');
   const results3 = await AggregateSearch3.aggregate(knex);
-  t.is(results3.count.find((item) => item.key === 'running').count, 1);
+  const expectedResponse3 = [{ key: 'running', count: 1 }];
+  t.deepEqual(results3.count, expectedResponse3);
   t.is(results3.meta.count, 1);
 });
 
@@ -207,10 +220,13 @@ test('StatsSearch filters PDRs correctly', async (t) => {
 
   const AggregateSearch = new StatsSearch({ queryStringParameters }, 'pdr');
   const results = await AggregateSearch.aggregate(knex);
-  t.is(results.count.find((item) => item.key === 'completed').count, 7);
-  t.is(results.count.find((item) => item.key === 'failed').count, 7);
-  t.is(results.count.find((item) => item.key === 'running').count, 6);
+  const expectedResponse = [
+    { key: 'completed', count: 7 },
+    { key: 'failed', count: 7 },
+    { key: 'running', count: 6 },
+  ];
   t.is(results.meta.count, 20);
+  t.deepEqual(results.count, expectedResponse);
 
   queryStringParameters = {
     type: 'pdrs',
@@ -221,9 +237,10 @@ test('StatsSearch filters PDRs correctly', async (t) => {
 
   const AggregateSearch2 = new StatsSearch({ queryStringParameters }, 'pdr');
   const results2 = await AggregateSearch2.aggregate(knex);
-  t.is(results2.count.find((item) => item.key === 'completed').count, 4);
-  t.is(results2.count.find((item) => item.key === 'failed').count, 2);
+  const expectedResponse2 = [{ key: 'completed', count: 4 }, { key: 'failed', count: 2 }];
   t.is(results2.meta.count, 6);
+  t.deepEqual(results2.count, expectedResponse2);
+
   queryStringParameters = {
     type: 'pdrs',
     field: 'status',
@@ -234,8 +251,9 @@ test('StatsSearch filters PDRs correctly', async (t) => {
 
   const AggregateSearch3 = new StatsSearch({ queryStringParameters }, 'pdr');
   const results3 = await AggregateSearch3.aggregate(knex);
-  t.is(results3.count.find((item) => item.key === 'failed').count, 2);
+  const expectedResponse3 = [{ key: 'failed', count: 2 }];
   t.is(results3.meta.count, 2);
+  t.deepEqual(results3.count, expectedResponse3);
 });
 
 test('StatsSearch returns correct response when queried by provider', async (t) => {
@@ -248,9 +266,9 @@ test('StatsSearch returns correct response when queried by provider', async (t) 
 
   const AggregateSearch = new StatsSearch({ queryStringParameters }, 'granule');
   const results = await AggregateSearch.aggregate(knex);
+  const expectedResponse = [{ key: 'completed', count: 5 }, { key: 'queued', count: 5 }];
   t.is(results.meta.count, 10);
-  t.is(results.count.find((item) => item.key === 'completed').count, 5);
-  t.is(results.count.find((item) => item.key === 'queued').count, 5);
+  t.deepEqual(results.count, expectedResponse);
 });
 
 test('StatsSearch returns correct response when queried by collection', async (t) => {
@@ -263,7 +281,9 @@ test('StatsSearch returns correct response when queried by collection', async (t
 
   const AggregateSearch = new StatsSearch({ queryStringParameters }, 'granule');
   const results = await AggregateSearch.aggregate(knex);
+  const expectedResponse = [{ key: 'queued', count: 5 }];
   t.is(results.meta.count, 5);
+  t.deepEqual(results.count, expectedResponse);
 });
 
 test('StatsSearch returns correct response when queried by collection and provider', async (t) => {
@@ -277,8 +297,9 @@ test('StatsSearch returns correct response when queried by collection and provid
 
   const AggregateSearch = new StatsSearch({ queryStringParameters }, 'granule');
   const results = await AggregateSearch.aggregate(knex);
+  const expectedResponse = [{ key: 'failed', count: 5 }];
   t.is(results.meta.count, 5);
-  t.is(results.count.find((item) => item.key === 'failed').count, 5);
+  t.deepEqual(results.count, expectedResponse);
 
   queryStringParameters = {
     type: 'granules',
@@ -291,8 +312,9 @@ test('StatsSearch returns correct response when queried by collection and provid
 
   const AggregateSearch2 = new StatsSearch({ queryStringParameters }, 'granule');
   const results2 = await AggregateSearch2.aggregate(knex);
+  const expectedResponse2 = [{ key: 'failed', count: 2 }];
   t.is(results2.meta.count, 2);
-  t.is(results2.count.find((item) => item.key === 'failed').count, 2);
+  t.deepEqual(results2.count, expectedResponse2);
   queryStringParameters = {
     type: 'granules',
     field: 'status',
@@ -305,8 +327,9 @@ test('StatsSearch returns correct response when queried by collection and provid
 
   const AggregateSearch3 = new StatsSearch({ queryStringParameters }, 'granule');
   const results3 = await AggregateSearch3.aggregate(knex);
+  const expectedResponse3 = [{ key: 'failed', count: 2 }];
   t.is(results3.meta.count, 2);
-  t.is(results3.count.find((item) => item.key === 'failed').count, 2);
+  t.deepEqual(results3.count, expectedResponse3);
 });
 
 test('StatsSearch returns correct response when queried by error', async (t) => {
@@ -317,11 +340,15 @@ test('StatsSearch returns correct response when queried by error', async (t) => 
   };
   const AggregateSearch = new StatsSearch({ queryStringParameters }, 'granule');
   const results = await AggregateSearch.aggregate(knex);
+  const expectedResponse1 = [
+    { key: 'CmrFailure', count: 20 },
+    { key: 'CumulusMessageAdapterError', count: 20 },
+    { key: 'IngestFailure', count: 20 },
+    { key: 'UnknownError', count: 20 },
+    { key: '{}', count: 20 },
+  ];
   t.is(results.meta.count, 100);
-  t.is(results.count.find((item) => item.key === 'CmrFailure').count, 20);
-  t.is(results.count.find((item) => item.key === 'UnknownError').count, 20);
-  t.is(results.count.find((item) => item.key === 'IngestFailure').count, 20);
-  t.is(results.count.find((item) => item.key === 'CumulusMessageAdapterError').count, 20);
+  t.deepEqual(results.count, expectedResponse1);
 
   queryStringParameters = {
     type: 'granules',
@@ -331,11 +358,15 @@ test('StatsSearch returns correct response when queried by error', async (t) => 
   };
   const AggregateSearch2 = new StatsSearch({ queryStringParameters }, 'granule');
   const results2 = await AggregateSearch2.aggregate(knex);
+  const expectedResponse2 = [
+    { key: 'CmrFailure', count: 8 },
+    { key: 'IngestFailure', count: 7 },
+    { key: '{}', count: 7 },
+    { key: 'CumulusMessageAdapterError', count: 6 },
+    { key: 'UnknownError', count: 6 },
+  ];
   t.is(results2.meta.count, 34);
-  t.is(results2.count.find((item) => item.key === 'CmrFailure').count, 8);
-  t.is(results2.count.find((item) => item.key === 'UnknownError').count, 6);
-  t.is(results2.count.find((item) => item.key === 'IngestFailure').count, 7);
-  t.is(results2.count.find((item) => item.key === 'CumulusMessageAdapterError').count, 6);
+  t.deepEqual(results2.count, expectedResponse2);
 
   queryStringParameters = {
     type: 'granules',
@@ -347,8 +378,9 @@ test('StatsSearch returns correct response when queried by error', async (t) => 
   };
   const AggregateSearch3 = new StatsSearch({ queryStringParameters }, 'granule');
   const results3 = await AggregateSearch3.aggregate(knex);
+  const expectedResponse3 = [{ key: 'CumulusMessageAdapterError', count: 2 }];
   t.is(results3.meta.count, 2);
-  t.is(results3.count.find((item) => item.key === 'CumulusMessageAdapterError').count, 2);
+  t.deepEqual(results3.count, expectedResponse3);
 });
 
 test('StatsSearch can query by infix and prefix when type is defined', async (t) => {
@@ -359,9 +391,9 @@ test('StatsSearch can query by infix and prefix when type is defined', async (t)
   };
   const AggregateSearch = new StatsSearch({ queryStringParameters }, 'granule');
   const results = await AggregateSearch.aggregate(knex);
+  const expectedResponse1 = [{ key: 'completed', count: 25 }, { key: 'queued', count: 25 }];
   t.is(results.meta.count, 50);
-  t.is(results.count.find((item) => item.key === 'completed').count, 25);
-  t.is(results.count.find((item) => item.key === 'queued').count, 25);
+  t.deepEqual(results.count, expectedResponse1);
 
   queryStringParameters = {
     type: 'granules',
@@ -369,9 +401,9 @@ test('StatsSearch can query by infix and prefix when type is defined', async (t)
   };
   const AggregateSearch2 = new StatsSearch({ queryStringParameters }, 'granule');
   const results2 = await AggregateSearch2.aggregate(knex);
+  const expectedResponse2 = [{ key: 'failed', count: 25 }, { key: 'running', count: 25 }];
   t.is(results2.meta.count, 50);
-  t.is(results2.count.find((item) => item.key === 'failed').count, 25);
-  t.is(results2.count.find((item) => item.key === 'running').count, 25);
+  t.deepEqual(results2.count, expectedResponse2);
 
   queryStringParameters = {
     type: 'collections',
@@ -380,7 +412,9 @@ test('StatsSearch can query by infix and prefix when type is defined', async (t)
   };
   const AggregateSearch3 = new StatsSearch({ queryStringParameters }, 'collection');
   const results3 = await AggregateSearch3.aggregate(knex);
+  const expectedResponse3 = [{ key: 'testCollection___8', count: 1 }];
   t.is(results3.meta.count, 1);
+  t.deepEqual(results3.count, expectedResponse3);
 });
 
 test('StatsSummary works', async (t) => {

--- a/packages/db/tests/search/test-StatsSearch.js
+++ b/packages/db/tests/search/test-StatsSearch.js
@@ -49,7 +49,7 @@ test.before(async (t) => {
   range(20).map((num) => (
     // collections is never aggregate queried
     collections.push(fakeCollectionRecordFactory({
-      name: `testCollection${num}`,
+      name: `testCollection___${num}`,
       cumulus_id: num,
     }))
   ));
@@ -134,12 +134,12 @@ test('StatsSearch returns correct response for basic granules query', async (t) 
   const queryStringParameters = {
     type: 'granules',
   };
-  const AggregateSearch = new StatsSearch({ queryStringParameters }, 'aggregate');
-  const results = await AggregateSearch.query(knex);
-  t.is(results.results.count.find((item) => item.key === 'completed').count, 25);
-  t.is(results.results.count.find((item) => item.key === 'failed')?.count, 25);
-  t.is(results.results.count.find((item) => item.key === 'queued')?.count, 25);
-  t.is(results.results.count.find((item) => item.key === 'running')?.count, 25);
+  const AggregateSearch = new StatsSearch({ queryStringParameters }, 'granule');
+  const results = await AggregateSearch.aggregate(knex);
+  t.is(results.count.find((item) => item.key === 'completed')?.count, 25);
+  t.is(results.count.find((item) => item.key === 'failed')?.count, 25);
+  t.is(results.count.find((item) => item.key === 'queued')?.count, 25);
+  t.is(results.count.find((item) => item.key === 'running')?.count, 25);
   t.is(results.meta.count, 100);
 });
 
@@ -151,12 +151,12 @@ test('StatsSearch filters correctly by date', async (t) => {
     timestamp__to: `${(new Date(2022, 2, 30)).getTime()}`,
   };
 
-  const AggregateSearch = new StatsSearch({ queryStringParameters }, 'aggregate');
-  const results = await AggregateSearch.query(knex);
-  t.is(results.results.count.find((item) => item.key === 'completed').count, 9);
-  t.is(results.results.count.find((item) => item.key === 'failed')?.count, 8);
-  t.is(results.results.count.find((item) => item.key === 'queued')?.count, 8);
-  t.is(results.results.count.find((item) => item.key === 'running')?.count, 9);
+  const AggregateSearch = new StatsSearch({ queryStringParameters }, 'granule');
+  const results = await AggregateSearch.aggregate(knex);
+  t.is(results.count.find((item) => item.key === 'completed').count, 9);
+  t.is(results.count.find((item) => item.key === 'failed')?.count, 8);
+  t.is(results.count.find((item) => item.key === 'queued')?.count, 8);
+  t.is(results.count.find((item) => item.key === 'running')?.count, 9);
   t.is(results.meta.count, 34);
 });
 
@@ -167,11 +167,11 @@ test('StatsSearch filters executions correctly', async (t) => {
     field: 'status',
   };
 
-  const AggregateSearch = new StatsSearch({ queryStringParameters }, 'aggregate');
-  const results = await AggregateSearch.query(knex);
-  t.is(results.results.count.find((item) => item.key === 'completed').count, 7);
-  t.is(results.results.count.find((item) => item.key === 'failed').count, 7);
-  t.is(results.results.count.find((item) => item.key === 'running').count, 6);
+  const AggregateSearch = new StatsSearch({ queryStringParameters }, 'execution');
+  const results = await AggregateSearch.aggregate(knex);
+  t.is(results.count.find((item) => item.key === 'completed').count, 7);
+  t.is(results.count.find((item) => item.key === 'failed').count, 7);
+  t.is(results.count.find((item) => item.key === 'running').count, 6);
   t.is(results.meta.count, 20);
 
   queryStringParameters = {
@@ -181,11 +181,11 @@ test('StatsSearch filters executions correctly', async (t) => {
     timestamp__from: `${(new Date(2021, 1, 28)).getTime()}`,
   };
 
-  const AggregateSearch2 = new StatsSearch({ queryStringParameters }, 'aggregate');
-  const results2 = await AggregateSearch2.query(knex);
-  t.is(results2.results.count.find((item) => item.key === 'completed').count, 3);
-  t.is(results2.results.count.find((item) => item.key === 'failed').count, 3);
-  t.is(results2.results.count.find((item) => item.key === 'running').count, 3);
+  const AggregateSearch2 = new StatsSearch({ queryStringParameters }, 'execution');
+  const results2 = await AggregateSearch2.aggregate(knex);
+  t.is(results2.count.find((item) => item.key === 'completed').count, 3);
+  t.is(results2.count.find((item) => item.key === 'failed').count, 3);
+  t.is(results2.count.find((item) => item.key === 'running').count, 3);
   t.is(results2.meta.count, 9);
 
   queryStringParameters = {
@@ -193,13 +193,13 @@ test('StatsSearch filters executions correctly', async (t) => {
     field: 'status',
     timestamp__to: `${(new Date(2023, 11, 30)).getTime()}`,
     timestamp__from: `${(new Date(2021, 1, 28)).getTime()}`,
-    collectionId: 'testCollection5',
+    collectionId: 'testCollection___5',
     status: 'running',
   };
 
-  const AggregateSearch3 = new StatsSearch({ queryStringParameters }, 'aggregate');
-  const results3 = await AggregateSearch3.query(knex);
-  t.is(results3.results.count.find((item) => item.key === 'running').count, 1);
+  const AggregateSearch3 = new StatsSearch({ queryStringParameters }, 'execution');
+  const results3 = await AggregateSearch3.aggregate(knex);
+  t.is(results3.count.find((item) => item.key === 'running').count, 1);
   t.is(results3.meta.count, 1);
 });
 
@@ -210,11 +210,11 @@ test('StatsSearch filters PDRs correctly', async (t) => {
     field: 'status',
   };
 
-  const AggregateSearch = new StatsSearch({ queryStringParameters }, 'aggregate');
-  const results = await AggregateSearch.query(knex);
-  t.is(results.results.count.find((item) => item.key === 'completed').count, 7);
-  t.is(results.results.count.find((item) => item.key === 'failed').count, 7);
-  t.is(results.results.count.find((item) => item.key === 'running').count, 6);
+  const AggregateSearch = new StatsSearch({ queryStringParameters }, 'pdr');
+  const results = await AggregateSearch.aggregate(knex);
+  t.is(results.count.find((item) => item.key === 'completed').count, 7);
+  t.is(results.count.find((item) => item.key === 'failed').count, 7);
+  t.is(results.count.find((item) => item.key === 'running').count, 6);
   t.is(results.meta.count, 20);
 
   queryStringParameters = {
@@ -224,10 +224,10 @@ test('StatsSearch filters PDRs correctly', async (t) => {
     timestamp__from: `${(new Date(2018, 1, 28)).getTime()}`,
   };
 
-  const AggregateSearch2 = new StatsSearch({ queryStringParameters }, 'aggregate');
-  const results2 = await AggregateSearch2.query(knex);
-  t.is(results2.results.count.find((item) => item.key === 'completed').count, 4);
-  t.is(results2.results.count.find((item) => item.key === 'failed').count, 2);
+  const AggregateSearch2 = new StatsSearch({ queryStringParameters }, 'pdr');
+  const results2 = await AggregateSearch2.aggregate(knex);
+  t.is(results2.count.find((item) => item.key === 'completed').count, 4);
+  t.is(results2.count.find((item) => item.key === 'failed').count, 2);
   t.is(results2.meta.count, 6);
   queryStringParameters = {
     type: 'pdrs',
@@ -237,9 +237,9 @@ test('StatsSearch filters PDRs correctly', async (t) => {
     status: 'failed',
   };
 
-  const AggregateSearch3 = new StatsSearch({ queryStringParameters }, 'aggregate');
-  const results3 = await AggregateSearch3.query(knex);
-  t.is(results3.results.count.find((item) => item.key === 'failed').count, 2);
+  const AggregateSearch3 = new StatsSearch({ queryStringParameters }, 'pdr');
+  const results3 = await AggregateSearch3.aggregate(knex);
+  t.is(results3.count.find((item) => item.key === 'failed').count, 2);
   t.is(results3.meta.count, 2);
 });
 
@@ -251,11 +251,11 @@ test('StatsSearch returns correct response when queried by provider', async (t) 
     provider: 'testProvider2',
   };
 
-  const AggregateSearch = new StatsSearch({ queryStringParameters }, 'aggregate');
-  const results = await AggregateSearch.query(knex);
+  const AggregateSearch = new StatsSearch({ queryStringParameters }, 'granule');
+  const results = await AggregateSearch.aggregate(knex);
   t.is(results.meta.count, 10);
-  t.is(results.results.count.find((item) => item.key === 'completed').count, 5);
-  t.is(results.results.count.find((item) => item.key === 'queued').count, 5);
+  t.is(results.count.find((item) => item.key === 'completed').count, 5);
+  t.is(results.count.find((item) => item.key === 'queued').count, 5);
 });
 
 test('StatsSearch returns correct response when queried by collection', async (t) => {
@@ -263,11 +263,11 @@ test('StatsSearch returns correct response when queried by collection', async (t
   const queryStringParameters = {
     type: 'granules',
     field: 'status',
-    collectionId: 'testCollection8',
+    collectionId: 'testCollection___8',
   };
 
-  const AggregateSearch = new StatsSearch({ queryStringParameters }, 'aggregate');
-  const results = await AggregateSearch.query(knex);
+  const AggregateSearch = new StatsSearch({ queryStringParameters }, 'granule');
+  const results = await AggregateSearch.aggregate(knex);
   t.is(results.meta.count, 5);
 });
 
@@ -276,42 +276,42 @@ test('StatsSearch returns correct response when queried by collection and provid
   let queryStringParameters = {
     type: 'granules',
     field: 'status',
-    collectionId: 'testCollection1',
+    collectionId: 'testCollection___1',
     providerId: 'testProvider1',
   };
 
-  const AggregateSearch = new StatsSearch({ queryStringParameters }, 'aggregate');
-  const results = await AggregateSearch.query(knex);
+  const AggregateSearch = new StatsSearch({ queryStringParameters }, 'granule');
+  const results = await AggregateSearch.aggregate(knex);
   t.is(results.meta.count, 5);
-  t.is(results.results.count.find((item) => item.key === 'failed').count, 5);
+  t.is(results.count.find((item) => item.key === 'failed').count, 5);
 
   queryStringParameters = {
     type: 'granules',
     field: 'status',
-    collectionId: 'testCollection1',
+    collectionId: 'testCollection___1',
     providerId: 'testProvider1',
     timestamp__to: `${(new Date(2019, 12, 9)).getTime()}`,
     timestamp__from: `${(new Date(2018, 1, 28)).getTime()}`,
   };
 
-  const AggregateSearch2 = new StatsSearch({ queryStringParameters }, 'aggregate');
-  const results2 = await AggregateSearch2.query(knex);
+  const AggregateSearch2 = new StatsSearch({ queryStringParameters }, 'granule');
+  const results2 = await AggregateSearch2.aggregate(knex);
   t.is(results2.meta.count, 2);
-  t.is(results2.results.count.find((item) => item.key === 'failed').count, 2);
+  t.is(results2.count.find((item) => item.key === 'failed').count, 2);
   queryStringParameters = {
     type: 'granules',
     field: 'status',
-    collectionId: 'testCollection1',
+    collectionId: 'testCollection___1',
     providerId: 'testProvider1',
     timestamp__to: `${(new Date(2019, 12, 9)).getTime()}`,
     timestamp__from: `${(new Date(2018, 1, 28)).getTime()}`,
     status: 'failed',
   };
 
-  const AggregateSearch3 = new StatsSearch({ queryStringParameters }, 'aggregate');
-  const results3 = await AggregateSearch3.query(knex);
+  const AggregateSearch3 = new StatsSearch({ queryStringParameters }, 'granule');
+  const results3 = await AggregateSearch3.aggregate(knex);
   t.is(results3.meta.count, 2);
-  t.is(results3.results.count.find((item) => item.key === 'failed').count, 2);
+  t.is(results3.count.find((item) => item.key === 'failed').count, 2);
 });
 
 test('StatsSearch returns correct response when queried by error', async (t) => {
@@ -320,26 +320,26 @@ test('StatsSearch returns correct response when queried by error', async (t) => 
     type: 'granules',
     field: 'error.Error.keyword',
   };
-  const AggregateSearch = new StatsSearch({ queryStringParameters }, 'aggregate');
-  const results = await AggregateSearch.query(knex);
+  const AggregateSearch = new StatsSearch({ queryStringParameters }, 'granule');
+  const results = await AggregateSearch.aggregate(knex);
   t.is(results.meta.count, 100);
-  t.is(results.results.count.find((item) => item.key === 'CmrFailure').count, 20);
-  t.is(results.results.count.find((item) => item.key === 'UnknownError').count, 20);
-  t.is(results.results.count.find((item) => item.key === 'IngestFailure').count, 20);
-  t.is(results.results.count.find((item) => item.key === 'CumulusMessageAdapterError').count, 20);
+  t.is(results.count.find((item) => item.key === 'CmrFailure').count, 20);
+  t.is(results.count.find((item) => item.key === 'UnknownError').count, 20);
+  t.is(results.count.find((item) => item.key === 'IngestFailure').count, 20);
+  t.is(results.count.find((item) => item.key === 'CumulusMessageAdapterError').count, 20);
   queryStringParameters = {
     type: 'granules',
     field: 'error.Error.keyword',
     timestamp__to: `${(new Date(2021, 12, 9)).getTime()}`,
     timestamp__from: `${(new Date(2020, 1, 28)).getTime()}`,
   };
-  const AggregateSearch2 = new StatsSearch({ queryStringParameters }, 'aggregate');
-  const results2 = await AggregateSearch2.query(knex);
+  const AggregateSearch2 = new StatsSearch({ queryStringParameters }, 'granule');
+  const results2 = await AggregateSearch2.aggregate(knex);
   t.is(results2.meta.count, 34);
-  t.is(results2.results.count.find((item) => item.key === 'CmrFailure').count, 8);
-  t.is(results2.results.count.find((item) => item.key === 'UnknownError').count, 6);
-  t.is(results2.results.count.find((item) => item.key === 'IngestFailure').count, 7);
-  t.is(results2.results.count.find((item) => item.key === 'CumulusMessageAdapterError').count, 6);
+  t.is(results2.count.find((item) => item.key === 'CmrFailure').count, 8);
+  t.is(results2.count.find((item) => item.key === 'UnknownError').count, 6);
+  t.is(results2.count.find((item) => item.key === 'IngestFailure').count, 7);
+  t.is(results2.count.find((item) => item.key === 'CumulusMessageAdapterError').count, 6);
 });
 
 test('StatsSearch can query by infix and prefix when type is defined', async (t) => {
@@ -348,29 +348,29 @@ test('StatsSearch can query by infix and prefix when type is defined', async (t)
     type: 'granules',
     infix: 'testGra',
   };
-  const AggregateSearch = new StatsSearch({ queryStringParameters }, 'aggregate');
-  const results = await AggregateSearch.query(knex);
+  const AggregateSearch = new StatsSearch({ queryStringParameters }, 'granule');
+  const results = await AggregateSearch.aggregate(knex);
   t.is(results.meta.count, 50);
-  t.is(results.results.count.find((item) => item.key === 'completed').count, 25);
-  t.is(results.results.count.find((item) => item.key === 'queued').count, 25);
+  t.is(results.count.find((item) => item.key === 'completed').count, 25);
+  t.is(results.count.find((item) => item.key === 'queued').count, 25);
 
   queryStringParameters = {
     type: 'granules',
     prefix: 'query',
   };
-  const AggregateSearch2 = new StatsSearch({ queryStringParameters }, 'aggregate');
-  const results2 = await AggregateSearch2.query(knex);
+  const AggregateSearch2 = new StatsSearch({ queryStringParameters }, 'granule');
+  const results2 = await AggregateSearch2.aggregate(knex);
   t.is(results2.meta.count, 50);
-  t.is(results2.results.count.find((item) => item.key === 'failed').count, 25);
-  t.is(results2.results.count.find((item) => item.key === 'running').count, 25);
+  t.is(results2.count.find((item) => item.key === 'failed').count, 25);
+  t.is(results2.count.find((item) => item.key === 'running').count, 25);
 
   queryStringParameters = {
     type: 'collections',
-    infix: 'testCollection8',
+    infix: 'testCollection___8',
     field: 'name',
   };
-  const AggregateSearch3 = new StatsSearch({ queryStringParameters }, 'aggregate');
-  const results3 = await AggregateSearch3.query(knex);
+  const AggregateSearch3 = new StatsSearch({ queryStringParameters }, 'collection');
+  const results3 = await AggregateSearch3.aggregate(knex);
   t.is(results3.meta.count, 1);
 });
 

--- a/packages/db/tests/search/test-StatsSearch.js
+++ b/packages/db/tests/search/test-StatsSearch.js
@@ -47,7 +47,6 @@ test.before(async (t) => {
   const providers = [];
 
   range(20).map((num) => (
-    // collections is never aggregate queried
     collections.push(fakeCollectionRecordFactory({
       name: `testCollection___${num}`,
       cumulus_id: num,
@@ -55,7 +54,6 @@ test.before(async (t) => {
   ));
 
   range(10).map((num) => (
-    // providers is never aggregate queried
     providers.push(fakeProviderRecordFactory({
       cumulus_id: num,
       name: `testProvider${num}`,
@@ -63,7 +61,6 @@ test.before(async (t) => {
   ));
 
   range(100).map((num) => (
-    // granules can be queried by timestampto/from, collectionid, providerid, status,
     granules.push(fakeGranuleRecordFactory({
       collection_cumulus_id: num % 20,
       granule_id: num % 2 === 0 ? `testGranule${num}` : `query__Granule${num}`,
@@ -77,7 +74,6 @@ test.before(async (t) => {
   ));
 
   range(20).map((num) => (
-    // pdrs can be queried by timestampto/from, status
     pdrs.push(fakePdrRecordFactory({
       collection_cumulus_id: num,
       status: statuses[(num % 3) + 1],
@@ -86,7 +82,6 @@ test.before(async (t) => {
       updated_at: (new Date(2018 + (num % 6), (num % 12), ((num + 1) % 29))).toISOString(),
     // eslint-disable-next-line no-sequences
     })),
-    // executions can be queried by: timestampto/from, collectionid, status
     executions.push(fakeExecutionRecordFactory({
       collection_cumulus_id: num,
       status: statuses[(num % 3) + 1],

--- a/packages/db/tests/search/test-StatsSearch.js
+++ b/packages/db/tests/search/test-StatsSearch.js
@@ -385,7 +385,7 @@ test('StatsSearch can query by infix and prefix when type is defined', async (t)
 
 test('StatsSummary works', async (t) => {
   const { knex } = t.context;
-  const StatsSummary = new StatsSearch({}, 'summary');
+  const StatsSummary = new StatsSearch({}, 'granule');
   const results = await StatsSummary.summary(knex);
   t.is(results.collections.value, 20);
   t.is(results.granules.value, 100);
@@ -395,7 +395,7 @@ test('StatsSummary works', async (t) => {
     timestamp__to: `${(new Date(2019, 12, 9)).getTime()}`,
     timestamp__from: `${(new Date(2018, 1, 28)).getTime()}`,
   };
-  const StatsSummary2 = new StatsSearch({ queryStringParameters }, 'summary');
+  const StatsSummary2 = new StatsSearch({ queryStringParameters }, 'granule');
   const results2 = await StatsSummary2.summary(knex);
   t.is(results2.collections.value, 15);
   t.is(results2.granules.value, 25);

--- a/packages/db/tests/search/test-StatsSearch.js
+++ b/packages/db/tests/search/test-StatsSearch.js
@@ -1,0 +1,395 @@
+'use strict';
+
+const test = require('ava');
+const cryptoRandomString = require('crypto-random-string');
+const range = require('lodash/range');
+const { StatsSearch } = require('../../dist/search/StatsSearch');
+
+const {
+  destroyLocalTestDb,
+  generateLocalTestDb,
+  GranulePgModel,
+  CollectionPgModel,
+  fakeCollectionRecordFactory,
+  fakeGranuleRecordFactory,
+  fakeProviderRecordFactory,
+  migrationDir,
+  fakePdrRecordFactory,
+  fakeExecutionRecordFactory,
+  PdrPgModel,
+  ExecutionPgModel,
+  ProviderPgModel,
+} = require('../../dist');
+
+const testDbName = `collection_${cryptoRandomString({ length: 10 })}`;
+
+test.before(async (t) => {
+  const { knexAdmin, knex } = await generateLocalTestDb(
+    testDbName,
+    migrationDir
+  );
+
+  t.context.knexAdmin = knexAdmin;
+  t.context.knex = knex;
+
+  t.context.collectionPgModel = new CollectionPgModel();
+  t.context.granulePgModel = new GranulePgModel();
+  t.context.providerPgModel = new ProviderPgModel();
+  t.context.PdrPgModel = new PdrPgModel();
+  t.context.ExecutionPgModel = new ExecutionPgModel();
+
+  const statuses = ['queued', 'failed', 'completed', 'running'];
+  const errors = [{ Error: { keyword: 'UnknownError' } }, { Error: { keyword: 'CumulusMessageAdapterError' } }, { Error: { keyword: 'IngestFailure' } }, { Error: { keyword: 'CmrFailure' } }, { Error: {} }];
+  const granules = [];
+  const collections = [];
+  const executions = [];
+  const pdrs = [];
+  const providers = [];
+
+  range(20).map((num) => (
+    // collections is never aggregate queried
+    collections.push(fakeCollectionRecordFactory({
+      name: `testCollection${num}`,
+      cumulus_id: num,
+    }))
+  ));
+
+  range(10).map((num) => (
+    // providers is never aggregate queried
+    providers.push(fakeProviderRecordFactory({
+      cumulus_id: num,
+      name: `testProvider${num}`,
+    }))
+  ));
+
+  range(100).map((num) => (
+    // granules can be queried by timestampto/from, collectionid, providerid, status,
+    granules.push(fakeGranuleRecordFactory({
+      collection_cumulus_id: num % 20,
+      granule_id: num % 2 === 0 ? `testGranule${num}` : `query__Granule${num}`,
+      status: statuses[num % 4],
+      created_at: (new Date(2018 + (num % 6), (num % 12), (num % 30))).toISOString(),
+      updated_at: (new Date(2018 + (num % 6), (num % 12), ((num + 1) % 29))).toISOString(),
+      error: errors[num % 5],
+      duration: num + (num / 10),
+      provider_cumulus_id: num % 10,
+    }))
+  ));
+
+  range(20).map((num) => (
+    // pdrs can be queried by timestampto/from, status
+    pdrs.push(fakePdrRecordFactory({
+      collection_cumulus_id: num,
+      status: statuses[(num % 3) + 1],
+      provider_cumulus_id: num % 10,
+      created_at: (new Date(2018 + (num % 6), (num % 12), (num % 30))).toISOString(),
+      updated_at: (new Date(2018 + (num % 6), (num % 12), ((num + 1) % 29))).toISOString(),
+    // eslint-disable-next-line no-sequences
+    })),
+    // executions can be queried by: timestampto/from, collectionid, status
+    executions.push(fakeExecutionRecordFactory({
+      collection_cumulus_id: num,
+      status: statuses[(num % 3) + 1],
+      error: errors[num % 5],
+      created_at: (new Date(2018 + (num % 6), (num % 12), (num % 30))).toISOString(),
+      updated_at: (new Date(2018 + (num % 6), (num % 12), ((num + 1) % 29))).toISOString(),
+    }))
+  ));
+
+  await t.context.collectionPgModel.insert(
+    t.context.knex,
+    collections
+  );
+
+  await t.context.providerPgModel.insert(
+    t.context.knex,
+    providers
+  );
+
+  await t.context.granulePgModel.insert(
+    t.context.knex,
+    granules
+  );
+
+  await t.context.ExecutionPgModel.insert(
+    t.context.knex,
+    executions
+  );
+
+  await t.context.PdrPgModel.insert(
+    t.context.knex,
+    pdrs
+  );
+});
+
+test.after.always(async (t) => {
+  await destroyLocalTestDb({
+    ...t.context,
+    testDbName,
+  });
+});
+
+test('StatsSearch returns correct response for basic granules query', async (t) => {
+  const { knex } = t.context;
+  const queryStringParameters = {
+    type: 'granules',
+  };
+  const AggregateSearch = new StatsSearch({ queryStringParameters }, 'aggregate');
+  const results = await AggregateSearch.query(knex);
+  t.is(results.results.count.find((item) => item.key === 'completed').count, 25);
+  t.is(results.results.count.find((item) => item.key === 'failed')?.count, 25);
+  t.is(results.results.count.find((item) => item.key === 'queued')?.count, 25);
+  t.is(results.results.count.find((item) => item.key === 'running')?.count, 25);
+  t.is(results.meta.count, 100);
+});
+
+test('StatsSearch filters correctly by date', async (t) => {
+  const { knex } = t.context;
+  const queryStringParameters = {
+    type: 'granules',
+    timestamp__from: `${(new Date(2020, 1, 28)).getTime()}`,
+    timestamp__to: `${(new Date(2022, 2, 30)).getTime()}`,
+  };
+
+  const AggregateSearch = new StatsSearch({ queryStringParameters }, 'aggregate');
+  const results = await AggregateSearch.query(knex);
+  t.is(results.results.count.find((item) => item.key === 'completed').count, 9);
+  t.is(results.results.count.find((item) => item.key === 'failed')?.count, 8);
+  t.is(results.results.count.find((item) => item.key === 'queued')?.count, 8);
+  t.is(results.results.count.find((item) => item.key === 'running')?.count, 9);
+  t.is(results.meta.count, 34);
+});
+
+test('StatsSearch filters executions correctly', async (t) => {
+  const { knex } = t.context;
+  let queryStringParameters = {
+    type: 'executions',
+    field: 'status',
+  };
+
+  const AggregateSearch = new StatsSearch({ queryStringParameters }, 'aggregate');
+  const results = await AggregateSearch.query(knex);
+  t.is(results.results.count.find((item) => item.key === 'completed').count, 7);
+  t.is(results.results.count.find((item) => item.key === 'failed').count, 7);
+  t.is(results.results.count.find((item) => item.key === 'running').count, 6);
+  t.is(results.meta.count, 20);
+
+  queryStringParameters = {
+    type: 'executions',
+    field: 'status',
+    timestamp__to: `${(new Date(2023, 11, 30)).getTime()}`,
+    timestamp__from: `${(new Date(2021, 1, 28)).getTime()}`,
+  };
+
+  const AggregateSearch2 = new StatsSearch({ queryStringParameters }, 'aggregate');
+  const results2 = await AggregateSearch2.query(knex);
+  t.is(results2.results.count.find((item) => item.key === 'completed').count, 3);
+  t.is(results2.results.count.find((item) => item.key === 'failed').count, 3);
+  t.is(results2.results.count.find((item) => item.key === 'running').count, 3);
+  t.is(results2.meta.count, 9);
+
+  queryStringParameters = {
+    type: 'executions',
+    field: 'status',
+    timestamp__to: `${(new Date(2023, 11, 30)).getTime()}`,
+    timestamp__from: `${(new Date(2021, 1, 28)).getTime()}`,
+    collectionId: 'testCollection5',
+    status: 'running',
+  };
+
+  const AggregateSearch3 = new StatsSearch({ queryStringParameters }, 'aggregate');
+  const results3 = await AggregateSearch3.query(knex);
+  t.is(results3.results.count.find((item) => item.key === 'running').count, 1);
+  t.is(results3.meta.count, 1);
+});
+
+test('StatsSearch filters PDRs correctly', async (t) => {
+  const { knex } = t.context;
+  let queryStringParameters = {
+    type: 'pdrs',
+    field: 'status',
+  };
+
+  const AggregateSearch = new StatsSearch({ queryStringParameters }, 'aggregate');
+  const results = await AggregateSearch.query(knex);
+  t.is(results.results.count.find((item) => item.key === 'completed').count, 7);
+  t.is(results.results.count.find((item) => item.key === 'failed').count, 7);
+  t.is(results.results.count.find((item) => item.key === 'running').count, 6);
+  t.is(results.meta.count, 20);
+
+  queryStringParameters = {
+    type: 'pdrs',
+    field: 'status',
+    timestamp__to: `${(new Date(2019, 12, 9)).getTime()}`,
+    timestamp__from: `${(new Date(2018, 1, 28)).getTime()}`,
+  };
+
+  const AggregateSearch2 = new StatsSearch({ queryStringParameters }, 'aggregate');
+  const results2 = await AggregateSearch2.query(knex);
+  t.is(results2.results.count.find((item) => item.key === 'completed').count, 4);
+  t.is(results2.results.count.find((item) => item.key === 'failed').count, 2);
+  t.is(results2.meta.count, 6);
+  queryStringParameters = {
+    type: 'pdrs',
+    field: 'status',
+    timestamp__to: `${(new Date(2019, 12, 9)).getTime()}`,
+    timestamp__from: `${(new Date(2018, 1, 28)).getTime()}`,
+    status: 'failed',
+  };
+
+  const AggregateSearch3 = new StatsSearch({ queryStringParameters }, 'aggregate');
+  const results3 = await AggregateSearch3.query(knex);
+  t.is(results3.results.count.find((item) => item.key === 'failed').count, 2);
+  t.is(results3.meta.count, 2);
+});
+
+test('StatsSearch returns correct response when queried by provider', async (t) => {
+  const { knex } = t.context;
+  const queryStringParameters = {
+    type: 'granules',
+    field: 'status',
+    provider: 'testProvider2',
+  };
+
+  const AggregateSearch = new StatsSearch({ queryStringParameters }, 'aggregate');
+  const results = await AggregateSearch.query(knex);
+  t.is(results.meta.count, 10);
+  t.is(results.results.count.find((item) => item.key === 'completed').count, 5);
+  t.is(results.results.count.find((item) => item.key === 'queued').count, 5);
+});
+
+test('StatsSearch returns correct response when queried by collection', async (t) => {
+  const { knex } = t.context;
+  const queryStringParameters = {
+    type: 'granules',
+    field: 'status',
+    collectionId: 'testCollection8',
+  };
+
+  const AggregateSearch = new StatsSearch({ queryStringParameters }, 'aggregate');
+  const results = await AggregateSearch.query(knex);
+  t.is(results.meta.count, 5);
+});
+
+test('StatsSearch returns correct response when queried by collection and provider', async (t) => {
+  const { knex } = t.context;
+  let queryStringParameters = {
+    type: 'granules',
+    field: 'status',
+    collectionId: 'testCollection1',
+    providerId: 'testProvider1',
+  };
+
+  const AggregateSearch = new StatsSearch({ queryStringParameters }, 'aggregate');
+  const results = await AggregateSearch.query(knex);
+  t.is(results.meta.count, 5);
+  t.is(results.results.count.find((item) => item.key === 'failed').count, 5);
+
+  queryStringParameters = {
+    type: 'granules',
+    field: 'status',
+    collectionId: 'testCollection1',
+    providerId: 'testProvider1',
+    timestamp__to: `${(new Date(2019, 12, 9)).getTime()}`,
+    timestamp__from: `${(new Date(2018, 1, 28)).getTime()}`,
+  };
+
+  const AggregateSearch2 = new StatsSearch({ queryStringParameters }, 'aggregate');
+  const results2 = await AggregateSearch2.query(knex);
+  t.is(results2.meta.count, 2);
+  t.is(results2.results.count.find((item) => item.key === 'failed').count, 2);
+  queryStringParameters = {
+    type: 'granules',
+    field: 'status',
+    collectionId: 'testCollection1',
+    providerId: 'testProvider1',
+    timestamp__to: `${(new Date(2019, 12, 9)).getTime()}`,
+    timestamp__from: `${(new Date(2018, 1, 28)).getTime()}`,
+    status: 'failed',
+  };
+
+  const AggregateSearch3 = new StatsSearch({ queryStringParameters }, 'aggregate');
+  const results3 = await AggregateSearch3.query(knex);
+  t.is(results3.meta.count, 2);
+  t.is(results3.results.count.find((item) => item.key === 'failed').count, 2);
+});
+
+test('StatsSearch returns correct response when queried by error', async (t) => {
+  const { knex } = t.context;
+  let queryStringParameters = {
+    type: 'granules',
+    field: 'error.Error.keyword',
+  };
+  const AggregateSearch = new StatsSearch({ queryStringParameters }, 'aggregate');
+  const results = await AggregateSearch.query(knex);
+  t.is(results.meta.count, 100);
+  t.is(results.results.count.find((item) => item.key === 'CmrFailure').count, 20);
+  t.is(results.results.count.find((item) => item.key === 'UnknownError').count, 20);
+  t.is(results.results.count.find((item) => item.key === 'IngestFailure').count, 20);
+  t.is(results.results.count.find((item) => item.key === 'CumulusMessageAdapterError').count, 20);
+  queryStringParameters = {
+    type: 'granules',
+    field: 'error.Error.keyword',
+    timestamp__to: `${(new Date(2021, 12, 9)).getTime()}`,
+    timestamp__from: `${(new Date(2020, 1, 28)).getTime()}`,
+  };
+  const AggregateSearch2 = new StatsSearch({ queryStringParameters }, 'aggregate');
+  const results2 = await AggregateSearch2.query(knex);
+  t.is(results2.meta.count, 34);
+  t.is(results2.results.count.find((item) => item.key === 'CmrFailure').count, 8);
+  t.is(results2.results.count.find((item) => item.key === 'UnknownError').count, 6);
+  t.is(results2.results.count.find((item) => item.key === 'IngestFailure').count, 7);
+  t.is(results2.results.count.find((item) => item.key === 'CumulusMessageAdapterError').count, 6);
+});
+
+test('StatsSearch can query by infix and prefix when type is defined', async (t) => {
+  const { knex } = t.context;
+  let queryStringParameters = {
+    type: 'granules',
+    infix: 'testGra',
+  };
+  const AggregateSearch = new StatsSearch({ queryStringParameters }, 'aggregate');
+  const results = await AggregateSearch.query(knex);
+  t.is(results.meta.count, 50);
+  t.is(results.results.count.find((item) => item.key === 'completed').count, 25);
+  t.is(results.results.count.find((item) => item.key === 'queued').count, 25);
+
+  queryStringParameters = {
+    type: 'granules',
+    prefix: 'query',
+  };
+  const AggregateSearch2 = new StatsSearch({ queryStringParameters }, 'aggregate');
+  const results2 = await AggregateSearch2.query(knex);
+  t.is(results2.meta.count, 50);
+  t.is(results2.results.count.find((item) => item.key === 'failed').count, 25);
+  t.is(results2.results.count.find((item) => item.key === 'running').count, 25);
+
+  queryStringParameters = {
+    type: 'collections',
+    infix: 'testCollection8',
+    field: 'name',
+  };
+  const AggregateSearch3 = new StatsSearch({ queryStringParameters }, 'aggregate');
+  const results3 = await AggregateSearch3.query(knex);
+  t.is(results3.meta.count, 1);
+});
+
+test('StatsSummary works', async (t) => {
+  const { knex } = t.context;
+  const StatsSummary = new StatsSearch({}, 'summary');
+  const results = await StatsSummary.summary(knex);
+  t.is(results.collections.value, 20);
+  t.is(results.granules.value, 100);
+  t.is(results.errors.value, 80);
+  t.is(results.processingTime.value, 54.44999999642372);
+  const queryStringParameters = {
+    timestamp__to: `${(new Date(2019, 12, 9)).getTime()}`,
+    timestamp__from: `${(new Date(2018, 1, 28)).getTime()}`,
+  };
+  const StatsSummary2 = new StatsSearch({ queryStringParameters }, 'summary');
+  const results2 = await StatsSummary2.summary(knex);
+  t.is(results2.collections.value, 15);
+  t.is(results2.granules.value, 25);
+  t.is(results2.errors.value, 21);
+  t.is(results2.processingTime.value, 53.54799992084503);
+});


### PR DESCRIPTION
**Summary:**  Updated `stats/aggregate` api endpoint to query postgres instead of elasticsearch by creating a new StatsSearch class for querying postgres with the stats endpoint. Works for both stats/summary and stats/aggregate endpoints. 

Addresses [CUMULUS-3689: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3689)] and [CUMULUS-3688: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3688)]

## PR Checklist

- [ x] Update CHANGELOG
- [ x] Unit tests
- [ x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
