### PR TITLE
[CUMULUS-3671]: Update docs for Serverless V2

### DIFF
--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -263,7 +263,7 @@ $ aws dynamodb create-table \
 
 Cumulus requires a [PostgreSQL compatible database](../deployment/postgres-database-deployment.md) cluster deployed to AWS. We suggest utilizing [RDS](https://docs.aws.amazon.com/rds/index.html). For further guidance about what type of RDS database to use, please [see the guide on choosing and configuring your RDS database](./choosing_configuring_rds.md).
 
-Cumulus provides a default [template and RDS cluster module](../deployment/postgres-database-deployment.md) utilizing Aurora Serverless.
+Cumulus provides a default [template and RDS cluster module](../deployment/postgres-database-deployment.md) utilizing Aurora Serverless V2.
 
 However, Core intentionally provides a "bring your own" approach, and any well-planned cluster setup should work, given the following:
 

--- a/docs/deployment/postgres-database-deployment.md
+++ b/docs/deployment/postgres-database-deployment.md
@@ -145,6 +145,7 @@ Fill in the appropriate values in `terraform.tfvars`. See the [rds-cluster-tf mo
 - `max_capacity` -- the max ACUs the cluster is allowed to use.    Carefully consider cost/performance concerns when setting this value.
 - `min_capacity` -- the minimum ACUs the cluster will scale to
 - `provision_user_database` -- Optional flag to allow module to provision a user database in addition to creating the cluster.   Described in the [next section](#provision-user-and-user-database).
+- `cluster_instance_count` -- Number of RDS instances in the custer. Defaults to 1.
 
 #### Provision User and User Database
 
@@ -227,6 +228,7 @@ Terraform will perform the following actions:
       + backup_retention_period         = 1
       + cluster_identifier              = "xxxxxxxxx"
       + cluster_identifier_prefix       = (known after apply)
+      + cluster_instance_count          = 1
       + cluster_members                 = (known after apply)
       + cluster_resource_id             = (known after apply)
       + copy_tags_to_snapshot           = false

--- a/docs/deployment/postgres-database-deployment.md
+++ b/docs/deployment/postgres-database-deployment.md
@@ -16,7 +16,7 @@ configured [Aurora Serverless](https://aws.amazon.com/rds/aurora/serverless/) cl
 
 To that end, Cumulus provides a terraform module
 [`cumulus-rds-tf`](https://github.com/nasa/cumulus/tree/master/tf-modules/cumulus-rds-tf)
-that will deploy an AWS RDS Aurora Serverless PostgreSQL 13 compatible [database cluster](https://aws.amazon.com/rds/aurora/postgresql-features/), and optionally provision a single deployment database with credentialed secrets for use with Cumulus.
+that will deploy an AWS RDS Aurora Serverless V2 PostgreSQL 13 compatible [database cluster](https://aws.amazon.com/rds/aurora/postgresql-features/), and optionally provision a single deployment database with credentialed secrets for use with Cumulus.
 
 We have provided an example terraform deployment using this module in the [Cumulus template-deploy repository](https://github.com/nasa/cumulus-template-deploy/tree/master/rds-cluster-tf) on GitHub.
 
@@ -59,7 +59,7 @@ For Cumulus specific instructions on installation of Terraform, refer to the mai
 
 #### Aurora/RDS
 
-This document also assumes some basic familiarity with PostgreSQL databases and Amazon Aurora/RDS.   If you're unfamiliar consider perusing the [AWS docs](https://aws.amazon.com/rds/aurora/) and the [Aurora Serverless V1 docs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.html).
+This document also assumes some basic familiarity with PostgreSQL databases and Amazon Aurora/RDS.   If you're unfamiliar consider perusing the [AWS docs](https://aws.amazon.com/rds/aurora/) and the [Aurora Serverless V2 docs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.html).
 
 ## Prepare Deployment Repository
 
@@ -237,7 +237,7 @@ Terraform will perform the following actions:
       + enable_http_endpoint            = true
       + endpoint                        = (known after apply)
       + engine                          = "aurora-postgresql"
-      + engine_mode                     = "serverless"
+      + engine_mode                     = "provisioned"
       + engine_version                  = "10.12"
       + final_snapshot_identifier       = "xxxxxxxxx"
       + hosted_zone_id                  = (known after apply)
@@ -250,7 +250,7 @@ Terraform will perform the following actions:
       + preferred_maintenance_window    = (known after apply)
       + reader_endpoint                 = (known after apply)
       + skip_final_snapshot             = false
-      + storage_encrypted               = (known after apply)
+      + storage_encrypted               = true
       + tags                            = {
           + "Deployment" = "xxxxxxxxx"
         }

--- a/docs/upgrade-notes/serverless-v2-upgrade.md
+++ b/docs/upgrade-notes/serverless-v2-upgrade.md
@@ -1,0 +1,27 @@
+---
+id: serverless-v2-upgrade
+title: Upgrading from Aurora Serverless V1 to V2
+hide_title: false
+---
+
+## There are 2 approaches to this migration
+
+### Option 1: Snapshot and Restore (simple process, more downtime)
+
+1. Take a manual snapshot of the v1 instance, including the current YYYY-MM-DD in the name of the snapshot. Wait for successful completion showing Status = Available. If this is an initial snapshot of the instance, it may take a substantial amount of time to complete.
+2. Ensure delete protection is turned off on the v1 instance, as it will be deleted and replaced with a v2 cluster and instance. Deletion protection can be toggled in the AWS Console under RDS > Databases > select database > Modify.
+3. Run "terraform show" to view the current state for module.rds_cluster.aws_rds_cluster.cumulus.
+Ensure final_snapshot_identifier is set in resource "aws_rds_cluster" "cumulus". Copy the value. If a snapshot exists with that name, delete that snapshot.
+Ensure skip_final_snapshot is false in resource "aws_rds_cluster" "cumulus".
+4. Update /example/rds-cluster-tf/terraform.tfvars (or custom .tfvars filename) to:
+remove: enable_upgrade
+add: snapshot_identifier = "final_snapshot_identifier" (Paste value from prior step)
+5. Stop ingest.
+6. Run "terraform apply" to create a new v2 cluster and instance(s) based on the v1 final snapshot, using the updated tfvars file (or custom .tfvars filename). Wait for completion.
+terraform apply -var-file=terraform.tfvars (or custom .tfvars filename)
+7. Resume ingest.
+8. The end result is the new v2 cluster is created containing the existing v1 data.
+
+### Option 2: Blue/Green Cutover (complex process, less downtime)
+
+AWS instructions for setting up a blue/green deployment: https://aws.amazon.com/blogs/database/upgrade-from-amazon-aurora-serverless-v1-to-v2-with-minimal-downtime/

--- a/docs/upgrade-notes/serverless-v2-upgrade.md
+++ b/docs/upgrade-notes/serverless-v2-upgrade.md
@@ -24,4 +24,4 @@ terraform apply -var-file=terraform.tfvars (or custom .tfvars filename)
 
 ### Option 2: Blue/Green Cutover (complex process, less downtime)
 
-AWS instructions for setting up a blue/green deployment: https://aws.amazon.com/blogs/database/upgrade-from-amazon-aurora-serverless-v1-to-v2-with-minimal-downtime/
+Please see [AWS instructions](https://aws.amazon.com/blogs/database/upgrade-from-amazon-aurora-serverless-v1-to-v2-with-minimal-downtime/) for setting up a blue/green deployment.


### PR DESCRIPTION
These updates change a few links and shuffle wording to point to Serverless V2 info. For the most part the changes are relatively minor as we're not trying to duplicate AWS docs. There are, however, a couple areas that recommend configuration. I will comment in-line with my intention there.