### PR TITLE
CUMULUS-3696: Update granules List endpoints to query postgres - match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Added functionality to `@cumulus/db/src/search` to support term queries
   - Updated `BaseSearch` and `GranuleSearch` classes to support term queries for granules
   - Updated granules List endpoint to search postgres
+- **CUMULUS-3696**
+  - Added functionality to `@cumulus/db/src/search` to support terms, `not` and `exists` queries
 
 ### Migration Notes
 

--- a/packages/db/src/search/BaseSearch.ts
+++ b/packages/db/src/search/BaseSearch.ts
@@ -237,6 +237,13 @@ class BaseSearch {
     const { term = {} } = dbQueryParameters ?? this.dbQueryParameters;
 
     Object.entries(term).forEach(([name, value]) => {
+      if (name === 'error.Error') {
+        countQuery?.whereRaw(`${this.tableName}.error->>'Error' = '${value}'`);
+        searchQuery.whereRaw(`${this.tableName}.error->>'Error' = '${value}'`);
+      }
+    });
+
+    Object.entries(omit(term, 'error.Error')).forEach(([name, value]) => {
       switch (name) {
         case 'collectionName':
           countQuery?.where(`${collectionsTable}.name`, value);

--- a/packages/db/src/search/GranuleSearch.ts
+++ b/packages/db/src/search/GranuleSearch.ts
@@ -67,15 +67,15 @@ export class GranuleSearch extends BaseSearch {
     }
 
     if (this.searchProvider()) {
-      countQuery.innerJoin(providersTable, `${this.tableName}.provider_cumulus_id`, `${providersTable}.cumulus_id`);
-      searchQuery.innerJoin(providersTable, `${this.tableName}.provider_cumulus_id`, `${providersTable}.cumulus_id`);
+      [countQuery, searchQuery]
+        .forEach((query) => query.innerJoin(providersTable, `${this.tableName}.provider_cumulus_id`, `${providersTable}.cumulus_id`));
     } else {
       searchQuery.leftJoin(providersTable, `${this.tableName}.provider_cumulus_id`, `${providersTable}.cumulus_id`);
     }
 
     if (this.searchPdr()) {
-      countQuery.innerJoin(pdrsTable, `${this.tableName}.pdr_cumulus_id`, `${pdrsTable}.cumulus_id`);
-      searchQuery.innerJoin(pdrsTable, `${this.tableName}.pdr_cumulus_id`, `${pdrsTable}.cumulus_id`);
+      [countQuery, searchQuery]
+        .forEach((query) => query.innerJoin(pdrsTable, `${this.tableName}.pdr_cumulus_id`, `${pdrsTable}.cumulus_id`));
     } else {
       searchQuery.leftJoin(pdrsTable, `${this.tableName}.pdr_cumulus_id`, `${pdrsTable}.cumulus_id`);
     }
@@ -98,12 +98,10 @@ export class GranuleSearch extends BaseSearch {
     const { countQuery, searchQuery, dbQueryParameters } = params;
     const { infix, prefix } = dbQueryParameters ?? this.dbQueryParameters;
     if (infix) {
-      countQuery.whereLike(`${this.tableName}.granule_id`, `%${infix}%`);
-      searchQuery.whereLike(`${this.tableName}.granule_id`, `%${infix}%`);
+      [countQuery, searchQuery].forEach((query) => query.whereLike(`${this.tableName}.granule_id`, `%${infix}%`));
     }
     if (prefix) {
-      countQuery.whereLike(`${this.tableName}.granule_id`, `${prefix}%`);
-      searchQuery.whereLike(`${this.tableName}.granule_id`, `${prefix}%`);
+      [countQuery, searchQuery].forEach((query) => query.whereLike(`${this.tableName}.granule_id`, `${prefix}%`));
     }
   }
 

--- a/packages/db/src/search/GranuleSearch.ts
+++ b/packages/db/src/search/GranuleSearch.ts
@@ -67,15 +67,15 @@ export class GranuleSearch extends BaseSearch {
     }
 
     if (this.searchProvider()) {
-      [countQuery, searchQuery]
-        .forEach((query) => query.innerJoin(providersTable, `${this.tableName}.provider_cumulus_id`, `${providersTable}.cumulus_id`));
+      countQuery.innerJoin(providersTable, `${this.tableName}.provider_cumulus_id`, `${providersTable}.cumulus_id`);
+      searchQuery.innerJoin(providersTable, `${this.tableName}.provider_cumulus_id`, `${providersTable}.cumulus_id`);
     } else {
       searchQuery.leftJoin(providersTable, `${this.tableName}.provider_cumulus_id`, `${providersTable}.cumulus_id`);
     }
 
     if (this.searchPdr()) {
-      [countQuery, searchQuery]
-        .forEach((query) => query.innerJoin(pdrsTable, `${this.tableName}.pdr_cumulus_id`, `${pdrsTable}.cumulus_id`));
+      countQuery.innerJoin(pdrsTable, `${this.tableName}.pdr_cumulus_id`, `${pdrsTable}.cumulus_id`);
+      searchQuery.innerJoin(pdrsTable, `${this.tableName}.pdr_cumulus_id`, `${pdrsTable}.cumulus_id`);
     } else {
       searchQuery.leftJoin(pdrsTable, `${this.tableName}.pdr_cumulus_id`, `${pdrsTable}.cumulus_id`);
     }

--- a/packages/db/src/search/GranuleSearch.ts
+++ b/packages/db/src/search/GranuleSearch.ts
@@ -1,5 +1,4 @@
 import { Knex } from 'knex';
-import omit from 'lodash/omit';
 import pick from 'lodash/pick';
 
 import { ApiGranuleRecord } from '@cumulus/types/api/granules';
@@ -106,35 +105,6 @@ export class GranuleSearch extends BaseSearch {
       countQuery.whereLike(`${this.tableName}.granule_id`, `${prefix}%`);
       searchQuery.whereLike(`${this.tableName}.granule_id`, `${prefix}%`);
     }
-  }
-
-  /**
-   * Build queries for term fields
-   *
-   * @param params
-   * @param params.countQuery - query builder for getting count
-   * @param params.searchQuery - query builder for search
-   * @param [params.dbQueryParameters] - db query parameters
-   */
-  protected buildTermQuery(params: {
-    countQuery: Knex.QueryBuilder,
-    searchQuery: Knex.QueryBuilder,
-    dbQueryParameters?: DbQueryParameters,
-  }) {
-    const { countQuery, searchQuery, dbQueryParameters } = params;
-    const { term = {} } = dbQueryParameters ?? this.dbQueryParameters;
-
-    Object.entries(term).forEach(([name, value]) => {
-      if (name === 'error.Error') {
-        countQuery.whereRaw(`${this.tableName}.error->>'Error' = '${value}'`);
-        searchQuery.whereRaw(`${this.tableName}.error->>'Error' = '${value}'`);
-      }
-    });
-
-    super.buildTermQuery({
-      ...params,
-      dbQueryParameters: { term: omit(term, 'error.Error') },
-    });
   }
 
   /**

--- a/packages/db/src/search/field-mapping.ts
+++ b/packages/db/src/search/field-mapping.ts
@@ -56,6 +56,9 @@ const granuleMapping: { [key: string]: Function } = {
   updatedAt: (value?: string) => ({
     updated_at: value && new Date(Number(value)),
   }),
+  error: (value?: string) => ({
+    error: value,
+  }),
   // nested error field
   'error.Error': (value?: string) => ({
     'error.Error': value,

--- a/packages/db/src/search/queries.ts
+++ b/packages/db/src/search/queries.ts
@@ -154,7 +154,7 @@ const convertTerms = (
 
     // build a terms field, e.g.
     // { granuleId__in: 'granuleId1,granuleId2' } =>
-    // [[granule_id, granuleId], [granule_id, granuleId2]] =>
+    // [[granule_id, granuleId1], [granule_id, granuleId2]] =>
     // { granule_id: [granuleId1, granuleId2] }
     // this converts collectionId into name and version fields
     const name = match[1];

--- a/packages/db/src/search/queries.ts
+++ b/packages/db/src/search/queries.ts
@@ -48,8 +48,7 @@ const convertExists = (
     // get corresponding db field name, e.g. granuleId => granule_id
     const dbField = mapQueryStringFieldToDbField(type, { name: match[1] });
     if (!dbField) return acc;
-    const dbFieldName = Object.keys(dbField)[0];
-    dbField[dbFieldName] = (queryField.value === 'true');
+    Object.keys(dbField).forEach((key) => { dbField[key] = (queryField.value === 'true'); });
     return { ...acc, ...dbField };
   }, {});
 

--- a/packages/db/src/types/search.ts
+++ b/packages/db/src/types/search.ts
@@ -33,5 +33,5 @@ export type DbQueryParameters = {
   prefix?: string,
   range?: { [key: string]: RangeType },
   term?: { [key: string]: QueriableType | undefined },
-  terms?: { [key: string]: QueriableType | undefined },
+  terms?: { [key: string]: QueriableType[] },
 };

--- a/packages/db/src/types/search.ts
+++ b/packages/db/src/types/search.ts
@@ -32,7 +32,7 @@ export type DbQueryParameters = {
   infix?: string,
   limit?: number,
   exists?: { [key: string]: boolean },
-  not?: QueriableType,
+  not?: { [key: string]: QueriableType | undefined },
   offset?: number,
   page?: number,
   prefix?: string,

--- a/packages/db/src/types/search.ts
+++ b/packages/db/src/types/search.ts
@@ -15,7 +15,7 @@ export type QueryEvent = {
   queryStringParameters?: QueryStringParameters,
 };
 
-type QueriableType = boolean | Date | number | string;
+export type QueriableType = boolean | Date | number | string;
 
 export type RangeType = {
   gte?: Omit<QueriableType, 'boolean'>,
@@ -26,10 +26,12 @@ export type DbQueryParameters = {
   fields?: string[],
   infix?: string,
   limit?: number,
+  exists?: { [key: string]: boolean },
+  not?: QueriableType,
   offset?: number,
   page?: number,
   prefix?: string,
   range?: { [key: string]: RangeType },
   term?: { [key: string]: QueriableType | undefined },
-  terms?: { [key: string]: any },
+  terms?: { [key: string]: QueriableType | undefined },
 };

--- a/packages/db/tests/search/test-GranuleSearch.js
+++ b/packages/db/tests/search/test-GranuleSearch.js
@@ -559,7 +559,7 @@ test('GranuleSearch supports terms search', async (t) => {
   let queryStringParameters = {
     limit: 200,
     granuleId__in: [t.context.granuleIds[0], t.context.granuleIds[5]].join(','),
-    published__in: ['true', 'false'].join(','),
+    published__in: 'true,false',
   };
   let dbSearch = new GranuleSearch({ queryStringParameters });
   let response = await dbSearch.query(knex);

--- a/packages/db/tests/search/test-GranuleSearch.js
+++ b/packages/db/tests/search/test-GranuleSearch.js
@@ -547,3 +547,102 @@ test('GranuleSearch supports sorting by Error', async (t) => {
   t.is(response10.results[0].error.Error, 'CumulusMessageAdapterExecutionError');
   t.is(response10.results[99].error, undefined);
 });
+
+test('GranuleSearch supports collectionId terms search', async (t) => {
+  const { knex } = t.context;
+  let queryStringParameters = {
+    limit: 200,
+    collectionId__in: [t.context.collectionId2, constructCollectionId('fakecollectionterms', 'v1')].join(','),
+  };
+  let dbSearch = new GranuleSearch({ queryStringParameters });
+  let response = await dbSearch.query(knex);
+  t.is(response.meta.count, 50);
+  t.is(response.results?.length, 50);
+
+  queryStringParameters = {
+    limit: 200,
+    collectionId__in: [t.context.collectionId, t.context.collectionId2].join(','),
+  };
+  dbSearch = new GranuleSearch({ queryStringParameters });
+  response = await dbSearch.query(knex);
+  t.is(response.meta.count, 100);
+  t.is(response.results?.length, 100);
+});
+
+test('GranuleSearch supports provider terms search', async (t) => {
+  const { knex } = t.context;
+  const queryStringParameters = {
+    limit: 200,
+    provider__in: [t.context.provider.name, 'fakeproviderterms'].join(','),
+  };
+  const dbSearch = new GranuleSearch({ queryStringParameters });
+  const response = await dbSearch.query(knex);
+  t.is(response.meta.count, 50);
+  t.is(response.results?.length, 50);
+});
+
+test('GranuleSearch supports pdrName terms search', async (t) => {
+  const { knex } = t.context;
+  const queryStringParameters = {
+    limit: 200,
+    pdrName__in: [t.context.pdr.name, 'fakepdrterms'].join(','),
+  };
+  const dbSearch = new GranuleSearch({ queryStringParameters });
+  const response = await dbSearch.query(knex);
+  t.is(response.meta.count, 50);
+  t.is(response.results?.length, 50);
+});
+
+test('GranuleSearch supports search which collectionId does not match the given value', async (t) => {
+  const { knex } = t.context;
+  const queryStringParameters = {
+    limit: 200,
+    collectionId__not: t.context.collectionId2,
+  };
+  const dbSearch = new GranuleSearch({ queryStringParameters });
+  const response = await dbSearch.query(knex);
+  t.is(response.meta.count, 50);
+  t.is(response.results?.length, 50);
+});
+
+test('GranuleSearch supports search which provider does not match the given value', async (t) => {
+  const { knex } = t.context;
+  let queryStringParameters = {
+    limit: 200,
+    provider__not: t.context.provider.name,
+  };
+  let dbSearch = new GranuleSearch({ queryStringParameters });
+  let response = await dbSearch.query(knex);
+  t.is(response.meta.count, 0);
+  t.is(response.results?.length, 0);
+
+  queryStringParameters = {
+    limit: 200,
+    provider__not: 'providernotexist',
+  };
+  dbSearch = new GranuleSearch({ queryStringParameters });
+  response = await dbSearch.query(knex);
+  t.is(response.meta.count, 50);
+  t.is(response.results?.length, 50);
+});
+
+test('GranuleSearch supports search which pdrName does not match the given value', async (t) => {
+  const { knex } = t.context;
+  let queryStringParameters = {
+    limit: 200,
+    pdrName__not: t.context.pdr.name,
+  };
+  let dbSearch = new GranuleSearch({ queryStringParameters });
+  let response = await dbSearch.query(knex);
+  t.is(response.meta.count, 0);
+  t.is(response.results?.length, 0);
+
+  queryStringParameters = {
+    limit: 200,
+    pdrName__not: 'pdrnotexist',
+  };
+  dbSearch = new GranuleSearch({ queryStringParameters });
+  response = await dbSearch.query(knex);
+  t.is(response.meta.count, 50);
+  t.is(response.results?.length, 50);
+});

--- a/packages/db/tests/search/test-queries.js
+++ b/packages/db/tests/search/test-queries.js
@@ -19,6 +19,10 @@ test('convertQueryStringToDbQueryParameters correctly converts api query string 
     collectionId: 'MOD09GQ___006',
     nonExistingField: 'nonExistingFieldValue',
     nonExistingField__from: 'nonExistingFieldValue',
+    granuleId__in: 'granuleId1,granuleId2',
+    collectionId__in: 'MOD09GQ___006,MODIS___007',
+    granuleId__not: 'notMatchingGranuleId',
+    error__exists: 'true',
   };
 
   const expectedDbQueryParameters = {
@@ -43,6 +47,11 @@ test('convertQueryStringToDbQueryParameters correctly converts api query string 
       published: true,
       status: 'completed',
       'error.Error': 'CumulusMessageAdapterExecutionError',
+    },
+    terms: {
+      granule_id: ['granuleId1', 'granuleId2'],
+      collectionName: ['MOD09GQ', 'MODIS'],
+      collectionVersion: ['006', '007'],
     },
   };
 

--- a/packages/db/tests/search/test-queries.js
+++ b/packages/db/tests/search/test-queries.js
@@ -27,9 +27,15 @@ test('convertQueryStringToDbQueryParameters correctly converts api query string 
   };
 
   const expectedDbQueryParameters = {
+    exists: {
+      error: true,
+    },
     fields: ['granuleId', 'collectionId', 'status', 'updatedAt'],
     infix: 'A1657416',
     limit: 20,
+    not: {
+      granule_id: 'notMatchingGranuleId',
+    },
     offset: 40,
     page: 3,
     prefix: 'MO',


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3696: Update granules List endpoints to query postgres - match](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3696)

## Changes

* Added functionality to `@cumulus/db/src/search` to support terms, `not` and `exists` queries

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
