### PR TITLE
Merges release 18.2.2 documentation changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The following applies only to users with a custom value configured for
   Users making use of a custom image configuration should note the base image
   for Core async operations must support node v20.x.
 
-#### CUMULUS-3449 Please follow instructions before upgrading Cumulus.
+#### CUMULUS-3449 Please follow instructions before upgrading Cumulus
 
 - The updates in CUMULUS-3449 requires manual update to postgres database in
   production environment. Please follow [Update Cumulus_id Type and
@@ -61,13 +61,6 @@ Endpoint](https://nasa.github.io/cumulus-api/#retrieve-async-operation) for the
 output or status of your request. If you want to directly observe the progress
 of the migration as it runs, you can view the CloudWatch logs for your async
 operations (e.g. `PREFIX-AsyncOperationEcsLogs`).
-
-#### CUMULUS-3951 - SNS topics set to use encrypted storage
-
-As part of the requirements for this ticket Cumulus Core created SNS topics are
-being updated to use server-side encryption with an AWS managed key.    No user
-action is required, this note is being added to increase visibility re: this
-modification.
 
 ### Breaking Changes
 
@@ -132,9 +125,6 @@ modification.
   - Update `@cumulus/ingest/HttpProviderClient` to use direct injection test mocks, and remove rewire from unit tests
 - **CUMULUS-3720**
   - add cicd unit test error logging to s3 for testing improvements
-- **CUMULUS-3951**
-  - Enable server-side encryption for all SNS topcis deployed by Cumulus Core
-  - Update all integration/unit tests to use encrypted SNS topics
 - **CUMULUS-3433**
   - Updated all node.js lambda dependencies to node 20.x/20.12.2
   - Modified `@cumulus/ingest` unit test HTTPs server to accept localhost POST
@@ -199,8 +189,6 @@ modification.
     from columns ending with "cumulus_id" to number.
 - **CUMULUS-3497**
   - Updated `example/cumulus-tf/orca.tf` to use v9.0.4
-- **CUMULUS-3527**
-  - Added suppport for additional kex algorithms in the sftp-client.
 - **CUMULUS-3610**
   - Updated `aws-client`'s ES client to use AWS SDK v3.
 - **CUMULUS-3617**
@@ -225,6 +213,30 @@ modification.
     credentialing timeout in long-running ECS jobs.
 - **CUMULUS-3323**
   - Minor edits to errant integration test titles (dyanmo->postgres)
+
+## [v18.2.2] 2024-06-4
+
+### Migration Notes
+
+#### CUMULUS-3591 - SNS topics set to use encrypted storage
+
+As part of the requirements for this ticket Cumulus Core created SNS topics are
+being updated to use server-side encryption with an AWS managed key.    No user
+action is required, this note is being added to increase visibility re: this
+modification.
+
+### Changed
+
+- **CUMULUS-3591**
+  - Enable server-side encryption for all SNS topcis deployed by Cumulus Core
+  - Update all integration/unit tests to use encrypted SNS topics
+
+### Fixed
+
+- **CUMULUS-3547**
+  - Updated ECS Cluster `/dev/xvdcz` EBS volumes so they're encrypted.
+- **CUMULUS-3527**
+  - Added suppport for additional kex algorithms in the sftp-client.
 - **CUMULUS-3587**
   - Ported https://github.com/scottcorgan/express-boom into API/lib to allow
     updates of sub-dependencies and maintain without refactoring errors in
@@ -322,8 +334,6 @@ instructions](https://nasa.github.io/cumulus/docs/upgrade-notes/upgrade-rds-clus
   - stubbed cmr interfaces in integration tests allow integration tests to pass
   - needed while cmr is failing to continue needed releases and progress
   - this change should be reverted ASAP when cmr is working as needed again
-- **CUMULUS-3547**
-  - Updated ECS Cluster `/dev/xvdcz` EBS volumes so they're encrypted.
 
 ### Fixed
 
@@ -7816,7 +7826,8 @@ Note: There was an issue publishing 1.12.0. Upgrade to 1.12.1.
 
 ## [v1.0.0] - 2018-02-23
 
-[unreleased]: https://github.com/nasa/cumulus/compare/v18.2.0...HEAD
+[unreleased]: https://github.com/nasa/cumulus/compare/v18.2.2...HEAD
+[v18.2.2]: https://github.com/nasa/cumulus/compare/v18.2.1...v18.2.2
 [v18.2.1]: https://github.com/nasa/cumulus/compare/v18.2.0...v18.2.1
 [v18.2.0]: https://github.com/nasa/cumulus/compare/v18.1.0...v18.2.0
 [v18.1.0]: https://github.com/nasa/cumulus/compare/v18.0.0...v18.1.0

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -35,6 +35,7 @@
 * Nate Pauzenga
 * Pat Cappelaere
 * Patrick Quinn
+* Paul Pilone
 * Phil Osip
 * Sara Chaparro Diaz
 * Sean Quinlan

--- a/packages/aws-client/README.md
+++ b/packages/aws-client/README.md
@@ -840,6 +840,11 @@ Move an S3 object to another location in S3
 <a name="module_SNS"></a>
 
 ## SNS
+
+* [SNS](#module_SNS)
+    * [~publishSnsMessage(snsTopicArn, message, retryOptions)](#module_SNS..publishSnsMessage) ⇒ <code>Promise.&lt;undefined&gt;</code>
+    * [~createSnsTopic(snsTopicName)](#module_SNS..createSnsTopic) ⇒
+
 <a name="module_SNS..publishSnsMessage"></a>
 
 ### SNS~publishSnsMessage(snsTopicArn, message, retryOptions) ⇒ <code>Promise.&lt;undefined&gt;</code>
@@ -853,6 +858,18 @@ errors, to allow more specific handling by the caller.
 | snsTopicArn | <code>string</code> | SNS topic ARN |
 | message | <code>Object</code> | Message object |
 | retryOptions | <code>Object</code> | options to control retry behavior when publishing a message fails. See https://github.com/tim-kos/node-retry#retryoperationoptions |
+
+<a name="module_SNS..createSnsTopic"></a>
+
+### SNS~createSnsTopic(snsTopicName) ⇒
+Create an SNS topic with a given name.
+
+**Kind**: inner method of [<code>SNS</code>](#module_SNS)  
+**Returns**: - ARN of the created SNS topic  
+
+| Param | Description |
+| --- | --- |
+| snsTopicName | Name of the SNS topic |
 
 <a name="module_SQS"></a>
 


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3726: Release 18.2.2](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3726).

## Changes

* Merges down updated CHANGELOG, CONTRIBUTOR, and `aws-client` README as a result of releasing 18.2.2

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
