### PR TITLE
Excludes aws-sdk v3 from webpack packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,10 @@ operations (e.g. `PREFIX-AsyncOperationEcsLogs`).
     credentialing timeout in long-running ECS jobs.
 - **CUMULUS-3323**
   - Minor edits to errant integration test titles (dyanmo->postgres)
+- **AWS-SDK v3 Exclusion (v18.3.0 fix)***
+  - Excludes aws-sdk v3 from packages to reduce overall package size. With the requirement of Node v20
+    packaging the aws-sdk v3 with our code is no longer necessary and prevented some packages from being
+    published to npm.
 
 ## [v18.2.2] 2024-06-4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,11 @@ output or status of your request. If you want to directly observe the progress
 of the migration as it runs, you can view the CloudWatch logs for your async
 operations (e.g. `PREFIX-AsyncOperationEcsLogs`).
 
+#### CUMULUS-3779 async_operations Docker image version upgrade
+  
+The `async_operations` Docker image has been updated to support Node v20 and `aws-sdk` v3. Users will need to bump
+the version tag of `async_operations` to at least 52 if using the Docker image.
+
 ### Breaking Changes
 
 - **CUMULUS-3618**
@@ -103,6 +108,9 @@ operations (e.g. `PREFIX-AsyncOperationEcsLogs`).
   - Changed granules table unique constraint to granules_collection_cumulus_id_granule_id_unique
   - Added indexes granules_granule_id_index and granules_provider_collection_cumulus_id_granule_id_index
     to granules table
+- **CUMULUS-3779**
+  - Updates async_operations Docker image to Node v20 and bumps its cumulus dependencies to v18.3.0 to
+    support `aws-sdk` v3 changes.
 
 ### Added
 - **CUMULUS-3742**

--- a/example/cumulus-tf/variables.tf
+++ b/example/cumulus-tf/variables.tf
@@ -362,7 +362,7 @@ variable "cumulus_process_activity_version" {
 variable "ecs_task_image_version" {
   description = "docker image version to use for Cumulus hello world task"
     type = string
-    default = "1.9.0"
+    default = "2.1.0-alpha"
 }
 
 variable "cumulus_test_ingest_image_version" {

--- a/example/cumulus-tf/variables.tf
+++ b/example/cumulus-tf/variables.tf
@@ -350,7 +350,7 @@ variable "rds_admin_access_secret_arn" {
 variable "async_operation_image_version" {
   description = "docker image version to use for Cumulus async operations tasks"
   type = string
-  default = "49"
+  default = "52"
 }
 
 variable "cumulus_process_activity_version" {

--- a/example/cumulus-tf/variables.tf
+++ b/example/cumulus-tf/variables.tf
@@ -362,7 +362,7 @@ variable "cumulus_process_activity_version" {
 variable "ecs_task_image_version" {
   description = "docker image version to use for Cumulus hello world task"
     type = string
-    default = "2.1.0-alpha"
+    default = "2.1.0"
 }
 
 variable "cumulus_test_ingest_image_version" {

--- a/lambdas/db-migration/webpack.config.js
+++ b/lambdas/db-migration/webpack.config.js
@@ -80,5 +80,8 @@ module.exports = {
   node: {
     __dirname: false
   },
-  target: 'node'
+  target: 'node',
+  externals: [
+    /@aws-sdk\//
+  ]
 };

--- a/lambdas/db-provision-user-database/webpack.config.js
+++ b/lambdas/db-provision-user-database/webpack.config.js
@@ -46,5 +46,8 @@ module.exports = {
       },
     ],
   },
-  target: 'node'
+  target: 'node',
+  externals: [
+    /@aws-sdk\//
+  ]
 };

--- a/lambdas/dla-migration/webpack.config.js
+++ b/lambdas/dla-migration/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
     path: path.resolve(__dirname, 'dist', 'webpack'),
     filename: 'index.js'
   },
-  externals: ['aws-sdk'],
+  externals: [/@aws-sdk\//],
   target: 'node',
   devtool: 'eval-cheap-module-source-map',
   optimization: {

--- a/lambdas/migration-helper-async-operation/webpack.config.js
+++ b/lambdas/migration-helper-async-operation/webpack.config.js
@@ -46,5 +46,8 @@ module.exports = {
       },
     ],
   },
-  target: 'node'
+  target: 'node',
+  externals: [
+    /@aws-sdk\//
+  ]
 };

--- a/lambdas/sqs-message-remover/webpack.config.js
+++ b/lambdas/sqs-message-remover/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'}
   ],

--- a/packages/api/ecs/async-operation/Dockerfile
+++ b/packages/api/ecs/async-operation/Dockerfile
@@ -17,3 +17,5 @@ RUN cp -a /var/runtime/node_modules/. /home/task/node_modules/
 COPY index.js /home/task/
 
 CMD [ "node", "--harmony", "index.js" ]
+
+ENTRYPOINT [ ]

--- a/packages/api/ecs/async-operation/Dockerfile
+++ b/packages/api/ecs/async-operation/Dockerfile
@@ -1,17 +1,18 @@
-FROM node:20.12.2-buster
+FROM amazon/aws-lambda-nodejs:20
 
 USER root
-RUN sed -i -e '/jessie-updates/d' /etc/apt/sources.list
-RUN apt-get update && apt-get install -y unzip
+RUN dnf install -y unzip shadow-utils
 
-RUN groupadd -r task -g 433
-RUN useradd -u 431 -r -g task -m -s /sbin/nologin -c "Docker image user" task
+RUN /usr/sbin/groupadd -r task -g 433
+RUN /usr/sbin/useradd -u 431 -r -g task -m -s /sbin/nologin -c "Docker image user" task
 
 USER task
 WORKDIR /home/task
 
 COPY package.json /home/task/
 RUN npm install
+
+RUN cp -a /var/runtime/node_modules/. /home/task/node_modules/
 
 COPY index.js /home/task/
 

--- a/packages/api/ecs/async-operation/package.json
+++ b/packages/api/ecs/async-operation/package.json
@@ -22,10 +22,10 @@
     "coverage": "python ../../../../scripts/coverage_handler/coverage.py"
   },
   "dependencies": {
-    "@cumulus/aws-client": "18.2.0",
-    "@cumulus/db": "18.2.0",
-    "@cumulus/es-client": "18.2.0",
-    "@cumulus/logger": "18.2.0",
+    "@cumulus/aws-client": "18.3.0",
+    "@cumulus/db": "18.3.0",
+    "@cumulus/es-client": "18.3.0",
+    "@cumulus/logger": "18.3.0",
     "@aws-sdk/client-lambda": "^3.529.1",
     "crypto-random-string": "^3.2.0",
     "got": "^11.8.5",

--- a/packages/api/webpack.config.js
+++ b/packages/api/webpack.config.js
@@ -80,6 +80,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     { formidable: 'url' },
     { fsevents: "require('fsevents')" }

--- a/packages/integration-tests/webpack.config.js
+++ b/packages/integration-tests/webpack.config.js
@@ -31,6 +31,7 @@ module.exports = {
     },
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     { formidable: 'url' },
   ],

--- a/packages/s3-credentials-endpoint/webpack.config.js
+++ b/packages/s3-credentials-endpoint/webpack.config.js
@@ -32,6 +32,7 @@ module.exports = {
     },
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     { formidable: 'url' },
   ],

--- a/packages/tea-map-cache/webpack.config.js
+++ b/packages/tea-map-cache/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
     path: path.resolve(__dirname, 'dist'),
     filename: 'index.js'
   },
-  externals: [],
+  externals: [/@aws-sdk\//],
   target: 'node',
   devtool: 'eval-cheap-module-source-map',
   optimization: {

--- a/tasks/add-missing-file-checksums/webpack.config.js
+++ b/tasks/add-missing-file-checksums/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
     path: path.resolve(__dirname, 'dist', 'webpack'),
     filename: 'index.js'
   },
-  externals: [],
+  externals: [/@aws-sdk\//],
   target: 'node',
   devtool: 'eval-cheap-module-source-map',
   optimization: {

--- a/tasks/discover-granules/webpack.config.js
+++ b/tasks/discover-granules/webpack.config.js
@@ -27,6 +27,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'}
   ],

--- a/tasks/discover-pdrs/webpack.config.js
+++ b/tasks/discover-pdrs/webpack.config.js
@@ -27,6 +27,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'}
   ],

--- a/tasks/files-to-granules/webpack.config.js
+++ b/tasks/files-to-granules/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'}
   ],

--- a/tasks/hello-world/webpack.config.js
+++ b/tasks/hello-world/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'}
   ],

--- a/tasks/hyrax-metadata-updates/webpack.config.js
+++ b/tasks/hyrax-metadata-updates/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'}
   ],

--- a/tasks/lzards-backup/webpack.config.js
+++ b/tasks/lzards-backup/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
     path: path.resolve(__dirname, 'dist', 'webpack'),
     filename: 'index.js'
   },
-  externals: [],
+  externals: [/@aws-sdk\//],
   target: 'node',
   devtool: 'eval-cheap-module-source-map',
   optimization: {

--- a/tasks/move-granules/webpack.config.js
+++ b/tasks/move-granules/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'},
     // See https://github.com/knex/knex/issues/1128 re: webpack configuration

--- a/tasks/orca-copy-to-archive-adapter/webpack.config.js
+++ b/tasks/orca-copy-to-archive-adapter/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
     path: path.resolve(__dirname, 'dist', 'webpack'),
     filename: 'index.js'
   },
-  externals: [],
+  externals: [/@aws-sdk\//],
   target: 'node',
   devtool: 'eval-cheap-module-source-map',
   optimization: {

--- a/tasks/orca-recovery-adapter/webpack.config.js
+++ b/tasks/orca-recovery-adapter/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
     path: path.resolve(__dirname, 'dist', 'webpack'),
     filename: 'index.js'
   },
-  externals: [],
+  externals: [/@aws-sdk\//],
   target: 'node',
   devtool: 'eval-cheap-module-source-map',
   optimization: {

--- a/tasks/parse-pdr/webpack.config.js
+++ b/tasks/parse-pdr/webpack.config.js
@@ -27,6 +27,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'}
   ],

--- a/tasks/pdr-status-check/webpack.config.js
+++ b/tasks/pdr-status-check/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'}
   ],

--- a/tasks/post-to-cmr/webpack.config.js
+++ b/tasks/post-to-cmr/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'}
   ],

--- a/tasks/queue-granules/webpack.config.js
+++ b/tasks/queue-granules/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
     path: path.resolve(__dirname, 'dist', 'webpack'),
     filename: 'index.js'
   },
-  externals: [],
+  externals: [/@aws-sdk\//],
   target: 'node',
   devtool: 'eval-cheap-module-source-map',
   optimization: {

--- a/tasks/queue-pdrs/webpack.config.js
+++ b/tasks/queue-pdrs/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'}
   ],

--- a/tasks/queue-workflow/webpack.config.js
+++ b/tasks/queue-workflow/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'}
   ],

--- a/tasks/send-pan/webpack.config.js
+++ b/tasks/send-pan/webpack.config.js
@@ -31,7 +31,7 @@ module.exports = {
     path: path.resolve(__dirname, 'dist', 'webpack'),
     filename: 'index.js'
   },
-  externals: [],
+  externals: [/@aws-sdk\//],
   target: 'node',
   devtool: 'eval-cheap-module-source-map',
   optimization: {

--- a/tasks/sf-sqs-report/webpack.config.js
+++ b/tasks/sf-sqs-report/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     { formidable: 'url' }
   ],

--- a/tasks/sync-granule/webpack.config.js
+++ b/tasks/sync-granule/webpack.config.js
@@ -27,6 +27,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'},
     // See https://github.com/knex/knex/issues/1128 re: webpack configuration

--- a/tasks/test-processing/webpack.config.js
+++ b/tasks/test-processing/webpack.config.js
@@ -31,6 +31,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     { formidable: 'url' },
   ],

--- a/tasks/update-cmr-access-constraints/webpack.config.js
+++ b/tasks/update-cmr-access-constraints/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'}
   ],

--- a/tasks/update-granules-cmr-metadata-file-links/webpack.config.js
+++ b/tasks/update-granules-cmr-metadata-file-links/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'}
   ],

--- a/tf-modules/internal/cumulus-test-cleanup/webpack.config.js
+++ b/tf-modules/internal/cumulus-test-cleanup/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'}
   ],


### PR DESCRIPTION
**Summary:** Summary of changes

Excludes @aws-sdk v3 as part of the webpack packaging since we're now requiring Node v20 and don't want to include all of the SDK packages with our code.

I did this by running through the opposite PR (removal of v2): https://github.com/nasa/cumulus/pull/3618

This change is necessary because after attempting to publish v18.3.0 some of the packages were too large to publish to npm.

## Changes

* Excludes @aws-sdk v3 from lambda packages.

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
