### PR TITLE
CUMULUS-3639: Add support to db/CollectionSearch to retrieve active collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 ### Replace ElasticSearch Phase 1
+- **CUMULUS-3639**
+ - Updated `/collections/active` endpoint to query postgres
 - **CUMULUS-3699**
  - Updated `collections` api endpoint to be able to support `includeStats` query string parameter
 - **CUMULUS-3641**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 ### Replace ElasticSearch Phase 1
+
 - **CUMULUS-3639**
  - Updated `/collections/active` endpoint to query postgres
 - **CUMULUS-3699**

--- a/example/config.yml
+++ b/example/config.yml
@@ -13,6 +13,11 @@ cumulus-es:
   apiUsername: jasmine
   pdrNodeNameProviderBucket: cumulus-sit-pdr-node-name-provider
 
+cumulus-lp:
+  bucket: cumulus-sit-internal
+  apiUsername: jasmine
+  pdrNodeNameProviderBucket: cumulus-sit-pdr-node-name-provider
+
 mvd-tf:
   bucket: mvd-internal
 

--- a/example/deployments/cumulus/cumulus-lp.tfvars
+++ b/example/deployments/cumulus/cumulus-lp.tfvars
@@ -1,0 +1,4 @@
+prefix = "cumulus-lp"
+archive_api_port = 8000
+key_name = "lp"
+cmr_oauth_provider = "launchpad"

--- a/example/deployments/data-persistence/cumulus-lp.tfvars
+++ b/example/deployments/data-persistence/cumulus-lp.tfvars
@@ -1,0 +1,1 @@
+prefix = "cumulus-lp"

--- a/example/deployments/db-migration/cumulus-lp.tfvars
+++ b/example/deployments/db-migration/cumulus-lp.tfvars
@@ -1,0 +1,1 @@
+prefix = "cumulus-lp"

--- a/packages/api/endpoints/collections.js
+++ b/packages/api/endpoints/collections.js
@@ -67,6 +67,7 @@ async function list(req, res) {
  * @returns {Promise<Object>} the promise of express response object
  */
 async function activeList(req, res) {
+  log.debug(`activeList query ${JSON.stringify(req.query)}`);
   const { getMMT, ...queryStringParameters } = req.query;
   const dbSearch = new CollectionSearch({ queryStringParameters: { active: 'true', ...queryStringParameters } });
   let result = await dbSearch.query();

--- a/packages/api/endpoints/collections.js
+++ b/packages/api/endpoints/collections.js
@@ -26,7 +26,6 @@ const {
   indexCollection,
   deleteCollection,
 } = require('@cumulus/es-client/indexer');
-const Collection = require('@cumulus/es-client/collections');
 const {
   publishCollectionCreateSnsMessage,
   publishCollectionDeleteSnsMessage,
@@ -46,7 +45,7 @@ const log = new Logger({ sender: '@cumulus/api/collections' });
  * @returns {Promise<Object>} the promise of express response object
  */
 async function list(req, res) {
-  log.trace(`list query ${JSON.stringify(req.query)}`);
+  log.debug(`list query ${JSON.stringify(req.query)}`);
   const { getMMT, ...queryStringParameters } = req.query;
   const dbSearch = new CollectionSearch(
     { queryStringParameters }

--- a/packages/api/endpoints/collections.js
+++ b/packages/api/endpoints/collections.js
@@ -68,7 +68,7 @@ async function list(req, res) {
  */
 async function activeList(req, res) {
   const { getMMT, ...queryStringParameters } = req.query;
-  const dbSearch = new CollectionSearch({ active: 'true', ...queryStringParameters });
+  const dbSearch = new CollectionSearch({ queryStringParameters: { active: 'true', ...queryStringParameters } });
   let result = await dbSearch.query();
   if (getMMT === 'true') {
     result = await insertMMTLinks(result);

--- a/packages/api/endpoints/collections.js
+++ b/packages/api/endpoints/collections.js
@@ -78,15 +78,9 @@ async function list(req, res) {
  * @returns {Promise<Object>} the promise of express response object
  */
 async function activeList(req, res) {
-  const { getMMT, includeStats, ...queryStringParameters } = req.query;
-
-  const collection = new Collection(
-    { queryStringParameters },
-    undefined,
-    process.env.ES_INDEX,
-    includeStats === 'true'
-  );
-  let result = await collection.queryCollectionsWithActiveGranules();
+  const { getMMT, ...queryStringParameters } = req.query;
+  const dbSearch = new CollectionSearch({ active: 'true', ...queryStringParameters });
+  let result = await dbSearch.query();
   if (getMMT === 'true') {
     result = await insertMMTLinks(result);
   }

--- a/packages/api/endpoints/granules.js
+++ b/packages/api/endpoints/granules.js
@@ -101,7 +101,7 @@ function _createNewGranuleDateValue() {
  * @returns {Promise<Object>} the promise of express response object
  */
 async function list(req, res) {
-  log.trace(`list query ${JSON.stringify(req.query)}`);
+  log.debug(`list query ${JSON.stringify(req.query)}`);
   const { getRecoveryStatus, ...queryStringParameters } = req.query;
 
   const dbSearch = new GranuleSearch({ queryStringParameters });

--- a/packages/api/endpoints/stats.js
+++ b/packages/api/endpoints/stats.js
@@ -1,3 +1,5 @@
+//@ts-check
+
 'use strict';
 
 const router = require('express-promise-router')();

--- a/packages/api/tests/endpoints/collections/active-collections.js
+++ b/packages/api/tests/endpoints/collections/active-collections.js
@@ -2,22 +2,17 @@
 
 const test = require('ava');
 const request = require('supertest');
-const sinon = require('sinon');
-const rewire = require('rewire');
+const range = require('lodash/range');
 const awsServices = require('@cumulus/aws-client/services');
 const {
   recursivelyDeleteS3Bucket,
 } = require('@cumulus/aws-client/S3');
 const { randomId } = require('@cumulus/common/test-utils');
-const { bootstrapElasticSearch } = require('@cumulus/es-client/bootstrap');
-const indexer = rewire('@cumulus/es-client/indexer');
-const { getEsClient } = require('@cumulus/es-client/search');
+const { randomString } = require('@cumulus/common/test-utils');
 
 const models = require('../../../models');
 const {
   createFakeJwtAuthToken,
-  fakeCollectionFactory,
-  fakeGranuleFactoryV2,
   setAuthorizedOAuthUsers,
 } = require('../../../lib/testUtils');
 const assertions = require('../../../lib/assertions');
@@ -27,23 +22,41 @@ process.env.stackName = randomId('stackName');
 process.env.system_bucket = randomId('bucket');
 process.env.TOKEN_SECRET = randomId('tokenSecret');
 
+const testDbName = randomId('collection');
+
+const {
+  destroyLocalTestDb,
+  generateLocalTestDb,
+  CollectionPgModel,
+  GranulePgModel,
+  fakeCollectionRecordFactory,
+  fakeGranuleRecordFactory,
+  migrationDir,
+  localStackConnectionEnv,
+} = require('../../../../db/dist');
+
+process.env.PG_HOST = randomId('hostname');
+process.env.PG_USER = randomId('user');
+process.env.PG_PASSWORD = randomId('password');
+
+process.env.AccessTokensTable = randomString();
+process.env.stackName = randomString();
+process.env.system_bucket = randomString();
+process.env.TOKEN_SECRET = randomString();
+
 // import the express app after setting the env variables
 const { app } = require('../../../app');
-
-const esIndex = randomId('esindex');
-let esClient;
 
 let jwtAuthToken;
 let accessTokenModel;
 
-test.before(async () => {
-  const esAlias = randomId('esAlias');
-  process.env.ES_INDEX = esAlias;
-  await bootstrapElasticSearch({
-    host: 'fakehost',
-    index: esIndex,
-    alias: esAlias,
-  });
+process.env = {
+  ...process.env,
+  ...localStackConnectionEnv,
+  PG_DATABASE: testDbName,
+};
+
+test.before(async (t) => {
   await awsServices.s3().createBucket({ Bucket: process.env.system_bucket });
 
   const username = randomId('username');
@@ -53,45 +66,63 @@ test.before(async () => {
   await accessTokenModel.createTable();
 
   jwtAuthToken = await createFakeJwtAuthToken({ accessTokenModel, username });
-  esClient = await getEsClient('fakehost');
 
-  await Promise.all([
-    indexer.indexCollection(esClient, fakeCollectionFactory({
-      name: 'coll1',
-      version: '1',
-    }), esAlias),
-    indexer.indexCollection(esClient, fakeCollectionFactory({
-      name: 'coll2',
-      version: '1',
-    }), esAlias),
-    indexer.indexGranule(esClient, fakeGranuleFactoryV2({ collectionId: 'coll1___1' }), esAlias),
-    indexer.indexGranule(esClient, fakeGranuleFactoryV2({ collectionId: 'coll1___1' }), esAlias),
-  ]);
+  const { knexAdmin, knex } = await generateLocalTestDb(
+    testDbName,
+    migrationDir
+  );
 
-  // Indexing using Date.now() to generate the timestamp
-  const stub = sinon.stub(Date, 'now').returns((new Date(2020, 0, 29)).getTime());
+  t.context.knexAdmin = knexAdmin;
+  t.context.knex = knex;
 
-  try {
-    await Promise.all([
-      indexer.indexCollection(esClient, fakeCollectionFactory({
-        name: 'coll3',
-        version: '1',
-        updatedAt: new Date(2020, 0, 29),
-      }), esAlias),
-      indexer.indexGranule(esClient, fakeGranuleFactoryV2({
-        updatedAt: new Date(2020, 1, 29),
-        collectionId: 'coll3___1',
-      }), esAlias),
-    ]);
-  } finally {
-    stub.restore();
-  }
+  t.context.collectionPgModel = new CollectionPgModel();
+  const collections = [];
+
+  range(3).map((num) => (
+    collections.push(fakeCollectionRecordFactory({
+      name: `coll${num + 1}`,
+      version: 1,
+      cumulus_id: num,
+      updated_at: num === 2 ? new Date(2020, 0, 29) : new Date(),
+    }))
+  ));
+
+  t.context.granulePgModel = new GranulePgModel();
+  const granules = [];
+
+  range(2).map(() => (
+    granules.push(fakeGranuleRecordFactory({
+      collection_cumulus_id: 0,
+    }))
+  ));
+
+  range(2).map((num) => (
+    granules.push(fakeGranuleRecordFactory({
+      collection_cumulus_id: 2,
+      updated_at: new Date(2020, num, 29),
+    }))
+  ));
+
+  t.context.collections = collections;
+  await t.context.collectionPgModel.insert(
+    t.context.knex,
+    collections
+  );
+
+  t.context.granules = granules;
+  await t.context.granulePgModel.insert(
+    t.context.knex,
+    granules
+  );
 });
 
-test.after.always(async () => {
+test.after.always(async (t) => {
   await accessTokenModel.deleteTable();
   await recursivelyDeleteS3Bucket(process.env.system_bucket);
-  await esClient.client.indices.delete({ index: esIndex });
+  await destroyLocalTestDb({
+    ...t.context,
+    testDbName,
+  });
 });
 
 test('GET without pathParameters and without an Authorization header returns an Authorization Missing response', async (t) => {
@@ -152,4 +183,36 @@ test.serial('timestamps filters collections by granule date', async (t) => {
   const { results } = response.body;
   t.is(results.length, 1);
   t.is(results[0].name, 'coll3');
+});
+
+test.serial('timestamps filters collections and stats by granule date', async (t) => {
+  const fromDate = new Date(2020, 0, 1);
+  const toDate = new Date(2020, 1, 1);
+  const toDate2 = new Date(2020, 2, 1);
+
+  let response = await request(app)
+    .get(`/collections/active?timestamp__from=${fromDate.getTime()}&timestamp__to=${toDate.getTime()}&includeStats=true`)
+    .set('Accept', 'application/json')
+    .set('Authorization', `Bearer ${jwtAuthToken}`)
+    .expect(200);
+
+  let results = response.body.results;
+  t.is(results.length, 1);
+  let { name, stats } = results[0];
+  t.is(name, 'coll3');
+  t.truthy(stats);
+  t.is(stats.total, 1);
+
+  response = await request(app)
+    .get(`/collections/active?timestamp__from=${fromDate.getTime()}&timestamp__to=${toDate2.getTime()}&includeStats=true`)
+    .set('Accept', 'application/json')
+    .set('Authorization', `Bearer ${jwtAuthToken}`)
+    .expect(200);
+
+  results = response.body.results;
+  t.is(results.length, 1);
+  ({ name, stats } = results[0]);
+  t.is(name, 'coll3');
+  t.truthy(stats);
+  t.is(stats.total, 2);
 });

--- a/packages/db/src/search/BaseSearch.ts
+++ b/packages/db/src/search/BaseSearch.ts
@@ -98,7 +98,7 @@ class BaseSearch {
     this.buildTermQuery({ countQuery, searchQuery });
     this.buildTermsQuery({ countQuery, searchQuery });
     this.buildNotMatchQuery({ countQuery, searchQuery });
-    this.buildRangeQuery({ countQuery, searchQuery });
+    this.buildRangeQuery({ knex, countQuery, searchQuery });
     this.buildExistsQuery({ countQuery, searchQuery });
     this.buildInfixPrefixQuery({ countQuery, searchQuery });
     this.buildSortQuery({ searchQuery });
@@ -200,11 +200,13 @@ class BaseSearch {
    * Build queries for range fields
    *
    * @param params
+   * @param params.knex - db client
    * @param [params.countQuery] - query builder for getting count
    * @param params.searchQuery - query builder for search
    * @param [params.dbQueryParameters] - db query parameters
    */
   protected buildRangeQuery(params: {
+    knex?: Knex,
     countQuery?: Knex.QueryBuilder,
     searchQuery: Knex.QueryBuilder,
     dbQueryParameters?: DbQueryParameters,

--- a/packages/db/src/search/BaseSearch.ts
+++ b/packages/db/src/search/BaseSearch.ts
@@ -419,13 +419,12 @@ class BaseSearch {
     const knex = testKnex ?? await getKnexClient();
     const { countQuery, searchQuery } = this.buildSearch(knex);
     try {
-      const countResult = await countQuery;
+      const [countResult, pgRecords] = await Promise.all([countQuery, searchQuery]);
       const meta = this._metaTemplate();
       meta.limit = this.dbQueryParameters.limit;
       meta.page = this.dbQueryParameters.page;
       meta.count = Number(countResult[0]?.count ?? 0);
 
-      const pgRecords = await searchQuery;
       const apiRecords = await this.translatePostgresRecordsToApiRecords(pgRecords, knex);
 
       return {

--- a/packages/db/src/search/CollectionSearch.ts
+++ b/packages/db/src/search/CollectionSearch.ts
@@ -119,6 +119,7 @@ export class CollectionSearch extends BaseSearch {
         subQuery.where(`${granulesTable}.${name}`, '<=', rangeValues.lte);
       }
     });
+    subQuery.limit(1);
 
     [countQuery, searchQuery].forEach((query) => query.whereExists(subQuery));
   }

--- a/packages/db/src/search/CollectionSearch.ts
+++ b/packages/db/src/search/CollectionSearch.ts
@@ -3,7 +3,9 @@ import pick from 'lodash/pick';
 
 import Logger from '@cumulus/logger';
 import { CollectionRecord } from '@cumulus/types/api/collections';
+import { GranuleStatus } from '@cumulus/types/api/granules';
 import { BaseSearch } from './BaseSearch';
+import { TableNames } from '../tables';
 import { DbQueryParameters, QueryEvent } from '../types/search';
 import { translatePostgresCollectionToApiCollection } from '../translate/collections';
 import { PostgresCollectionRecord } from '../types/collection';
@@ -19,8 +21,11 @@ const log = new Logger({ sender: '@cumulus/db/CollectionSearch' });
  * Class to build and execute db search query for collection
  */
 export class CollectionSearch extends BaseSearch {
+  readonly active: boolean;
   constructor(event: QueryEvent) {
-    super(event, 'collection');
+    const { active, ...queryStringParameters } = event.queryStringParameters || {};
+    super({ queryStringParameters }, 'collection');
+    this.active = (active === 'true');
   }
 
   /**
@@ -62,6 +67,44 @@ export class CollectionSearch extends BaseSearch {
     }
     if (prefix) {
       [countQuery, searchQuery].forEach((query) => query.whereLike(`${this.tableName}.name`, `%${prefix}%`));
+    }
+  }
+
+  /**
+   * Build queries for range fields
+   *
+   * @param params
+   * @param params.knex - db client
+   * @param [params.countQuery] - query builder for getting count
+   * @param params.searchQuery - query builder for search
+   * @param [params.dbQueryParameters] - db query parameters
+   */
+  protected buildRangeQuery(params: {
+    knex: Knex,
+    countQuery: Knex.QueryBuilder,
+    searchQuery: Knex.QueryBuilder,
+    dbQueryParameters?: DbQueryParameters,
+  }) {
+    if (!this.active) super.buildRangeQuery(params);
+
+    const granulesTable = TableNames.granules;
+    const { knex, countQuery, searchQuery, dbQueryParameters } = params;
+    const { range = {} } = dbQueryParameters ?? this.dbQueryParameters;
+
+    const subQuery = knex.select(1).from(granulesTable)
+      .join(`${this.tableName}`, `${granulesTable}.collection_cumulus_id`, `${this.tableName}.cumulus_id`);
+
+    Object.entries(range).forEach(([name, rangeValues]) => {
+      if (rangeValues.gte) {
+        subQuery.where(`${granulesTable}.${name}`, '>=', rangeValues.gte);
+      }
+      if (rangeValues.lte) {
+        subQuery.where(`${granulesTable}.${name}`, '<=', rangeValues.lte);
+      }
+    });
+
+    if (Object.keys(range).length > 0) {
+      [countQuery, searchQuery].forEach((query) => query.whereExists(subQuery));
     }
   }
 

--- a/packages/db/src/search/CollectionSearch.ts
+++ b/packages/db/src/search/CollectionSearch.ts
@@ -3,9 +3,7 @@ import pick from 'lodash/pick';
 
 import Logger from '@cumulus/logger';
 import { CollectionRecord } from '@cumulus/types/api/collections';
-import { GranuleStatus } from '@cumulus/types/api/granules';
 import { BaseSearch } from './BaseSearch';
-import { TableNames } from '../tables';
 import { DbQueryParameters, QueryEvent } from '../types/search';
 import { translatePostgresCollectionToApiCollection } from '../translate/collections';
 import { PostgresCollectionRecord } from '../types/collection';
@@ -101,14 +99,17 @@ export class CollectionSearch extends BaseSearch {
     searchQuery: Knex.QueryBuilder,
     dbQueryParameters?: DbQueryParameters,
   }) {
-    if (!this.active) super.buildRangeQuery(params);
+    if (!this.active) {
+      super.buildRangeQuery(params);
+      return;
+    }
 
     const granulesTable = TableNames.granules;
     const { knex, countQuery, searchQuery, dbQueryParameters } = params;
     const { range = {} } = dbQueryParameters ?? this.dbQueryParameters;
 
     const subQuery = knex.select(1).from(granulesTable)
-      .join(`${this.tableName}`, `${granulesTable}.collection_cumulus_id`, `${this.tableName}.cumulus_id`);
+      .where(`${granulesTable}.collection_cumulus_id`, knex.raw(`${this.tableName}.cumulus_id`));
 
     Object.entries(range).forEach(([name, rangeValues]) => {
       if (rangeValues.gte) {
@@ -119,15 +120,13 @@ export class CollectionSearch extends BaseSearch {
       }
     });
 
-    if (Object.keys(range).length > 0) {
-      [countQuery, searchQuery].forEach((query) => query.whereExists(subQuery));
-    }
-   }
+    [countQuery, searchQuery].forEach((query) => query.whereExists(subQuery));
+  }
 
   /**
    * Executes stats query to get granules' status aggregation
    *
-   * @param ids - array of cumulusIds of the collections
+   * @param collectionCumulusIds - array of cumulusIds of the collections
    * @param knex - knex for the stats query
    * @returns the collection's granules status' aggregation
    */
@@ -139,6 +138,18 @@ export class CollectionSearch extends BaseSearch {
       .count(`${granulesTable}.status`)
       .groupBy(`${granulesTable}.collection_cumulus_id`, `${granulesTable}.status`)
       .whereIn(`${granulesTable}.collection_cumulus_id`, collectionCumulusIds);
+
+    if (this.active) {
+      Object.entries(this.dbQueryParameters?.range ?? {}).forEach(([name, rangeValues]) => {
+        if (rangeValues.gte) {
+          statsQuery.where(`${granulesTable}.${name}`, '>=', rangeValues.gte);
+        }
+        if (rangeValues.lte) {
+          statsQuery.where(`${granulesTable}.${name}`, '<=', rangeValues.lte);
+        }
+      });
+    }
+    log.debug(`retrieveGranuleStats statsQuery: ${statsQuery?.toSQL().sql}`);
     const results = await statsQuery;
     const reduced = results.reduce((acc, record) => {
       const cumulusId = Number(record.collection_cumulus_id);
@@ -181,8 +192,8 @@ export class CollectionSearch extends BaseSearch {
         : apiRecord;
 
       if (statsRecords) {
-        apiRecordFinal.stats = statsRecords[record.cumulus_id] ? statsRecords[record.cumulus_id] :
-          {
+        apiRecordFinal.stats = statsRecords[record.cumulus_id] ? statsRecords[record.cumulus_id]
+          : {
             queued: 0,
             completed: 0,
             failed: 0,

--- a/packages/db/src/search/field-mapping.ts
+++ b/packages/db/src/search/field-mapping.ts
@@ -23,6 +23,9 @@ const granuleMapping: { [key: string]: Function } = {
   granuleId: (value?: string) => ({
     granule_id: value,
   }),
+  _id: (value?: string) => ({
+    granule_id: value,
+  }),
   lastUpdateDateTime: (value?: string) => ({
     last_update_date_time: value,
   }),
@@ -82,7 +85,6 @@ const granuleMapping: { [key: string]: Function } = {
   }),
 };
 
-// TODO add and verify all queryable fields for the following record types
 const asyncOperationMapping : { [key: string]: Function } = {
   createdAt: (value?: string) => ({
     created_at: value && new Date(Number(value)),
@@ -124,6 +126,15 @@ const collectionMapping : { [key: string]: Function } = {
       collectionVersion: version,
     };
   },
+  duplicateHandling: (value?: string) => ({
+    duplicate_handling: value,
+  }),
+  granuleId: (value?: string) => ({
+    granule_id_validation_regex: value,
+  }),
+  granuleIdExtraction: (value?: string) => ({
+    granule_id_extraction_regex: value,
+  }),
   timestamp: (value?: string) => ({
     updated_at: value && new Date(Number(value)),
   }),
@@ -139,11 +150,12 @@ const collectionMapping : { [key: string]: Function } = {
   sampleFileName: (value?: string) => ({
     sample_file_name: value,
   }),
-  urlPath: (value?: string) => ({
+  url_path: (value?: string) => ({
     url_path: value,
   }),
 };
 
+// TODO add and verify all queryable fields for the following record types
 const executionMapping : { [key: string]: Function } = {
   arn: (value?: string) => ({
     arn: value,

--- a/packages/db/tests/search/test-CollectionSearch.js
+++ b/packages/db/tests/search/test-CollectionSearch.js
@@ -348,7 +348,7 @@ test('CollectionSearch supports search which checks existence of collection fiel
   const { knex } = t.context;
   const queryStringParameters = {
     limit: 200,
-    urlPath__exists: 'true',
+    url_path__exists: 'true',
   };
   const dbSearch = new CollectionSearch({ queryStringParameters });
   const response = await dbSearch.query(knex);

--- a/packages/db/tests/search/test-field-mapping.js
+++ b/packages/db/tests/search/test-field-mapping.js
@@ -106,7 +106,7 @@ test('mapQueryStringFieldToDbField correctly converts all collection api fields 
     createdAt: '1591312763823',
     name: 'MOD11A1',
     reportToEms: 'true',
-    urlPath: 'http://fakepath.com',
+    url_path: 'http://fakepath.com',
     sampleFileName: 'hello.txt',
     version: '006',
     updatedAt: 1591384094512,


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3639: Update /collections/active endpoint to query postgres](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3639)

## Changes

* Updated `/collections/active` endpoint to query postgres

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
