### PR TITLE
CUMULUS-3737: Cherry-picks CUMULUS-3779. Reverts CL to Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
-## [v18.3.0] 2024-06-14
+## [Unreleased]
 
 ### Migration Notes
 
@@ -58,6 +56,11 @@ output or status of your request. If you want to directly observe the progress
 of the migration as it runs, you can view the CloudWatch logs for your async
 operations (e.g. `PREFIX-AsyncOperationEcsLogs`).
 
+#### CUMULUS-3779 async_operations Docker image version upgrade
+  
+The `async_operations` Docker image has been updated to support Node v20 and `aws-sdk` v3. Users will need to bump
+the version tag of `async_operations` to at least 52 if using the Docker image.
+
 ### Breaking Changes
 
 - **CUMULUS-3618**
@@ -92,6 +95,9 @@ operations (e.g. `PREFIX-AsyncOperationEcsLogs`).
 - **CUMULUS-2897**
   - Removed unused Systems Manager AWS SDK client. This change removes the Systems Manager client
     from the `@cumulus/aws-client` package.
+- **CUMULUS-3779**
+  - Updates async_operations Docker image to Node v20 and bumps its cumulus dependencies to v18.3.0 to
+    support `aws-sdk` v3 changes.
 
 ### Added
 
@@ -203,6 +209,10 @@ operations (e.g. `PREFIX-AsyncOperationEcsLogs`).
     credentialing timeout in long-running ECS jobs.
 - **CUMULUS-3323**
   - Minor edits to errant integration test titles (dyanmo->postgres)
+- **AWS-SDK v3 Exclusion (v18.3.0 fix)***
+  - Excludes aws-sdk v3 from packages to reduce overall package size. With the requirement of Node v20
+    packaging the aws-sdk v3 with our code is no longer necessary and prevented some packages from being
+    published to npm.
 
 ## [v18.2.2] 2024-06-4
 
@@ -7814,8 +7824,7 @@ Note: There was an issue publishing 1.12.0. Upgrade to 1.12.1.
 
 ## [v1.0.0] - 2018-02-23
 
-[unreleased]: https://github.com/nasa/cumulus/compare/v18.3.0...HEAD
-[v18.3.0]: https://github.com/nasa/cumulus/compare/v18.2.2...v18.3.0
+[Unreleased]: https://github.com/nasa/cumulus/compare/v18.2.2...HEAD
 [v18.2.2]: https://github.com/nasa/cumulus/compare/v18.2.1...v18.2.2
 [v18.2.1]: https://github.com/nasa/cumulus/compare/v18.2.0...v18.2.1
 [v18.2.0]: https://github.com/nasa/cumulus/compare/v18.1.0...v18.2.0

--- a/example/cumulus-tf/variables.tf
+++ b/example/cumulus-tf/variables.tf
@@ -350,7 +350,7 @@ variable "rds_admin_access_secret_arn" {
 variable "async_operation_image_version" {
   description = "docker image version to use for Cumulus async operations tasks"
   type = string
-  default = "49"
+  default = "52"
 }
 
 variable "cumulus_process_activity_version" {
@@ -362,7 +362,7 @@ variable "cumulus_process_activity_version" {
 variable "ecs_task_image_version" {
   description = "docker image version to use for Cumulus hello world task"
     type = string
-    default = "1.9.0"
+    default = "2.1.0"
 }
 
 variable "cumulus_test_ingest_image_version" {

--- a/lambdas/db-migration/webpack.config.js
+++ b/lambdas/db-migration/webpack.config.js
@@ -80,5 +80,8 @@ module.exports = {
   node: {
     __dirname: false
   },
-  target: 'node'
+  target: 'node',
+  externals: [
+    /@aws-sdk\//
+  ]
 };

--- a/lambdas/db-provision-user-database/webpack.config.js
+++ b/lambdas/db-provision-user-database/webpack.config.js
@@ -46,5 +46,8 @@ module.exports = {
       },
     ],
   },
-  target: 'node'
+  target: 'node',
+  externals: [
+    /@aws-sdk\//
+  ]
 };

--- a/lambdas/dla-migration/webpack.config.js
+++ b/lambdas/dla-migration/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
     path: path.resolve(__dirname, 'dist', 'webpack'),
     filename: 'index.js'
   },
-  externals: ['aws-sdk'],
+  externals: [/@aws-sdk\//],
   target: 'node',
   devtool: 'eval-cheap-module-source-map',
   optimization: {

--- a/lambdas/migration-helper-async-operation/webpack.config.js
+++ b/lambdas/migration-helper-async-operation/webpack.config.js
@@ -46,5 +46,8 @@ module.exports = {
       },
     ],
   },
-  target: 'node'
+  target: 'node',
+  externals: [
+    /@aws-sdk\//
+  ]
 };

--- a/lambdas/sqs-message-remover/webpack.config.js
+++ b/lambdas/sqs-message-remover/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'}
   ],

--- a/packages/api/ecs/async-operation/Dockerfile
+++ b/packages/api/ecs/async-operation/Dockerfile
@@ -1,11 +1,10 @@
-FROM node:20.12.2-buster
+FROM amazon/aws-lambda-nodejs:20
 
 USER root
-RUN sed -i -e '/jessie-updates/d' /etc/apt/sources.list
-RUN apt-get update && apt-get install -y unzip
+RUN dnf install -y unzip shadow-utils
 
-RUN groupadd -r task -g 433
-RUN useradd -u 431 -r -g task -m -s /sbin/nologin -c "Docker image user" task
+RUN /usr/sbin/groupadd -r task -g 433
+RUN /usr/sbin/useradd -u 431 -r -g task -m -s /sbin/nologin -c "Docker image user" task
 
 USER task
 WORKDIR /home/task
@@ -13,6 +12,10 @@ WORKDIR /home/task
 COPY package.json /home/task/
 RUN npm install
 
+RUN cp -a /var/runtime/node_modules/. /home/task/node_modules/
+
 COPY index.js /home/task/
 
 CMD [ "node", "--harmony", "index.js" ]
+
+ENTRYPOINT [ ]

--- a/packages/api/webpack.config.js
+++ b/packages/api/webpack.config.js
@@ -80,6 +80,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     { formidable: 'url' },
     { fsevents: "require('fsevents')" }

--- a/packages/integration-tests/webpack.config.js
+++ b/packages/integration-tests/webpack.config.js
@@ -31,6 +31,7 @@ module.exports = {
     },
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     { formidable: 'url' },
   ],

--- a/packages/s3-credentials-endpoint/webpack.config.js
+++ b/packages/s3-credentials-endpoint/webpack.config.js
@@ -32,6 +32,7 @@ module.exports = {
     },
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     { formidable: 'url' },
   ],

--- a/packages/tea-map-cache/webpack.config.js
+++ b/packages/tea-map-cache/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
     path: path.resolve(__dirname, 'dist'),
     filename: 'index.js'
   },
-  externals: [],
+  externals: [/@aws-sdk\//],
   target: 'node',
   devtool: 'eval-cheap-module-source-map',
   optimization: {

--- a/tasks/add-missing-file-checksums/webpack.config.js
+++ b/tasks/add-missing-file-checksums/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
     path: path.resolve(__dirname, 'dist', 'webpack'),
     filename: 'index.js'
   },
-  externals: [],
+  externals: [/@aws-sdk\//],
   target: 'node',
   devtool: 'eval-cheap-module-source-map',
   optimization: {

--- a/tasks/discover-granules/webpack.config.js
+++ b/tasks/discover-granules/webpack.config.js
@@ -27,6 +27,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'}
   ],

--- a/tasks/discover-pdrs/webpack.config.js
+++ b/tasks/discover-pdrs/webpack.config.js
@@ -27,6 +27,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'}
   ],

--- a/tasks/files-to-granules/webpack.config.js
+++ b/tasks/files-to-granules/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'}
   ],

--- a/tasks/hello-world/webpack.config.js
+++ b/tasks/hello-world/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'}
   ],

--- a/tasks/hyrax-metadata-updates/webpack.config.js
+++ b/tasks/hyrax-metadata-updates/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'}
   ],

--- a/tasks/lzards-backup/webpack.config.js
+++ b/tasks/lzards-backup/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
     path: path.resolve(__dirname, 'dist', 'webpack'),
     filename: 'index.js'
   },
-  externals: [],
+  externals: [/@aws-sdk\//],
   target: 'node',
   devtool: 'eval-cheap-module-source-map',
   optimization: {

--- a/tasks/move-granules/webpack.config.js
+++ b/tasks/move-granules/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'},
     // See https://github.com/knex/knex/issues/1128 re: webpack configuration

--- a/tasks/orca-copy-to-archive-adapter/webpack.config.js
+++ b/tasks/orca-copy-to-archive-adapter/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
     path: path.resolve(__dirname, 'dist', 'webpack'),
     filename: 'index.js'
   },
-  externals: [],
+  externals: [/@aws-sdk\//],
   target: 'node',
   devtool: 'eval-cheap-module-source-map',
   optimization: {

--- a/tasks/orca-recovery-adapter/webpack.config.js
+++ b/tasks/orca-recovery-adapter/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
     path: path.resolve(__dirname, 'dist', 'webpack'),
     filename: 'index.js'
   },
-  externals: [],
+  externals: [/@aws-sdk\//],
   target: 'node',
   devtool: 'eval-cheap-module-source-map',
   optimization: {

--- a/tasks/parse-pdr/webpack.config.js
+++ b/tasks/parse-pdr/webpack.config.js
@@ -27,6 +27,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'}
   ],

--- a/tasks/pdr-status-check/webpack.config.js
+++ b/tasks/pdr-status-check/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'}
   ],

--- a/tasks/post-to-cmr/webpack.config.js
+++ b/tasks/post-to-cmr/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'}
   ],

--- a/tasks/queue-granules/webpack.config.js
+++ b/tasks/queue-granules/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
     path: path.resolve(__dirname, 'dist', 'webpack'),
     filename: 'index.js'
   },
-  externals: [],
+  externals: [/@aws-sdk\//],
   target: 'node',
   devtool: 'eval-cheap-module-source-map',
   optimization: {

--- a/tasks/queue-pdrs/webpack.config.js
+++ b/tasks/queue-pdrs/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'}
   ],

--- a/tasks/queue-workflow/webpack.config.js
+++ b/tasks/queue-workflow/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'}
   ],

--- a/tasks/send-pan/webpack.config.js
+++ b/tasks/send-pan/webpack.config.js
@@ -31,7 +31,7 @@ module.exports = {
     path: path.resolve(__dirname, 'dist', 'webpack'),
     filename: 'index.js'
   },
-  externals: [],
+  externals: [/@aws-sdk\//],
   target: 'node',
   devtool: 'eval-cheap-module-source-map',
   optimization: {

--- a/tasks/sf-sqs-report/webpack.config.js
+++ b/tasks/sf-sqs-report/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     { formidable: 'url' }
   ],

--- a/tasks/sync-granule/webpack.config.js
+++ b/tasks/sync-granule/webpack.config.js
@@ -27,6 +27,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'},
     // See https://github.com/knex/knex/issues/1128 re: webpack configuration

--- a/tasks/test-processing/webpack.config.js
+++ b/tasks/test-processing/webpack.config.js
@@ -31,6 +31,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     { formidable: 'url' },
   ],

--- a/tasks/update-cmr-access-constraints/webpack.config.js
+++ b/tasks/update-cmr-access-constraints/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'}
   ],

--- a/tasks/update-granules-cmr-metadata-file-links/webpack.config.js
+++ b/tasks/update-granules-cmr-metadata-file-links/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'}
   ],

--- a/tf-modules/internal/cumulus-test-cleanup/webpack.config.js
+++ b/tf-modules/internal/cumulus-test-cleanup/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     }
   },
   externals: [
+    /@aws-sdk\//,
     'electron',
     {'formidable': 'url'}
   ],


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3737: Release 18.3](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3737)

## Changes

* Adds https://github.com/nasa/cumulus/pull/3689 to 18.3.x to support stripping of aws-sdk v3 from packages
* Reverts 18.3.0 CL section to Unreleased since we're skipping that broken release.

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
