### PR TITLE
Ecarton/investigation build ts failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,7 +240,7 @@ the version tag of `async_operations` to at least 52 if using the Docker image.
   - Updated `@cumulus/aws-client/S3/recursivelyDeleteS3Bucket` to handle bucket with more than 1000 objects.
 
 ### Fixed
-- **CUMULUS-3738**
+- **CUMULUS-3787**
   - Fixed developer-side bug causing some ts error sto be swallowed in CI
 - **CUMULUS-3320**
   - Execution database deletions by `cumulus_id` should have greatly improved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,7 +240,8 @@ the version tag of `async_operations` to at least 52 if using the Docker image.
   - Updated `@cumulus/aws-client/S3/recursivelyDeleteS3Bucket` to handle bucket with more than 1000 objects.
 
 ### Fixed
-
+- **CUMULUS-3738**
+  - Fixed developer-side bug causing some ts error sto be swallowed in CI
 - **CUMULUS-3320**
   - Execution database deletions by `cumulus_id` should have greatly improved
     performance as a table scan will no longer be required for each record

--- a/bamboo/generate-ts-build-cache.sh
+++ b/bamboo/generate-ts-build-cache.sh
@@ -33,7 +33,8 @@ npm install
 npm run ci:bootstrap-no-scripts
 
 # Get a list of TS compiled files
-npm run tsc:listEmittedFiles | grep TSFILE | awk '{print $2}' | sed "s,$CURRENT_WORKING_DIR/,,g" >> .ts-build-cache-files
+npm run tsc:listEmittedFiles | tee emittedFiles.log 
+cat emittedFiles.log | grep TSFILE | awk '{print $2}' | sed "s,$CURRENT_WORKING_DIR/,,g" >> .ts-build-cache-files
 cat .ts-build-cache-files
 
 # Generate TS build cache artifact

--- a/packages/ingest/src/SftpProviderClient.js
+++ b/packages/ingest/src/SftpProviderClient.js
@@ -1,3 +1,4 @@
+//@ts-check
 'use strict';
 
 const get = require('lodash/get');

--- a/packages/ingest/src/SftpProviderClient.js
+++ b/packages/ingest/src/SftpProviderClient.js
@@ -1,4 +1,3 @@
-//@ts-check
 'use strict';
 
 const get = require('lodash/get');


### PR DESCRIPTION
fixes generate_ts_build_cache.sh swallowing outputs from running typescript which causes some rarer failures to happen without any indication of what went wrong

Addresses [CUMULUS-3787](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3787)

## Changes

* uses tee to display output from tsc:listEmittedFiles while also staging it for analysis

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
