### PR TITLE
CUMULUS-3608: Adds variable for sqs message consumer watcher message and time limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ degraded execution table operations.
   - Added `Bulk Execution Delete` migration type to async operations types
 - **CUMULUS-3742**
   - Script for dumping data into postgres database for testing and replicating issues
+- **CUMULUS-3608**
+  - Exposes variables for sqs_message_consumer_watcher messageLimit and timeLimit configurations.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,9 @@ degraded execution table operations.
 - **CUMULUS-3742**
   - Script for dumping data into postgres database for testing and replicating issues
 - **CUMULUS-3608**
-  - Exposes variables for sqs_message_consumer_watcher messageLimit and timeLimit configurations.
+  - Exposes variables for sqs_message_consumer_watcher messageLimit and timeLimit configurations. Descriptions
+    of the variables [here](tf-modules/ingest/variables.tf) include notes on usage and what users should
+    consider if configuring something other than the default values.
 
 ### Changed
 

--- a/tf-modules/ingest/cloudwatch-events.tf
+++ b/tf-modules/ingest/cloudwatch-events.tf
@@ -45,8 +45,8 @@ resource "aws_cloudwatch_event_target" "sqs_message_consumer_watcher" {
   rule = aws_cloudwatch_event_rule.sqs_message_consumer_watcher.name
   arn  = aws_lambda_function.sqs_message_consumer.arn
   input = jsonencode({
-    messageLimit = 500
-    timeLimit    = 60
+    messageLimit = var.sqs_message_consumer_watcher_message_limit
+    timeLimit    = var.sqs_message_consumer_watcher_time_limit
   })
 }
 

--- a/tf-modules/ingest/variables.tf
+++ b/tf-modules/ingest/variables.tf
@@ -196,3 +196,15 @@ variable "default_log_retention_days" {
   default = 30
   description = "Optional default value that user chooses for their log retention periods"
 }
+
+variable "sqs_message_consumer_watcher_message_limit" {
+  type = number
+  default = 500
+  description = "Number of messages the SQS message consumer Lambda will attempt to read from SQS in a single execution"
+}
+
+variable "sqs_message_consumer_watcher_time_limit" {
+  type = number
+  default = 60
+  description = "Number of seconds the SQS message consumer Lambda will remain active"
+}

--- a/tf-modules/ingest/variables.tf
+++ b/tf-modules/ingest/variables.tf
@@ -200,11 +200,20 @@ variable "default_log_retention_days" {
 variable "sqs_message_consumer_watcher_message_limit" {
   type = number
   default = 500
-  description = "Number of messages the SQS message consumer Lambda will attempt to read from SQS in a single execution"
+  description = <<EOF
+    Number of messages the SQS message consumer Lambda will attempt to read from SQS in a single execution. 
+    Note that increasing this value may result in a direct increase/decrease in triggered workflows. Users should
+    only adjust this value with the understanding of how it will impact the number of queued workflows in their 
+    system.
+  EOF
 }
 
 variable "sqs_message_consumer_watcher_time_limit" {
   type = number
   default = 60
-  description = "Number of seconds the SQS message consumer Lambda will remain active"
+  description = <<EOF
+    Number of seconds the SQS message consumer Lambda will remain active and polling for new messages. Note that this value 
+    should be less than the overall Lambda invocation timeout or else the Lambda may be terminated while still actively
+    polling SQS. This value should be adjusted in conjunction with sqs_message_consumer_watcher_message_limit.
+  EOF
 }


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3608: Make sqs_message_consumer_watcher messageLimit configurable](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3608)

## Changes

* Exposes message and time limit Terraform vars for sqs_message_consumer_watcher Lambda

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
