### PR TITLE
Fixes async-operation image tag for 18.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,18 +100,18 @@ degraded execution table operations.
 #### CUMULUS-3433 Update to node.js v20
 
 The following applies only to users with a custom value configured for
-`async_operation_image`:
+`async-operation`:
 
-- As part of the node v20 update process, a new version (49) of the Core
+- As part of the node v20 update process, a new version (52) of the Core
   async-operation container was published - [cumuluss/async
-  operation](https://hub.docker.com/layers/cumuluss/async-operation)  The
-  default value for `async_operation_image` has been updated in the `cumulus`
+  operation](https://hub.docker.com/layers/cumuluss/async-operation/52/images/sha256-78c05f9809c29707f9da87c0fc380d39a71379669cbebd227378c8481eb11c3a?context=explore)  The
+  default value for `async-operation` has been updated in the `cumulus`
   module, however if you are using an internal image repository such as ECR,
   please make sure to update your deployment configuration with the newly
   provided image.
 
   Users making use of a custom image configuration should note the base image
-  for Core async operations must support node v20.x.
+  for Core async operation must support node v20.x.
 
 #### CUMULUS-3617 Migration of DLA messages should be performed after Cumulus is upgraded
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,7 @@ The following applies only to users with a custom value configured for
   provided image.
 
   Users making use of a custom image configuration should note the base image
-  for Core async operation must support node v20.x.
+  for Core async operations must support node v20.x.
 
 #### CUMULUS-3617 Migration of DLA messages should be performed after Cumulus is upgraded
 


### PR DESCRIPTION
Fixes small error in the CHANGELOG where async-operation was updated via two different efforts. Only the latest tag should be referenced.

This commit should be merged into the 18.3.x branch after master.

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
