### PR TITLE
Jk/18.3.x cumulus 3789 backports 3592

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - **CUMULUS-3385**
   - updated cleanExecutions lambda to clean up postgres execution payloads
   - updated cleanExecutions lambda with configurable limit to control for large size
+- **NDCUM-1051**
+  - Modified addHyraxUrlToUmmG to test whether the provide Hyrax URL is already included in the metadata, and if so return the metadata unaltered.
+  - Modified addHyraxUrlToEcho10 to test whether the provide Hyrax URL is already included in the metadata, and if so return the metadata unaltered.
 
 ### Fixed
 

--- a/tasks/hyrax-metadata-updates/index.js
+++ b/tasks/hyrax-metadata-updates/index.js
@@ -209,12 +209,20 @@ function addHyraxUrlToUmmG(metadata, hyraxUrl) {
   if (metadataCopy.RelatedUrls === undefined) {
     metadataCopy.RelatedUrls = [];
   }
+
   const url = {
     URL: hyraxUrl,
     Type: 'USE SERVICE API',
     Subtype: 'OPENDAP DATA',
     Description: 'OPeNDAP request URL',
   };
+
+  for (const relatedUrl of metadataCopy.RelatedUrls) {
+    if (isEqual(relatedUrl, url)) {
+      return JSON.stringify(metadataCopy, undefined, 2);
+    }
+  }
+
   metadataCopy.RelatedUrls.push(url);
 
   return JSON.stringify(metadataCopy, undefined, 2);
@@ -245,6 +253,13 @@ function addHyraxUrlToEcho10(metadata, hyraxUrl) {
     Description: 'OPeNDAP request URL',
     Type: 'GET DATA : OPENDAP DATA',
   };
+
+  for (const resourceUrl of resourceUrls) {
+    if (isEqual(resourceUrl, url)) {
+      return generateEcho10XMLString(metadata.Granule);
+    }
+  }
+
   resourceUrls.push(url);
 
   metadataCopy.Granule.OnlineResources = {

--- a/tasks/hyrax-metadata-updates/tests/test-index.js
+++ b/tasks/hyrax-metadata-updates/tests/test-index.js
@@ -97,6 +97,16 @@ test('Test adding OPeNDAP URL to UMM-G file with no related urls', (t) => {
   t.is(actual, JSON.stringify(expectedObject, undefined, 2));
 });
 
+test('Test adding duplicate OPeNDAP URL to UMM-G file', (t) => {
+  const data = fs.readFileSync('tests/data/umm-gin.json', 'utf8');
+  const metadata = JSON.parse(data);
+  const expected = fs.readFileSync('tests/data/umm-gout.json', 'utf8');
+  const expectedObject = JSON.parse(expected);
+  const newMetadata = JSON.parse(addHyraxUrl(metadata, true, 'https://opendap.earthdata.nasa.gov/collections/C1453188197-GES_DISC/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4'));
+  const actual = addHyraxUrl(newMetadata, true, 'https://opendap.earthdata.nasa.gov/collections/C1453188197-GES_DISC/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4');
+  t.is(actual, JSON.stringify(expectedObject, undefined, 2));
+});
+
 test('Test adding OPeNDAP URL to ECHO10 file', async (t) => {
   const data = fs.readFileSync('tests/data/echo10in.xml', 'utf8');
   const metadata = await (promisify(xml2js.parseString))(data, xmlParseOptions);
@@ -127,6 +137,15 @@ test('Test adding OPeNDAP URL to ECHO10 file with two OnlineResources', async (t
   const metadata = await (promisify(xml2js.parseString))(data, xmlParseOptions);
   const expected = fs.readFileSync('tests/data/echo10out-2-online-resource-urls.xml', 'utf8');
   const actual = addHyraxUrl(metadata, false, 'https://opendap.earthdata.nasa.gov/collections/C1453188197-GES_DISC/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4');
+  t.is(actual, expected.trim('\n'));
+});
+
+test('Test adding duplicate OPeNDAP URL to ECHO10 file', async (t) => {
+  const data = fs.readFileSync('tests/data/echo10in.xml', 'utf8');
+  const metadata = await (promisify(xml2js.parseString))(data, xmlParseOptions);
+  const expected = fs.readFileSync('tests/data/echo10out.xml', 'utf8');
+  const newMetadata = await (promisify(xml2js.parseString))(addHyraxUrl(metadata, false, 'https://opendap.earthdata.nasa.gov/collections/C1453188197-GES_DISC/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4'), xmlParseOptions);
+  const actual = addHyraxUrl(newMetadata, false, 'https://opendap.earthdata.nasa.gov/collections/C1453188197-GES_DISC/granules/GLDAS_CLSM025_D.2.0%3AGLDAS_CLSM025_D.A20141230.020.nc4');
   t.is(actual, expected.trim('\n'));
 });
 


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3789](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3789)

## Changes

* Backport #3789 to 18.3.x 

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
