### PR TITLE
Fixes async-operation image tag for 18.3.1 release (#3730)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 #### CUMULUS-3433 Update to node.js v20
 
 The following applies only to users with a custom value configured for
-`async_operation_image`:
+`async-operation`:
 
-- As part of the node v20 update process, a new version (49) of the Core
+- As part of the node v20 update process, a new version (52) of the Core
   async-operation container was published - [cumuluss/async
-  operation](https://hub.docker.com/layers/cumuluss/async-operation)  The
-  default value for `async_operation_image` has been updated in the `cumulus`
+  operation](https://hub.docker.com/layers/cumuluss/async-operation/52/images/sha256-78c05f9809c29707f9da87c0fc380d39a71379669cbebd227378c8481eb11c3a?context=explore)  The
+  default value for `async-operation` has been updated in the `cumulus`
   module, however if you are using an internal image repository such as ECR,
   please make sure to update your deployment configuration with the newly
   provided image.


### PR DESCRIPTION
Pulls the fixes to async-operation image tag in the CL release notes from `master` into the release branch.
