### PR TITLE
WIP: Cumulus 3760 guidance on cleaning execution backlog (#3738)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- **CUMULUS-3760**
+  - Added guidance for handling large backlog of es executions
+- **CUMULUS-3385**
+  - Added generate_db_executions to dump large scale postgres executions
+
 ## [v18.3.1] 2024-07-08
 
 ### Migration Notes
@@ -59,7 +65,7 @@ of the migration as it runs, you can view the CloudWatch logs for your async
 operations (e.g. `PREFIX-AsyncOperationEcsLogs`).
 
 #### CUMULUS-3779 async_operations Docker image version upgrade
-  
+
 The `async-operation` Docker image has been updated to support Node v20 and `aws-sdk` v3. Users of the image will need
 to update to at least [async-operations:52](https://hub.docker.com/layers/cumuluss/async-operation/52/images/sha256-78c05f9809c29707f9da87c0fc380d39a71379669cbebd227378c8481eb11c3a?context=explore).
 

--- a/docs/features/execution_payload_retention.md
+++ b/docs/features/execution_payload_retention.md
@@ -10,7 +10,42 @@ This allows access via the API (or optionally direct DB/Elasticsearch querying) 
 
 ## Payload record cleanup
 
-To reduce storage requirements, a CloudWatch rule (`{stack-name}-dailyExecutionPayloadCleanupRule`) triggering a daily run of the provided cleanExecutions lambda has been added.  This lambda will remove all 'completed' and 'non-completed' payload records in the database that are older than the specified configuration.
+To reduce storage requirements, a CloudWatch rule (`{stack-name}-dailyExecutionPayloadCleanupRule`) triggering a daily run of the provided cleanExecutions lambda has been added.  This lambda will remove a batch of payload records in elasticsearch that are older than the specified configuration.
+
+### Asynchronous es task
+
+The cleanExecutions lambda launches an asynchronous elasticsearch cleanup task which can be monitored from outside of the lambda function.
+
+To poll the task's current status use
+
+``` bash
+ > curl --request GET ${es_endpoint}/_tasks/${task_id}
+
+ #{"completed":false,"task":{"node":"pmXVVuVLTDmkv5NWhQeoLg","id":3231161,"type":"transport","action":"indices:data/write/update/byquery","status":{"total":300000,"updated":12000,"created":0,"deleted":0,"batches":13,"version_conflicts":0,"noops":0,"retries":{"bulk":0,"search":0},"throttled_millis":0,"requests_per_second":-1.0,"throttled_until_millis":0},"description":"update-by-query [cumulus][execution] updated with Script{type=inline, lang='painless', idOrCode='ctx._source.remove('finalPayload'); ctx._source.remove('originalPayload')', options={}, params={}}","start_time_in_millis":1721400177604,"running_time_in_nanos":11020601675,"cancellable":true}}
+
+```
+
+to cancel the task use
+
+``` bash
+ > curl --request POST ${es_endpoint}/_tasks/${task_id}/_cancel
+
+ #{"nodes":{"pmXVVuVLTDmkv5NWhQeoLg":{"name":"pmXVVuV","roles":["master","data","ingest"],"tasks":{"pmXVVuVLTDmkv5NWhQeoLg:3231161":{"node":"pmXVVuVLTDmkv5NWhQeoLg","id":3231161,"type":"transport","action":"indices:data/write/update/byquery","start_time_in_millis":1721400177604,"running_time_in_nanos":58473690222,"cancellable":true}}}}}
+
+```
+
+Upon launch of this elasticsearch task, the cleanExecutions lambda will log (accessible from CloudWatch) the task_id needed above, along with its best guess (subject to change if you are ssh tunnelling to the es cluster etc.) of the es_endpoint and formatted curl commands
+
+## Execution backlog cleanup
+
+To facilitate removing payloads for a large quantity of executions, this lambda specifies an update_limit configuration to avoid overwhelming elasticsearch.
+For cleanup of existing execution payloads the following is recommended:
+
+- set the daily_execution_payload_cleanup_schedule_expression to run this hourly: `"cron(0 * * * ? *)"`
+- a conservative update_limit is 1,000,000: this has been tested to be workable on a 1 node t2.small.search cluster
+
+Starting with this configuration, 24 million Elasticsearch records per day can be cleaned up. A more aggressive schedule is likely possible, but will need testing in SIT/UAT to ensure compatibility with cluster configuration.
+Once the older executions have been taken care of, a similar configuration should be able to run once per day and keep up with ingest rate
 
 ### Configuration
 


### PR DESCRIPTION
* moved to postgres functionality in cleanup executions

* added tests and logging

* execution upload

* fairly exhastive tests are all passing, es and postgres functionality good

* linter cleanup in cleanExecutions

* fix lint errros in test-cleanExecutions

* cleanup and slight optimization

* linter cleanups

* linter fixes and cleanup for generate_db_executions

* remove a debug printout

* bug in file detail parsing fixed

* param pass through posibility in all loaders

* test param passthroughs

* test end to end with cleanup

* slight optimization for equal timeouts

* fix to concurrency

* linter error fixes

* Revert "slight optimization for equal timeouts"

This reverts commit 5e046e5d18d344e12babce766ea3ea0a0cf7b957.

* another pass at slight optimization wile doing both complete and noncomp

* update changelog

* more updated changelog

* added execution script to readme

* what if we stub this out?

* how bout stubbing this way?

* explicit set of LOCAL_ES_HOST

* are we in test mode?

* really though, am I in test mode?

* explicit set of LOCAL_ES_HOST

* pulled out a bunch of mocking stuff that might be unnecessary

* explicit set of local es host

* how is this not set righ tnow?

* how is this not set righ tnow?

* this seems to work?

* cleanup from testing

* fixed typo in changelog

* remove unneeded code from execution model

* bring cleanExecutions up to  running vs non-running and single payload timeout

* fix tests for new paradigm

* fix tests for new paradigm

* update tf files for new variable structure

* linter fixes

* fixed tf values

* toggleable postgres and ES

* better strings for printouts

* generate es executions

* launch and poll

* task id printout and comentary

* linter cleanup

* tf variables

* bring together js environment, variables.tf and clean_executions.tf

* following up on environment variables reference in tf

* fixed mistaken capitalization in archive.tf

* tests to new capitalization env vars

* WIP docs

* better printout

* refresh index in stead up sleeping in tests

* fix docs mistakes in variables.tf

* lint fixes

* postgres batching testing

* cut out postgres cleanup logic along with associated variables

* cleanup tests

* linter error cleanup

* remove generate_es_executions script

* new wording in readme description of generate_db_records

* docs update with preliminary tips

* lets try some increased ES resources

* print out commands to check and kill es cleanup task

* remove redundant es_executions test file

* docs update

* changelog bad merge

* pr feedback updates

* move changelog entries out of 18.3.1

* linter errors

* changelog

* docs added

* restore testing es cluster size

* Apply suggestions from code review

Minor nits

---------

**Summary:** Summary of changes

Addresses [CUMULUS-XX: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-XXX)

## Changes

* Detailed list or prose of changes
* ...

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
