### PR TITLE
Back port CUMULUS-3807 to 18.3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### FIXED
+
+- **CUMULUS-3807**
+  - Pinned @aws-sdk/client-s3 to 3.614 to address timeout/bug in s3().listObjectsV2
+
 ## [v18.3.1] 2024-07-08
 
 ### Migration Notes

--- a/packages/aws-client/package.json
+++ b/packages/aws-client/package.json
@@ -64,7 +64,7 @@
     "@aws-sdk/client-sqs": "^3.447.0",
     "@aws-sdk/client-sts": "^3.447.0",
     "@aws-sdk/lib-dynamodb": "^3.447.0",
-    "@aws-sdk/lib-storage": "^3.447.0",
+    "@aws-sdk/lib-storage": "^3.447.0 <3.614.2",
     "@aws-sdk/s3-request-presigner": "^3.447.0",
     "@aws-sdk/signature-v4-crt": "^3.447.0",
     "@aws-sdk/types": "^3.447.0",

--- a/packages/aws-client/package.json
+++ b/packages/aws-client/package.json
@@ -57,7 +57,7 @@
     "@aws-sdk/client-kinesis": "^3.447.0",
     "@aws-sdk/client-kms": "^3.447.0",
     "@aws-sdk/client-lambda": "^3.529.1",
-    "@aws-sdk/client-s3": "^3.447.0",
+    "@aws-sdk/client-s3": "^3.447.0 <3.614.2",
     "@aws-sdk/client-secrets-manager": "^3.447.0",
     "@aws-sdk/client-sfn": "^3.447.0",
     "@aws-sdk/client-sns": "^3.447.0",


### PR DESCRIPTION
**Summary:** Summary of changes

Back ports [CUMULUS-3807](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3808) which pins some clients of the `aws-sdk` to specific versions. This should match (other than the CL entry placement) https://github.com/nasa/cumulus/pull/3739
