### PR TITLE
Temporarily allowlist fast-xml-parser

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -12,6 +12,7 @@
     "cacheable-request",
     "http-cache-semantics",
     "lodash.pick",
-    "hoek"
+    "hoek",
+    "fast-xml-parser"
   ]
 }


### PR DESCRIPTION
Temporarily allowlist `fast-xml-parser` so as not to block work being merged to `master`. See https://bugs.earthdata.nasa.gov/browse/CUMULUS-3808 and https://bugs.earthdata.nasa.gov/browse/CUMULUS-3817 for follow up work.
