### PR TITLE
CUMULUS-3818: Fixes default value for tf-modules cumulus async-operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ degraded execution table operations.
   - Execution database deletions by `cumulus_id` should have greatly improved
     performance as a table scan will no longer be required for each record
     deletion to validate parent-child relationships
+- **CUMULUS-3818**
+  - Fixes default value (updated to tag 52) for async-operation-image in tf-modules/cumulus.
 
 ## [v18.3.2] 2024-07-24
 

--- a/tf-modules/cumulus/variables.tf
+++ b/tf-modules/cumulus/variables.tf
@@ -3,7 +3,7 @@
 variable "async_operation_image" {
   description = "docker image to use for Cumulus async operations tasks"
   type = string
-  default = "cumuluss/async-operation:48"
+  default = "cumuluss/async-operation:52"
 }
 
 variable "cmr_client_id" {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3818: Update default async_operation_image in tf-modules/cumulus/variables.tf](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3818)

## Changes

* Updates default Terraform variable value for async-operation to 52 in order to support Node v20 and aws-sdk v3.

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
