### PR TITLE
CUMULUS-3824: Set ECS docker storage driver to overlay2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ degraded execution table operations.
 - **CUMULUS-3449**
   - Updated `@cumulus/db` package and configure knex hook postProcessResponse to convert the return string
     from columns ending with "cumulus_id" to number.
+- **CUMULUS-3824**
+  - Changed the default ECS docker storage driver to `overlay2`, since `devicemapper` is removed in Docker Engine v25.0 
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,8 @@ degraded execution table operations.
   - Updated `@cumulus/db` package and configure knex hook postProcessResponse to convert the return string
     from columns ending with "cumulus_id" to number.
 - **CUMULUS-3824**
-  - Changed the default ECS docker storage driver to `overlay2`, since `devicemapper` is removed in Docker Engine v25.0 
+  - Changed the default ECS docker storage driver to `overlay2`, since `devicemapper` is removed in Docker Engine v25.0.
+  - Removed `devicemapper` option from ecs cluster autoscaling cloudformation template.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,8 +69,8 @@ degraded execution table operations.
   - Updated `@cumulus/db` package and configure knex hook postProcessResponse to convert the return string
     from columns ending with "cumulus_id" to number.
 - **CUMULUS-3824**
-  - Changed the default ECS docker storage driver to `overlay2`, since `devicemapper` is removed in Docker Engine v25.0.
-  - Removed `devicemapper` option from ecs cluster autoscaling cloudformation template.
+  - Changed the ECS docker storage driver to `overlay2`, since `devicemapper` is removed in Docker Engine v25.0.
+  - Removed `ecs_docker_storage_driver` property from cumulus module.
 
 ### Fixed
 

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -13,6 +13,7 @@
     "http-cache-semantics",
     "lodash.pick",
     "hoek",
-    "fast-xml-parser"
+    "fast-xml-parser",
+    "semver"
   ]
 }

--- a/example/cumulus-tf/orca.tf
+++ b/example/cumulus-tf/orca.tf
@@ -13,7 +13,7 @@ locals {
 # ORCA Module
 module "orca" {
   aws_region = var.region
-  source = "https://github.com/nasa/cumulus-orca/releases/download/v9.0.5/cumulus-orca-terraform.zip"
+  source = "https://github.com/nasa/cumulus-orca/releases/download/v9.0.4/cumulus-orca-terraform.zip"
 
   ## --------------------------
   ## Cumulus Variables

--- a/example/cumulus-tf/orca.tf
+++ b/example/cumulus-tf/orca.tf
@@ -13,7 +13,7 @@ locals {
 # ORCA Module
 module "orca" {
   aws_region = var.region
-  source = "https://github.com/nasa/cumulus-orca/releases/download/v9.0.4/cumulus-orca-terraform.zip"
+  source = "https://github.com/nasa/cumulus-orca/releases/download/v9.0.5/cumulus-orca-terraform.zip"
 
   ## --------------------------
   ## Cumulus Variables

--- a/tf-modules/cumulus/ecs_cluster.tf
+++ b/tf-modules/cumulus/ecs_cluster.tf
@@ -233,7 +233,6 @@ locals {
     cluster_name              = aws_ecs_cluster.default.name
     container_stop_timeout    = var.ecs_container_stop_timeout,
     docker_hub_config         = var.ecs_docker_hub_config,
-    docker_storage_driver     = var.ecs_docker_storage_driver,
     docker_volume_size        = var.ecs_cluster_instance_docker_volume_size,
     docker_volume_create_size = var.ecs_cluster_instance_docker_volume_size - 1,
     efs_dns_name              = var.ecs_efs_config == null ? null : data.aws_efs_mount_target.ecs_cluster_instance[0].dns_name,

--- a/tf-modules/cumulus/ecs_cluster_instance_autoscaling_cf_template.yml.tmpl
+++ b/tf-modules/cumulus/ecs_cluster_instance_autoscaling_cf_template.yml.tmpl
@@ -35,7 +35,7 @@ Resources:
           mount /dev/docker/docker-data /docker-data
 
           sed -i '/^\s*DOCKER_STORAGE_OPTIONS=/d' /etc/sysconfig/docker-storage
-          echo 'DOCKER_STORAGE_OPTIONS="--storage-driver ${docker_storage_driver}"' >> /etc/sysconfig/docker-storage
+          echo 'DOCKER_STORAGE_OPTIONS="--storage-driver overlay2' >> /etc/sysconfig/docker-storage
 
           sed -i '/^\s*OPTIONS=/d' /etc/sysconfig/docker
           echo 'OPTIONS="--default-ulimit nofile=1024:4096 --data-root=/docker-data"' >> /etc/sysconfig/docker

--- a/tf-modules/cumulus/ecs_cluster_instance_autoscaling_cf_template.yml.tmpl
+++ b/tf-modules/cumulus/ecs_cluster_instance_autoscaling_cf_template.yml.tmpl
@@ -26,15 +26,19 @@ Resources:
           --==BOUNDARY==
           Content-Type: text/cloud-boothook; charset="us-ascii"
 
-%{ if docker_storage_driver == "overlay2" ~}
           vgcreate docker /dev/xvdcz
+
+          lvcreate -n docker-data -L${docker_volume_create_size}G docker
+
+          mkfs.xfs /dev/docker/docker-data
+          mkdir /docker-data
+          mount /dev/docker/docker-data /docker-data
 
           sed -i '/^\s*DOCKER_STORAGE_OPTIONS=/d' /etc/sysconfig/docker-storage
           echo 'DOCKER_STORAGE_OPTIONS="--storage-driver ${docker_storage_driver}"' >> /etc/sysconfig/docker-storage
-%{ else ~}
-          sed -i '/^\s*DOCKER_STORAGE_OPTIONS=/d' /etc/sysconfig/docker-storage
-          echo 'DOCKER_STORAGE_OPTIONS="--storage-driver ${docker_storage_driver}"' >> /etc/sysconfig/docker-storage
-%{ endif ~}
+
+          sed -i '/^\s*OPTIONS=/d' /etc/sysconfig/docker
+          echo 'OPTIONS="--default-ulimit nofile=1024:4096 --data-root=/docker-data"' >> /etc/sysconfig/docker
 
 %{ if include_docker_cleanup_cronjob == true ~}
           echo '* * * * * sudo sh -c "docker ps -q | xargs docker inspect --format='\{{.State.Pid}}' | xargs -IZ fstrim /proc/Z/root/"' | crontab -

--- a/tf-modules/cumulus/ecs_cluster_instance_autoscaling_cf_template.yml.tmpl
+++ b/tf-modules/cumulus/ecs_cluster_instance_autoscaling_cf_template.yml.tmpl
@@ -29,13 +29,8 @@ Resources:
 %{ if docker_storage_driver == "overlay2" ~}
           vgcreate docker /dev/xvdcz
 
-          lvcreate -n docker-data -L${docker_volume_create_size}G docker
-
           sed -i '/^\s*DOCKER_STORAGE_OPTIONS=/d' /etc/sysconfig/docker-storage
-          echo 'DOCKER_STORAGE_OPTIONS="--storage-driver overlay2 --storage-opt dm.datadev=/dev/docker/docker-data"' >> /etc/sysconfig/docker-storage
-
-          sed -i '/^\s*OPTIONS=/d' /etc/sysconfig/docker
-          echo 'OPTIONS="--default-ulimit nofile=1024:4096 --storage-opt overlay2.size=${docker_volume_size}G --storage-opt dm.datadev=/dev/docker/docker-data"' >> /etc/sysconfig/docker
+          echo 'DOCKER_STORAGE_OPTIONS="--storage-driver ${docker_storage_driver}"' >> /etc/sysconfig/docker-storage
 %{ else ~}
           sed -i '/^\s*DOCKER_STORAGE_OPTIONS=/d' /etc/sysconfig/docker-storage
           echo 'DOCKER_STORAGE_OPTIONS="--storage-driver ${docker_storage_driver}"' >> /etc/sysconfig/docker-storage

--- a/tf-modules/cumulus/ecs_cluster_instance_autoscaling_cf_template.yml.tmpl
+++ b/tf-modules/cumulus/ecs_cluster_instance_autoscaling_cf_template.yml.tmpl
@@ -35,7 +35,7 @@ Resources:
           echo 'DOCKER_STORAGE_OPTIONS="--storage-driver overlay2 --storage-opt dm.datadev=/dev/docker/docker-data"' >> /etc/sysconfig/docker-storage
 
           sed -i '/^\s*OPTIONS=/d' /etc/sysconfig/docker
-          echo 'OPTIONS="--default-ulimit nofile=1024:4096 --storage-opt dm.basesize=${docker_volume_size}G --storage-opt dm.datadev=/dev/docker/docker-data"' >> /etc/sysconfig/docker
+          echo 'OPTIONS="--default-ulimit nofile=1024:4096 --storage-opt overlay2.size=${docker_volume_size}G --storage-opt dm.datadev=/dev/docker/docker-data"' >> /etc/sysconfig/docker
 %{ else ~}
           sed -i '/^\s*DOCKER_STORAGE_OPTIONS=/d' /etc/sysconfig/docker-storage
           echo 'DOCKER_STORAGE_OPTIONS="--storage-driver ${docker_storage_driver}"' >> /etc/sysconfig/docker-storage

--- a/tf-modules/cumulus/ecs_cluster_instance_autoscaling_cf_template.yml.tmpl
+++ b/tf-modules/cumulus/ecs_cluster_instance_autoscaling_cf_template.yml.tmpl
@@ -26,20 +26,8 @@ Resources:
           --==BOUNDARY==
           Content-Type: text/cloud-boothook; charset="us-ascii"
 
-%{ if docker_storage_driver == "devicemapper" ~}
-          vgcreate docker /dev/xvdcz
-
-          lvcreate -n docker-data -L${docker_volume_create_size}G docker
-
-          sed -i '/^\s*DOCKER_STORAGE_OPTIONS=/d' /etc/sysconfig/docker-storage
-          echo 'DOCKER_STORAGE_OPTIONS="--storage-driver devicemapper --storage-opt dm.datadev=/dev/docker/docker-data"' >> /etc/sysconfig/docker-storage
-
-          sed -i '/^\s*OPTIONS=/d' /etc/sysconfig/docker
-          echo 'OPTIONS="--default-ulimit nofile=1024:4096 --storage-opt dm.basesize=${docker_volume_size}G --storage-opt dm.datadev=/dev/docker/docker-data"' >> /etc/sysconfig/docker
-%{ else ~}
           sed -i '/^\s*DOCKER_STORAGE_OPTIONS=/d' /etc/sysconfig/docker-storage
           echo 'DOCKER_STORAGE_OPTIONS="--storage-driver ${docker_storage_driver}"' >> /etc/sysconfig/docker-storage
-%{ endif ~}
 
 %{ if include_docker_cleanup_cronjob == true ~}
           echo '* * * * * sudo sh -c "docker ps -q | xargs docker inspect --format='\{{.State.Pid}}' | xargs -IZ fstrim /proc/Z/root/"' | crontab -

--- a/tf-modules/cumulus/ecs_cluster_instance_autoscaling_cf_template.yml.tmpl
+++ b/tf-modules/cumulus/ecs_cluster_instance_autoscaling_cf_template.yml.tmpl
@@ -26,8 +26,20 @@ Resources:
           --==BOUNDARY==
           Content-Type: text/cloud-boothook; charset="us-ascii"
 
+%{ if docker_storage_driver == "overlay2" ~}
+          vgcreate docker /dev/xvdcz
+
+          lvcreate -n docker-data -L${docker_volume_create_size}G docker
+
+          sed -i '/^\s*DOCKER_STORAGE_OPTIONS=/d' /etc/sysconfig/docker-storage
+          echo 'DOCKER_STORAGE_OPTIONS="--storage-driver overlay2 --storage-opt dm.datadev=/dev/docker/docker-data"' >> /etc/sysconfig/docker-storage
+
+          sed -i '/^\s*OPTIONS=/d' /etc/sysconfig/docker
+          echo 'OPTIONS="--default-ulimit nofile=1024:4096 --storage-opt dm.basesize=${docker_volume_size}G --storage-opt dm.datadev=/dev/docker/docker-data"' >> /etc/sysconfig/docker
+%{ else ~}
           sed -i '/^\s*DOCKER_STORAGE_OPTIONS=/d' /etc/sysconfig/docker-storage
           echo 'DOCKER_STORAGE_OPTIONS="--storage-driver ${docker_storage_driver}"' >> /etc/sysconfig/docker-storage
+%{ endif ~}
 
 %{ if include_docker_cleanup_cronjob == true ~}
           echo '* * * * * sudo sh -c "docker ps -q | xargs docker inspect --format='\{{.State.Pid}}' | xargs -IZ fstrim /proc/Z/root/"' | crontab -

--- a/tf-modules/cumulus/variables.tf
+++ b/tf-modules/cumulus/variables.tf
@@ -303,12 +303,6 @@ variable "ecs_docker_hub_config" {
   default     = null
 }
 
-variable "ecs_docker_storage_driver" {
-  description = "Storage driver for ECS tasks"
-  type        = string
-  default     = "overlay2"
-}
-
 variable "ecs_efs_config" {
   description = "Config for using EFS with ECS instances"
   type        = object({ mount_target_id = string, mount_point = string })

--- a/tf-modules/cumulus/variables.tf
+++ b/tf-modules/cumulus/variables.tf
@@ -306,7 +306,7 @@ variable "ecs_docker_hub_config" {
 variable "ecs_docker_storage_driver" {
   description = "Storage driver for ECS tasks"
   type        = string
-  default     = "devicemapper"
+  default     = "overlay2"
 }
 
 variable "ecs_efs_config" {

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -230,6 +230,7 @@ const sidebars = {
         'upgrade-notes/rds-phase-3-data-migration-guidance',
         'upgrade-notes/upgrade-rds-cluster-tf-postgres-13',
         'upgrade-notes/update-cumulus_id-type-indexes-CUMULUS-3449',
+        'upgrade-notes/upgrade_execution_table_CUMULUS_3320',
       ],
     },
     {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3824: default ecs_docker_storage_driver devicemapper is removed in Docker Engine v25.0](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3824)

## Changes

* Changed the ECS docker storage driver to `overlay2`, since `devicemapper` is removed in Docker Engine v25.0.

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
