### PR TITLE
CUMULUS-3840:Fixed @cumulus/api/bin/serve to correctly use EsClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@ degraded execution table operations.
     deletion to validate parent-child relationships
 - **CUMULUS-3818**
   - Fixes default value (updated to tag 52) for async-operation-image in tf-modules/cumulus.
+- **CUMULUS-3840**
+  - Fixed `@cumulus/api/bin/serve` to correctly use EsClient.
 
 ## [v18.3.3] 2024-08-09
 

--- a/packages/api/bin/local-test-defaults.js
+++ b/packages/api/bin/local-test-defaults.js
@@ -20,7 +20,7 @@ const getESClientAndIndex = async (stackName = localStackName) => {
   setLocalEsVariables(stackName);
   const client = await getEsClient(process.env.ES_HOST);
   const index = process.env.ES_INDEX;
-  return { client: client.client, index };
+  return { client, index };
 };
 
 module.exports = {

--- a/packages/api/bin/serve.js
+++ b/packages/api/bin/serve.js
@@ -102,7 +102,7 @@ function checkEnvVariablesAreSet(moreRequiredEnvVars) {
  */
 async function eraseElasticsearchIndices(esClient, esIndex) {
   try {
-    await esClient.indices.delete({ index: esIndex });
+    await esClient.client.indices.delete({ index: esIndex });
   } catch (error) {
     if (error.message !== 'index_not_found_exception') throw error;
   }


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3840: serveUtils.addProviders throws exception](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3840)

## Changes

* Detailed list or prose of changes
* ...

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
