### PR TITLE
CUMULUS-3841: Increase fetchRules page size to improve performance.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ degraded execution table operations.
 - **CUMULUS-3449**
   - Updated `@cumulus/db` package and configure knex hook postProcessResponse to convert the return string
     from columns ending with "cumulus_id" to number.
+- **CUMULUS-3841**
+  - Increased `fetchRules` page size to default to 100 instead of 10. This improves overall query time when
+    fetching all rules such as in `sqsMessageConsumer`.
 
 ### Fixed
 

--- a/packages/api/lib/rulesHelpers.js
+++ b/packages/api/lib/rulesHelpers.js
@@ -62,7 +62,7 @@ const log = new Logger({ sender: '@cumulus/rulesHelpers' });
  * @returns {Promise<Array<Object>>} all matching rules
  */
 async function fetchRules({ pageNumber = 1, pageSize = 100, rules = [], queryParams = {} }) {
-  const query = { ...queryParams, page: pageNumber, limit: pageSize};
+  const query = { ...queryParams, page: pageNumber, limit: pageSize };
   const apiResponse = await listRules({
     prefix: process.env.stackName,
     query,

--- a/packages/api/lib/rulesHelpers.js
+++ b/packages/api/lib/rulesHelpers.js
@@ -56,7 +56,7 @@ const log = new Logger({ sender: '@cumulus/rulesHelpers' });
  *
  * @param {Object} params - function params
  * @param {number} [params.pageNumber] - current page of API results
- * @param {number} [params.pageSize] - databse query page size used when calling listRules
+ * @param {number} [params.pageSize] - database query page size used when calling listRules
  * @param {Array<Object>} [params.rules] - partial rules Array
  * @param {Object} [params.queryParams] - API query params, empty query returns all rules
  * @returns {Promise<Array<Object>>} all matching rules

--- a/packages/api/lib/rulesHelpers.js
+++ b/packages/api/lib/rulesHelpers.js
@@ -56,12 +56,13 @@ const log = new Logger({ sender: '@cumulus/rulesHelpers' });
  *
  * @param {Object} params - function params
  * @param {number} [params.pageNumber] - current page of API results
+ * @param {number} [params.pageSize] - databse query page size used when calling listRules
  * @param {Array<Object>} [params.rules] - partial rules Array
  * @param {Object} [params.queryParams] - API query params, empty query returns all rules
  * @returns {Promise<Array<Object>>} all matching rules
  */
-async function fetchRules({ pageNumber = 1, rules = [], queryParams = {} }) {
-  const query = { ...queryParams, page: pageNumber, limit: 100 };
+async function fetchRules({ pageNumber = 1, pageSize = 100, rules = [], queryParams = {} }) {
+  const query = { ...queryParams, page: pageNumber, limit: pageSize};
   const apiResponse = await listRules({
     prefix: process.env.stackName,
     query,
@@ -70,6 +71,7 @@ async function fetchRules({ pageNumber = 1, rules = [], queryParams = {} }) {
   if (responseBody.results.length > 0) {
     return fetchRules({
       pageNumber: (pageNumber + 1),
+      pageSize,
       rules: rules.concat(responseBody.results),
       queryParams,
     });

--- a/packages/api/lib/rulesHelpers.js
+++ b/packages/api/lib/rulesHelpers.js
@@ -61,7 +61,7 @@ const log = new Logger({ sender: '@cumulus/rulesHelpers' });
  * @returns {Promise<Array<Object>>} all matching rules
  */
 async function fetchRules({ pageNumber = 1, rules = [], queryParams = {} }) {
-  const query = { ...queryParams, page: pageNumber };
+  const query = { ...queryParams, page: pageNumber, limit: 100 };
   const apiResponse = await listRules({
     prefix: process.env.stackName,
     query,

--- a/packages/api/tests/lib/rules/test-rulesHelpers.js
+++ b/packages/api/tests/lib/rules/test-rulesHelpers.js
@@ -200,20 +200,30 @@ test.serial('fetchRules invokes API to fetch rules', async (t) => {
   t.true(listRulesStub.calledOnce);
 });
 
+test.serial('fetchRules allows for configurable page size', async (t) => {
+  listRulesStub.callsFake(({ query }) => {
+    t.is(query.limit, 50);
+    return { body: JSON.stringify({ results: [] }) };
+  });
+  
+  await rulesHelpers.fetchRules({ pageSize: 50 });
+  t.true(listRulesStub.calledOnce);
+});
+
 test.serial('fetchRules pages through results until reaching an empty list', async (t) => {
   const rule1 = { name: 'rule-1' };
   const rule2 = { name: 'rule-2' };
   const firstCallArgs = {
     prefix: process.env.stackName,
-    query: { page: 1 },
+    query: { limit: 100, page: 1 },
   };
   const secondCallArgs = {
     prefix: process.env.stackName,
-    query: { page: 2 },
+    query: { limit: 100, page: 2 },
   };
   const thirdCallArgs = {
     prefix: process.env.stackName,
-    query: { page: 3 },
+    query: { limit: 100, page: 3 },
   };
   listRulesStub.onFirstCall().callsFake((params) => {
     t.deepEqual(params, firstCallArgs);

--- a/packages/api/tests/lib/rules/test-rulesHelpers.js
+++ b/packages/api/tests/lib/rules/test-rulesHelpers.js
@@ -210,11 +210,10 @@ test.serial('fetchRules allows for configurable page size', async (t) => {
     t.is(query.limit, 50);
     return { body: JSON.stringify({ results: [] }) };
   });
-  
-  await rulesHelpers.fetchRules({});
 
+  await rulesHelpers.fetchRules({});
   await rulesHelpers.fetchRules({ pageSize: 50 });
-  
+
   t.true(listRulesStub.calledTwice);
 });
 

--- a/packages/api/tests/lib/rules/test-rulesHelpers.js
+++ b/packages/api/tests/lib/rules/test-rulesHelpers.js
@@ -201,13 +201,21 @@ test.serial('fetchRules invokes API to fetch rules', async (t) => {
 });
 
 test.serial('fetchRules allows for configurable page size', async (t) => {
-  listRulesStub.callsFake(({ query }) => {
+  listRulesStub.onFirstCall().callsFake(({ query }) => {
+    t.is(query.limit, 100);
+    return { body: JSON.stringify({ results: [] }) };
+  });
+
+  listRulesStub.onSecondCall().callsFake(({ query }) => {
     t.is(query.limit, 50);
     return { body: JSON.stringify({ results: [] }) };
   });
   
+  await rulesHelpers.fetchRules({});
+
   await rulesHelpers.fetchRules({ pageSize: 50 });
-  t.true(listRulesStub.calledOnce);
+  
+  t.true(listRulesStub.calledTwice);
 });
 
 test.serial('fetchRules pages through results until reaching an empty list', async (t) => {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3841 Increase fetchRules page limit size to improve overall query performance: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3841)

## Changes

* User contributed PR for issue: https://github.com/nasa/cumulus/issues/3772
* Original PR: https://github.com/nasa/cumulus/pull/3773

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
