### PR TITLE
CUMULUS-3756

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,10 @@ ElasticSearch, the `collections/granules/executions` API endpoints are updated t
 - **CUMULUS-3792**
   - Added database indexes to improve search performance
 
+### Added
+- **CUMULUS-3756**
+  - Added excludeFileRegex configuration to update-granules-cmr-metadata-file-links to allow files matching specified regex to be excluded when updating the Related URLs list. Defaults to the current behavior of excluding no files.
+
 ## [v18.4.0] 2024-08-16
 
 ### Migration Notes

--- a/tasks/update-granules-cmr-metadata-file-links/schemas/config.json
+++ b/tasks/update-granules-cmr-metadata-file-links/schemas/config.json
@@ -40,6 +40,10 @@
       "description": "The type of URL to add to the Online Access URLs in the CMR file. 'distribution' to point to the distribution API, 's3' to put in the S3 link, and 'none' to not add Online Access URLs for the granules.",
       "enum": ["distribution", "s3", "both", "none"],
       "default": "both"
+    },
+    "excludeFileRegex": {
+      "type": "string",
+      "description": "A regex string to match files that should be excluded from the CMR metadata file"
     }
   }
 }


### PR DESCRIPTION
**Summary:** Added excludeFileRegex configuration to update-granules-cmr-metadata-file-links and updated unit tests to exercise new file-exclusion feature.

Addresses [CUMULUS-3756: Add the ability to exclude URLs matching a specific pattern in the CMR metadata](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3756)

## Changes

* Updated the config schema for update-granules-cmr-metadata-file-links with excludeFileRegex
* Updated tasks/update-granules-cmr-metadata-file-links/index.js to read the excludeFileRegex configuration and, if it's specified, filter the files passed to updateCMRMetadata.
* Updated tasks/update-granules-cmr-metadata-file-links/tests/test-index.js to exercise both typical file exclusion functionality and exercise the case where the regex doesn't match any files in the files list.

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
