### PR TITLE
Fix isThrottlingException function to check error name

### DIFF
--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -49,7 +49,7 @@ export interface ErrorWithName extends Error {
  * Test to see if a given exception is an AWS Throttling Exception
  */
 export const isThrottlingException = (err: ErrorWithOptionalCode) =>
-  err.code === 'ThrottlingException';
+  err.name === 'ThrottlingException';
 
 /**
  * Returns true if the error is a resource error.


### PR DESCRIPTION
**Summary:** This PR addresses an issue in `SfEventSqsToDbRecords` that causes certain portion of granule records not from getting updated in the Cumulus database and CloudMetrics during high-throughput ingestion.
This PR has been tested in the GES DISC Cumulus UAT. Previously, > 20% of granule records were missed from the Cumulus database and CloudMetrics. After implementing the changes from this PR, no granule records were lost.

NOTE: I don't see any existing unit tests associated with the `isThrottlingException` function that is being modified in this PR. Please let me know if I missed something. Thanks!


Addresses [Github issue 3796: Granule records missing from CloudMetrics](https://github.com/nasa/cumulus/issues/3796)

## Changes

* `isThrottlingException` is modified to catch the error correctly.

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
