### PR TITLE
CUMULUS-3904

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     - cleanup of granule database resources to ensure no overlap
     - ensure uniqueness of execution names from getWorkflowNameIntersectFromGranuleIds
     - increase timeout in aws-client tests
+- **CUMULUS-3904**
+  - Passed sqs_message_consumer_watcher_message_limit and sqs_message_consumer_watcher_time_limit through the cumulus terraform module to the ingest terraform module.
 - **Snyk**
   - Upgraded moment from 2.29.4 to 2.30.1
   - Upgraded pg from ~8.10 to ~8.12

--- a/tf-modules/cumulus/ingest.tf
+++ b/tf-modules/cumulus/ingest.tf
@@ -59,6 +59,9 @@ module "ingest" {
 
   sf_event_sqs_to_db_records_sqs_queue_url = module.archive.sf_event_sqs_to_db_records_sqs_queue_url
 
+  sqs_message_consumer_watcher_time_limit = var.sqs_message_consumer_watcher_time_limit
+  sqs_message_consumer_watcher_message_limit = var.sqs_message_consumer_watcher_message_limit
+
   tags = var.tags
 
   # Cloudwatch log retention config

--- a/tf-modules/cumulus/variables.tf
+++ b/tf-modules/cumulus/variables.tf
@@ -626,3 +626,24 @@ variable "report_sns_topic_subscriber_arns" {
   default = null
   description = "Account ARNs to supply to report SNS topics policy with subscribe action"
 }
+
+variable "sqs_message_consumer_watcher_message_limit" {
+  type = number
+  default = 500
+  description = <<EOF
+    Number of messages the SQS message consumer Lambda will attempt to read from SQS in a single execution.
+    Note that increasing this value may result in a direct increase/decrease in triggered workflows. Users should
+    only adjust this value with the understanding of how it will impact the number of queued workflows in their
+    system.
+  EOF
+}
+
+variable "sqs_message_consumer_watcher_time_limit" {
+  type = number
+  default = 60
+  description = <<EOF
+    Number of seconds the SQS message consumer Lambda will remain active and polling for new messages. Note that this value
+    should be less than the overall Lambda invocation timeout or else the Lambda may be terminated while still actively
+    polling SQS. This value should be adjusted in conjunction with sqs_message_consumer_watcher_message_limit.
+  EOF
+}


### PR DESCRIPTION
**Summary:** Passed through sqs_message_consumer_watcher_time_limit and sqs_message_consumer_watcher_message_limit

Addresses [CUMULUS-3904](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3904): sqs_message_consumer_watcher_message_limit and sqs_message_consumer_watcher_time_limit not configurable through the Cumulus module]

## Changes

* Added sqs_message_consumer_watcher_time_limit and sqs_message_consumer_watcher_message_limit vars to cumulus that are identical to the vars in ingest.
* Passed sqs_message_consumer_watcher_time_limit and sqs_message_consumer_watcher_message_limit to the ingest module 

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
