### PR TITLE
Fix describeExecutionStatus in pdr-status-check to check error name

### DIFF
--- a/tasks/pdr-status-check/index.js
+++ b/tasks/pdr-status-check/index.js
@@ -136,7 +136,7 @@ async function describeExecutionStatus(executionArn) {
   try {
     return await StepFunctions.describeExecution({ executionArn });
   } catch (error) {
-    if (error.code === 'ExecutionDoesNotExist') {
+    if (error.name === 'ExecutionDoesNotExist') {
       return { executionArn: executionArn, status: 'RUNNING' };
     }
     throw error;


### PR DESCRIPTION
This PR fixes the `ExecutionDoesNotExist` error in `pdr-status-check`. If there's anything I have to add the PR let me know!

Addresses [Github Issue 3803](https://github.com/nasa/cumulus/issues/3803)

## Changes

* `describeExecutionStatus` updated to check `error.name` instead of `error.code`

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
