### PR TITLE
Prepares features for 18.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,105 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [v18.5.0] 2024-09-25
+
+### Migration Notes
+
+#### CUMULUS-3536 Upgrading from Aurora Serverless V1 to V2
+
+- The updates in CUMULUS-3536 require an upgrade of the postgres database.
+  Please follow [Upgrading from Aurora Serverless V1 to V2]
+  (https://nasa.github.io/cumulus/docs/next/upgrade-notes/serverless-v2-upgrade)
+  
+### Added
+
+- **CUMULUS-3536**
+  - Added `rejectUnauthorized` = false to db-provision-user-database as the Lambda
+    does not have the Serverless v2 SSL certifications installed.
+
+### Changed
+
+- **CUMULUS-3725**
+  - Updated the default parameter group for `cumulus-rds-tf` to set `force_ssl`
+    to 0. This setting for the Aurora Serverless v2 database allows non-SSL
+    connections to the database, and is intended to be a temporary solution
+    until Cumulus has been updated to import the RDS rds-ca-rsa2048-g1 CA bundles in Lambda environments.
+    See [CUMULUS-3724](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3724).
+
+### Fixed
+- **CUMULUS-3901**
+  - Fix error checking in @cumulus/errors to use Error.name in addition to Error.code
+- **CUMULUS-3824**
+  - Added the missing double quote in ecs_cluster autoscaling cf template
+- **CUMULUS-3846**
+  - improve reliability of unit tests
+    - tests for granules api get requests separated out to new file
+    - cleanup of granule database resources to ensure no overlap
+    - ensure uniqueness of execution names from getWorkflowNameIntersectFromGranuleIds
+    - increase timeout in aws-client tests
+- **Snyk**
+  - Upgraded moment from 2.29.4 to 2.30.1
+  - Upgraded pg from ~8.10 to ~8.12
+
+## [v19.0.0] 2024-08-28
+
+### Breaking Changes
+
+- This release includes `Replace ElasicSearch Phase 1` updates, we no longer save `collection/granule/execution` records to
+ElasticSearch, the `collections/granules/executions` API endpoints are updated to perform operations on the postgres database.
+
+### Migration Notes
+
+#### CUMULUS-3792 Add database indexes. Please follow the instructions before upgrading Cumulus
+
+- The updates in CUMULUS-3792 require a manual update to the postgres database in the production environment.
+  Please follow [Update Table Indexes for CUMULUS-3792]
+  (https://nasa.github.io/cumulus/docs/next/upgrade-notes/update_table_indexes_CUMULUS_3792)
+
+### Replace ElasticSearch Phase 1
+
+- **CUMULUS-3238**
+  - Removed elasticsearch dependency from collections endpoint
+- **CUMULUS-3239**
+  - Updated `executions` list api endpoint and added `ExecutionSearch` class to query postgres
+- **CUMULUS-3240**
+  - Removed Elasticsearch dependency from `executions` endpoints
+- **CUMULUS-3639**
+  - Updated `/collections/active` endpoint to query postgres
+- **CUMULUS-3640**
+  - Removed elasticsearch dependency from granules endpoint
+- **CUMULUS-3641**
+  - Updated `collections` api endpoint to query postgres instead of elasticsearch except if `includeStats` is in the query parameters
+- **CUMULUS-3642**
+  - Adjusted queries to improve performance:
+    - Used count(*) over count(id) to count rows
+    - Estimated row count for large tables (granules and executions) by default for basic query
+  - Updated stats summary to default to the last day
+  - Updated ExecutionSearch to not include asyncOperationId by default
+- **CUMULUS-3688**
+  - Updated `stats` api endpoint to query postgres instead of elasticsearch
+- **CUMULUS-3689**
+  - Updated `stats/aggregate` api endpoint to query postgres instead of elasticsearch
+  - Created a new StatsSearch class for querying postgres with the stats endpoint
+- **CUMULUS-3692**
+  - Added `@cumulus/db/src/search` `BaseSearch` and `GranuleSearch` classes to
+    support basic queries for granules
+  - Updated granules List endpoint to query postgres for basic queries
+- **CUMULUS-3693**
+  - Added functionality to `@cumulus/db/src/search` to support range queries
+- **CUMULUS-3694**
+  - Added functionality to `@cumulus/db/src/search` to support term queries
+  - Updated `BaseSearch` and `GranuleSearch` classes to support term queries for granules
+  - Updated granules List endpoint to search postgres
+- **CUMULUS-3695**
+  - Updated `granule` list api endpoint and BaseSearch class to handle sort fields
+- **CUMULUS-3696**
+  - Added functionality to `@cumulus/db/src/search` to support terms, `not` and `exists` queries
+- **CUMULUS-3699**
+  - Updated `collections` api endpoint to be able to support `includeStats` query string parameter
+- **CUMULUS-3792**
+  - Added database indexes to improve search performance
+
 ## [v18.4.0] 2024-08-16
 
 ### Migration Notes
@@ -37,7 +136,6 @@ degraded execution table operations.
 ### Breaking Changes
 
 ### Added
-
 - **CUMULUS-3320**
   - Added endpoint `/executions/bulkDeleteExecutionsByCollection` to allow
     bulk deletion of executions from elasticsearch by collectionId

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
-## [v18.5.0] 2024-09-25
+## [v18.5.0] 2024-10-03
 
 ### Migration Notes
 
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - The updates in CUMULUS-3536 require an upgrade of the postgres database.
   Please follow [Upgrading from Aurora Serverless V1 to V2]
   (https://nasa.github.io/cumulus/docs/next/upgrade-notes/serverless-v2-upgrade)
-  
+
 ### Added
 
 - **CUMULUS-3536**
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     See [CUMULUS-3724](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3724).
 
 ### Fixed
+
 - **CUMULUS-3901**
   - Fix error checking in @cumulus/errors to use Error.name in addition to Error.code
 - **CUMULUS-3824**
@@ -43,65 +44,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - **Snyk**
   - Upgraded moment from 2.29.4 to 2.30.1
   - Upgraded pg from ~8.10 to ~8.12
-
-## [v19.0.0] 2024-08-28
-
-### Breaking Changes
-
-- This release includes `Replace ElasicSearch Phase 1` updates, we no longer save `collection/granule/execution` records to
-ElasticSearch, the `collections/granules/executions` API endpoints are updated to perform operations on the postgres database.
-
-### Migration Notes
-
-#### CUMULUS-3792 Add database indexes. Please follow the instructions before upgrading Cumulus
-
-- The updates in CUMULUS-3792 require a manual update to the postgres database in the production environment.
-  Please follow [Update Table Indexes for CUMULUS-3792]
-  (https://nasa.github.io/cumulus/docs/next/upgrade-notes/update_table_indexes_CUMULUS_3792)
-
-### Replace ElasticSearch Phase 1
-
-- **CUMULUS-3238**
-  - Removed elasticsearch dependency from collections endpoint
-- **CUMULUS-3239**
-  - Updated `executions` list api endpoint and added `ExecutionSearch` class to query postgres
-- **CUMULUS-3240**
-  - Removed Elasticsearch dependency from `executions` endpoints
-- **CUMULUS-3639**
-  - Updated `/collections/active` endpoint to query postgres
-- **CUMULUS-3640**
-  - Removed elasticsearch dependency from granules endpoint
-- **CUMULUS-3641**
-  - Updated `collections` api endpoint to query postgres instead of elasticsearch except if `includeStats` is in the query parameters
-- **CUMULUS-3642**
-  - Adjusted queries to improve performance:
-    - Used count(*) over count(id) to count rows
-    - Estimated row count for large tables (granules and executions) by default for basic query
-  - Updated stats summary to default to the last day
-  - Updated ExecutionSearch to not include asyncOperationId by default
-- **CUMULUS-3688**
-  - Updated `stats` api endpoint to query postgres instead of elasticsearch
-- **CUMULUS-3689**
-  - Updated `stats/aggregate` api endpoint to query postgres instead of elasticsearch
-  - Created a new StatsSearch class for querying postgres with the stats endpoint
-- **CUMULUS-3692**
-  - Added `@cumulus/db/src/search` `BaseSearch` and `GranuleSearch` classes to
-    support basic queries for granules
-  - Updated granules List endpoint to query postgres for basic queries
-- **CUMULUS-3693**
-  - Added functionality to `@cumulus/db/src/search` to support range queries
-- **CUMULUS-3694**
-  - Added functionality to `@cumulus/db/src/search` to support term queries
-  - Updated `BaseSearch` and `GranuleSearch` classes to support term queries for granules
-  - Updated granules List endpoint to search postgres
-- **CUMULUS-3695**
-  - Updated `granule` list api endpoint and BaseSearch class to handle sort fields
-- **CUMULUS-3696**
-  - Added functionality to `@cumulus/db/src/search` to support terms, `not` and `exists` queries
-- **CUMULUS-3699**
-  - Updated `collections` api endpoint to be able to support `includeStats` query string parameter
-- **CUMULUS-3792**
-  - Added database indexes to improve search performance
 
 ## [v18.4.0] 2024-08-16
 
@@ -136,6 +78,7 @@ degraded execution table operations.
 ### Breaking Changes
 
 ### Added
+
 - **CUMULUS-3320**
   - Added endpoint `/executions/bulkDeleteExecutionsByCollection` to allow
     bulk deletion of executions from elasticsearch by collectionId
@@ -8063,7 +8006,7 @@ Note: There was an issue publishing 1.12.0. Upgrade to 1.12.1.
 
 ## [v1.0.0] - 2018-02-23
 
-[Unreleased]: https://github.com/nasa/cumulus/compare/v18.4.0...HEAD
+[v18.5.0]: https://github.com/nasa/cumulus/compare/v18.4.0...v18.5.0
 [v18.4.0]: https://github.com/nasa/cumulus/compare/v18.3.3...v18.4.0
 [v18.3.3]: https://github.com/nasa/cumulus/compare/v18.3.2...v18.3.3
 [v18.3.2]: https://github.com/nasa/cumulus/compare/v18.3.1...v18.3.2

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -263,7 +263,7 @@ $ aws dynamodb create-table \
 
 Cumulus requires a [PostgreSQL compatible database](../deployment/postgres-database-deployment.md) cluster deployed to AWS. We suggest utilizing [RDS](https://docs.aws.amazon.com/rds/index.html). For further guidance about what type of RDS database to use, please [see the guide on choosing and configuring your RDS database](./choosing_configuring_rds.md).
 
-Cumulus provides a default [template and RDS cluster module](../deployment/postgres-database-deployment.md) utilizing Aurora Serverless.
+Cumulus provides a default [template and RDS cluster module](../deployment/postgres-database-deployment.md) utilizing Aurora Serverless V2.
 
 However, Core intentionally provides a "bring your own" approach, and any well-planned cluster setup should work, given the following:
 

--- a/docs/deployment/postgres-database-deployment.md
+++ b/docs/deployment/postgres-database-deployment.md
@@ -16,7 +16,7 @@ configured [Aurora Serverless](https://aws.amazon.com/rds/aurora/serverless/) cl
 
 To that end, Cumulus provides a terraform module
 [`cumulus-rds-tf`](https://github.com/nasa/cumulus/tree/master/tf-modules/cumulus-rds-tf)
-that will deploy an AWS RDS Aurora Serverless PostgreSQL 13 compatible [database cluster](https://aws.amazon.com/rds/aurora/postgresql-features/), and optionally provision a single deployment database with credentialed secrets for use with Cumulus.
+that will deploy an AWS RDS Aurora Serverless V2 PostgreSQL 13 compatible [database cluster](https://aws.amazon.com/rds/aurora/postgresql-features/), and optionally provision a single deployment database with credentialed secrets for use with Cumulus.
 
 We have provided an example terraform deployment using this module in the [Cumulus template-deploy repository](https://github.com/nasa/cumulus-template-deploy/tree/master/rds-cluster-tf) on GitHub.
 
@@ -59,7 +59,7 @@ For Cumulus specific instructions on installation of Terraform, refer to the mai
 
 #### Aurora/RDS
 
-This document also assumes some basic familiarity with PostgreSQL databases and Amazon Aurora/RDS.   If you're unfamiliar consider perusing the [AWS docs](https://aws.amazon.com/rds/aurora/) and the [Aurora Serverless V1 docs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.html).
+This document also assumes some basic familiarity with PostgreSQL databases and Amazon Aurora/RDS.   If you're unfamiliar consider perusing the [AWS docs](https://aws.amazon.com/rds/aurora/) and the [Aurora Serverless V2 docs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.html).
 
 ## Prepare Deployment Repository
 
@@ -145,6 +145,7 @@ Fill in the appropriate values in `terraform.tfvars`. See the [rds-cluster-tf mo
 - `max_capacity` -- the max ACUs the cluster is allowed to use.    Carefully consider cost/performance concerns when setting this value.
 - `min_capacity` -- the minimum ACUs the cluster will scale to
 - `provision_user_database` -- Optional flag to allow module to provision a user database in addition to creating the cluster.   Described in the [next section](#provision-user-and-user-database).
+- `cluster_instance_count` -- Number of RDS instances in the custer. Defaults to 1.
 
 #### Provision User and User Database
 
@@ -227,6 +228,7 @@ Terraform will perform the following actions:
       + backup_retention_period         = 1
       + cluster_identifier              = "xxxxxxxxx"
       + cluster_identifier_prefix       = (known after apply)
+      + cluster_instance_count          = 1
       + cluster_members                 = (known after apply)
       + cluster_resource_id             = (known after apply)
       + copy_tags_to_snapshot           = false
@@ -237,7 +239,7 @@ Terraform will perform the following actions:
       + enable_http_endpoint            = true
       + endpoint                        = (known after apply)
       + engine                          = "aurora-postgresql"
-      + engine_mode                     = "serverless"
+      + engine_mode                     = "provisioned"
       + engine_version                  = "10.12"
       + final_snapshot_identifier       = "xxxxxxxxx"
       + hosted_zone_id                  = (known after apply)
@@ -250,7 +252,7 @@ Terraform will perform the following actions:
       + preferred_maintenance_window    = (known after apply)
       + reader_endpoint                 = (known after apply)
       + skip_final_snapshot             = false
-      + storage_encrypted               = (known after apply)
+      + storage_encrypted               = true
       + tags                            = {
           + "Deployment" = "xxxxxxxxx"
         }

--- a/docs/upgrade-notes/serverless-v2-upgrade.md
+++ b/docs/upgrade-notes/serverless-v2-upgrade.md
@@ -1,0 +1,27 @@
+---
+id: serverless-v2-upgrade
+title: Upgrading from Aurora Serverless V1 to V2
+hide_title: false
+---
+
+## There are 2 approaches to this migration
+
+### Option 1: Snapshot and Restore (simple process, more downtime)
+
+1. Take a manual snapshot of the v1 instance, including the current YYYY-MM-DD in the name of the snapshot. Wait for successful completion showing Status = Available. If this is an initial snapshot of the instance, it may take a substantial amount of time to complete.
+2. Ensure delete protection is turned off on the v1 instance, as it will be deleted and replaced with a v2 cluster and instance. Deletion protection can be toggled in the AWS Console under RDS > Databases > select database > Modify.
+3. Run "terraform show" to view the current state for module.rds_cluster.aws_rds_cluster.cumulus.
+Ensure final_snapshot_identifier is set in resource "aws_rds_cluster" "cumulus". Copy the value. If a snapshot exists with that name, delete that snapshot.
+Ensure skip_final_snapshot is false in resource "aws_rds_cluster" "cumulus".
+4. Update /example/rds-cluster-tf/terraform.tfvars (or custom .tfvars filename) to:
+remove: enable_upgrade
+add: snapshot_identifier = "final_snapshot_identifier" (Paste value from prior step)
+5. Stop ingest.
+6. Run "terraform apply" to create a new v2 cluster and instance(s) based on the v1 final snapshot, using the updated tfvars file (or custom .tfvars filename). Wait for completion.
+terraform apply -var-file=terraform.tfvars (or custom .tfvars filename)
+7. Resume ingest.
+8. The end result is the new v2 cluster is created containing the existing v1 data.
+
+### Option 2: Blue/Green Cutover (complex process, less downtime)
+
+Please see [AWS instructions](https://aws.amazon.com/blogs/database/upgrade-from-amazon-aurora-serverless-v1-to-v2-with-minimal-downtime/) for setting up a blue/green deployment.

--- a/example/rds-cluster-tf/main.tf
+++ b/example/rds-cluster-tf/main.tf
@@ -23,11 +23,10 @@ module "rds_cluster" {
   engine_version             = var.engine_version
   deletion_protection        = true
   cluster_identifier         = var.cluster_identifier
+  cluster_instance_count     = var.cluster_instance_count
   tags                       = var.tags
   snapshot_identifier        = var.snapshot_identifier
   lambda_timeouts            = var.lambda_timeouts
   lambda_memory_sizes        = var.lambda_memory_sizes
-  enable_upgrade             = var.enable_upgrade
-  parameter_group_family     = var.parameter_group_family
   parameter_group_family_v13 = var.parameter_group_family_v13
 }

--- a/example/rds-cluster-tf/outputs.tf
+++ b/example/rds-cluster-tf/outputs.tf
@@ -6,6 +6,10 @@ output "rds_endpoint" {
   value = module.rds_cluster.rds_endpoint
 }
 
+output "rds_reader_endpoint" {
+  value = module.rds_cluster.rds_reader_endpoint
+}
+
 output "admin_db_login_secret_arn" {
   value = module.rds_cluster.admin_db_login_secret_arn
 }

--- a/example/rds-cluster-tf/terraform.tfvars.example
+++ b/example/rds-cluster-tf/terraform.tfvars.example
@@ -1,9 +1,10 @@
-prefix              = "prefix"
-db_admin_username   = "changethisuser"
-db_admin_password   = "changethispassword"
-region              = "us-east-1"
-vpc_id              = "vpc_id"
-subnets             = ["subnet-some-subnet-1", "subnet-some-subnet-in-another-az-2"]
-deletion_protection = false
-cluster_identifier  = "some_cluster"
-tags                = { "Deployment" = "some_deployment_identifier" }
+prefix                 = "prefix"
+db_admin_username      = "changethisuser"
+db_admin_password      = "changethispassword"
+region                 = "us-east-1"
+vpc_id                 = "vpc_id"
+subnets                = ["subnet-some-subnet-1", "subnet-some-subnet-in-another-az-2"]
+deletion_protection    = false
+cluster_identifier     = "some_cluster"
+cluster_instance_count = 1
+tags                   = { "Deployment" = "some_deployment_identifier" }

--- a/example/rds-cluster-tf/variables.tf
+++ b/example/rds-cluster-tf/variables.tf
@@ -48,6 +48,16 @@ variable "cluster_identifier" {
   default     = "cumulus-rds-serverless-default-cluster"
 }
 
+variable "cluster_instance_count" {
+  description = "Number of instances to create inside of the cluster"
+  type = number
+  default = 1
+  validation {
+    condition = var.cluster_instance_count >= 1 && var.cluster_instance_count <= 16
+    error_message = "Variable cluster_instance_count should be between 1 and 16."
+  }
+}
+
 variable "snapshot_identifier" {
   description = "Optional database snapshot for restoration"
   type = string
@@ -86,24 +96,12 @@ variable "lambda_memory_sizes" {
   }
 }
 
-variable "enable_upgrade" {
-  description = "Flag to enable use of updated parameter group"
-  type = bool
-  default = false
-}
-
 variable "lambda_timeouts" {
   description = "Configurable map of timeouts for lambdas"
   type = map(number)
   default = {
     ProvisionPostgresDatabase = 600 # cumulus-rds-tf
   }
-}
-
-variable "parameter_group_family" {
-  description = "Database family to use for creating database parameter group"
-  type = string
-  default = "aurora-postgresql11"
 }
 
 variable "parameter_group_family_v13" {

--- a/lambdas/db-provision-user-database/src/index.ts
+++ b/lambdas/db-provision-user-database/src/index.ts
@@ -83,6 +83,7 @@ export const handler = async (event: HandlerEvent): Promise<void> => {
         database: `${dbUser}_db`,
         host: (rootKnexConfig.connection as Knex.PgConnectionConfig).host,
         port: (rootKnexConfig.connection as Knex.PgConnectionConfig).port,
+        rejectUnauthorized: 'false',
       }),
     });
   } finally {

--- a/packages/db/src/migrations/20210727104740_alter_async_operations_table_operation_type.ts
+++ b/packages/db/src/migrations/20210727104740_alter_async_operations_table_operation_type.ts
@@ -24,6 +24,7 @@ export const up = async (knex: Knex): Promise<void> => {
     'Dead-Letter Processing',
     'Kinesis Replay',
     'Reconciliation Report',
+    'Migration Count Report',
     'Data Migration',
     'SQS Replay',
   ]));
@@ -39,6 +40,7 @@ export const down = async (knex: Knex): Promise<void> => {
       'Dead-Letter Processing',
       'Kinesis Replay',
       'Reconciliation Report',
+      'Migration Count Report',
       'Data Migration',
     ])
   );

--- a/packages/db/src/migrations/20240322161147_alter_async_operations_table_operation_type.ts
+++ b/packages/db/src/migrations/20240322161147_alter_async_operations_table_operation_type.ts
@@ -25,6 +25,7 @@ export const up = async (knex: Knex): Promise<void> => {
     'DLA Migration',
     'Kinesis Replay',
     'Reconciliation Report',
+    'Migration Count Report',
     'Data Migration',
     'SQS Replay',
   ]));
@@ -40,6 +41,7 @@ export const down = async (knex: Knex): Promise<void> => {
       'Dead-Letter Processing',
       'Kinesis Replay',
       'Reconciliation Report',
+      'Migration Count Report',
       'Data Migration',
       'SQS Replay',
     ])

--- a/packages/db/src/migrations/20240606060726_alter_async_operations_add_operation_type_bulk_execution_delete.ts
+++ b/packages/db/src/migrations/20240606060726_alter_async_operations_add_operation_type_bulk_execution_delete.ts
@@ -27,6 +27,7 @@ export const up = async (knex: Knex): Promise<void> => {
     'ES Index',
     'Kinesis Replay',
     'Reconciliation Report',
+    'Migration Count Report',
     'SQS Replay',
   ]));
 };
@@ -42,6 +43,7 @@ export const down = async (knex: Knex): Promise<void> => {
       'DLA Migration',
       'Kinesis Replay',
       'Reconciliation Report',
+      'Migration Count Report',
       'Data Migration',
       'SQS Replay',
     ])

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -41,15 +41,11 @@ export interface ErrorWithOptionalCode extends Error {
   code?: string;
 }
 
-export interface ErrorWithName extends Error {
-  name: string;
-}
-
 /**
  * Test to see if a given exception is an AWS Throttling Exception
  */
 export const isThrottlingException = (err: ErrorWithOptionalCode) =>
-  err.code === 'ThrottlingException';
+  err.name === 'ThrottlingException' || err.code === 'ThrottlingException';
 
 /**
  * Returns true if the error is a resource error.
@@ -59,8 +55,8 @@ export const isWorkflowError = (error: Error) => error.name.includes('WorkflowEr
 /**
  * Returns true if the error is a DynamoDB conditional check exception.
  */
-export const isConditionalCheckException = (error: ErrorWithName) =>
-  error.name === 'ConditionalCheckFailedException';
+export const isConditionalCheckException = (error: ErrorWithOptionalCode) =>
+  error.name === 'ConditionalCheckFailedException' || error.code === 'ConditionalCheckFailedException';
 
 /**
  * WorkflowError should be bubbled out to the overall workflow in the 'exception' field, rather than

--- a/tf-modules/cumulus-rds-tf/main.tf
+++ b/tf-modules/cumulus-rds-tf/main.tf
@@ -38,6 +38,7 @@ resource "aws_secretsmanager_secret_version" "rds_login" {
     database            = "postgres"
     engine              = "postgres"
     host                = aws_rds_cluster.cumulus.endpoint
+    hostReader          = aws_rds_cluster.cumulus.reader_endpoint
     port                = 5432
     dbClusterIdentifier = aws_rds_cluster.cumulus.id
   })
@@ -50,21 +51,6 @@ resource "aws_security_group_rule" "rds_security_group_allow_postgres" {
   protocol          = "tcp"
   security_group_id = aws_security_group.rds_cluster_access.id
   self              = true
-}
-
-resource "aws_rds_cluster_parameter_group" "rds_cluster_group" {
-  count = var.enable_upgrade ? 0 : 1
-  name   = "${var.prefix}-cluster-parameter-group"
-  family = var.parameter_group_family
-
-  dynamic "parameter" {
-    for_each = var.db_parameters
-    content {
-      apply_method = parameter.value["apply_method"]
-      name = parameter.value["name"]
-      value = parameter.value["value"]
-    }
-  }
 }
 
 resource "aws_rds_cluster_parameter_group" "rds_cluster_group_v13" {
@@ -82,9 +68,9 @@ resource "aws_rds_cluster_parameter_group" "rds_cluster_group_v13" {
 }
 
 resource "aws_rds_cluster" "cumulus" {
-  depends_on              = [aws_db_subnet_group.default, aws_rds_cluster_parameter_group.rds_cluster_group]
+  depends_on              = [aws_db_subnet_group.default, aws_rds_cluster_parameter_group.rds_cluster_group_v13]
   cluster_identifier      = var.cluster_identifier
-  engine_mode             = "serverless"
+  engine_mode             = "provisioned"
   engine                  = "aurora-postgresql"
   engine_version          = var.engine_version
   database_name           = "postgres"
@@ -94,13 +80,11 @@ resource "aws_rds_cluster" "cumulus" {
   preferred_backup_window = var.backup_window
   db_subnet_group_name    = aws_db_subnet_group.default.id
   apply_immediately       = var.apply_immediately
-
-  scaling_configuration {
+  storage_encrypted       = true
+  
+  serverlessv2_scaling_configuration {
     max_capacity = var.max_capacity
     min_capacity = var.min_capacity
-    timeout_action = var.rds_scaling_timeout_action
-    auto_pause = var.auto_pause
-    seconds_until_auto_pause = var.seconds_until_auto_pause
   }
   vpc_security_group_ids          = [aws_security_group.rds_cluster_access.id]
   deletion_protection             = var.deletion_protection
@@ -108,9 +92,18 @@ resource "aws_rds_cluster" "cumulus" {
   tags                            = var.tags
   final_snapshot_identifier       = "${var.cluster_identifier}-final-snapshot"
   snapshot_identifier             = var.snapshot_identifier
-  db_cluster_parameter_group_name = var.enable_upgrade ? aws_rds_cluster_parameter_group.rds_cluster_group_v13.id : aws_rds_cluster_parameter_group.rds_cluster_group[0].id
+  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.rds_cluster_group_v13.id
 
   lifecycle {
     ignore_changes = [engine_version]
   }
+}
+
+resource "aws_rds_cluster_instance" "cumulus" {
+  cluster_identifier = aws_rds_cluster.cumulus.id
+  identifier = "${aws_rds_cluster.cumulus.id}-instance-${count.index+1}"
+  count              = var.cluster_instance_count
+  instance_class     = "db.serverless"
+  engine             = aws_rds_cluster.cumulus.engine
+  engine_version     = aws_rds_cluster.cumulus.engine_version
 }

--- a/tf-modules/cumulus-rds-tf/outputs.tf
+++ b/tf-modules/cumulus-rds-tf/outputs.tf
@@ -6,6 +6,10 @@ output "rds_endpoint" {
   value = aws_rds_cluster.cumulus.endpoint
 }
 
+output "rds_reader_endpoint" {
+  value = aws_rds_cluster.cumulus.reader_endpoint
+}
+
 output "admin_db_login_secret_arn" {
   value = aws_secretsmanager_secret_version.rds_login.arn
 }

--- a/tf-modules/cumulus-rds-tf/variables.tf
+++ b/tf-modules/cumulus-rds-tf/variables.tf
@@ -91,34 +91,10 @@ variable "engine_version" {
   default     = "13.12"
 }
 
-variable "parameter_group_family" {
-  description = "Database family to use for creating database parameter group"
-  type = string
-  default = "aurora-postgresql11"
-}
-
 variable "parameter_group_family_v13" {
   description = "Database family to use for creating database parameter group under postgres 13 upgrade conditions"
   type = string
   default = "aurora-postgresql13"
-}
-
-variable "enable_upgrade" {
-  description = "Flag to enable use of updated parameter group for postgres v13"
-  type = bool
-  default = true
-}
-
-variable "auto_pause" {
-  description = "Determines if the RDS cluster should automatically pause after a period of inactivity"
-  type = bool
-  default = true
-}
-
-variable "seconds_until_auto_pause" {
-  description = "Number of seconds of inactivity before RDS cluster is paused"
-  type = number
-  default = 300
 }
 
 variable "max_capacity" {
@@ -129,6 +105,16 @@ variable "max_capacity" {
 variable "min_capacity" {
   type = number
   default = 2
+}
+
+variable "cluster_instance_count" {
+  description = "Number of instances to create inside of the cluster"
+  type = number
+  default = 1
+  validation {
+    condition = var.cluster_instance_count >= 1 && var.cluster_instance_count <= 16
+    error_message = "Variable cluster_instance_count should be between 1 and 16."
+  }
 }
 
 ### Required for user/database provisioning
@@ -183,7 +169,7 @@ variable "db_parameters" {
     },
     {
       name         = "rds.force_ssl"
-      value        = 1
+      value        = 0
       apply_method = "pending-reboot"
     }
   ]

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -231,6 +231,8 @@ const sidebars = {
         'upgrade-notes/upgrade-rds-cluster-tf-postgres-13',
         'upgrade-notes/update-cumulus_id-type-indexes-CUMULUS-3449',
         'upgrade-notes/upgrade_execution_table_CUMULUS_3320',
+        'upgrade-notes/update_table_indexes_CUMULUS_3792',
+        'upgrade-notes/serverless-v2-upgrade',
       ],
     },
     {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3897: Prepare, Create, and Publish Release 18.5.x for Serverless v2](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3897)

## Changes

* Adds features for v18.5.0 release
* Updates CL

## PR Checklist

- [x]  Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
