### PR TITLE
CUMULUS-3906 - Update to ORCA v10.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     connections to the database, and is intended to be a temporary solution
     until Cumulus has been updated to import the RDS rds-ca-rsa2048-g1 CA bundles in Lambda environments.
     See [CUMULUS-3724](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3724).
+- **CUMULUS-3906**
+  - Bumps example ORCA deployment to version v10.0.0. This version is necessary to support
+    Aurora Serverless V2.
 
 ### Fixed
+
 - **CUMULUS-3902**
   - Update error handling to use AWS SDK V3 error classes instead of properties on js objects
 - **CUMULUS-3901**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     until Cumulus has been updated to import the RDS rds-ca-rsa2048-g1 CA bundles in Lambda environments.
     See [CUMULUS-3724](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3724).
 - **CUMULUS-3906**
-  - Bumps example ORCA deployment to version v10.0.0. This version is necessary to support
-    Aurora Serverless V2.
+  - Bumps example ORCA deployment to version v10.0.0.
 
 ### Fixed
 

--- a/bamboo/bootstrap-tf-deployment.sh
+++ b/bamboo/bootstrap-tf-deployment.sh
@@ -98,5 +98,3 @@ echo "Deploying Cumulus example to $DEPLOYMENT"
   -var "pdr_node_name_provider_bucket=$PDR_NODE_NAME_PROVIDER_BUCKET" \
   -var "rds_admin_access_secret_arn=$RDS_ADMIN_ACCESS_SECRET_ARN" \
   -var "orca_db_user_password=$ORCA_DATABASE_USER_PASSWORD" \
-  -var "orca_s3_access_key=$AWS_ACCESS_KEY_ID" \
-  -var "orca_s3_secret_key=$AWS_SECRET_ACCESS_KEY" \

--- a/example/cumulus-tf/orca.tf
+++ b/example/cumulus-tf/orca.tf
@@ -13,7 +13,7 @@ locals {
 # ORCA Module
 module "orca" {
   aws_region = var.region
-  source = "https://github.com/nasa/cumulus-orca/releases/download/v9.0.4/cumulus-orca-terraform.zip"
+  source = "https://github.com/nasa/cumulus-orca/releases/download/v10.0.0/cumulus-orca-terraform.zip"
 
   ## --------------------------
   ## Cumulus Variables
@@ -33,15 +33,14 @@ module "orca" {
   ## ORCA Variables
   ## --------------------------
   ## REQUIRED
-  db_admin_password    = local.rds_admin_login.password
-  db_host_endpoint     = local.rds_admin_login.host
-  db_user_password     = var.orca_db_user_password
-  dlq_subscription_email   = var.orca_dlq_subscription_email
-  orca_default_bucket  = var.orca_default_bucket
-  orca_reports_bucket_name = var.system_bucket
-  rds_security_group_id    = local.rds_security_group
-  s3_access_key        = var.orca_s3_access_key
-  s3_secret_key        = var.orca_s3_secret_key
+  db_admin_password         = local.rds_admin_login.password
+  db_cluster_identifier     = local.rds_admin_login.dbClusterIdentifier
+  db_host_endpoint          = local.rds_admin_login.host
+  db_user_password          = var.orca_db_user_password
+  dlq_subscription_email    = var.orca_dlq_subscription_email
+  orca_default_bucket       = var.orca_default_bucket
+  orca_reports_bucket_name  = var.system_bucket
+  rds_security_group_id     = local.rds_security_group
 
   ## OPTIONAL
   db_admin_username                                    = local.rds_admin_login.username

--- a/example/cumulus-tf/variables.tf
+++ b/example/cumulus-tf/variables.tf
@@ -394,18 +394,6 @@ variable "orca_dlq_subscription_email" {
   default = "test@email.com"
 }
 
-variable "orca_s3_access_key" {
-  type        = string
-  description = "Access key for communicating with Orca S3 buckets."
-  default = ""
-}
-
-variable "orca_s3_secret_key" {
-  type        = string
-  description = "Secret key for communicating with Orca S3 buckets."
-  default = ""
-}
-
 variable "lambda_timeouts" {
   description = "Configurable map of timeouts for lambdas"
   type = map(number)


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3906: Update ORCA source to reference final v10.0.0 release archive](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3906)

## Changes

* Bumps example orca deployment to v10.0.0
* Removes deprecated variables per orca v10.0.0 [release notes](https://github.com/nasa/cumulus-orca/releases/tag/v10.0.0)  

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [x] Integration tests
