### PR TITLE
Removes CUMULUS-3792 ID from website sidebars

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -231,7 +231,6 @@ const sidebars = {
         'upgrade-notes/upgrade-rds-cluster-tf-postgres-13',
         'upgrade-notes/update-cumulus_id-type-indexes-CUMULUS-3449',
         'upgrade-notes/upgrade_execution_table_CUMULUS_3320',
-        'upgrade-notes/update_table_indexes_CUMULUS_3792',
         'upgrade-notes/serverless-v2-upgrade',
       ],
     },

--- a/website/versioned_sidebars/version-v18.5.0-sidebars.json
+++ b/website/versioned_sidebars/version-v18.5.0-sidebars.json
@@ -236,7 +236,6 @@
         "upgrade-notes/upgrade-rds-cluster-tf-postgres-13",
         "upgrade-notes/update-cumulus_id-type-indexes-CUMULUS-3449",
         "upgrade-notes/upgrade_execution_table_CUMULUS_3320",
-        "upgrade-notes/update_table_indexes_CUMULUS_3792",
         "upgrade-notes/serverless-v2-upgrade"
       ]
     },


### PR DESCRIPTION
**Summary:** Summary of changes

Removes references to CUMULUS-3792 from website sidebars. Appears to have been a cherry-pick miss when the release branch was created. That ticket is not part of 18.5.0.