### PR TITLE
Allowing force_new_deployment to be configurable for ecs services.

### DIFF
--- a/tf-modules/cumulus_ecs_service/main.tf
+++ b/tf-modules/cumulus_ecs_service/main.tf
@@ -72,6 +72,7 @@ resource "aws_ecs_service" "default" {
   task_definition                    = aws_ecs_task_definition.default.arn
   deployment_maximum_percent         = 100
   deployment_minimum_healthy_percent = 0
+  force_new_deployment               = var.force_new_deployment
   # TODO Re-enable tags once this warning is addressed:
   #   The new ARN and resource ID format must be enabled to add tags to the
   #   service. Opt in to the new format and try again.

--- a/tf-modules/cumulus_ecs_service/variables.tf
+++ b/tf-modules/cumulus_ecs_service/variables.tf
@@ -111,3 +111,9 @@ variable "health_check" {
   })
   default = null
 }
+
+variable "force_new_deployment" {
+  description = "Enable to force a new task deployment of the service. See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service#force_new_deployment"
+  type = bool
+  default = false
+}


### PR DESCRIPTION
**Summary:** Allows the `force_new_deployment` argument for the ECS service to be configured.
Addresses https://bugs.earthdata.nasa.gov/browse/GHRCCLOUD-6780

## Changes

* Allow `force_new_deployment` to be set by module users. Will default to false.

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
