### PR TITLE
CUMULUS-3931: Allowing force_new_deployment to be configurable for ecs services.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     - cumulus-message-adapter-python 2.3.0
 - **CUMULUS-3906**
   - Bumps example ORCA deployment to version v10.0.1.
+- **CUMULUS-3931**
+  - Add `force_new_deployment` to `cumulus_ecs_service` to allow users to force
+    new task deployment on terraform redeploy.   See docs for more details:
+    https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service#force_new_deployment"
 
 ### Fixed
 

--- a/tf-modules/cumulus_ecs_service/main.tf
+++ b/tf-modules/cumulus_ecs_service/main.tf
@@ -72,6 +72,7 @@ resource "aws_ecs_service" "default" {
   task_definition                    = aws_ecs_task_definition.default.arn
   deployment_maximum_percent         = 100
   deployment_minimum_healthy_percent = 0
+  force_new_deployment               = var.force_new_deployment
   # TODO Re-enable tags once this warning is addressed:
   #   The new ARN and resource ID format must be enabled to add tags to the
   #   service. Opt in to the new format and try again.

--- a/tf-modules/cumulus_ecs_service/variables.tf
+++ b/tf-modules/cumulus_ecs_service/variables.tf
@@ -111,3 +111,9 @@ variable "health_check" {
   })
   default = null
 }
+
+variable "force_new_deployment" {
+  description = "Enable to force a new task deployment of the service. See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service#force_new_deployment"
+  type = bool
+  default = false
+}


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3931](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3931)

## Changes

- Adds `force_new_deployment` configuration to the ecs_service to force redeploy on update


## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
