### PR TITLE
CUMULUS-3859: Update @cumulus/api/bin/serveUtils to no longer add records to ES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ aws lambda invoke --function-name $PREFIX-ReconciliationReportMigration $OUTFILE
   - Created api types for `reconciliation_reports` in `@cumulus/types/api`
   - Updated reconciliation reports lambda to write to new RDS table instead of Dynamo
   - Updated `@cumulus/api/endpoints/reconciliation-reports` `getReport` and `deleteReport` to work with the new RDS table instead of Dynamo
+- **CUMULUS-3859**
+  - Updated `@cumulus/api/bin/serveUtils` to no longer add records to ElasticSearch
 
 ## [Unreleased]
 

--- a/lambdas/reconciliation-report-migration/package.json
+++ b/lambdas/reconciliation-report-migration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/reconciliation-report-migration",
-  "version": "19.0.0",
+  "version": "19.1.0",
   "description": "Lambda function for reconciliation report migration from DynamoDB to Postgres",
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
@@ -31,13 +31,13 @@
     "failFast": true
   },
   "dependencies": {
-    "@cumulus/api": "19.0.0",
-    "@cumulus/aws-client": "19.0.0",
-    "@cumulus/common": "19.0.0",
-    "@cumulus/db": "19.0.0",
-    "@cumulus/errors": "19.0.0",
-    "@cumulus/logger": "19.0.0",
-    "@cumulus/types": "19.0.0",
+    "@cumulus/api": "19.1.0",
+    "@cumulus/aws-client": "19.1.0",
+    "@cumulus/common": "19.1.0",
+    "@cumulus/db": "19.1.0",
+    "@cumulus/errors": "19.1.0",
+    "@cumulus/logger": "19.1.0",
+    "@cumulus/types": "19.1.0",
     "knex": "2.4.1",
     "lodash": "^4.17.21",
     "pg": "~8.12"


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3859: Update @cumulus packages for cypress tests](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3859)

## Changes

* Update @cumulus/api/bin/serveUtils to no longer add records to ES 

Notes: The serveUtils is used by dashboard to seed test data into the data store for cypress test.

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
