### PR TITLE
CUMULUS-3859-1: Remove es from local api code and update active collection search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ aws lambda invoke --function-name $PREFIX-ReconciliationReportMigration $OUTFILE
 - **CUMULUS-3859**
   - Updated `@cumulus/api/bin/serveUtils` to no longer add records to ElasticSearch
   - Removed ElasticSearch from local API server code
-  - Updated CollectionSearch to filter additional granule fields for active collections
+  - Updated CollectionSearch to filter granule fields in addition to time frame for active collections
 
 ## [Unreleased]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ aws lambda invoke --function-name $PREFIX-ReconciliationReportMigration $OUTFILE
   - Added `reconciliationReports` type to stats endpoint, so `aggregate` query will work for reconciliation reports
 - **CUMULUS-3859**
   - Updated `@cumulus/api/bin/serveUtils` to no longer add records to ElasticSearch
+  - Removed ElasticSearch from local API server code
+  - Updated CollectionSearch to filter additional granule fields for active collections
 
 ## [Unreleased]
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@babel/eslint-parser": "^7.24.1",
     "@babel/preset-env": "^7.24.4",
     "@docusaurus/eslint-plugin": "^2.3.0",
-    "@octokit/graphql": "2.1.1",
+    "@octokit/graphql": "^2.3.0",
     "@smithy/types": "^2.11.0",
     "@types/aws-lambda": "^8.10.58",
     "@types/lodash": "^4.14.150",

--- a/packages/api/bin/cli.js
+++ b/packages/api/bin/cli.js
@@ -54,7 +54,7 @@ program
 program
   .command('serve')
   .option('--stackName <stackName>', 'stackname to serve (defaults to "localrun")', undefined)
-  .option('--no-reseed', 'do not reseed dynamoDB and Elasticsearch with new data on start.')
+  .option('--no-reseed', 'do not reseed data stores with new data on start.')
   .description('Serves the local version of the Cumulus API')
   .action((cmd) => {
     serveApi(process.env.USERNAME, cmd.stackName, cmd.reseed).catch(console.error);

--- a/packages/api/bin/serve.js
+++ b/packages/api/bin/serve.js
@@ -19,18 +19,14 @@ const {
 
 const { constructCollectionId } = require('@cumulus/message/Collections');
 
-const { bootstrapElasticSearch } = require('@cumulus/es-client/bootstrap');
-
 const { ReconciliationReport } = require('../models');
 
 const testUtils = require('../lib/testUtils');
 const serveUtils = require('./serveUtils');
 const {
-  setLocalEsVariables,
   localStackName,
   localSystemBucket,
   localUserName,
-  getESClientAndIndex,
 } = require('./local-test-defaults');
 
 const workflowList = testUtils.getWorkflowList();
@@ -58,12 +54,6 @@ async function populateBucket(bucket, stackName) {
 }
 
 async function prepareServices(stackName, bucket) {
-  setLocalEsVariables(stackName);
-  console.log(process.env.ES_HOST);
-  await bootstrapElasticSearch({
-    host: process.env.ES_HOST,
-    index: process.env.ES_INDEX,
-  });
   await s3().createBucket({ Bucket: bucket });
 
   const { TopicArn } = await createSnsTopic(randomId('topicName'));
@@ -96,35 +86,7 @@ function checkEnvVariablesAreSet(moreRequiredEnvVars) {
 }
 
 /**
- * erases Elasticsearch index
- * @param {any} esClient - Elasticsearch client
- * @param {any} esIndex - index to delete
- */
-async function eraseElasticsearchIndices(esClient, esIndex) {
-  try {
-    await esClient.client.indices.delete({ index: esIndex });
-  } catch (error) {
-    if (error.message !== 'index_not_found_exception') throw error;
-  }
-}
-
-/**
- * resets Elasticsearch and returns the client and index.
- *
- * @param {string} stackName - The name of local stack. Used to prefix stack resources.
- * @returns {Object} - Elasticsearch client and index
- */
-async function initializeLocalElasticsearch(stackName) {
-  const es = await getESClientAndIndex(stackName);
-  await eraseElasticsearchIndices(es.client, es.index);
-  return bootstrapElasticSearch({
-    host: process.env.ES_HOST,
-    index: es.index,
-  });
-}
-
-/**
- * Fill Postgres and Elasticsearch with fake records for testing.
+ * Fill Postgres with fake records for testing.
  * @param {string} stackName - The name of local stack. Used to prefix stack resources.
  * @param {string} user - username
  * @param {Object} knexOverride - Used to override knex object for testing
@@ -140,7 +102,6 @@ async function createDBRecords(stackName, user, knexOverride) {
   const providerPgModel = new ProviderPgModel();
   const rulePgModel = new RulePgModel();
 
-  await initializeLocalElasticsearch(stackName);
   await serveUtils.resetPostgresDb();
 
   if (user) {
@@ -219,7 +180,7 @@ async function createDBRecords(stackName, user, knexOverride) {
  * @param {string} user - A username to add as an authorized user for the API.
  * @param {string} stackName - The name of local stack. Used to prefix stack resources.
  * @param {bool} reseed - boolean to control whether to load new data into
- *                        Postgres and Elasticsearch.
+ *                        Postgres.
  */
 async function serveApi(user, stackName = localStackName, reseed = true) {
   const port = process.env.PORT || 5001;
@@ -321,18 +282,6 @@ async function serveDistributionApi(stackName = localStackName, done) {
 }
 
 /**
- * Resets Elasticsearch
- *
- * @param {string} stackName - defaults to local stack, 'localrun'
- * @param {string} systemBucket - defaults to 'localbucket'
- */
-function eraseDataStack(
-  stackName = localStackName
-) {
-  return initializeLocalElasticsearch(stackName);
-}
-
-/**
  * Removes all additional data from tables and repopulates with original data.
  *
  * @param {string} user - defaults to local user, testUser
@@ -353,7 +302,6 @@ async function resetTables(
 }
 
 module.exports = {
-  eraseDataStack,
   serveApi,
   serveDistributionApi,
   resetTables,

--- a/packages/api/bin/serveUtils.js
+++ b/packages/api/bin/serveUtils.js
@@ -17,6 +17,7 @@ const {
   ProviderPgModel,
   ReconciliationReportPgModel,
   RulePgModel,
+  translateApiAsyncOperationToPostgresAsyncOperation,
   translateApiCollectionToPostgresCollection,
   translateApiExecutionToPostgresExecution,
   translateApiGranuleToPostgresGranule,
@@ -79,6 +80,22 @@ async function resetPostgresDb() {
   await knex.migrate.latest();
 
   await erasePostgresTables(knex);
+}
+
+async function addAsyncOperations(asyncOperations) {
+  const knex = await getKnexClient({
+    env: {
+      ...envParams,
+      ...localStackConnectionEnv,
+    },
+  });
+  const asyncOperationPgModel = new AsyncOperationPgModel();
+  return await Promise.all(
+    asyncOperations.map(async (r) => {
+      const dbRecord = await translateApiAsyncOperationToPostgresAsyncOperation(r, knex);
+      await asyncOperationPgModel.create(knex, dbRecord);
+    })
+  );
 }
 
 async function addCollections(collections) {
@@ -230,6 +247,7 @@ async function addReconciliationReports(reconciliationReports) {
 
 module.exports = {
   resetPostgresDb,
+  addAsyncOperations,
   addProviders,
   addCollections,
   addExecutions,

--- a/packages/api/bin/serveUtils.js
+++ b/packages/api/bin/serveUtils.js
@@ -44,6 +44,7 @@ async function erasePostgresTables(knex) {
   const granulesExecutionsPgModel = new GranulesExecutionsPgModel();
   const pdrPgModel = new PdrPgModel();
   const providerPgModel = new ProviderPgModel();
+  const reconReportPgModel = new ReconciliationReportPgModel();
   const rulePgModel = new RulePgModel();
 
   await granulesExecutionsPgModel.delete(knex, {});
@@ -56,6 +57,7 @@ async function erasePostgresTables(knex) {
   await rulePgModel.delete(knex, {});
   await collectionPgModel.delete(knex, {});
   await providerPgModel.delete(knex, {});
+  await reconReportPgModel.delete(knex, {});
 }
 
 async function resetPostgresDb() {
@@ -210,7 +212,6 @@ async function addPdrs(pdrs) {
   );
 }
 
-// TODO this is dynamodb
 async function addReconciliationReports(reconciliationReports) {
   const knex = await getKnexClient({
     env: {

--- a/packages/db/src/search/CollectionSearch.ts
+++ b/packages/db/src/search/CollectionSearch.ts
@@ -30,11 +30,9 @@ interface CollectionRecordApi extends CollectionRecord {
   stats?: Statuses,
 }
 
-const isGranuleField = (_value: any, key: string): boolean => {
-  const granuleFields = ['createdAt', 'granuleId', 'timestamp', 'updatedAt'];
-  const field = key.split('__')[0];
-  return granuleFields.includes(field);
-};
+const granuleFields = ['createdAt', 'granuleId', 'timestamp', 'updatedAt'];
+const isGranuleField = (_value: any, key: string): boolean =>
+  granuleFields.includes(key.split('__')[0]);
 
 /**
  * Class to build and execute db search query for collections

--- a/packages/db/src/search/CollectionSearch.ts
+++ b/packages/db/src/search/CollectionSearch.ts
@@ -1,9 +1,11 @@
 import { Knex } from 'knex';
+import omit from 'lodash/omit';
 import pick from 'lodash/pick';
 
 import Logger from '@cumulus/logger';
 import { CollectionRecord } from '@cumulus/types/api/collections';
 import { BaseSearch } from './BaseSearch';
+import { convertQueryStringToDbQueryParameters } from './queries';
 import { GranuleSearch } from './GranuleSearch';
 import { DbQueryParameters, QueryEvent } from '../types/search';
 import { translatePostgresCollectionToApiCollection } from '../translate/collections';
@@ -40,6 +42,13 @@ export class CollectionSearch extends BaseSearch {
     super({ queryStringParameters }, 'collection');
     this.active = (active === 'true');
     this.includeStats = (includeStats === 'true');
+
+    // for active collection search, granuleId is a granule field
+    if (this.active) {
+      this.dbQueryParameters = convertQueryStringToDbQueryParameters(
+        this.type, omit(this.queryStringParameters, ['granuleId', 'granuleId__in'])
+      );
+    }
   }
 
   /**

--- a/packages/db/src/search/CollectionSearch.ts
+++ b/packages/db/src/search/CollectionSearch.ts
@@ -30,9 +30,7 @@ interface CollectionRecordApi extends CollectionRecord {
   stats?: Statuses,
 }
 
-const isGranuleField = (
-  _value: any, key: string
-): boolean => {
+const isGranuleField = (_value: any, key: string): boolean => {
   const granuleFields = ['createdAt', 'granuleId', 'timestamp', 'updatedAt'];
   const field = key.split('__')[0];
   return granuleFields.includes(field);

--- a/packages/db/src/search/CollectionSearch.ts
+++ b/packages/db/src/search/CollectionSearch.ts
@@ -90,9 +90,9 @@ export class CollectionSearch extends BaseSearch {
   private buildSubQueryForActiveCollections(knex: Knex): Knex.QueryBuilder {
     const granulesTable = TableNames.granules;
     const granuleSearch = new GranuleSearch({ queryStringParameters: this.queryStringParameters });
-    const { countQuery } = granuleSearch.buildSearchForActiveCollections(knex);
+    const { countQuery: subQuery } = granuleSearch.buildSearchForActiveCollections(knex);
 
-    const subQuery = countQuery.clone()
+    subQuery
       .clear('select')
       .select(1)
       .where(`${granulesTable}.collection_cumulus_id`, knex.raw(`${this.tableName}.cumulus_id`))
@@ -134,15 +134,17 @@ export class CollectionSearch extends BaseSearch {
   private async retrieveGranuleStats(collectionCumulusIds: number[], knex: Knex)
     : Promise<StatsRecords> {
     const granulesTable = TableNames.granules;
-    let granuleQuery = knex(granulesTable);
+    let statsQuery = knex(granulesTable);
+
     if (this.active) {
       const granuleSearch = new GranuleSearch({
         queryStringParameters: this.queryStringParameters,
       });
       const { countQuery } = granuleSearch.buildSearchForActiveCollections(knex);
-      granuleQuery = countQuery.clear('select');
+      statsQuery = countQuery.clear('select');
     }
-    const statsQuery = granuleQuery.clone()
+
+    statsQuery
       .select(`${granulesTable}.collection_cumulus_id`, `${granulesTable}.status`)
       .count('*')
       .groupBy(`${granulesTable}.collection_cumulus_id`, `${granulesTable}.status`)

--- a/packages/db/src/search/GranuleSearch.ts
+++ b/packages/db/src/search/GranuleSearch.ts
@@ -134,6 +134,7 @@ export class GranuleSearch extends BaseSearch {
    * Translate postgres records to api records
    *
    * @param pgRecords - postgres records returned from query
+   * @param knex - DB client
    * @returns translated api records
    */
   protected async translatePostgresRecordsToApiRecords(pgRecords: GranuleRecord[], knex: Knex)

--- a/packages/db/src/search/GranuleSearch.ts
+++ b/packages/db/src/search/GranuleSearch.ts
@@ -109,6 +109,28 @@ export class GranuleSearch extends BaseSearch {
   }
 
   /**
+   * Build the search query for active collections.
+   * If time params are specified the query will search granules that have been updated
+   * in that time frame.  If granuleId or providerId are provided, it will filter those as well.
+   *
+   * @param knex - DB client
+   * @returns queries for getting count and search result
+   */
+  public buildSearchForActiveCollections(knex: Knex)
+    : {
+      countQuery: Knex.QueryBuilder,
+      searchQuery: Knex.QueryBuilder,
+    } {
+    const { countQuery, searchQuery } = this.buildBasicQuery(knex);
+    this.buildTermQuery({ countQuery, searchQuery });
+    this.buildTermsQuery({ countQuery, searchQuery });
+    this.buildRangeQuery({ knex, countQuery, searchQuery });
+
+    log.debug(`buildSearchForActiveCollections returns countQuery: ${countQuery?.toSQL().sql}, searchQuery: ${searchQuery.toSQL().sql}`);
+    return { countQuery, searchQuery };
+  }
+
+  /**
    * Translate postgres records to api records
    *
    * @param pgRecords - postgres records returned from query

--- a/packages/db/src/search/StatsSearch.ts
+++ b/packages/db/src/search/StatsSearch.ts
@@ -252,7 +252,6 @@ class StatsSearch extends BaseSearch {
    * @param params
    * @param params.searchQuery - the search query
    * @param [params.dbQueryParameters] - the db query parameters
-   * @returns the updated search query based on queryStringParams
    */
   protected buildTermQuery(params: {
     searchQuery: Knex.QueryBuilder,
@@ -265,7 +264,7 @@ class StatsSearch extends BaseSearch {
       searchQuery.whereRaw(`${this.tableName}.error ->> 'Error' is not null`);
     }
 
-    return super.buildTermQuery({
+    super.buildTermQuery({
       ...params,
       dbQueryParameters: { term: omit(term, 'error.Error') },
     });

--- a/packages/db/src/translate/async_operations.ts
+++ b/packages/db/src/translate/async_operations.ts
@@ -1,3 +1,4 @@
+import omit from 'lodash/omit';
 import { toSnake } from 'snake-camel';
 import { ApiAsyncOperation } from '@cumulus/types/api/async_operations';
 import Logger from '@cumulus/logger';
@@ -38,7 +39,7 @@ export const translateApiAsyncOperationToPostgresAsyncOperation = (
   record: ApiAsyncOperation
 ): PostgresAsyncOperation => {
   // fix for old implementation of async-operation output assignment
-  const translatedRecord = <PostgresAsyncOperation>toSnake(record);
+  const translatedRecord = <PostgresAsyncOperation>toSnake(omit(record, 'timestamp'));
   if (record.output === 'none') {
     delete translatedRecord.output;
   } else if (record.output !== undefined) {

--- a/packages/db/tests/lib/test-granule.js
+++ b/packages/db/tests/lib/test-granule.js
@@ -178,14 +178,14 @@ test('upsertGranuleWithExecutionJoinRecord() handles multiple executions for a g
     }
   );
   t.deepEqual(
-    await granulesExecutionsPgModel.search(
+    orderBy(await granulesExecutionsPgModel.search(
       knex,
       { granule_cumulus_id: granuleCumulusId }
-    ),
-    [executionCumulusId, secondExecutionCumulusId].map((executionId) => ({
+    ), 'execution_cumulus_id'),
+    orderBy([executionCumulusId, secondExecutionCumulusId].map((executionId) => ({
       granule_cumulus_id: granuleCumulusId,
       execution_cumulus_id: executionId,
-    }))
+    })), 'execution_cumulus_id')
   );
 });
 

--- a/packages/db/tests/search/test-CollectionSearch.js
+++ b/packages/db/tests/search/test-CollectionSearch.js
@@ -44,10 +44,6 @@ test.before(async (t) => {
     })
   ));
 
-  t.context.granulePgModel = new GranulePgModel();
-  const statuses = ['queued', 'failed', 'completed', 'running'];
-  t.context.granuleSearchTmestamp = 1688888800000;
-
   // Create provider
   t.context.providerPgModel = new ProviderPgModel();
   t.context.provider = fakeProviderRecordFactory();
@@ -58,6 +54,9 @@ test.before(async (t) => {
   );
   t.context.providerCumulusId = pgProvider.cumulus_id;
 
+  t.context.granulePgModel = new GranulePgModel();
+  const statuses = ['queued', 'failed', 'completed', 'running'];
+  t.context.granuleSearchTmestamp = 1688888800000;
   t.context.granules = range(1000).map((num) => (
     fakeGranuleRecordFactory({
       // collection with cumulus_id 0-9 each has 11 granules,


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3859: [cumulus-dashboard: Update @cumulus packages for cypress tests](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3859)

## Changes

* Removed ElasticSearch from local API server code
* Updated CollectionSearch to filter additional granule fields for active collections

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
