### PR TITLE
Ecarton/cumulus 3751 granule collection update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Breaking Changes
+
 - **CUMULUS-3751**
   - Updated `move-granules` task to get source bucket from input granules files' configured bucket,
     rather than config.bucket parameter
@@ -25,6 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
 ### Added
+
 - **CUMULUS-3751**
   - updated `move-granules` task to accept a collection that *is not* the current granules collection
     as an instruction to *move* that granule to that collection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Breaking Changes
-
+- **CUMULUS-3751**
+  - Updated `move-granules` task to get source bucket from input granules files' configured bucket,
+    rather than config.bucket parameter
 - **CUMULUS-2564**
   - Updated `sync-granule` task to add `useGranIdPath` as a configuration flag.
     This modifies the task behavior to stage granules to
@@ -23,7 +25,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
 ### Added
-
+- **CUMULUS-3751**
+  - updated `move-granules` task to accept a collection that *is not* the current granules collection
+    as an instruction to *move* that granule to that collection
+    - updating granule metadata in task return
+    - updating granule metadata in cumulus data stores
+    - moving s3 files to new collection buckets and prefixes
 - **CUMULUS-3919**
   - Added terraform variables `disableSSL` and `rejectUnauthorized` to `tf-modules/cumulus-rds-tf` module.
 

--- a/example/spec/parallel/moveGranules/MoveGranulesCollectionSpec.js
+++ b/example/spec/parallel/moveGranules/MoveGranulesCollectionSpec.js
@@ -141,7 +141,11 @@ describe('The MoveGranules task', () => {
     ).catch(console.error);
   });
 
-  it('succeeds moving the 0 byte file', async () => {
+  it('updates granule data in cumulus datastores', async () => {
+    // #TODO
+  });
+
+  it('succeeds moving file to new collection', async () => {
     if (beforeAllFailed) fail('beforeAll() failed');
 
     const existCheck = await s3ObjectExists({ Bucket: movedCollectionFile.bucket, Key: movedCollectionFile.key });
@@ -152,7 +156,7 @@ describe('The MoveGranules task', () => {
     expect(objectSize).toEqual(0);
   });
 
-  it('preserves object tags', async () => {
+  it('preserves object tags across collection move', async () => {
     if (beforeAllFailed) fail('beforeAll() failed');
 
     // Verify that the tags of the moved granule match the tags of the source

--- a/example/spec/parallel/moveGranules/MoveGranulesCollectionSpec.js
+++ b/example/spec/parallel/moveGranules/MoveGranulesCollectionSpec.js
@@ -124,7 +124,8 @@ describe('The MoveGranules task', () => {
     await pAll(
       [
         () => deleteS3Object(sourceBucket, sourceKey),
-        () => deleteS3Object(movedCollectionFile.bucket, movedCollectionFile.filepath),
+        () => deleteS3Object(movedFile.bucket, movedFile.key),
+        () => deleteS3Object(movedCollectionFile.bucket, movedCollectionFile.key),
         () => deleteCollection({
           prefix,
           collectionName: get(collection, 'name'),

--- a/example/spec/parallel/moveGranules/MoveGranulesCollectionSpec.js
+++ b/example/spec/parallel/moveGranules/MoveGranulesCollectionSpec.js
@@ -1,0 +1,167 @@
+'use strict';
+
+// TODO: rename this file to be clear it is also testing moving zero byte files
+
+/**
+ * LocalStack has a bug where it ignores the `Tagging` parameter to the
+ * `s3.createMultipartUpload` method. Since we are unable to verify that
+ * MoveGranules preserves tags using LocalStack, we're going to have to test
+ * it here instead.
+ * Also, Localstack does not behave the same as S3 when trying to move 0 byte files with
+ * multipartCopyObject. Since we are unable to accurately test moving a 0 byte file with Localstack,
+ * we are testing it here.
+ */
+
+const get = require('lodash/get');
+const pAll = require('p-all');
+const querystring = require('querystring');
+
+const { createCollection } = require('@cumulus/integration-tests/Collections');
+const { deleteCollection } = require('@cumulus/api-client/collections');
+const { deleteS3Object, s3GetObjectTagging, s3PutObject } = require('@cumulus/aws-client/S3');
+const { randomId } = require('@cumulus/common/test-utils');
+
+const { moveGranules } = require('@cumulus/move-granules');
+const { headObject, s3ObjectExists } = require('@cumulus/aws-client/S3');
+const { loadConfig } = require('../../helpers/testUtils');
+
+describe('The MoveGranules task', () => {
+  let beforeAllFailed = false;
+  let collection;
+  let collection2;
+  let config;
+  let granuleId;
+  let movedCollectionFile;
+  let movedFile;
+  let preliminaryMoveGranulesResponse;
+  let moveGranulesCollectionResponse;
+  let prefix;
+  let sourceBucket;
+  let sourceKey;
+
+  beforeAll(async () => {
+    try {
+      config = await loadConfig();
+      prefix = config.stackName;
+      sourceBucket = config.bucket;
+
+      process.env.stackName = config.stackName;
+      process.env.system_bucket = config.buckets.internal.name;
+
+      // Create the collection
+      collection = await createCollection(
+        prefix,
+        {
+          duplicateHandling: 'error',
+          process: 'modis',
+        }
+      );
+      collection2 = await createCollection(
+        prefix,
+        {
+          duplicateHandling: 'replace',
+          process: 'modis2',
+          bucket: 'a'
+        }
+      );
+
+      granuleId = randomId('granule-id-');
+
+      // Stage the granule file to S3 (zero byte file with tagging)
+      const stagingDir = 'file-staging';
+      const stagedZeroByteFilename = `${randomId('file-')}.dat`;
+      sourceKey = `${stagingDir}/${stagedZeroByteFilename}`;
+      await s3PutObject({
+        Bucket: sourceBucket,
+        Key: sourceKey,
+        Body: '',
+        Tagging: querystring.stringify({ granuleId }),
+      });
+
+      preliminaryMoveGranulesResponse = await moveGranules({
+        config: {
+          buckets: config.buckets,
+          distribution_endpoint: 'http://www.example.com',
+          collection,
+        },
+        input: {
+          granules: [
+            {
+              files: [
+                {
+                  bucket: sourceBucket,
+                  key: sourceKey,
+                  fileName: stagedZeroByteFilename,
+                  size: 0,
+                },
+              ],
+            },
+          ],
+        },
+      });
+      movedFile = preliminaryMoveGranulesResponse.granules[0].files[0];
+      moveGranulesCollectionResponse = await moveGranules({
+        config: {
+          buckets: config.buckets,
+          distribution_endpoint: 'http://www.example.com',
+          collection: collection2,
+        },
+        input: {
+          granules: preliminaryMoveGranulesResponse.granules
+        },
+      });
+
+      movedCollectionFile = moveGranulesCollectionResponse.granules[0].files[0];
+
+
+    } catch (error) {
+      beforeAllFailed = true;
+      throw error;
+    }
+  });
+
+  afterAll(async () => {
+    await pAll(
+      [
+        () => deleteS3Object(sourceBucket, sourceKey),
+        () => deleteS3Object(movedFile.bucket, movedFile.filepath),
+        () => deleteCollection({
+          prefix,
+          collectionName: get(collection, 'name'),
+          collectionVersion: get(collection, 'version'),
+        }),
+      ],
+      { stopOnError: false }
+    ).catch(console.error);
+  });
+
+  it('succeeds moving the 0 byte file', async () => {
+    if (beforeAllFailed) fail('beforeAll() failed');
+
+    const existCheck = await s3ObjectExists({ Bucket: movedCollectionFile.bucket, Key: movedCollectionFile.key });
+    const object = await headObject(movedCollectionFile.bucket, movedCollectionFile.key);
+    const objectSize = object.ContentLength;
+
+    expect(existCheck).toEqual(true);
+    expect(objectSize).toEqual(0);
+  });
+
+  it('preserves object tags', async () => {
+    if (beforeAllFailed) fail('beforeAll() failed');
+
+    // Verify that the tags of the moved granule match the tags of the source
+    const movedFileTags = await s3GetObjectTagging(
+      movedCollectionFile.bucket,
+      movedCollectionFile.key
+    );
+
+    const expectedTagSet = [
+      {
+        Key: 'granuleId',
+        Value: granuleId,
+      },
+    ];
+
+    expect(movedFileTags.TagSet).toEqual(expectedTagSet);
+  });
+});

--- a/example/spec/parallel/moveGranules/MoveGranulesCollectionSpec.js
+++ b/example/spec/parallel/moveGranules/MoveGranulesCollectionSpec.js
@@ -61,7 +61,6 @@ describe('The MoveGranules task', () => {
         {
           duplicateHandling: 'replace',
           process: 'modis2',
-          bucket: 'a'
         }
       );
 
@@ -107,13 +106,11 @@ describe('The MoveGranules task', () => {
           collection: collection2,
         },
         input: {
-          granules: preliminaryMoveGranulesResponse.granules
+          granules: preliminaryMoveGranulesResponse.granules,
         },
       });
 
       movedCollectionFile = moveGranulesCollectionResponse.granules[0].files[0];
-
-
     } catch (error) {
       beforeAllFailed = true;
       throw error;

--- a/example/spec/parallel/moveGranules/MoveGranulesCollectionSpec.js
+++ b/example/spec/parallel/moveGranules/MoveGranulesCollectionSpec.js
@@ -124,11 +124,16 @@ describe('The MoveGranules task', () => {
     await pAll(
       [
         () => deleteS3Object(sourceBucket, sourceKey),
-        () => deleteS3Object(movedFile.bucket, movedFile.filepath),
+        () => deleteS3Object(movedCollectionFile.bucket, movedCollectionFile.filepath),
         () => deleteCollection({
           prefix,
           collectionName: get(collection, 'name'),
           collectionVersion: get(collection, 'version'),
+        }),
+        () => deleteCollection({
+          prefix,
+          collectionName: get(collection2, 'name'),
+          collectionVersion: get(collection2, 'version'),
         }),
       ],
       { stopOnError: false }

--- a/example/spec/parallel/moveGranules/MoveGranulesTagsSpec.js
+++ b/example/spec/parallel/moveGranules/MoveGranulesTagsSpec.js
@@ -101,7 +101,7 @@ describe('The MoveGranules task', () => {
     await pAll(
       [
         () => deleteS3Object(sourceBucket, sourceKey),
-        () => deleteS3Object(movedFile.bucket, movedFile.filepath),
+        () => deleteS3Object(movedFile.bucket, movedFile.key),
         () => deleteCollection({
           prefix,
           collectionName: get(collection, 'name'),

--- a/example/spec/parallel/moveGranules/MoveGranulesTagsSpec.js
+++ b/example/spec/parallel/moveGranules/MoveGranulesTagsSpec.js
@@ -70,7 +70,6 @@ describe('The MoveGranules task', () => {
 
       moveGranulesResponse = await moveGranules({
         config: {
-          bucket: config.bucket,
           buckets: config.buckets,
           distribution_endpoint: 'http://www.example.com',
           collection,

--- a/tasks/move-granules/index.js
+++ b/tasks/move-granules/index.js
@@ -28,7 +28,6 @@ const BucketsConfig = require('@cumulus/common/BucketsConfig');
 const { urlPathTemplate } = require('@cumulus/ingest/url-path-template');
 const { isFileExtensionMatched } = require('@cumulus/message/utils');
 const log = require('@cumulus/common/log');
-const { updateGranule } = require('@cumulus/api-client/granules');
 const { constructCollectionId } = require('@cumulus/message/Collections');
 
 const MB = 1024 * 1024;
@@ -59,6 +58,7 @@ function buildGranuleDuplicatesObject(movedGranulesByGranuleId) {
  * @param {CollectionRecord} collection
  * @returns {}
  */
+// eslint-disable-next-line require-await
 async function updateGranuleCollection(granule, collection) {
   const collectionId = constructCollectionId(collection.name, collection.version);
   const updatedGranule = { ...granule };

--- a/tasks/move-granules/index.js
+++ b/tasks/move-granules/index.js
@@ -64,12 +64,7 @@ async function updateGranuleCollection(granule, collection) {
   const updatedGranule = { ...granule };
   if (granule.collectionId !== collectionId) {
     updatedGranule.collectionId = collectionId;
-    await updateGranule({
-      prefix: process.env.stackName,
-      body: updatedGranule,
-      granuleId: updatedGranule.granuleId,
-      collectionId,
-    });
+    // TODO api call to update granule in pg here
   }
   return updatedGranule;
 }

--- a/tasks/move-granules/index.js
+++ b/tasks/move-granules/index.js
@@ -278,7 +278,6 @@ async function moveGranules(event) {
   // We have to post the meta-xml file of all output granules
   const config = event.config;
   const bucketsConfig = new BucketsConfig(config.buckets);
-  const prefix = process.env.stackName;
   const moveStagedFiles = get(config, 'moveStagedFiles', true);
   const s3MultipartChunksizeMb = config.s3MultipartChunksizeMb
     ? config.s3MultipartChunksizeMb : process.env.default_s3_multipart_chunksize_mb;

--- a/tasks/move-granules/package.json
+++ b/tasks/move-granules/package.json
@@ -49,6 +49,7 @@
     "@cumulus/errors": "19.1.0",
     "@cumulus/ingest": "19.1.0",
     "@cumulus/message": "19.1.0",
+    "@cumulus/api-client": "19.1.0",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/tasks/move-granules/package.json
+++ b/tasks/move-granules/package.json
@@ -41,6 +41,7 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
+    "@cumulus/api-client": "19.1.0",
     "@cumulus/aws-client": "19.1.0",
     "@cumulus/cmrjs": "19.1.0",
     "@cumulus/common": "19.1.0",
@@ -49,10 +50,10 @@
     "@cumulus/errors": "19.1.0",
     "@cumulus/ingest": "19.1.0",
     "@cumulus/message": "19.1.0",
-    "@cumulus/api-client": "19.1.0",
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@cumulus/schemas": "19.1.0"
+    "@cumulus/schemas": "19.1.0",
+    "deep-equal": "^2.2.3"
   }
 }

--- a/tasks/move-granules/tests/data/payload.json
+++ b/tasks/move-granules/tests/data/payload.json
@@ -67,6 +67,7 @@
   "input": {
     "granules": [
       {
+        "collectionId": "MOD11A1___006",
         "granuleId": "MOD11A1.A2017200.h19v04.006.2017201090724",
         "files": [
           {

--- a/tasks/move-granules/tests/data/payload_iso.json
+++ b/tasks/move-granules/tests/data/payload_iso.json
@@ -20,7 +20,7 @@
       "files": [
         {
           "regex": "^ATL08_[\\d]{14}_[\\d]{8}_004_[\\d]{2}\\.h5$",
-          "sampleFileName": "ATL08_20181027045009_04360109_004_01.h5",
+          "sampleFileName": "AFFTL08_20181027045009_04360109_004_01.h5",
           "bucket": "protected"
         },
         {
@@ -40,6 +40,7 @@
   "input": {
     "granules": [
       {
+        "collectionId": "ATL08___004",
         "granuleId": "ATL08_20181208064514_10790104_004_01",
         "files": [
           {

--- a/tasks/move-granules/tests/data/payload_iso_metadata.json
+++ b/tasks/move-granules/tests/data/payload_iso_metadata.json
@@ -75,6 +75,7 @@
   "input": {
     "granules": [
       {
+        "collectionId": "MOD11A1___006",
         "granuleId": "MOD11A1.A2017200.h19v04.006.2017201090724",
         "files": [
           {

--- a/tasks/move-granules/tests/test-index.js
+++ b/tasks/move-granules/tests/test-index.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const sinon = require('sinon');
 const test = require('ava');
+const keyBy = require('lodash/keyBy');
 const range = require('lodash/range');
 const proxyquire = require('proxyquire');
 const deepEqual = require('deep-equal');
@@ -30,7 +31,6 @@ const {
 } = require('@cumulus/common/test-utils');
 const { getDistributionBucketMapKey } = require('@cumulus/distribution-utils');
 const { isECHO10Filename, isISOFilename } = require('@cumulus/cmrjs/cmr-utils');
-const { keyBy } = require('lodash/keyBy');
 
 const { updateGranuleMetadata } = require('..');
 
@@ -208,7 +208,6 @@ test('updateGranuleMetadata edits a copy of granules object without altering ori
   t.deepEqual(granulesById, granulesCopy);
   t.false(deepEqual(granulesObject, output.granules));
 });
-
 
 test.serial('Should move files to final location.', async (t) => {
   const newPayload = buildPayload(t);
@@ -879,7 +878,7 @@ test.serial('new collection causes granule to move to that collection', async (t
         sampleFileName: 'MOD11A1.A2017200.h19v04.006.2017201090724_1.jpg',
         bucket: 'public',
         url_path: 'jpg/example2/',
-      }
+      },
     ],
     url_path: 'example2/{extractYear(cmrMetadata.Granule.Temporal.RangeDateTime.BeginningDateTime)}/',
     name: 'MOD11A2',
@@ -888,23 +887,22 @@ test.serial('new collection causes granule to move to that collection', async (t
     process: 'modis',
     version: '006',
     sampleFileName: 'MOD11A1.A2017200.h19v04.006.2017201090724.hdf',
-    id: 'MOD11A2'
+    id: 'MOD11A2',
   };
-  t.context.payload.config.collection = newCollection
-  t.context.payload.input.granules = firstOutput.granules
-  const newPayload = buildCollectionMovePayload(t)
+  t.context.payload.config.collection = newCollection;
+  t.context.payload.input.granules = firstOutput.granules;
+  const newPayload = buildCollectionMovePayload(t);
   const expectedFileKeys = [
     'example2/2003/MOD11A1.A2017200.h19v04.006.2017201090724.hdf',
     'jpg/example2/MOD11A1.A2017200.h19v04.006.2017201090724_1.jpg',
     'example2/2003/MOD11A1.A2017200.h19v04.006.2017201090724_2.jpg',
     'example2/2003/MOD11A1.A2017200.h19v04.006.2017201090724.cmr.xml',
-  ]
+  ];
 
   const output = await moveGranules(newPayload);
   const outputFileKeys = output.granules[0].files.map((f) => f.key);
   t.deepEqual(expectedFileKeys.sort(), outputFileKeys.sort());
   await Promise.all(output.granules[0].files.map(async (fileObj) => {
-    t.true(await s3ObjectExists({ Bucket: fileObj.bucket, Key: fileObj.key }))
-  }))
-
-})
+    t.true(await s3ObjectExists({ Bucket: fileObj.bucket, Key: fileObj.key }));
+  }));
+});


### PR DESCRIPTION
**Summary:** allow configuration of moveGranules task with new collection in order to move a granule to the given collection, along with its files

Addresses [CUMULUS-3751: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3751)

## Changes

* moveGranules source bucket is no longer configured by config.bucket param, but by granule files configured bucket
* moveGranules target information is still configured by collection, but with an acceptance of "different" collection indicating a need to update granule in datastore and workflow, along with movement of files to target collection

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
