### PR TITLE
CUMULUS-3682 -- Update @cumulus/message.Granule to handle missing values in CMR metadata

### DIFF
--- a/packages/cmrjs/package.json
+++ b/packages/cmrjs/package.json
@@ -49,5 +49,8 @@
     "public-ip": "^5.0.0",
     "url-join": "^1.0.0",
     "xml2js": "0.5.0"
+  },
+  "devDependencies": {
+    "@cumulus/types": "19.1.0"
   }
 }

--- a/packages/cmrjs/src/cmr-utils.js
+++ b/packages/cmrjs/src/cmr-utils.js
@@ -1084,7 +1084,8 @@ async function getUserAccessibleBuckets(edlUser, cmrProvider = process.env.cmr_p
  * Extract temporal information from granule object
  *
  * @param {Object} granule - granule object
- * @returns {Promise<Object>} - temporal information (beginningDateTime,
+ * @returns {Promise<import('@cumulus/types').PartialGranuleProcessingInfo>}
+ * - temporal information (beginningDateTime,
  *    endingDateTime, productionDateTime, lastUpdateDateTime) of the granule if
  *    available.
  */

--- a/packages/message/src/types.ts
+++ b/packages/message/src/types.ts
@@ -1,5 +1,5 @@
 import { Message } from '@cumulus/types';
-import { GranuleTemporalInfo, MessageGranule } from '@cumulus/types/api/granules';
+import { PartialGranuleProcessingInfo, MessageGranule } from '@cumulus/types/api/granules';
 
 export interface WorkflowMessageTemplateCumulusMeta {
   queueExecutionLimits: Message.QueueExecutionLimits
@@ -18,5 +18,5 @@ export interface Workflow {
 }
 
 export interface CmrUtilsClass {
-  getGranuleTemporalInfo(granule: MessageGranule): Promise<GranuleTemporalInfo | {}>
+  getGranuleTemporalInfo(granule: MessageGranule): Promise<PartialGranuleProcessingInfo | {}>
 }

--- a/packages/types/api/granules.d.ts
+++ b/packages/types/api/granules.d.ts
@@ -25,7 +25,7 @@ export type NullablePartialType<T> = {
 };
 
 type PartialGranuleTemporalInfo = NullablePartialType<GranuleTemporalInfo>;
-type ParitalGranuleProcessingInfo = NullablePartialType<import('./executions').ExecutionProcessingTimes>;
+type PartialGranuleProcessingInfo = NullablePartialType<import('./executions').ExecutionProcessingTimes>;
 
 export type ApiGranuleRecord = {
   granuleId: string
@@ -46,7 +46,7 @@ export type ApiGranuleRecord = {
   timestamp?: number
   timeToArchive?: number
   timeToPreprocess?: number
-} & PartialGranuleTemporalInfo & ParitalGranuleProcessingInfo;
+} & PartialGranuleTemporalInfo & PartialGranuleProcessingInfo;
 
 export type ApiGranule = {
   granuleId: string
@@ -67,4 +67,4 @@ export type ApiGranule = {
   timestamp?: number | null
   timeToArchive?: number | null
   timeToPreprocess?: number | null
-} & PartialGranuleTemporalInfo & ParitalGranuleProcessingInfo;
+} & PartialGranuleTemporalInfo & PartialGranuleProcessingInfo;


### PR DESCRIPTION
This commit adds logic in convertDateToISOStringSettingNull to

- set '' as an expected null if encountered in any of the granule temporal fields handled by the Granules methods.
- Handle explicit undefined values by returning them rather than attempting to date convert them (the error case for this ticket)

This update should be compatible with api granule write logic in that it's preserving the intent of implicit undefined values while allowing for explicit undefineds that weren't originally part of the expected typing coming from the CMR metadata spec.

**Summary:** Summary of changes

Addresses [CUMULUS-3682](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3682)

## Changes

* Detailed list or prose of changes
* ...

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
