### PR TITLE
Address audit issue and update integration test bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - **CUMULUS-3876**
   - Fixed `s3-replicator` lambda cross region write failure
   - Added `target_region` variable to `tf-modules/s3-replicator` module
+- **Security Vulnerabilities**
+  - Updated `@octokit/graphql` from 2.1.1 to ^2.3.0 to address [CVE-2024-21538]
+    (https://github.com/advisories/GHSA-3xgq-45jj-v275)
 
 ## [v19.1.0] 2024-10-07
 

--- a/example/spec/parallel/cnmWorkflow/KinesisTestTriggerSpec.js
+++ b/example/spec/parallel/cnmWorkflow/KinesisTestTriggerSpec.js
@@ -429,7 +429,7 @@ describe('The Cloud Notification Mechanism Kinesis workflow', () => {
       badRecord = cloneDeep(record);
       badRecord.identifier = randomString();
       // bad record has a file which doesn't exist
-      badRecord.product.files[0].uri = 's3://not-exist-bucket/somepath/somekey';
+      badRecord.product.files[0].uri = `s3://${testConfig.bucket}/somepath/key-does-not-exist`;
 
       await tryCatchExit(cleanUp, async () => {
         console.log(`Dropping bad record onto ${streamName}, recordIdentifier: ${badRecord.identifier}.`);

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@babel/eslint-parser": "^7.24.1",
     "@babel/preset-env": "^7.24.4",
     "@docusaurus/eslint-plugin": "^2.3.0",
-    "@octokit/graphql": "2.1.1",
+    "@octokit/graphql": "^2.3.0",
     "@smithy/types": "^2.11.0",
     "@types/aws-lambda": "^8.10.58",
     "@types/lodash": "^4.14.150",


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-XX: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-XXX)

## Changes

* Updated `@octokit/graphql` from 2.1.1 to ^2.3.0 to address
* Updated integration test to use configured bucket, `not-exist-bucket` bucket does exist

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
