### PR TITLE
Updated user-data for compatibility with Amazon Linux 2023 AMI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Add `force_new_deployment` to `cumulus_ecs_service` to allow users to force
     new task deployment on terraform redeploy.   See docs for more details:
     https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service#force_new_deployment"
+- **CUMULUS-3948**
+  - Updated user-data for compatibility with Amazon Linux 2023 AMI
 
 ### Fixed
 

--- a/tf-modules/cumulus/ecs_cluster_instance_autoscaling_cf_template.yml.tmpl
+++ b/tf-modules/cumulus/ecs_cluster_instance_autoscaling_cf_template.yml.tmpl
@@ -26,6 +26,7 @@ Resources:
           --==BOUNDARY==
           Content-Type: text/cloud-boothook; charset="us-ascii"
 
+          #!/bin/bash
           vgcreate docker /dev/xvdcz
 
           lvcreate -n docker-data -L${docker_volume_create_size}G docker
@@ -47,6 +48,7 @@ Resources:
           --==BOUNDARY==
           Content-Type: text/x-shellscript; charset="us-ascii"
 
+          #!/bin/bash
 %{ if efs_dns_name != null && efs_mount_point != null ~}
           AZ=$(curl http://169.254.169.254/latest/meta-data/placement/availability-zone)
 
@@ -82,9 +84,6 @@ Resources:
 
           aws s3 cp s3://${task_reaper_object.bucket}/${task_reaper_object.key} /usr/local/bin/task-reaper.sh
           chmod +x /usr/local/bin/task-reaper.sh
-          echo "$(echo '0,30 * * * * /usr/sbin/logrotate -v /etc/logrotate.conf' ; crontab -l)" | crontab -
-          sed -i 's/size.*/size 100M\n    dateformat -%Y%m%d%s\n    copytruncate/' /etc/logrotate.d/awslogs
-          sed -i 's/rotate 4/rotate 2/' /etc/logrotate.d/awslogs
           cat <<'EOF' >> /etc/cron.d/task-reaper
           PATH=/bin:/usr/local/bin
           AWS_DEFAULT_REGION=${region}


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3948: Update user-data with information necessary for Amazon Linux 2023 AMI](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3948)

## Changes

* Removed old awslogs log rotation since aws cloudwatch agent is now used instead of awslogs on the instance.
* Added a bash shebang at the start of both cloud-init scripts

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
