### PR TITLE
[CUMULUS-3955] Update migration to remove vacuum statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **CUMULUS-3955**
+  - Removed `VACUUM` statements from db migrations. In cases where the PG database is very large, these queries
+    can take a long time and exceed the Lambda timeout, causing failures on deployment.
 - **CUMULUS-3931**
   - Add `force_new_deployment` to `cumulus_ecs_service` to allow users to force
     new task deployment on terraform redeploy.   See docs for more details:

--- a/packages/db/src/migrations/20240125171703_update_granule_execution_cumulus_id_type.ts
+++ b/packages/db/src/migrations/20240125171703_update_granule_execution_cumulus_id_type.ts
@@ -5,10 +5,6 @@ export const up = async (knex: Knex): Promise<void> => {
   await knex.raw('ALTER TABLE executions ALTER COLUMN cumulus_id TYPE BIGINT, ALTER COLUMN parent_cumulus_id TYPE BIGINT');
   await knex.raw('ALTER TABLE granules_executions ALTER COLUMN granule_cumulus_id TYPE BIGINT, ALTER COLUMN execution_cumulus_id TYPE BIGINT');
   await knex.raw('ALTER TABLE pdrs ALTER COLUMN execution_cumulus_id TYPE BIGINT');
-  await knex.raw('VACUUM (ANALYZE, VERBOSE) executions');
-  await knex.raw('VACUUM (ANALYZE, VERBOSE) files');
-  await knex.raw('VACUUM (ANALYZE, VERBOSE) granules_executions');
-  await knex.raw('VACUUM (ANALYZE, VERBOSE) pdrs');
 };
 
 export const down = async (): Promise<void> => {

--- a/packages/db/src/migrations/20240728101230_add_table_indexes.ts
+++ b/packages/db/src/migrations/20240728101230_add_table_indexes.ts
@@ -24,15 +24,6 @@ export const up = async (knex: Knex): Promise<void> => {
   await knex.raw('CREATE INDEX CONCURRENTLY IF NOT EXISTS providers_updated_at_index ON providers(updated_at)');
 
   await knex.raw('CREATE INDEX CONCURRENTLY IF NOT EXISTS rules_updated_at_index ON rules(updated_at)');
-
-  await knex.raw('VACUUM (ANALYZE, VERBOSE) async_operations');
-  await knex.raw('VACUUM (ANALYZE, VERBOSE) collections');
-  await knex.raw('VACUUM (ANALYZE, VERBOSE) executions');
-  await knex.raw('VACUUM (ANALYZE, VERBOSE) files');
-  await knex.raw('VACUUM (ANALYZE, VERBOSE) granules');
-  await knex.raw('VACUUM (ANALYZE, VERBOSE) pdrs');
-  await knex.raw('VACUUM (ANALYZE, VERBOSE) providers');
-  await knex.raw('VACUUM (ANALYZE, VERBOSE) rules');
 };
 
 export const down = async (knex: Knex): Promise<void> => {


### PR DESCRIPTION
This changes an existing db migration to remove VACUUM statements. If run in a Lambda env, these can cause timeouts on large datasets. See ticket for more details.