### PR TITLE
CUMULUS-3965:Update launch templates to require IMDSv2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     user-data for compatibility with Amazon Linux 2023 AMI
   - Fixed `tf-modules/cumulus` scripts to use Instance Metadata Service V2
   - Updated `fake-provider-cf.yml` to work for Amazon Linux 2023 AMI
+- **CUMULUS-3965**
+  - Updated `tf-modules/cumulus/ecs_cluster` and `fake-provider-cf.yml` launch templates to require IMDSv2 
 
 ### Fixed
 

--- a/example/fake-provider-cf.yml
+++ b/example/fake-provider-cf.yml
@@ -99,6 +99,8 @@ Resources:
       LaunchTemplateData:
         IamInstanceProfile:
           Arn: !GetAtt InstanceProfile.Arn
+        MetadataOptions:
+          HttpTokens: required
         ImageId: !Ref LatestAmiId
         Monitoring:
           Enabled: false

--- a/tf-modules/cumulus/ecs_cluster.tf
+++ b/tf-modules/cumulus/ecs_cluster.tf
@@ -260,6 +260,9 @@ resource "aws_launch_template" "ecs_cluster_instance" {
   iam_instance_profile {
     arn = aws_iam_instance_profile.ecs_cluster_instance.arn
   }
+  metadata_options {
+    http_tokens = "required"
+  }
   monitoring {
     enabled = true
   }


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3965: Cumulus ECS Auto Scaling to require Instance Metadata Service Version 2 (IMDSv2)](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3965)

## Changes

* Update launch templates to require IMDSv2

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
