### PR TITLE
CUMULUS-3978:Add iops and throughput options to elasticsearch_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - **CUMULUS-3919**
   - Added terraform variables `disableSSL` and `rejectUnauthorized` to `tf-modules/cumulus-rds-tf` module.
+- **CUMULUS-3978**
+  - Added `iops` and `throughput` options to `elasticsearch_config` variable
+    in `tf-modules/data-persistence`; These two options are necessary for gp3 EBS volume type.
 
 ### Changed
 

--- a/example/data-persistence-tf/variables.tf
+++ b/example/data-persistence-tf/variables.tf
@@ -43,6 +43,8 @@ variable "elasticsearch_config" {
     version        = string
     volume_size    = number
     volume_type    = string
+    iops           = optional(number)
+    throughput     = optional(number)
   })
   default = {
     domain_name    = "es"

--- a/tf-modules/data-persistence/elasticsearch.tf
+++ b/tf-modules/data-persistence/elasticsearch.tf
@@ -96,6 +96,8 @@ resource "aws_elasticsearch_domain" "es_vpc" {
     ebs_enabled = true
     volume_type = var.elasticsearch_config.volume_type
     volume_size = var.elasticsearch_config.volume_size
+    iops        = var.elasticsearch_config.iops
+    throughput  = var.elasticsearch_config.throughput
   }
 
   advanced_options = {

--- a/tf-modules/data-persistence/variables.tf
+++ b/tf-modules/data-persistence/variables.tf
@@ -26,6 +26,9 @@ variable "elasticsearch_config" {
     version        = string
     volume_type    = string
     volume_size    = number
+    iops           = optional(number)
+    throughput     = optional(number)
+
   })
   default = {
     domain_name    = "es"


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3978: Add iops and throughput options to elasticsearch_config](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3978)

## Changes

* Add iops and throughput options to elasticsearch_config

### Tested with the following configuration
elasticsearch_config = {
  domain_name    = "es"
  instance_count = 1
  instance_type  = "m5.large.elasticsearch"
  version        = "5.3"
  volume_type    = "gp3"
  volume_size    = 10
  iops           = 3100
  throughput     = 130
}
## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
