### PR TITLE
CUMULUS-3981: AWS ServiceException has required $metadata field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Fixed `s3-replicator` lambda cross region write failure
   - Added `target_region` variable to `tf-modules/s3-replicator` module
 - **CUMULUS-3981**
-  - Fixed
+  - Added required $metadata field when creating new instance of ServiceException.
 - **Security Vulnerabilities**
   - Updated `@octokit/graphql` from 2.1.1 to ^2.3.0 to address [CVE-2024-21538]
     (https://github.com/advisories/GHSA-3xgq-45jj-v275)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - **CUMULUS-3876**
   - Fixed `s3-replicator` lambda cross region write failure
   - Added `target_region` variable to `tf-modules/s3-replicator` module
+- **CUMULUS-3981**
+  - Fixed
 - **Security Vulnerabilities**
   - Updated `@octokit/graphql` from 2.1.1 to ^2.3.0 to address [CVE-2024-21538]
     (https://github.com/advisories/GHSA-3xgq-45jj-v275)

--- a/packages/api/tests/endpoints/test-execution-status.js
+++ b/packages/api/tests/endpoints/test-execution-status.js
@@ -165,7 +165,7 @@ const stepFunctionMock = {
 const executionExistsMock = (arn) => {
   if ((arn.executionArn === expiredExecutionArn)
       || (arn.executionArn === expiredMissingExecutionArn)) {
-    const error = new StepFunctions.ExecutionDoesNotExist();
+    const error = new StepFunctions.ExecutionDoesNotExist({ $metadata: {} });
     return Promise.reject(error);
   }
 

--- a/packages/api/tests/lambdas/test-sf-starter.js
+++ b/packages/api/tests/lambdas/test-sf-starter.js
@@ -197,7 +197,7 @@ test.serial('handleEvent deletes message if execution already exists', async (t)
 
   const stubSFNThrowError = () => ({
     startExecution: () => {
-      throw new ExecutionAlreadyExists();
+      throw new ExecutionAlreadyExists({ $metadata: {} });
     },
   });
   const revert = sfStarter.__set__('sfn', stubSFNThrowError);
@@ -297,7 +297,7 @@ test.serial('handleThrottledEvent logs error and deletes message when execution 
       promise: async () => {
         const response = await semaphore.get(queueUrl);
         t.is(response.semvalue, 1);
-        throw new ExecutionAlreadyExists();
+        throw new ExecutionAlreadyExists({ $metadata: {} });
       },
     }),
   });
@@ -406,7 +406,7 @@ test.serial('handleSourceMappingEvent calls dispatch on messages in an EventSour
   };
   const stubSFNThrowError = () => ({
     startExecution: () => {
-      throw new ExecutionAlreadyExists();
+      throw new ExecutionAlreadyExists({ $metadata: {} });
     },
   });
   const stubSFNRandomThrowError = () => ({

--- a/packages/aws-client/tests/test-Kinesis.js
+++ b/packages/aws-client/tests/test-Kinesis.js
@@ -37,7 +37,7 @@ test.serial('describeStream returns stream on retry', async (t) => {
   const describeStreamStub = sinon.stub(kinesis(), 'describeStream').callsFake(() => {
     if (retryCount < maxRetries) {
       retryCount += 1;
-      throw new ResourceNotFoundException({ message: 'not found' });
+      throw new ResourceNotFoundException({ message: 'not found', $metadata: {} });
     } else {
       return { StreamDescription: {} };
     }

--- a/packages/aws-client/tests/test-StepFunctions.js
+++ b/packages/aws-client/tests/test-StepFunctions.js
@@ -167,7 +167,7 @@ test('doesExecutionExist() returns true if the Promise resolves', async (t) => {
 });
 
 test('doesExecutionExist() returns false if the Promise rejects with an ExecutionDoesNotExist name', async (t) => {
-  const err = new StepFunctions.ExecutionDoesNotExist();
+  const err = new StepFunctions.ExecutionDoesNotExist({ $metadata: {} });
   t.false(await StepFunctions.doesExecutionExist(Promise.reject(err)));
 });
 

--- a/tasks/pdr-status-check/tests/index.js
+++ b/tasks/pdr-status-check/tests/index.js
@@ -91,7 +91,7 @@ test.serial('returns the correct results in the nominal case', async (t) => {
   try {
     sfn.describeExecution = ({ executionArn }) => {
       if (!executionStatuses[executionArn]) {
-        const error = new StepFunctions.ExecutionDoesNotExist();
+        const error = new StepFunctions.ExecutionDoesNotExist({ $metadata: {} });
         return Promise.reject(error);
       }
       return Promise.resolve({


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3981: Unit test failures due to package(ServiceException) updates](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3981)

## Changes

* Added required $metadata field when creating new instance of ServiceException.

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
