### PR TITLE
CUMULUS-3967 -- Forward port of release fix -- Pin @aws-sdk/client-s3 to 3.726 due to unit failure in > 3.729.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - **CUMULUS-3967**
   - Pinned @aws-sdk/client-s3 in @cumulus/aws-client to 3.726.0 to address breaking changes/incompatibility in releases > 3.726.0
+  - Pinned @aws-sdk/client-s3 in @cumulus/lib-storage to 3.726.0 to address breaking changes/incompatibility in releases > 3.726.0
 
 - **CUMULUS-3940**
   - Added 'dead_letter_recovery_cpu' and 'dead_letter_recovery_memory' to `cumulus` and `archive` module configuration to allow configuration of the dead_letter_recovery_operation task definition to better allow configuration of the tool's operating environment.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **CUMULUS-3967**
+  - Pinned @aws-sdk/client-s3 in @cumulus/aws-client to 3.726.0 to address breaking changes/incompatibility in releases > 3.726.0
+
 - **CUMULUS-3940**
   - Added 'dead_letter_recovery_cpu' and 'dead_letter_recovery_memory' to `cumulus` and `archive` module configuration to allow configuration of the dead_letter_recovery_operation task definition to better allow configuration of the tool's operating environment.
   - Updated the dead letter recovery tool to utilize it's own log group "${var.prefix}-DeadLetterRecoveryEcsLogs"

--- a/example/lambdas/s3AccessTest/package.json
+++ b/example/lambdas/s3AccessTest/package.json
@@ -18,6 +18,6 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.621.0"
+    "@aws-sdk/client-s3": "3.726.0"
   }
 }

--- a/example/lambdas/snsS3Test/package.json
+++ b/example/lambdas/snsS3Test/package.json
@@ -18,6 +18,6 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.621.0"
+    "@aws-sdk/client-s3": "3.726.0"
   }
 }

--- a/packages/aws-client/package.json
+++ b/packages/aws-client/package.json
@@ -64,7 +64,7 @@
     "@aws-sdk/client-sqs": "^3.621.0",
     "@aws-sdk/client-sts": "^3.621.0",
     "@aws-sdk/lib-dynamodb": "^3.621.0",
-    "@aws-sdk/lib-storage": "^3.621.0",
+    "@aws-sdk/lib-storage": "3.726.0",
     "@aws-sdk/s3-request-presigner": "^3.621.0",
     "@aws-sdk/signature-v4-crt": "^3.621.0",
     "@aws-sdk/types": "^3.609.0",

--- a/packages/aws-client/package.json
+++ b/packages/aws-client/package.json
@@ -57,7 +57,7 @@
     "@aws-sdk/client-kinesis": "^3.621.0",
     "@aws-sdk/client-kms": "^3.621.0",
     "@aws-sdk/client-lambda": "^3.621.0",
-    "@aws-sdk/client-s3": "^3.621.0",
+    "@aws-sdk/client-s3": "3.726.0",
     "@aws-sdk/client-secrets-manager": "^3.621.0",
     "@aws-sdk/client-sfn": "^3.621.0",
     "@aws-sdk/client-sns": "^3.621.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -44,7 +44,7 @@
   "author": "Cumulus Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.621.0",
+    "@aws-sdk/client-s3": "3.726.0",
     "@aws-sdk/signature-v4-crt": "^3.621.0",
     "@cumulus/aws-client": "19.1.0",
     "@cumulus/errors": "19.1.0",

--- a/tf-modules/internal/cumulus-test-cleanup/package.json
+++ b/tf-modules/internal/cumulus-test-cleanup/package.json
@@ -16,7 +16,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/client-kinesis": "^3.621.0",
-    "@aws-sdk/client-s3": "^3.621.0",
+    "@aws-sdk/client-s3": "3.726.0",
     "@aws-sdk/signature-v4-crt": "^3.621.0",
     "moment": "^2.30.1"
   },


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses fix found in [CUMULUS-3967 ](https://bugs.earthdata.nasa.gov/browse/CUMULUS-XXX) -- dependency issue with s3-client's `  moveObject() moves a 0 byte file` test throwing 

  Rejected promise returned by test. Reason:

  InternalError (S3ServiceException) {
    $fault: 'client',
    $metadata: {
      attempts: 3,
      cfId: undefined,
      extendedRequestId: 's9lzHYrFp76ZVxRcpX9+5cjAnEH2ROuNkd2BHfIa6UkFVdtjf5mKR3/eTPFvsiP/XV/VLi31234=',
      httpStatusCode: 500,
      requestId: 'fec3950c-a7d2-4935-b05a-b6e68e50e407',
      totalRetryDelay: 222,
    },
    Code: 'InternalError',
    RequestId: 'fec3950c-a7d2-4935-b05a-b6e68e50e407',
    message: 'exception while calling s3.PutObject: \'NoneType\' object has no attribute \'to_bytes\'',
  }
  
 
 This appears to be due to a change in the client-s3 releases after 3.729.  