### PR TITLE
CUMULUS-4006: update changelog and release instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,8 +65,7 @@ External tooling making use of `searchContext` in the `GET` `/granules/` endpoin
 
 #### CUMULUS-4006
 
-The async_operation_image property of the cumulus module should be updated to pull the ECR image
-for cumuluss/async-operation:53.
+The async_operation_image property of the cumulus module should be [updated to pull the ECR image for cumuluss/async-operation:53](./packages/api/ecs/async-operation/README.md).
 This version of the image will be made the default in the next release.
 
 ### Replace ElasticSearch Phase 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Notable Changes
+
+- The async_operation_image property of cumulus module should be updated to pull
+  the ECR image for cumuluss/async-operation:53
+
+### Fixed
+
+- **CUMULUS-4006**
+  - Created docker image from v20.0.0, and published new tag [`53` of `cumuluss/async-operation` to Docker Hub](https://hub.docker.com/layers/cumuluss/async-operation/53/images/sha256-6e1b26f5933bc6685861a7cb31fbbace01c3a0090b1e41c26e313b15620762cc?context=explore)
+
 ## [v20.0.0] 2025-02-04
 
 ## Phase 2 Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Notable Changes
 
-- The async_operation_image property of cumulus module should be updated to pull
+- The async_operation_image property of the cumulus module should be updated to pull
   the ECR image for cumuluss/async-operation:53
 
 ### Fixed
@@ -62,6 +62,12 @@ aws lambda invoke --function-name $PREFIX-ReconciliationReportMigration $OUTFILE
 #### CUMULUS-3967
 
 External tooling making use of `searchContext` in the `GET` `/granules/` endpoint will need to update to make use of standard pagination via `limit` and `page` scrolling, as `searchContext` is no longer supported/is an ES specific feature.
+
+#### CUMULUS-4006
+
+The async_operation_image property of the cumulus module should be updated to pull the ECR image
+for cumuluss/async-operation:53.
+This version of the image will be made the default in the next release.
 
 ### Replace ElasticSearch Phase 2
 

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -380,7 +380,12 @@ module "cumulus" {
 }
 ```
 
-### 15. Merge base branch back to master
+### 15. Publish async_operations image to Docker Hub and AWS ECR
+
+If ____, then a [new docker image for async_operations should be created and published](https://github.com/nasa/cumulus/blob/master/packages/api/ecs/async-operation/README.md).
+The changelog should also be updated to reflect this update.
+
+### 16. Merge base branch back to master
 
 Finally, you need to reproduce the version update changes back to master.
 

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -382,8 +382,9 @@ module "cumulus" {
 
 ### 15. Publish async_operations image to Docker Hub and AWS ECR
 
-If ____, then a [new docker image for async_operations should be created and published](https://github.com/nasa/cumulus/blob/master/packages/api/ecs/async-operation/README.md).
-The changelog should also be updated to reflect this update.
+If there were any changes that modify the functionality of the async-operations image *or* patch underlying packages for security reasons,
+a [new docker image for async_operations should be created and published](https://github.com/nasa/cumulus/blob/master/packages/api/ecs/async-operation/README.md).
+The changelog should also be updated accordingly.
 
 ### 16. Merge base branch back to master
 

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -170,17 +170,22 @@ If there is exists a PR in the cumulus-dashboard repo with a name containing: "V
 - There will be a placeholder `change-me` value that should be replaced with the Cumulus Core to-be-released-version.
 - Mark that PR as ready to be reviewed.
 
-### 4. Update CHANGELOG.md
+### 4. Publish async_operations image to Docker Hub and AWS ECR
+
+For consistency and security reasons, a [new docker image for async_operations should be created and published](../../packages/api/ecs/async-operation/README.md)
+for each release. Make sure to follow the instructions for *Updating the Cumulus deployment configuration*
+
+### 5. Update CHANGELOG.md
 
 Update the `CHANGELOG.md`. Put a header under the `Unreleased` section with the new version number and the date.
 
-Add a link reference for the github "compare" view at the bottom of the `CHANGELOG.md`, following the existing pattern. This link reference should create a link in the CHANGELOG's release header to changes in the corresponding release.
+Add a notice for the new async_operations image. Add a link reference for the github "compare" view at the bottom of the `CHANGELOG.md`, following the existing pattern. This link reference should create a link in the CHANGELOG's release header to changes in the corresponding release.
 
-### 5. Update DATA\_MODEL\_CHANGELOG.md
+### 6. Update DATA\_MODEL\_CHANGELOG.md
 
 Similar to #4, make sure the DATA\_MODEL\_CHANGELOG is updated if there are data model changes in the release, and the link reference at the end of the document is updated as appropriate.
 
-### 6. Update CONTRIBUTORS.md
+### 7. Update CONTRIBUTORS.md
 
 ```bash
 ./bin/update-contributors.sh
@@ -189,7 +194,7 @@ git add CONTRIBUTORS.md
 
 Commit and push these changes, if any.
 
-### 7. Update Cumulus package API documentation
+### 8. Update Cumulus package API documentation
 
 Update auto-generated API documentation for any Cumulus packages that have it:
 
@@ -199,7 +204,7 @@ npm run docs-build-packages
 
 Commit and push these changes, if any.
 
-### 8. Cut new version of Cumulus Documentation
+### 9. Cut new version of Cumulus Documentation
 
 Docusaurus v2 uses snapshot approach for [documentation versioning](https://docusaurus.io/docs/versioning). Every versioned docs
 does not depends on other version.
@@ -230,7 +235,7 @@ Where `${release_version}` corresponds to the version tag `v1.2.3`, for example.
 
 Commit and push these changes.
 
-### 9. Create a pull request against the minor version branch
+### 10. Create a pull request against the minor version branch
 
 1. Push the release branch (e.g. `release-1.2.3`) to GitHub.
 2. Create a PR against the minor version base branch (e.g. `release-1.2.x`).
@@ -251,7 +256,7 @@ Commit and push these changes.
     - It **is safe** to do a squash merge in this instance, but not required
 5. You may delete your release branch (`release-1.2.3`) after merging to the base branch.
 
-### 10. Create a git tag for the release
+### 11. Create a git tag for the release
 
 Check out the minor version base branch (`release-1.2.x`) now that your changes are merged in and do a `git pull`.
 
@@ -268,7 +273,7 @@ e.g.:
     git push origin v9.1.0
 ```
 
-### 11. Publishing the release
+### 12. Publishing the release
 
 Publishing of new releases is handled by a custom Bamboo branch plan and is manually triggered.
 
@@ -323,7 +328,7 @@ If this is a new minor version branch, then you will need to create a new Bamboo
 
 Bamboo will build and run lint and unit tests against that tagged release, publish the new packages to NPM, and then run the integration tests using those newly released packages.
 
-### 12. Create a new Cumulus release on github
+### 13. Create a new Cumulus release on github
 
 The CI release scripts will automatically create a GitHub release based on the release version tag, as well as upload artifacts to the Github release for the Terraform modules provided by Cumulus. The Terraform release artifacts include:
 
@@ -352,13 +357,13 @@ The "Publish" step in Bamboo will push the release artifcats to GitHub (and NPM)
 
 :::
 
-### 13. Update Cumulus API document
+### 14. Update Cumulus API document
 
 There may be unreleased changes in the [Cumulus API document](https://github.com/nasa/cumulus-api) that are waiting on the Cumulus Core release.
 If there are unrelease changes in the cumulus-api repo, follow the release instruction to create the release, the release version should match
 the Cumulus Core release.
 
-### 14. Update Cumulus Template Deploy
+### 15. Update Cumulus Template Deploy
 
 Users are encouraged to use our [Cumulus Template Deploy Project](https://github.com/nasa/cumulus-template-deploy) for deployments. The Cumulus Core version should be updated in this repo when a new Cumulus Core version is released.
 
@@ -379,12 +384,6 @@ module "cumulus" {
   ...
 }
 ```
-
-### 15. Publish async_operations image to Docker Hub and AWS ECR
-
-If there were any changes that modify the functionality of the async-operations image *or* patch underlying packages for security reasons,
-a [new docker image for async_operations should be created and published](https://github.com/nasa/cumulus/blob/master/packages/api/ecs/async-operation/README.md).
-The changelog should also be updated accordingly.
 
 ### 16. Merge base branch back to master
 

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -173,7 +173,7 @@ If there is exists a PR in the cumulus-dashboard repo with a name containing: "V
 ### 4. Publish async_operations image to Docker Hub and AWS ECR
 
 For consistency and security reasons, a [new docker image for async_operations should be created and published](../../packages/api/ecs/async-operation/README.md)
-for each release. Make sure to follow the instructions for *Updating the Cumulus deployment configuration*
+for each release. Make sure to follow the instructions for **Updating the Cumulus deployment configuration**
 
 ### 5. Update CHANGELOG.md
 

--- a/packages/api/ecs/async-operation/README.md
+++ b/packages/api/ecs/async-operation/README.md
@@ -21,9 +21,13 @@ The built image is deployed to
 
 Logs will be output to `${stackName}-${OperationName}EcsLogs`
 
+## Development
+If you are making changes to this section of the repo, including security patches, you will need to follow the steps to
+build the Docker image, push the image to ECR, update the [example deployment](../../../../example/cumulus-tf/), and run your changes in Bamboo.
+
 ## Building and pushing Docker images
 
-For the following commands, replace `<build-number>` with the next build number. You can
+This step should be done as part of the release process. For the following commands, replace `<build-number>` with the next build number. You can
 find the latest build number at <https://hub.docker.com/r/cumuluss/async-operation/tags>.
 Currently we are using a regular number as the build number (e.g. `41`) and not a semantic
 versioning string (e.g. `1.0.0`).
@@ -44,7 +48,8 @@ Then you can push the new image to Dockerhub:
 
 We also keep a copy of this Docker image in the AWS ECR service for all of our Cumulus
 testing accounts in order to work around limits on how many times an image can be pulled
-from DockerHub.
+from DockerHub. This step may be done as part of the release process, but more likely should
+be done as part of development and testing of a change or update.
 
 **IMPORTANT: You must follow these steps to push the image to ECR in both the Cumulus sandbox and SIT accounts.**
 
@@ -63,9 +68,9 @@ Lastly, you can push the image to ECR in the AWS account:
 docker push <AWS_ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/async_operations:<build-number>
 ```
 
-## Updating Cumulus deployment configuration
+## Updating the Cumulus deployment configuration
 
-Once you have built a new image, you should configure the Cumulus Terraform module to use that new image by updating the `async_operation_image` variable in the
+This step should also be done as part of the release process. Once you have built a new image, you should configure the Cumulus Terraform module to use that new image by updating the `async_operation_image` variable in the
 [`variables.tf` file for the `cumulus` module](../../../../tf-modules/cumulus/variables.tf)
 to match the new `<build-number>`.
 

--- a/tf-modules/cumulus/variables.tf
+++ b/tf-modules/cumulus/variables.tf
@@ -3,7 +3,7 @@
 variable "async_operation_image" {
   description = "docker image to use for Cumulus async operations tasks"
   type = string
-  default = "cumuluss/async-operation:52"
+  default = "cumuluss/async-operation:53"
 }
 
 variable "cmr_client_id" {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-4006: Bulk Operations status not updating in Cumulus v20](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4006)

## Changes

* Detailed list or prose of changes
* ...

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
