### PR TITLE
CUMULUS-3992: Jk/cumulus 3992 fix options

### DIFF
--- a/packages/api/endpoints/granules.js
+++ b/packages/api/endpoints/granules.js
@@ -954,7 +954,7 @@ const bulkChangeCollectionSchema = z.object({
   targetCollectionId: z.string().nonempty('targetCollectionId is required'),
   batchSize: z.number().positive().optional().default(100),
   concurrency: z.number().positive().optional().default(100),
-  invalidBehavior: z.enum(['error', 'skip']).default('error'),
+  invalidGranuleBehavior: z.enum(['error', 'skip']).default('error'),
   cmrGranuleUrlType: z.enum(['http', 's3', 'both']).default('both'),
   s3MultipartChunkSizeMb: z.number().optional(),
   executionName: z.string().optional(),
@@ -972,7 +972,7 @@ const parsebulkChangeCollectionPayload = zodParser('bulkChangeCollection payload
  * @param {number} [req.body.batchSize=100] - The batch size for processing granules.
  * @param {number} [req.body.concurrency=100] - The per-file concurrency level for processing
  * granules and granule records
- * @param {string} [req.body.invalidBehavior='error'] - The behavior for invalid granules
+ * @param {string} [req.body.invalidGranuleBehavior='error'] - The behavior for invalid granules
  * ('error' or 'skip').
  * @param {number} [req.body.s3MultipartChunkSizeMb] - The S3 multipart chunk size in MB
  * @param {string} [req.body.executionName] - Override to allow specifying an execution 'name'
@@ -1069,7 +1069,7 @@ async function bulkChangeCollection(req, res) {
         cmrGranuleUrlType: body.cmrGranuleUrlType,
         concurrency: body.concurrency,
         dbMaxPool: body.dbMaxPool,
-        invalidBehavior: body.invalidBehavior,
+        invalidGranuleBehavior: body.invalidGranuleBehavior,
         s3MultipartChunkSizeMb: body.s3MultipartChunkSizeMb,
         targetCollection: deconstructCollectionId(body.targetCollectionId),
       },

--- a/packages/api/tests/endpoints/test-granules-bulkChangeCollection.js
+++ b/packages/api/tests/endpoints/test-granules-bulkChangeCollection.js
@@ -247,7 +247,7 @@ test.serial('bulkChangeCollection generates the proper payload and calls startEx
   });
 
   const testBodyValues = {
-    invalidBehavior: 'error',
+    invalidGranuleBehavior: 'error',
     s3MultipartChunkSizeMb: 500,
     batchSize: 200,
     concurrency: 50,
@@ -306,7 +306,7 @@ test.serial('bulkChangeCollection handles ExecutionAlreadyExists error correctly
     body: {
       batchSize: 100,
       concurrency: 10,
-      invalidBehavior: 'error',
+      invalidGranuleBehavior: 'error',
       sourceCollectionId: t.context.collectionId,
       targetCollectionId: t.context.collectionId2,
     },
@@ -342,7 +342,7 @@ test.serial('bulkChangeCollection errors correctly when workflow configuration f
     body: {
       batchSize: 100,
       concurrency: 10,
-      invalidBehavior: 'error',
+      invalidGranuleBehavior: 'error',
       sourceCollectionId: t.context.collectionId,
       targetCollectionId: t.context.collectionId2,
     },
@@ -375,7 +375,7 @@ test.serial('bulkChangeCollection handles a collection with zero granules correc
     body: {
       batchSize: 100,
       concurrency: 10,
-      invalidBehavior: 'error',
+      invalidGranuleBehavior: 'error',
       sourceCollectionId: t.context.collectionId3,
       targetCollectionId: t.context.collectionId,
     },


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3992](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3992)

## Changes

* Minor update to change API parameter `invalidBehavior` ->  `invalidGranuleBehavior` to match downstream task. 
