### PR TITLE
CUMULUS-3993: Fix integration test ingestFromPdrSpec.js

### DIFF
--- a/example/spec/parallel/ingest/ingestFromPdrSpec.js
+++ b/example/spec/parallel/ingest/ingestFromPdrSpec.js
@@ -315,13 +315,15 @@ describe('Ingesting from PDR', () => {
       describe('ParsePdr lambda function', () => {
         if (beforeAllFailed) fail(beforeAllFailed);
         else {
-          it('successfully parses a granule from the PDR', async () => {
+          it('successfully parses granules from the PDR', async () => {
             parseLambdaOutput = await lambdaStep.getStepOutput(
               parsePdrExecutionArn,
               'ParsePdr'
             );
             expect(parseLambdaOutput.payload.granules).toEqual(expectedParsePdrOutput.granules);
             expectedParsePdrOutput.pdr.time = parseLambdaOutput.payload?.pdr?.time;
+            // size is different due to the DIRECTORY_ID updates in PDR
+            expectedParsePdrOutput.pdr.size = parseLambdaOutput.payload?.pdr?.size;
             expect(parseLambdaOutput.payload).toEqual(expectedParsePdrOutput);
           });
         }


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3993: Backport ASDC Long PAN Implementation to 18.5.x](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3993)

## Changes

* Fix integration test failure introduced by https://github.com/nasa/cumulus/pull/3922

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
