### PR TITLE
DUPLICATE - CUMULUS-3842 Delete DynamoDB ReconciliationReportsTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Changed
-
+ 
 - **CUMULUS-3994**
-  - Removed references to elasticsearch in data-persistence
+  - Removed references to elasticsearch in data-persistence Terraform module and example.
+  - Running `terraform apply` on this change will **permanently delete** the elasticsearch domain and all of the the data it contains.
+  - Ensure that the elasticsearch domain is not longer needed before applying this update.
   
 ### Notable Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Removed references to elasticsearch in data-persistence Terraform module and example.
   - Running `terraform apply` on this change will **permanently delete** the elasticsearch domain and all of the the data it contains.
   - Ensure that the elasticsearch domain is not longer needed before applying this update.
-  
+
+- **CUMULUS-3842**
+  - Removed references to the DynamoDB table named `{prefix}-ReconciliationReportsTable` in data-persistence Terraform module.
+  - Running `terraform apply` on this change will **permanently delete** the DynamoDB table named `{prefix}-ReconciliationReportsTable` and all of the the data it contains.
+  - Ensure that this DynamoDB table named `{prefix}-ReconciliationReportsTable` is not longer needed before applying this update.
+
 ### Notable Changes
 
 - The async_operation_image property of the cumulus module should be updated to pull

--- a/tf-modules/archive/api.tf
+++ b/tf-modules/archive/api.tf
@@ -3,7 +3,6 @@ resource "aws_ssm_parameter" "dynamo_table_names" {
   type = "String"
   value = jsonencode({
     AccessTokensTable          = var.dynamo_tables.access_tokens.name
-    ReconciliationReportsTable = var.dynamo_tables.reconciliation_reports.name
   })
 }
 locals {
@@ -13,7 +12,6 @@ locals {
   api_redirect_uri          = "${local.api_uri}token"
   dynamo_table_namestring   = jsonencode({
     AccessTokensTable          = var.dynamo_tables.access_tokens.name
-    ReconciliationReportsTable = var.dynamo_tables.reconciliation_reports.name
   })
   api_env_variables = {
         auth_mode                      = "public"

--- a/tf-modules/data-persistence/dynamo.tf
+++ b/tf-modules/data-persistence/dynamo.tf
@@ -2,7 +2,6 @@ locals {
   enable_point_in_time_table_names = [for x in var.enable_point_in_time_tables : "${var.prefix}-${x}"]
   table_names = {
     access_tokens_table          = "${var.prefix}-AccessTokensTable"
-    reconciliation_reports_table = "${var.prefix}-ReconciliationReportsTable"
     semaphores_table             = "${var.prefix}-SemaphoresTable"
   }
 }
@@ -24,30 +23,6 @@ resource "aws_dynamodb_table" "access_tokens_table" {
 
   point_in_time_recovery {
     enabled = contains(local.enable_point_in_time_table_names, local.table_names.access_tokens_table)
-  }
-
-  lifecycle {
-    prevent_destroy = true
-    ignore_changes = [ name ]
-  }
-
-  tags = var.tags
-}
-
-resource "aws_dynamodb_table" "reconciliation_reports_table" {
-  name             = local.table_names.reconciliation_reports_table
-  billing_mode     = "PAY_PER_REQUEST"
-  hash_key         = "name"
-  stream_enabled   = true
-  stream_view_type = "NEW_AND_OLD_IMAGES"
-
-  attribute {
-    name = "name"
-    type = "S"
-  }
-
-  point_in_time_recovery {
-    enabled = contains(local.enable_point_in_time_table_names, local.table_names.reconciliation_reports_table)
   }
 
   lifecycle {

--- a/tf-modules/data-persistence/outputs.tf
+++ b/tf-modules/data-persistence/outputs.tf
@@ -4,10 +4,6 @@ output "dynamo_tables" {
       name = aws_dynamodb_table.access_tokens_table.name,
       arn  = aws_dynamodb_table.access_tokens_table.arn
     }
-    reconciliation_reports = {
-      name = aws_dynamodb_table.reconciliation_reports_table.name
-      arn  = aws_dynamodb_table.reconciliation_reports_table.arn
-    }
     semaphores = {
       name = aws_dynamodb_table.semaphores_table.name
       arn  = aws_dynamodb_table.semaphores_table.arn


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3842: Delete DynamoDB ReconciliationReportsTable](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3842)

## Changes

* Delete DynamoDB ReconciliationReportsTable

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
