### PR TITLE
fix sftp client not connected bug

### DIFF
--- a/packages/sftp-client/src/index.ts
+++ b/packages/sftp-client/src/index.ts
@@ -60,6 +60,7 @@ export class SftpClient {
     if (config.privateKey) this.clientOptions.privateKey = config.privateKey;
 
     this.sftpClient = new Client();
+    this.connect();
   }
 
   async connect(): Promise<void> {


### PR DESCRIPTION
Running the basic usage code in docs does not work and always throw "Client not connected" error. Upon inspection I found that a `connect` method is defined that connects to an SFTP server. But that method is not called anywhere. This is fixed by calling `connect` in the constructor that then opens an SFTP connection for subsequent use.

**Summary:** Summary of changes

Addresses [CUMULUS-XX: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-XXX)

## Changes

* Detailed list or prose of changes
* ...

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
