### PR TITLE
CUMULUS-4019: Support case-insensitive comparison in lzards-backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - **CUMULUS-3994**
   - Removed references to elasticsearch in data-persistence
+
+- **CUMULUS-4019**
+  - Made checksum type name comparison case-insensitive in lzards-backup
   
 ### Notable Changes
 

--- a/tasks/lzards-backup/src/index.ts
+++ b/tasks/lzards-backup/src/index.ts
@@ -129,13 +129,13 @@ export const setLzardsChecksumQueryType = (
   file: MessageGranuleFilesObject,
   granuleId: string
 ) => {
-  if (file.checksumType === 'md5') {
+  if (file.checksumType?.toLowerCase() === 'md5') {
     return { expectedMd5Hash: file.checksum };
   }
-  if (file.checksumType === 'sha256') {
+  if (file.checksumType?.toLowerCase() === 'sha256') {
     return { expectedSha256Hash: file.checksum };
   }
-  if (file.checksumType === 'sha512') {
+  if (file.checksumType?.toLowerCase() === 'sha512') {
     return { expectedSha512Hash: file.checksum };
   }
   log.error(`${granuleId}: File ${buildS3Uri(file.bucket, file.key)} did not have a checksum or supported checksumType defined`);

--- a/tasks/lzards-backup/tests/test-index.js
+++ b/tasks/lzards-backup/tests/test-index.js
@@ -1446,3 +1446,19 @@ test.serial('backupGranulesToLzards returns failed record (by default) or throws
   const errorResults = JSON.parse(error.message).map((result) => result.value).flat();
   t.deepEqual(errorResults, expectedBackupResults);
 });
+
+test.serial('setLzardsChecksumQueryType is case insensitive', (t) => {
+  const granuleId = 'fakeGranuleId';
+
+  let file = { checksumType: 'MD5', checksum: 'md5Checksum' };
+  actual = index.setLzardsChecksumQueryType(file, granuleId);
+  t.deepEqual(actual.expectedMd5Hash, 'md5Checksum');
+
+  file = { checksumType: 'SHA256', checksum: 'sha256Checksum' };
+  actual = index.setLzardsChecksumQueryType(file, granuleId);
+  t.deepEqual(actual.expectedSha256Hash, 'sha256Checksum');
+
+  file = { checksumType: 'SHA512', checksum: 'sha512Checksum' };
+  actual = index.setLzardsChecksumQueryType(file, granuleId);
+  t.deepEqual(actual.expectedSha512Hash, 'sha512Checksum');
+});


### PR DESCRIPTION
**Summary:** Change comparison of checksum type names in lzards-backup to be case-insenstive

Addresses [CUMULUS-4019: Support case-insensitive comparison in lzards-backup](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4019)

## Changes

* Convert checksum type names to lowercase before comparison
* Add unit test

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
