### PR TITLE
CUMULUS-4018: Fix Postgres pagination missing records issue by sorting on cumulus_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - **CUMULUS-4006**
   - Created docker image from v20.0.0, and published new tag [`53` of `cumuluss/async-operation` to Docker Hub](https://hub.docker.com/layers/cumuluss/async-operation/53/images/sha256-6e1b26f5933bc6685861a7cb31fbbace01c3a0090b1e41c26e313b15620762cc?context=explore)
 
+- **CUMULUS-4018**
+  - Fixed Postgres pagination missing records issue by sorting on unique cumulus_id column
+
 ## [v20.0.0] 2025-02-04
 
 ## Phase 2 Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Created docker image from v20.0.0, and published new tag [`53` of `cumuluss/async-operation` to Docker Hub](https://hub.docker.com/layers/cumuluss/async-operation/53/images/sha256-6e1b26f5933bc6685861a7cb31fbbace01c3a0090b1e41c26e313b15620762cc?context=explore)
 
 - **CUMULUS-4018**
-  - Fixed Postgres pagination missing records issue by sorting on unique cumulus_id column
+  - Fixed API list endpoints pagination missing records issue by sorting on unique cumulus_id column
 
 ## [v20.0.0] 2025-02-04
 

--- a/packages/db/src/search/StatsSearch.ts
+++ b/packages/db/src/search/StatsSearch.ts
@@ -70,9 +70,8 @@ class StatsSearch extends BaseSearch {
 
   constructor(event: QueryEvent, type: string) {
     const { field, ...queryStringParameters } = event.queryStringParameters || {};
-    super({ queryStringParameters }, type);
+    super({ queryStringParameters: { ...queryStringParameters, limit: null } }, type);
     this.field = field ?? 'status';
-    this.dbQueryParameters = omit(this.dbQueryParameters, ['limit', 'offset']);
   }
 
   /**

--- a/packages/db/src/search/queries.ts
+++ b/packages/db/src/search/queries.ts
@@ -33,6 +33,14 @@ const regexes: { [key: string]: RegExp } = {
 };
 
 /**
+ * Based on PostgreSQL documentation, when using LIMIT, it is important to use
+ * an ORDER BY clause that constrains the result rows into a unique order.
+ * The following is the default sort column and order for the pagination.
+ */
+const defaultSortColumn = 'cumulus_id';
+const defaultSortOrder = 'asc';
+
+/**
  * Convert 'exists' query fields to db query parameters from api query string fields
  *
  * @param type - query record type
@@ -192,7 +200,7 @@ const convertSort = (
   queryStringParameters: QueryStringParameters
 ): SortType[] => {
   const sortArray: SortType[] = [];
-  const { sort_by: sortBy, sort_key: sortKey } = queryStringParameters;
+  const { sort_by: sortBy, sort_key: sortKey, limit } = queryStringParameters;
   let { order } = queryStringParameters;
   if (sortBy) {
     order = order ?? 'asc';
@@ -205,6 +213,11 @@ const convertSort = (
       return Object.keys(queryParam ?? {}).map((key) => sortArray.push({ column: key, order }));
     });
   }
+
+  if (limit !== null) {
+    sortArray.push({ column: defaultSortColumn, order: defaultSortOrder });
+  }
+
   return sortArray;
 };
 

--- a/packages/db/tests/search/test-PdrSearch.js
+++ b/packages/db/tests/search/test-PdrSearch.js
@@ -136,6 +136,7 @@ test.before(async (t) => {
 
 test('PdrSearch returns 10 PDR records by default', async (t) => {
   const { knex } = t.context;
+  const execution = `https://console.aws.amazon.com/states/home?region=us-east-1#/executions/details/${t.context.execution.arn}`;
   const dbSearch = new PdrSearch();
   const response = await dbSearch.query(knex);
 
@@ -146,7 +147,7 @@ test('PdrSearch returns 10 PDR records by default', async (t) => {
   const validatedRecords = apiPdrs.filter((pdr) => (
     [t.context.collectionId, t.context.collectionId2].includes(pdr.collectionId)
     && (pdr.provider === t.context.provider.name)
-    && (!pdr.execution || pdr.execution === t.context.execution.arn)));
+    && (!pdr.execution || pdr.execution === execution)));
   t.is(validatedRecords.length, apiPdrs.length);
 });
 

--- a/packages/db/tests/search/test-queries.js
+++ b/packages/db/tests/search/test-queries.js
@@ -91,7 +91,7 @@ test('convertQueryStringToDbQueryParameters does not include limit/offset parame
   t.is(dbQueryParams.offset, undefined);
 });
 
-test('convertQueryStringToDbQueryParameters adds limt and sorting on cumulus_id to db query parameters by default', (t) => {
+test('convertQueryStringToDbQueryParameters adds limit and sorting on cumulus_id to db query parameters by default', (t) => {
   const expectedDbQueryParameters = {
     estimateTableRowCount: false,
     limit: 10,
@@ -107,6 +107,74 @@ test('convertQueryStringToDbQueryParameters adds limt and sorting on cumulus_id 
   };
   const dbQueryParams = convertQueryStringToDbQueryParameters('granule', {});
   t.deepEqual(dbQueryParams, expectedDbQueryParameters);
+});
+
+test('convertQueryStringToDbQueryParameters adds sorting on cumulus_id to db query parameters if limit is not set to null and sort_key is provided', (t) => {
+  const queryStringParameters = {
+    sort_key: ['-productVolume'],
+  };
+  const expectedSortParameter = [
+    {
+      column: 'product_volume',
+      order: 'desc',
+    },
+    {
+      column: 'cumulus_id',
+      order: 'asc',
+    },
+  ];
+  const dbQueryParams = convertQueryStringToDbQueryParameters('granule', queryStringParameters);
+  t.deepEqual(dbQueryParams.sort, expectedSortParameter);
+});
+
+test('convertQueryStringToDbQueryParameters adds sorting on cumulus_id to db query parameters if limit is not set to null and sort_by is provided', (t) => {
+  const queryStringParameters = {
+    sort_by: 'productVolume',
+    order: 'desc',
+  };
+  const expectedSortParameter = [
+    {
+      column: 'product_volume',
+      order: 'desc',
+    },
+    {
+      column: 'cumulus_id',
+      order: 'asc',
+    },
+  ];
+  const dbQueryParams = convertQueryStringToDbQueryParameters('granule', queryStringParameters);
+  t.deepEqual(dbQueryParams.sort, expectedSortParameter);
+});
+
+test('convertQueryStringToDbQueryParameters does not add sorting on cumulus_id to db query parameters if limit is set to null and sort_key is provided', (t) => {
+  const queryStringParameters = {
+    limit: null,
+    sort_key: ['-productVolume'],
+  };
+  const expectedSortParameter = [
+    {
+      column: 'product_volume',
+      order: 'desc',
+    },
+  ];
+  const dbQueryParams = convertQueryStringToDbQueryParameters('granule', queryStringParameters);
+  t.deepEqual(dbQueryParams.sort, expectedSortParameter);
+});
+
+test('convertQueryStringToDbQueryParameters does not add sorting on cumulus_id to db query parameters if limit is set to null and sort_by is provided', (t) => {
+  const queryStringParameters = {
+    limit: null,
+    sort_by: 'productVolume',
+    order: 'desc',
+  };
+  const expectedSortParameter = [
+    {
+      column: 'product_volume',
+      order: 'desc',
+    },
+  ];
+  const dbQueryParams = convertQueryStringToDbQueryParameters('granule', queryStringParameters);
+  t.deepEqual(dbQueryParams.sort, expectedSortParameter);
 });
 
 test('convertQueryStringToDbQueryParameters correctly converts sortby error parameter to db query parameters', (t) => {

--- a/packages/db/tests/search/test-queries.js
+++ b/packages/db/tests/search/test-queries.js
@@ -49,6 +49,10 @@ test('convertQueryStringToDbQueryParameters correctly converts api query string 
     {
       column: 'updated_at',
       order: 'asc',
+    },
+    {
+      column: 'cumulus_id',
+      order: 'asc',
     }],
     range: {
       duration: {
@@ -102,6 +106,10 @@ test('convertQueryStringToDbQueryParameters correctly converts sortby error para
     sort: [
       {
         column: 'error.Error',
+        order: 'asc',
+      },
+      {
+        column: 'cumulus_id',
         order: 'asc',
       },
     ],

--- a/packages/db/tests/search/test-queries.js
+++ b/packages/db/tests/search/test-queries.js
@@ -91,6 +91,24 @@ test('convertQueryStringToDbQueryParameters does not include limit/offset parame
   t.is(dbQueryParams.offset, undefined);
 });
 
+test('convertQueryStringToDbQueryParameters adds limt and sorting on cumulus_id to db query parameters by default', (t) => {
+  const expectedDbQueryParameters = {
+    estimateTableRowCount: false,
+    limit: 10,
+    offset: 0,
+    page: 1,
+    includeFullRecord: false,
+    sort: [
+      {
+        column: 'cumulus_id',
+        order: 'asc',
+      },
+    ],
+  };
+  const dbQueryParams = convertQueryStringToDbQueryParameters('granule', {});
+  t.deepEqual(dbQueryParams, expectedDbQueryParameters);
+});
+
 test('convertQueryStringToDbQueryParameters correctly converts sortby error parameter to db query parameters', (t) => {
   const queryStringParameters = {
     sort_by: 'error.Error.keyword',


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-4018: Cumulus API Paging not working as expected, impacting messageConsumer](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4018)

## Changes

* Fixed Postgres pagination missing records issue by sorting on unique cumulus_id column

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
