### PR TITLE
CUMULUS-4018-2:Updated @cumulus/db/search to correctly handle limit=null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - **CUMULUS-3994**
   - Removed references to elasticsearch in data-persistence
+
+### Fixed
+
+- **CUMULUS-4018**
+  - Updated `@cumulus/db/search` to correctly handle string parameter when limit is `null`
   
 ### Notable Changes
 

--- a/packages/db/src/search/queries.ts
+++ b/packages/db/src/search/queries.ts
@@ -214,7 +214,7 @@ const convertSort = (
     });
   }
 
-  if (limit !== null) {
+  if (limit !== 'null') {
     sortArray.push({ column: defaultSortColumn, order: defaultSortOrder });
   }
 
@@ -256,7 +256,7 @@ export const convertQueryStringToDbQueryParameters = (
 
   const dbQueryParameters: DbQueryParameters = {};
   dbQueryParameters.page = Number.parseInt(page ?? '1', 10);
-  if (limit !== null) {
+  if (limit !== 'null') {
     dbQueryParameters.limit = Number.parseInt(limit ?? '10', 10);
     dbQueryParameters.offset = (dbQueryParameters.page - 1) * dbQueryParameters.limit;
   }

--- a/packages/db/tests/search/test-queries.js
+++ b/packages/db/tests/search/test-queries.js
@@ -5,11 +5,11 @@ const {
 
 test('convertQueryStringToDbQueryParameters correctly converts api query string parameters to db query parameters', (t) => {
   const queryStringParameters = {
-    duration__from: 25,
+    duration__from: '25',
     fields: 'granuleId,collectionId,status,updatedAt',
     infix: 'A1657416',
-    limit: 20,
-    page: 3,
+    limit: '20',
+    page: '3',
     prefix: 'MO',
     sort_key: ['-productVolume', '+timestamp'],
     published: 'true',
@@ -56,7 +56,7 @@ test('convertQueryStringToDbQueryParameters correctly converts api query string 
     }],
     range: {
       duration: {
-        gte: queryStringParameters.duration__from,
+        gte: Number(queryStringParameters.duration__from),
       },
       updated_at: {
         gte: new Date(Number(queryStringParameters.timestamp__from)),
@@ -83,8 +83,8 @@ test('convertQueryStringToDbQueryParameters correctly converts api query string 
 
 test('convertQueryStringToDbQueryParameters does not include limit/offset parameters if limit is explicitly set to null', (t) => {
   const queryStringParameters = {
-    limit: null,
-    offset: 3,
+    limit: 'null',
+    offset: '3',
   };
   const dbQueryParams = convertQueryStringToDbQueryParameters('granule', queryStringParameters);
   t.is(dbQueryParams.limit, undefined);
@@ -148,7 +148,7 @@ test('convertQueryStringToDbQueryParameters adds sorting on cumulus_id to db que
 
 test('convertQueryStringToDbQueryParameters does not add sorting on cumulus_id to db query parameters if limit is set to null and sort_key is provided', (t) => {
   const queryStringParameters = {
-    limit: null,
+    limit: 'null',
     sort_key: ['-productVolume'],
   };
   const expectedSortParameter = [
@@ -163,7 +163,7 @@ test('convertQueryStringToDbQueryParameters does not add sorting on cumulus_id t
 
 test('convertQueryStringToDbQueryParameters does not add sorting on cumulus_id to db query parameters if limit is set to null and sort_by is provided', (t) => {
   const queryStringParameters = {
-    limit: null,
+    limit: 'null',
     sort_by: 'productVolume',
     order: 'desc',
   };


### PR DESCRIPTION
**Summary:** Summary of changes

This is additional fix for 4018 and is not needed to solve NSIDC issue.
Addresses [CUMULUS-4018: Cumulus API Paging not working as expected, impacting messageConsumer](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4018)

## Changes

* Updated @cumulus/db/search to correctly handle limit=null

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
