### PR TITLE
Jk/cumulus 4077 update search query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **CUMULUS-4077**
+  - Update list/search endpoints and corresponding BaseSearch `@cumulus/db` logic to allow `countOnly` as a configuration-modifying query parameter that *only* returns a useful value for `meta.count` to allow users to get a count without returning results/incurring pagination/translation costs
+
 ## [v20.1.1] 2025-03-26
 
 ### Changed
@@ -25,7 +30,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - **CUMULUS-4018**
   - Updated `@cumulus/db/search` to correctly handle string parameter when limit is `null`
-  
+
 ## [v20.0.1] 2025-03-12
 
 ### Notable Changes

--- a/packages/api/tests/endpoints/test-granules-get.js
+++ b/packages/api/tests/endpoints/test-granules-get.js
@@ -497,6 +497,23 @@ test.serial('GET returns a 404 response if the granule is not found', async (t) 
   t.is(message, 'Granule not found');
 });
 
+test.serial('LIST endpoint with countOnly set returns only count of matching granules', async (t) => {
+  const granuleIds = t.context.fakePGGranules.map((i) => i.granule_id);
+  const searchParams = new URLSearchParams({
+    granuleId: granuleIds[3],
+    countOnly: true,
+  });
+  const response = await request(app)
+    .get(`/granules?${searchParams}`)
+    .set('Accept', 'application/json')
+    .set('Authorization', `Bearer ${jwtAuthToken}`)
+    .expect(200);
+
+  const { meta, results } = response.body;
+  t.is(meta.count, 2);
+  t.is(results.length, 0);
+});
+
 test.serial('LIST endpoint returns search result correctly', async (t) => {
   const granuleIds = t.context.fakePGGranules.map((i) => i.granule_id);
   const searchParams = new URLSearchParams({

--- a/packages/db/src/search/BaseSearch.ts
+++ b/packages/db/src/search/BaseSearch.ts
@@ -522,10 +522,12 @@ abstract class BaseSearch {
     const getEstimate = shouldEstimateRowcount
       ? this.getEstimatedRowcount({ knex })
       : undefined;
+    const shouldReturnCountOnly = this.dbQueryParameters.countOnly === true;
 
     try {
       const [countResult, pgRecords] = await Promise.all([
-        getEstimate || countQuery, searchQuery,
+        getEstimate || countQuery,
+        shouldReturnCountOnly ? [] : searchQuery,
       ]);
       const meta = this._metaTemplate();
       meta.limit = this.dbQueryParameters.limit;

--- a/packages/db/src/search/queries.ts
+++ b/packages/db/src/search/queries.ts
@@ -253,6 +253,7 @@ export const convertQueryStringToDbQueryParameters = (
     fields,
     estimateTableRowCount,
     includeFullRecord,
+    countOnly,
   } = queryStringParameters;
 
   const dbQueryParameters: DbQueryParameters = {};
@@ -266,8 +267,8 @@ export const convertQueryStringToDbQueryParameters = (
   if (typeof fields === 'string') dbQueryParameters.fields = fields.split(',');
   dbQueryParameters.estimateTableRowCount = (estimateTableRowCount === 'true');
   dbQueryParameters.includeFullRecord = (includeFullRecord === 'true');
+  dbQueryParameters.countOnly = (countOnly === 'true');
   dbQueryParameters.sort = convertSort(type, queryStringParameters);
-  dbQueryParameters.countOnly = (queryStringParameters.countOnly === 'true');
 
   // remove reserved words (that are not fields)
   const fieldParams = omit(queryStringParameters, reservedWords);

--- a/packages/db/src/search/queries.ts
+++ b/packages/db/src/search/queries.ts
@@ -19,6 +19,7 @@ const reservedWords = [
   'fields',
   'includeFullRecord',
   'searchContext',
+  'countOnly',
 ];
 
 /**
@@ -266,6 +267,7 @@ export const convertQueryStringToDbQueryParameters = (
   dbQueryParameters.estimateTableRowCount = (estimateTableRowCount === 'true');
   dbQueryParameters.includeFullRecord = (includeFullRecord === 'true');
   dbQueryParameters.sort = convertSort(type, queryStringParameters);
+  dbQueryParameters.countOnly = (queryStringParameters.countOnly === 'true');
 
   // remove reserved words (that are not fields)
   const fieldParams = omit(queryStringParameters, reservedWords);

--- a/packages/db/src/types/search.ts
+++ b/packages/db/src/types/search.ts
@@ -1,4 +1,5 @@
 export type QueryStringParameters = {
+  countOnly?: string,
   field?: string,
   fields?: string,
   infix?: string,
@@ -30,6 +31,7 @@ export type SortType = {
 
 export type DbQueryParameters = {
   collate?: string,
+  countOnly?: boolean,
   fields?: string[],
   infix?: string,
   limit?: number,

--- a/packages/db/tests/search/test-AsyncOperationSearch.js
+++ b/packages/db/tests/search/test-AsyncOperationSearch.js
@@ -31,12 +31,12 @@ test.before(async (t) => {
 
   t.context.asyncOperationPgModel = new AsyncOperationPgModel();
   t.context.asyncOperations = [];
-  t.context.asyncOperationSearchTmestamp = 1579352700000;
+  t.context.asyncOperationSearchTimestamp = 1579352700000;
 
   range(100).map((num) => (
     t.context.asyncOperations.push(fakeAsyncOperationRecordFactory({
       cumulus_id: num,
-      updated_at: new Date(t.context.asyncOperationSearchTmestamp + (num % 2)),
+      updated_at: new Date(t.context.asyncOperationSearchTimestamp + (num % 2)),
       operation_type: num % 2 === 0 ? 'Bulk Granules' : 'Data Migration',
       task_arn: num % 2 === 0 ? cryptoRandomString({ length: 3 }) : undefined,
     }))
@@ -134,7 +134,7 @@ test('AsyncOperationSearch supports term search for date field', async (t) => {
   const { knex } = t.context;
   const queryStringParameters = {
     limit: 200,
-    updatedAt: `${t.context.asyncOperationSearchTmestamp + 1}`,
+    updatedAt: `${t.context.asyncOperationSearchTimestamp + 1}`,
   };
   const dbSearch = new AsyncOperationSearch({ queryStringParameters });
   const { results, meta } = await dbSearch.query(knex);
@@ -171,8 +171,8 @@ test('AsyncOperationSearch supports range search', async (t) => {
   const { knex } = t.context;
   const queryStringParameters = {
     limit: 200,
-    timestamp__from: `${t.context.asyncOperationSearchTmestamp + 1}`,
-    timestamp__to: `${t.context.asyncOperationSearchTmestamp + 2}`,
+    timestamp__from: `${t.context.asyncOperationSearchTimestamp + 1}`,
+    timestamp__to: `${t.context.asyncOperationSearchTimestamp + 2}`,
   };
   const dbSearch = new AsyncOperationSearch({ queryStringParameters });
   const { results, meta } = await dbSearch.query(knex);
@@ -185,7 +185,7 @@ test('AsyncOperationSearch supports search for multiple fields', async (t) => {
   const queryStringParameters = {
     limit: 200,
     id: t.context.asyncOperations[2].id,
-    updatedAt: `${t.context.asyncOperationSearchTmestamp}`,
+    updatedAt: `${t.context.asyncOperationSearchTimestamp}`,
   };
   const dbSearch = new AsyncOperationSearch({ queryStringParameters });
   const { results, meta } = await dbSearch.query(knex);

--- a/packages/db/tests/search/test-ExecutionSearch.js
+++ b/packages/db/tests/search/test-ExecutionSearch.js
@@ -608,6 +608,17 @@ test('ExecutionSearch estimates the rowcount of the table by default', async (t)
   };
   const dbSearch = new ExecutionSearch({ queryStringParameters });
   const response = await dbSearch.query(knex);
-  t.true(response.meta.count > 0);
+  t.true(response.meta.count > 0, 'Expected response.meta.count to be greater than 0');
   t.is(response.results?.length, 50);
+});
+
+test('ExecutionSearch only returns count if countOnly is set to true', async (t) => {
+  const { knex } = t.context;
+  const queryStringParameters = {
+    countOnly: 'true',
+  };
+  const dbSearch = new ExecutionSearch({ queryStringParameters });
+  const response = await dbSearch.query(knex);
+  t.true(response.meta.count > 0, 'Expected response.meta.count to be greater than 0');
+  t.is(response.results?.length, 0);
 });

--- a/packages/db/tests/search/test-GranuleSearch.js
+++ b/packages/db/tests/search/test-GranuleSearch.js
@@ -928,8 +928,19 @@ test('GranuleSearch estimates the rowcount of the table by default', async (t) =
   };
   const dbSearch = new GranuleSearch({ queryStringParameters });
   const response = await dbSearch.query(knex);
-  t.true(response.meta.count > 0);
+  t.true(response.meta.count > 0, 'Expected response.meta.count to be greater than 0');
   t.is(response.results?.length, 50);
+});
+
+test('GranuleSearch only returns count if countOnly is set to true', async (t) => {
+  const { knex } = t.context;
+  const queryStringParameters = {
+    countOnly: 'true',
+  };
+  const dbSearch = new GranuleSearch({ queryStringParameters });
+  const response = await dbSearch.query(knex);
+  t.true(response.meta.count > 0, 'Expected response.meta.count to be greater than 0');
+  t.is(response.results?.length, 0);
 });
 
 test('GranuleSearch with includeFullRecord true retrieves associated file objects for granules', async (t) => {

--- a/packages/db/tests/search/test-PdrSearch.js
+++ b/packages/db/tests/search/test-PdrSearch.js
@@ -750,3 +750,14 @@ test('PdrSearch returns the correct record', async (t) => {
 
   t.deepEqual(results?.[0], expectedApiRecord);
 });
+
+test('PdrSearch only returns count if countOnly is set to true', async (t) => {
+  const { knex } = t.context;
+  const queryStringParameters = {
+    countOnly: 'true',
+  };
+  const dbSearch = new PdrSearch({ queryStringParameters });
+  const response = await dbSearch.query(knex);
+  t.true(response.meta.count > 0, 'Expected response.meta.count to be greater than 0');
+  t.is(response.results?.length, 0);
+});

--- a/packages/db/tests/search/test-queries.js
+++ b/packages/db/tests/search/test-queries.js
@@ -28,6 +28,7 @@ test('convertQueryStringToDbQueryParameters correctly converts api query string 
   };
 
   const expectedDbQueryParameters = {
+    countOnly: false,
     estimateTableRowCount: false,
     exists: {
       error: true,
@@ -93,6 +94,7 @@ test('convertQueryStringToDbQueryParameters does not include limit/offset parame
 
 test('convertQueryStringToDbQueryParameters adds limit and sorting on cumulus_id to db query parameters by default', (t) => {
   const expectedDbQueryParameters = {
+    countOnly: false,
     estimateTableRowCount: false,
     limit: 10,
     offset: 0,
@@ -184,6 +186,7 @@ test('convertQueryStringToDbQueryParameters correctly converts sortby error para
   };
 
   const expectedDbQueryParameters = {
+    countOnly: false,
     estimateTableRowCount: false,
     limit: 10,
     offset: 0,


### PR DESCRIPTION
**Summary:** 
Addresses [CUMULUS-4077](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4077)

## Changes

- **CUMULUS-4077**
  - Update list/search endpoints and corresponding BaseSearch `@cumulus/db` logic to allow `countOnly` as a configuration-modifying query parameter that *only* returns a useful value for `meta.count` to allow users to get a count without returning results/incurring pagination/translation costs


Addressed a minor test typo: https://github.com/nasa/cumulus/pull/3952/commits/c3c97b04cb254c2787625c09bd55b6b2092f71a3 


## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
