### PR TITLE
CUMULUS-3788:Update launchpad token in s3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **CUMULUS-3788**
+  - Updated `@cumulus/launchpad-auth/getLaunchpadToken` to check if the token in s3 has been updated
+    before updating it with a new token
+
 ## [v20.1.1] 2025-03-26
 
 ### Changed

--- a/packages/launchpad-auth/src/index.ts
+++ b/packages/launchpad-auth/src/index.ts
@@ -108,14 +108,19 @@ export async function getLaunchpadToken(params: LaunchpadTokenParams): Promise<s
       session_starttime: (Date.now() / 1000) - (5 * 60),
     };
 
-    const s3location = launchpadTokenBucketKey();
-    await s3PutObject({
-      Bucket: s3location.Bucket,
-      Key: s3location.Key,
-      Body: JSON.stringify(tokenObject),
-    });
+    // check if the token in s3 has been updated before updating it with the new token
+    token = await getValidLaunchpadTokenFromS3();
+    if (!token) {
+      log.debug('getLaunchpadToken updating launchpad token in s3');
+      const s3location = launchpadTokenBucketKey();
+      await s3PutObject({
+        Bucket: s3location.Bucket,
+        Key: s3location.Key,
+        Body: JSON.stringify(tokenObject),
+      });
 
-    token = tokenObject.sm_token;
+      token = tokenObject.sm_token;
+    }
   }
 
   return token;

--- a/packages/launchpad-auth/tests/test-LaunchpadToken.js
+++ b/packages/launchpad-auth/tests/test-LaunchpadToken.js
@@ -143,15 +143,10 @@ test.serial('getLaunchpadToken does not update the token in s3 if the token has 
   const firstToken = randomString();
   const secondToken = randomString();
 
-  console.log(stubS3Token, firstToken, secondToken);
   nock('https://www.example.com:12345')
     .get('/api/gettoken')
     .reply(200,
       JSON.stringify({ ...getTokenResponse, sm_token: firstToken }));
-  nock('https://www.example.com:12345')
-    .get('/api/gettoken')
-    .reply(200,
-      JSON.stringify({ ...getTokenResponse, sm_token: secondToken }));
 
   // does not update the token if token has been updated since
   const tokenReturnWithStubFunc = await launchpad.getLaunchpadToken(config);
@@ -160,6 +155,10 @@ test.serial('getLaunchpadToken does not update the token in s3 if the token has 
 
   // restore the original function
   revert();
+  nock('https://www.example.com:12345')
+    .get('/api/gettoken')
+    .reply(200,
+      JSON.stringify({ ...getTokenResponse, sm_token: secondToken }));
   // token is updated
   const tokenReturned = await launchpad.getLaunchpadToken(config);
   t.is(tokenReturned, secondToken);

--- a/packages/launchpad-auth/tests/test-LaunchpadToken.js
+++ b/packages/launchpad-auth/tests/test-LaunchpadToken.js
@@ -4,6 +4,7 @@ const test = require('ava');
 const cryptoRandomString = require('crypto-random-string');
 const nock = require('nock');
 const rewire = require('rewire');
+const sinon = require('sinon');
 const {
   createBucket,
   deleteS3Object,
@@ -127,6 +128,45 @@ test.serial('getLaunchpadToken gets a new token when existing token is expired',
   // get a new token when the existing token is expired
   const fourthToken = await getLaunchpadToken(config);
   t.not(thirdToken, fourthToken);
+
+  await deleteS3Object(Bucket, Key);
+});
+
+test.serial('getLaunchpadToken does not update the token in s3 if the token has been updated by another thread', async (t) => {
+  const stubS3Token = randomString();
+  const getValidLaunchpadTokenFromS3Stub = sinon.stub();
+  getValidLaunchpadTokenFromS3Stub.onCall(0).returns(undefined);
+  getValidLaunchpadTokenFromS3Stub.onCall(1).returns(stubS3Token);
+
+  const revert = launchpad.__set__('getValidLaunchpadTokenFromS3', getValidLaunchpadTokenFromS3Stub);
+
+  const firstToken = randomString();
+  const secondToken = randomString();
+
+  console.log(stubS3Token, firstToken, secondToken);
+  nock('https://www.example.com:12345')
+    .get('/api/gettoken')
+    .reply(200,
+      JSON.stringify({ ...getTokenResponse, sm_token: firstToken }));
+  nock('https://www.example.com:12345')
+    .get('/api/gettoken')
+    .reply(200,
+      JSON.stringify({ ...getTokenResponse, sm_token: secondToken }));
+
+  // does not update the token if token has been updated since
+  const tokenReturnWithStubFunc = await launchpad.getLaunchpadToken(config);
+  t.is(tokenReturnWithStubFunc, stubS3Token);
+  t.not(tokenReturnWithStubFunc, firstToken);
+
+  // restore the original function
+  revert();
+  // token is updated
+  const tokenReturned = await launchpad.getLaunchpadToken(config);
+  t.is(tokenReturned, secondToken);
+
+  // delete s3 token
+  const { Bucket, Key } = launchpadTokenBucketKey();
+  await deleteS3Object(Bucket, Key);
 });
 
 test.serial('validateLaunchpadToken returns success status when user is in specified group', async (t) => {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3788: Multiple DAACs: Frequent 401 errors in PostToCMR](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3788)

## Changes

* Updated `@cumulus/launchpad-auth/getLaunchpadToken` to check if the token in s3 has been updated
    before updating it with a new token

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
