### PR TITLE
CUMULUS-4057:Update psql installation instruction for Amazon Linux 2023

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Updated bulkPatchGranuleCollection to error when the collection it is getting updated to doesn't exist
 - **CUMULUS-4077**
   - Update list/search endpoints and corresponding BaseSearch `@cumulus/db` logic to allow `countOnly` as a configuration-modifying query parameter that *only* returns a useful value for `meta.count` to allow users to get a count without returning results/incurring pagination/translation costs
+- **CUMULUS-4057**
+  - Updated psql installation instruction for Amazon Linux 2023
 
 ## [v20.1.1] 2025-03-26
 

--- a/docs/upgrade-notes/update-cumulus_id-type-indexes-CUMULUS-3449.md
+++ b/docs/upgrade-notes/update-cumulus_id-type-indexes-CUMULUS-3449.md
@@ -138,7 +138,10 @@ exit
 
     ```sh
     sudo yum install -y tmux
+    # Amazon Linux 2
     sudo amazon-linux-extras install postgresql13
+    # Amazon Linux 2023
+    sudo dnf install -y postgresql15
     ```
 
     Once installed, a tmux session is started with two windows. The Cumulus database is connected to in each window

--- a/docs/upgrade-notes/update-table-indexes-CUMULUS-3792.md
+++ b/docs/upgrade-notes/update-table-indexes-CUMULUS-3792.md
@@ -41,7 +41,10 @@ other issues that would result in the client being killed.
 
     ```sh
     sudo yum install -y tmux
+    # Amazon Linux 2
     sudo amazon-linux-extras install postgresql13
+    # Amazon Linux 2023
+    sudo dnf install -y postgresql15
     ```
 
     Once installed, a tmux session is started with two windows, the Cumulus database is connected to each window


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-4057: Update psql installation instruction for Amazon Linux 2023](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4057)

## Changes

* Update psql installation instruction for Amazon Linux 2023

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
