### PR TITLE
Ecarton/fix webpack db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **CUMULUS-3868**
+  - exclude package cloudflare:sockets" in webpack.config in various places to prevent packaging bug
 - **CUMULUS-3752**
   - Fixed api return codes expected in api-client for bulkPatch and bulkPatchGranuleCollections
 - **CUMULUS-3394**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - **CUMULUS-3868**
-  - exclude package cloudflare:sockets" in webpack.config in various places to prevent packaging bug
+  - exclude package cloudflare:sockets" in webpack.config throughout to prevent packaging bug
 - **CUMULUS-3752**
   - Fixed api return codes expected in api-client for bulkPatch and bulkPatchGranuleCollections
 - **CUMULUS-3394**

--- a/example/lambdas/ftpPopulateTestLambda/webpack.config.js
+++ b/example/lambdas/ftpPopulateTestLambda/webpack.config.js
@@ -4,6 +4,7 @@ const { IgnorePlugin } = require('webpack');
 const root = path.resolve(__dirname);
 
 const ignoredPackages = [
+  'cloudflare:sockets',
   'cpu-features',
   'sshcrypto.node',
 ];

--- a/example/lambdas/lzardsClientTest/webpack.config.js
+++ b/example/lambdas/lzardsClientTest/webpack.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const { IgnorePlugin } = require('webpack');
 
-const ignoredPackages = [ ];
+const ignoredPackages = [ 'cloudflare:sockets', ];
 
 module.exports = {
   plugins: [

--- a/lambdas/db-migration/webpack.config.js
+++ b/lambdas/db-migration/webpack.config.js
@@ -13,7 +13,8 @@ const ignoredPackages = [
   'pg-native',
   'pg-query-stream',
   'sqlite3',
-  'tedious'
+  'tedious',
+  'cloudflare:sockets'
 ];
 
 module.exports = {

--- a/lambdas/db-migration/webpack.config.js
+++ b/lambdas/db-migration/webpack.config.js
@@ -3,6 +3,7 @@ const { IgnorePlugin } = require('webpack');
 const CopyPlugin = require('copy-webpack-plugin');
 
 const ignoredPackages = [
+  'cloudflare:sockets',
   'better-sqlite3',
   'mssql',
   'mssql/lib/base',
@@ -14,7 +15,6 @@ const ignoredPackages = [
   'pg-query-stream',
   'sqlite3',
   'tedious',
-  'cloudflare:sockets'
 ];
 
 module.exports = {

--- a/lambdas/db-provision-user-database/webpack.config.js
+++ b/lambdas/db-provision-user-database/webpack.config.js
@@ -13,7 +13,8 @@ const ignoredPackages = [
   'pg-native',
   'pg-query-stream',
   'sqlite3',
-  'tedious'
+  'tedious',
+  'cloudflare:sockets'
 ];
 
 module.exports = {

--- a/lambdas/migration-helper-async-operation/webpack.config.js
+++ b/lambdas/migration-helper-async-operation/webpack.config.js
@@ -13,7 +13,8 @@ const ignoredPackages = [
   'pg-native',
   'pg-query-stream',
   'sqlite3',
-  'tedious'
+  'tedious',
+  'cloudflare:sockets'
 ];
 
 module.exports = {

--- a/packages/api/webpack.config.js
+++ b/packages/api/webpack.config.js
@@ -15,7 +15,8 @@ const ignoredPackages = [
   'pg-native',
   'pg-query-stream',
   'sqlite3',
-  'tedious'
+  'tedious',
+  'cloudflare:sockets'
 ];
 
 const root = path.resolve(__dirname);

--- a/packages/integration-tests/webpack.config.js
+++ b/packages/integration-tests/webpack.config.js
@@ -4,6 +4,7 @@ const { IgnorePlugin } = require('webpack');
 const root = path.resolve(__dirname);
 
 const ignoredPackages = [
+  'cloudflare:sockets',
   'better-sqlite3',
   'mssql',
   'mssql/lib/base',

--- a/packages/s3-credentials-endpoint/webpack.config.js
+++ b/packages/s3-credentials-endpoint/webpack.config.js
@@ -17,6 +17,7 @@ const ignoredPackages = [
   'pg-query-stream',
   'sqlite3',
   'tedious',
+  'cloudflare:sockets'
 ];
 
 module.exports = {

--- a/tasks/discover-granules/webpack.config.js
+++ b/tasks/discover-granules/webpack.config.js
@@ -4,6 +4,7 @@ const { IgnorePlugin } = require('webpack');
 const root = path.resolve(__dirname);
 
 const ignoredPackages = [
+  'cloudflare:sockets',
   'cpu-features',
   'sshcrypto.node'
 ];

--- a/tasks/discover-pdrs/webpack.config.js
+++ b/tasks/discover-pdrs/webpack.config.js
@@ -4,6 +4,7 @@ const { IgnorePlugin } = require('webpack');
 const root = path.resolve(__dirname);
 
 const ignoredPackages = [
+  'cloudflare:sockets',
   'cpu-features',
   'sshcrypto.node'
 ];

--- a/tasks/parse-pdr/webpack.config.js
+++ b/tasks/parse-pdr/webpack.config.js
@@ -4,6 +4,7 @@ const { IgnorePlugin } = require('webpack');
 const root = path.resolve(__dirname);
 
 const ignoredPackages = [
+  'cloudflare:sockets',
   'cpu-features',
   'sshcrypto.node'
 ];

--- a/tasks/send-pan/webpack.config.js
+++ b/tasks/send-pan/webpack.config.js
@@ -15,6 +15,7 @@ const ignoredPackages = [
   'pg-query-stream',
   'sqlite3',
   'tedious',
+  'cloudflare:sockets'
 ];
 
 module.exports = {

--- a/tasks/sync-granule/webpack.config.js
+++ b/tasks/sync-granule/webpack.config.js
@@ -4,6 +4,7 @@ const { IgnorePlugin } = require('webpack');
 const root = path.resolve(__dirname);
 
 const ignoredPackages = [
+  'cloudflare:sockets',
   'cpu-features',
   'sshcrypto.node'
 ];

--- a/tasks/test-processing/webpack.config.js
+++ b/tasks/test-processing/webpack.config.js
@@ -4,6 +4,7 @@ const { IgnorePlugin } = require('webpack');
 const root = path.resolve(__dirname);
 
 const ignoredPackages = [
+  'cloudflare:sockets',
   'better-sqlite3',
   'mssql',
   'mssql/lib/base',


### PR DESCRIPTION
hot fix exclude cloudflare:sockets in webpack so that we can publish

* because for some reason we could publish before without this
* but now we can't
* even though this bug was introduced in PG 8.11
* and we're on PG 8.13 and have been for a hot minute

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
