### PR TITLE
CUMULUS-4106:Add private property to new private packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-
-## [v20.1.2] 2025-04-22
-
 ### Added
 - **CUMULUS-4020**
   - Added sanitizeSensitive function to mitigate credential exposure in ElasticSearch client (metrics)
   - Update BaseSearch functions to sanitize the errors
+
+### Fixed
+- **CUMULUS-4106**
+  - Fixed the release npm publish error by adding private property to `@cumulus/change-granule-collection-pg`
+    and `@cumulus/change-granule-collection-s3` package.json.
+
+## [v20.1.2] 2025-04-22
+
+### Added
 - **CUMULUS-3868**
   - added listGranulesConcurrency parameter to control the size of requests made to the listGranules api endpoint. this should be lowered from default if granuleIds are larger than 300 characters.
 - **CUMULUS-4004**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+
 - **CUMULUS-4020**
   - Added sanitizeSensitive function to mitigate credential exposure in ElasticSearch client (metrics)
   - Update BaseSearch functions to sanitize the errors
 
 ### Fixed
+
 - **CUMULUS-4106**
   - Fixed the release npm publish error by adding private property to `@cumulus/change-granule-collection-pg`
     and `@cumulus/change-granule-collection-s3` package.json.
@@ -19,6 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [v20.1.2] 2025-04-22
 
 ### Added
+
 - **CUMULUS-3868**
   - added listGranulesConcurrency parameter to control the size of requests made to the listGranules api endpoint. this should be lowered from default if granuleIds are larger than 300 characters.
 - **CUMULUS-4004**

--- a/tasks/change-granule-collection-pg/package.json
+++ b/tasks/change-granule-collection-pg/package.json
@@ -2,6 +2,7 @@
   "name": "@cumulus/change-granule-collection-pg",
   "version": "20.1.2",
   "description": "Move granule files and postgres records to a new collection",
+  "private": true,
   "main": "dist/index.js",
   "directories": {
     "test": "tests"

--- a/tasks/change-granule-collection-s3/package.json
+++ b/tasks/change-granule-collection-s3/package.json
@@ -2,6 +2,7 @@
   "name": "@cumulus/change-granule-collection-s3",
   "version": "20.1.2",
   "description": "Move granule files and postgres records to a new collection",
+  "private": true,
   "main": "dist/index.js",
   "directories": {
     "test": "tests"

--- a/tasks/test-processing/package.json
+++ b/tasks/test-processing/package.json
@@ -9,6 +9,9 @@
     "url": "https://github.com/nasa/cumulus",
     "directory": "tasks/test-processing"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=20.12.2"
   },


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-4106: Add private property to new private packages package.json](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4106)

## Changes

* Fixed the release npm publish error by adding private property to `@cumulus/change-granule-collection-pg`
    and `@cumulus/change-granule-collection-s3` package.json.

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
