### PR TITLE
[CUMULUS-4085]: Add config value for unique Granule IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **CUMULUS-4085**
+  - Added config option for files-to-granules task to use `producerGranuleId` when mapping files to their granules.
 - **CUMULUS-4059**
   - Added new non-null column `producer_granule_id` to Postgres `granules` table.
   - Added `producerGranuleId` property to `granule` record schema.

--- a/tasks/files-to-granules/index.js
+++ b/tasks/files-to-granules/index.js
@@ -36,19 +36,20 @@ async function fileObjectFromS3URI(s3URI) {
  * Takes the files from input and granules and merges them into an object where
  * each file is associated with its granuleId.
  *
- * @param {Array<string>} inputFiles - list of s3 files to add to the inputgranules
- * @param {Array<Object>} inputGranules - an array of the granules
- * @param {string} regex - regex needed to extract granuleId from filenames
- * @param {boolean} matchFilesWithProducerGranuleId -
+ * @param {Object} params - params object
+ * @param {Array<string>} params.inputFiles - list of s3 files to add to the inputgranules
+ * @param {Array<Object>} params.inputGranules - an array of the granules
+ * @param {string} params.regex - regex needed to extract granuleId from filenames
+ * @param {boolean} params.matchFilesWithProducerGranuleId -
  *  If true, match files to granules using producerGranuleId. Else, granuleId.
  * @returns {Object} inputGranules with updated file lists
  */
-async function mergeInputFilesWithInputGranules(
+async function mergeInputFilesWithInputGranules({
   inputFiles,
   inputGranules,
   regex,
   matchFilesWithProducerGranuleId
-) {
+}) {
   // create hash list of the granules
   // and a list of files
   const granulesHash = matchFilesWithProducerGranuleId ?
@@ -92,14 +93,17 @@ async function mergeInputFilesWithInputGranules(
  * @returns {Object} Granules object
  */
 function filesToGranules(event) {
-  const granuleIdExtractionRegex = get(event.config, 'granuleIdExtraction', '(.*)');
+  const regex = get(event.config, 'granuleIdExtraction', '(.*)');
   const matchFilesWithProducerGranuleId = get(event.config, 'matchFilesWithProducerGranuleId');
   const inputGranules = event.config.inputGranules;
-  const inputFileList = event.input;
+  const inputFiles = event.input;
 
-  return mergeInputFilesWithInputGranules(
-    inputFileList, inputGranules, granuleIdExtractionRegex, matchFilesWithProducerGranuleId
-  );
+  return mergeInputFilesWithInputGranules({
+    inputFiles,
+    inputGranules,
+    regex,
+    matchFilesWithProducerGranuleId
+});
 }
 exports.filesToGranules = filesToGranules;
 

--- a/tasks/files-to-granules/index.js
+++ b/tasks/files-to-granules/index.js
@@ -43,7 +43,7 @@ async function fileObjectFromS3URI(s3URI) {
  * @param {string} params.regex - regex needed to extract granuleId from filenames
  * @param {boolean} params.matchFilesWithProducerGranuleId -
  *  If true, match files to granules using producerGranuleId. Else, granuleId.
- * @param {Object} params.testMock - Mocks used for testing.
+ * @param {Object} params.testMocks - Mocks used for testing.
  * @returns {Object} inputGranules with updated file lists
  */
 async function mergeInputFilesWithInputGranules({
@@ -51,7 +51,7 @@ async function mergeInputFilesWithInputGranules({
   inputGranules,
   regex,
   matchFilesWithProducerGranuleId,
-  testMock,
+  testMocks,
 }) {
   // create hash list of the granules
   // and a list of files
@@ -73,8 +73,8 @@ async function mergeInputFilesWithInputGranules({
     const fileId = getGranuleId(f, regex);
     try {
       granulesHash[fileId].files.push(
-        testMock?.fileObjectFromS3URI ?
-          await testMock.fileObjectFromS3URI(f) :
+        testMocks?.fileObjectFromS3URI ?
+          await testMocks.fileObjectFromS3URI(f) :
           await fileObjectFromS3URI(f)
       );
     } catch (error) {
@@ -102,11 +102,11 @@ async function mergeInputFilesWithInputGranules({
  *                                                    from filenames
  * @param {Array<Object>} event.config.inputGranules - an array of granules
  * @param {Array<string>} event.input - an array of s3 uris
- * @param {Object} testMock - Mocks used for testing.
+ * @param {Object} testMocks - Mocks used for testing.
  *
  * @returns {Object} Granules object
  */
-function filesToGranules(event, testMock) {
+function filesToGranules(event, testMocks) {
   const regex = get(event.config, 'granuleIdExtraction', '(.*)');
   const matchFilesWithProducerGranuleId = get(event.config, 'matchFilesWithProducerGranuleId');
   const inputGranules = event.config.inputGranules;
@@ -117,7 +117,7 @@ function filesToGranules(event, testMock) {
     inputGranules,
     regex,
     matchFilesWithProducerGranuleId,
-    testMock,
+    testMocks,
   });
 }
 exports.filesToGranules = filesToGranules;

--- a/tasks/files-to-granules/index.js
+++ b/tasks/files-to-granules/index.js
@@ -68,16 +68,16 @@ async function mergeInputFilesWithInputGranules({
   /* eslint-disable no-await-in-loop */
   for (let i = 0; i < filesToAdd.length; i += 1) {
     const f = filesToAdd[i];
-    const fileGranuleId = getGranuleId(f, regex);
+    const fileId = getGranuleId(f, regex);
     try {
-      granulesHash[fileGranuleId].files.push(await fileObjectFromS3URI(f));
+      granulesHash[fileId].files.push(await fileObjectFromS3URI(f));
     } catch (error) {
-      if (!granulesHash[fileGranuleId]) {
+      if (!granulesHash[fileId]) {
         throw new UnmetRequirementsError(
-          `fileGranuleId ${fileGranuleId} does not match an input granule. Check that 'matchFilesWithProducerGranuleId' is configured as expected.`
+          `fileId ${fileId} does not match an input granule. Check that 'matchFilesWithProducerGranuleId' is configured as expected.`
         );
       }
-      throw new Error(`Failed adding ${f} to ${fileGranuleId}'s files: ${error.name} ${error.message}`);
+      throw new Error(`Failed adding ${f} to ${fileId}'s files: ${error.name} ${error.message}`);
     }
   }
   /* eslint-enable no-await-in-loop */

--- a/tasks/files-to-granules/index.js
+++ b/tasks/files-to-granules/index.js
@@ -39,12 +39,21 @@ async function fileObjectFromS3URI(s3URI) {
  * @param {Array<string>} inputFiles - list of s3 files to add to the inputgranules
  * @param {Array<Object>} inputGranules - an array of the granules
  * @param {string} regex - regex needed to extract granuleId from filenames
+ * @param {boolean} matchFilesWithProducerGranuleId -
+ *  If true, match files to granules using producerGranuleId. Else, granuleId.
  * @returns {Object} inputGranules with updated file lists
  */
-async function mergeInputFilesWithInputGranules(inputFiles, inputGranules, regex, isUniqueGranuleId) {
+async function mergeInputFilesWithInputGranules(
+  inputFiles,
+  inputGranules,
+  regex,
+  matchFilesWithProducerGranuleId
+) {
   // create hash list of the granules
   // and a list of files
-  const granulesHash = isUniqueGranuleId ? keyBy(inputGranules, 'producerGranuleId') : keyBy(inputGranules, 'granuleId');
+  const granulesHash = matchFilesWithProducerGranuleId ?
+    keyBy(inputGranules, 'producerGranuleId') :
+    keyBy(inputGranules, 'granuleId');
   const filesFromInputGranules = flatten(inputGranules.map((g) => g.files.map((f) => `s3://${f.bucket}/${f.key}`)));
 
   // add input files to corresponding granules
@@ -84,12 +93,12 @@ async function mergeInputFilesWithInputGranules(inputFiles, inputGranules, regex
  */
 function filesToGranules(event) {
   const granuleIdExtractionRegex = get(event.config, 'granuleIdExtraction', '(.*)');
-  const isUniqueGranuleId = get(event.config, 'isUniqueGranuleId', false);
+  const matchFilesWithProducerGranuleId = get(event.config, 'matchFilesWithProducerGranuleId', false);
   const inputGranules = event.config.inputGranules;
   const inputFileList = event.input;
 
   return mergeInputFilesWithInputGranules(
-    inputFileList, inputGranules, granuleIdExtractionRegex, isUniqueGranuleId
+    inputFileList, inputGranules, granuleIdExtractionRegex, matchFilesWithProducerGranuleId
   );
 }
 exports.filesToGranules = filesToGranules;

--- a/tasks/files-to-granules/index.js
+++ b/tasks/files-to-granules/index.js
@@ -93,7 +93,7 @@ async function mergeInputFilesWithInputGranules(
  */
 function filesToGranules(event) {
   const granuleIdExtractionRegex = get(event.config, 'granuleIdExtraction', '(.*)');
-  const matchFilesWithProducerGranuleId = get(event.config, 'matchFilesWithProducerGranuleId', false);
+  const matchFilesWithProducerGranuleId = get(event.config, 'matchFilesWithProducerGranuleId');
   const inputGranules = event.config.inputGranules;
   const inputFileList = event.input;
 

--- a/tasks/files-to-granules/index.js
+++ b/tasks/files-to-granules/index.js
@@ -41,10 +41,10 @@ async function fileObjectFromS3URI(s3URI) {
  * @param {string} regex - regex needed to extract granuleId from filenames
  * @returns {Object} inputGranules with updated file lists
  */
-async function mergeInputFilesWithInputGranules(inputFiles, inputGranules, regex) {
+async function mergeInputFilesWithInputGranules(inputFiles, inputGranules, regex, isUniqueGranuleId) {
   // create hash list of the granules
   // and a list of files
-  const granulesHash = keyBy(inputGranules, 'granuleId');
+  const granulesHash = isUniqueGranuleId ? keyBy(inputGranules, 'producerGranuleId') : keyBy(inputGranules, 'granuleId');
   const filesFromInputGranules = flatten(inputGranules.map((g) => g.files.map((f) => `s3://${f.bucket}/${f.key}`)));
 
   // add input files to corresponding granules
@@ -84,11 +84,12 @@ async function mergeInputFilesWithInputGranules(inputFiles, inputGranules, regex
  */
 function filesToGranules(event) {
   const granuleIdExtractionRegex = get(event.config, 'granuleIdExtraction', '(.*)');
+  const isUniqueGranuleId = get(event.config, 'isUniqueGranuleId', false);
   const inputGranules = event.config.inputGranules;
   const inputFileList = event.input;
 
   return mergeInputFilesWithInputGranules(
-    inputFileList, inputGranules, granuleIdExtractionRegex
+    inputFileList, inputGranules, granuleIdExtractionRegex, isUniqueGranuleId
   );
 }
 exports.filesToGranules = filesToGranules;

--- a/tasks/files-to-granules/index.js
+++ b/tasks/files-to-granules/index.js
@@ -8,9 +8,9 @@ const path = require('path');
 const { getObjectSize, parseS3Uri } = require('@cumulus/aws-client/S3');
 const { s3 } = require('@cumulus/aws-client/services');
 const cumulusMessageAdapter = require('@cumulus/cumulus-message-adapter-js');
+const { UnmetRequirementsError } = require('@cumulus/errors');
 
 const { getGranuleId } = require('./utils');
-const { UnmetRequirementsError } = require('@cumulus/errors');
 
 /**
  * Helper to turn an s3URI into a fileobject
@@ -49,7 +49,7 @@ async function mergeInputFilesWithInputGranules({
   inputFiles,
   inputGranules,
   regex,
-  matchFilesWithProducerGranuleId
+  matchFilesWithProducerGranuleId,
 }) {
   // create hash list of the granules
   // and a list of files
@@ -109,8 +109,8 @@ function filesToGranules(event) {
     inputFiles,
     inputGranules,
     regex,
-    matchFilesWithProducerGranuleId
-});
+    matchFilesWithProducerGranuleId,
+  });
 }
 exports.filesToGranules = filesToGranules;
 

--- a/tasks/files-to-granules/package.json
+++ b/tasks/files-to-granules/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@cumulus/aws-client": "20.1.2",
     "@cumulus/cumulus-message-adapter-js": "2.3.0",
+    "@cumulus/errors": "20.1.2",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/tasks/files-to-granules/schemas/config.json
+++ b/tasks/files-to-granules/schemas/config.json
@@ -45,7 +45,7 @@
     },
     "matchFilesWithProducerGranuleId": {
       "type": "boolean",
-      "description": "Use the 'producerGranuleId' instead of 'granuleId' when mapping files. Defaults to 'false'"
+      "description": "When set to true, use the 'producerGranuleId' instead default behavior of using 'granuleId' when mapping files to granules. Defaults to 'false'"
     }
   }
 }

--- a/tasks/files-to-granules/schemas/config.json
+++ b/tasks/files-to-granules/schemas/config.json
@@ -16,6 +16,9 @@
           "granuleId": {
             "type": "string"
           },
+          "producerGranuleId": {
+            "type": "string"
+          },
           "files": {
             "type": "array",
             "items": {
@@ -39,6 +42,10 @@
     "granuleIdExtraction": {
       "type": "string",
       "description": "The regex needed for extracting granuleId from filenames"
+    },
+    "matchFilesWithProducerGranuleId": {
+      "type": "boolean",
+      "description": "Use the 'producerGranuleId' instead of 'granuleId' when mapping files. Defaults to 'false'"
     }
   }
 }

--- a/tasks/files-to-granules/tests/data/output.json
+++ b/tasks/files-to-granules/tests/data/output.json
@@ -2,6 +2,7 @@
   "granules": [
     {
       "granuleId": "MOD11A1.A2017200.h19v04.006.2017201090724",
+      "producerGranuleId": "MOD11A1.A2017200.h19v04.006.2017201090724",
       "files": [
         {
           "key": "file-staging/subdir/MOD11A1.A2017200.h19v04.006.2017201090724.hdf",

--- a/tasks/files-to-granules/tests/data/payload.json
+++ b/tasks/files-to-granules/tests/data/payload.json
@@ -1,9 +1,11 @@
 {
   "config": {
     "granuleIdExtraction": "(MOD11A1\\..*)(\\.hdf|\\.cmr\\.xml|_[\\w]{1,}\\.jpg)",
+    "matchFilesWithProducerGranuleId": false,
     "inputGranules": [
       {
         "granuleId": "MOD11A1.A2017200.h19v04.006.2017201090724",
+        "producerGranuleId": "MOD11A1.A2017200.h19v04.006.2017201090724",
         "files": [
           {
             "key": "file-staging/subdir/MOD11A1.A2017200.h19v04.006.2017201090724.hdf",

--- a/tasks/files-to-granules/tests/test-index.js
+++ b/tasks/files-to-granules/tests/test-index.js
@@ -100,3 +100,23 @@ test('files-to-granules throws error if configured to use ID that does not exist
     { instanceOf: UnmetRequirementsError }
   );
 });
+
+test('files-to-granules throws error if configured to use uniquified granuleId for matching files', async (t) => {
+  const event = t.context.payload;
+
+  // Make the payload granuleId unique
+  const granuleDateString = '2017201090724';
+  const granuleIdReplacement = cryptoRandomString({ length: 13, type: 'numeric' });
+  event.config.inputGranules[0].granuleId = event.config.inputGranules[0].granuleId
+    .replace(granuleDateString, granuleIdReplacement);
+
+  event.config.matchFilesWithProducerGranuleId = true;
+
+  await validateConfig(t, event.config);
+  await validateInput(t, event.input);
+
+  await t.throwsAsync(
+    filesToGranules(event, { fileObjectFromS3URI: () => Promise.reject() }),
+    { instanceOf: Error }
+  );
+});

--- a/tasks/files-to-granules/tests/test-index.js
+++ b/tasks/files-to-granules/tests/test-index.js
@@ -62,7 +62,7 @@ test('files-to-granules matches granules using producerGranuleId if configured',
 
   // Make the payload granuleId unique
   const granuleDateString = '2017201090724';
-  const granuleIdReplacement = cryptoRandomString({ length: 13, type: 'numeric' });;
+  const granuleIdReplacement = cryptoRandomString({ length: 13, type: 'numeric' });
   event.config.inputGranules[0].granuleId = event.config.inputGranules[0].granuleId
     .replace(granuleDateString, granuleIdReplacement);
 
@@ -81,11 +81,11 @@ test('files-to-granules matches granules using producerGranuleId if configured',
 });
 
 test('files-to-granules throws error if configured to use ID that does not exist', async (t) => {
-const event = t.context.payload;
+  const event = t.context.payload;
 
   // Make the payload granuleId unique
   const granuleDateString = '2017201090724';
-  const granuleIdReplacement = cryptoRandomString({ length: 13, type: 'numeric' });;
+  const granuleIdReplacement = cryptoRandomString({ length: 13, type: 'numeric' });
   event.config.inputGranules[0].granuleId = event.config.inputGranules[0].granuleId
     .replace(granuleDateString, granuleIdReplacement);
 

--- a/tasks/files-to-granules/tests/test-index.js
+++ b/tasks/files-to-granules/tests/test-index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const cryptoRandomString = require('crypto-random-string');
 const fs = require('fs');
 const path = require('path');
 const test = require('ava');
@@ -53,15 +54,25 @@ test('files-to-granules transforms files array to granules object', async (t) =>
   t.deepEqual(output, expectedOutput);
 });
 
- // TODO unique the granuleId
 test('files-to-granules matches granules using producerGranuleId if configured', async (t) => {
   const event = t.context.payload;
+
+  // Make the payload granuleId unique
+  const granuleDateString = '2017201090724';
+  const granuleIdReplacement = cryptoRandomString({ length: 13, type: 'numeric' });;
+  event.config.inputGranules[0].granuleId = event.config.inputGranules[0].granuleId
+    .replace(granuleDateString, granuleIdReplacement);
+
   event.config.matchFilesWithProducerGranuleId = true;
 
   await validateConfig(t, event.config);
   await validateInput(t, event.input);
   const expectedOutput = t.context.output;
+  // Make the expected output granuleId unique
+  expectedOutput.granules[0].granuleId = expectedOutput.granules[0].granuleId
+    .replace(granuleDateString, granuleIdReplacement);
   const output = await filesToGranules(event);
   await validateOutput(t, output);
+
   t.deepEqual(output, expectedOutput);
 });

--- a/tasks/files-to-granules/tests/test-index.js
+++ b/tasks/files-to-granules/tests/test-index.js
@@ -52,3 +52,16 @@ test('files-to-granules transforms files array to granules object', async (t) =>
   await validateOutput(t, output);
   t.deepEqual(output, expectedOutput);
 });
+
+ // TODO unique the granuleId
+test('files-to-granules matches granules using producerGranuleId if configured', async (t) => {
+  const event = t.context.payload;
+  event.config.matchFilesWithProducerGranuleId = true;
+
+  await validateConfig(t, event.config);
+  await validateInput(t, event.input);
+  const expectedOutput = t.context.output;
+  const output = await filesToGranules(event);
+  await validateOutput(t, output);
+  t.deepEqual(output, expectedOutput);
+});


### PR DESCRIPTION
**Summary:** Summary of changes

We'd decided to revisit this logic. Previously we were expecting the user to pass a regex that accommodated the unique granuleId. That's a bit cumbersome so this change adds a new flag `matchFilesWithProducerGranuleId` in the event configuration that tells the task to use `producerGranuleId` instead of `granuleId`.

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
