### PR TITLE
CUMULUS-4132: Expose `sf_start_rate` to main module configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **CUMULUS-4132**
+  - Expose `sf_start_rate` configuration from the `ingest` terraform module via
+    the `cumulus` module at user request.   Please note we still suggest use of
+    https://nasa.github.io/cumulus/docs/data-cookbooks/throttling-queued-executions/
+    instead if the queue parameters need modified.
 - **CUMULUS-3945**
   - Upgrade Aurora Postgresql engine from 13.12 to 17.4
 - **CUMULUS-4020**

--- a/tf-modules/cumulus/ingest.tf
+++ b/tf-modules/cumulus/ingest.tf
@@ -67,4 +67,7 @@ module "ingest" {
   # Cloudwatch log retention config
   cloudwatch_log_retention_periods = var.cloudwatch_log_retention_periods
   default_log_retention_days = var.default_log_retention_days
+
+  ## Background processing config
+  sf_start_rate = var.sf_start_rate
 }

--- a/tf-modules/cumulus/variables.tf
+++ b/tf-modules/cumulus/variables.tf
@@ -613,3 +613,11 @@ variable "deploy_cumulus_workflows" {
   default = { change_granule_collections_workflow: true }
   description = "for each workflow, if true deploy that workflow"
 }
+
+## Ingest Module Optional Configuration
+
+variable "sf_start_rate" {
+  type    = number
+  default = 500
+  description = "The number of messages to process per run when polling the background processing SQS queue.    Use at your own risk, as increasing this beyond the default may result in sqs2sfThrottle lambda timeout and DLQ entries if messages cannot be processed in under 60 seconds. "
+}


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-4132](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4132)

## Changes

- **CUMULUS-4132**
  - Expose `sf_start_rate` configuration from the `ingest` terraform module via
    the `cumulus` module at user request.   Please note we still suggest use of
    https://nasa.github.io/cumulus/docs/data-cookbooks/throttling-queued-executions/
    instead if the queue parameters need modified.

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
