### PR TITLE
CUMULUS-4174: Fix CreateReconciliationReportSpec test cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **CUMULUS_4174**
+  - Fix broken CreateReconciliationReportSpec test cleanup
 - **CUMULUS-4170**
   - Upgrade Node Docker image from buster to bullseye for a compatible debian version
 ## [v20.2.0] 2025-06-24

--- a/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
+++ b/example/spec/parallel/createReconciliationReport/CreateReconciliationReportSpec.js
@@ -393,6 +393,7 @@ describe('When there are granule differences and granule reconciliation is run',
 
       console.log('dbGranuleId', dbGranuleId);
       console.log('publishedGranuleId', publishedGranuleId);
+      console.log('cmrGranule', cmrGranule);
 
       console.log('XXXXX Waiting for collections in list');
       const collectionIds = [
@@ -901,7 +902,7 @@ describe('When there are granule differences and granule reconciliation is run',
       removeCollectionAndAllDependencies({ prefix: config.stackName, collection }),
       s3().deleteObject(extraS3Object),
       deleteFolder(config.bucket, testDataFolder),
-      cmrClient.deleteGranule(cmrGranule),
+      cmrClient.deleteGranule(cmrGranule.granuleId),
     ]);
     cleanupResults.forEach((result) => {
       if (result.status === 'rejected') {


### PR DESCRIPTION
**Summary:** 

PR fixes broken integration test cleanup 

Addresses [CUMULUS-4174](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4174)

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
