### PR TITLE
Restrict IAM Policy Wildcard Access to Specific ARNs for db_provision Lambda

### DIFF
--- a/lambdas/db-provision-user-database/main.tf
+++ b/lambdas/db-provision-user-database/main.tf
@@ -85,17 +85,27 @@ data "aws_iam_policy_document" "lambda_assume_role_policy" {
 }
 
 data "aws_iam_policy_document" "db_provision" {
-  statement {
+    statement {
     actions = [
       "ec2:CreateNetworkInterface",
       "ec2:DeleteNetworkInterface",
-      "ec2:DescribeNetworkInterfaces",
+      "ec2:DescribeNetworkInterfaces"
+    ]
+    resources = [
+      "arn:aws:ec2:${var.region}:${var.account_id}:network-interface/*"
+    ]
+  }
+
+  statement {
+    actions = [
       "logs:CreateLogGroup",
       "logs:CreateLogStream",
       "logs:DescribeLogStreams",
       "logs:PutLogEvents"
     ]
-    resources = ["*"]
+    resources = [
+      "arn:aws:logs:${var.region}:${var.account_id}:log-group:/aws/lambda/${var.prefix}-ProvisionPostgresDatabase:*"
+    ]
   }
   statement {
     actions = [


### PR DESCRIPTION
### Summary

This patch improves IAM security in the `db_provision` Lambda policy by replacing overly permissive `"*"` wildcard resources with tightly scoped ARNs for EC2 network interfaces and CloudWatch logs.

### Security Impact

- Previously, the Lambda had access to **all** EC2 and CloudWatch resources in the AWS account due to `resources = ["*"]`.
- This violates the **principle of least privilege**, increasing blast radius if the Lambda is ever exploited.
- By restricting access to only required network interfaces and Lambda log groups, this patch significantly **reduces attack surface**.

### Changes Made

- Scoped EC2 permissions to:  
  `arn:aws:ec2:${var.region}:${var.account_id}:network-interface/*`
- Scoped logging to only the Lambda's log group:  
  `arn:aws:logs:${var.region}:${var.account_id}:log-group:/aws/lambda/${var.prefix}-ProvisionPostgresDatabase:*`
---

Thanks for reviewing!
