### PR TITLE
Restrict IAM Policy Wildcard Access to Specific ARNs in db_provision Lambda

### DIFF
--- a/lambdas/db-provision-user-database/main.tf
+++ b/lambdas/db-provision-user-database/main.tf
@@ -85,18 +85,29 @@ data "aws_iam_policy_document" "lambda_assume_role_policy" {
 }
 
 data "aws_iam_policy_document" "db_provision" {
-  statement {
+    statement {
     actions = [
       "ec2:CreateNetworkInterface",
       "ec2:DeleteNetworkInterface",
-      "ec2:DescribeNetworkInterfaces",
+      "ec2:DescribeNetworkInterfaces"
+    ]
+    resources = [
+      "arn:aws:ec2:${var.region}:${var.account_id}:network-interface/*"
+    ]
+  }
+
+  statement {
+    actions = [
       "logs:CreateLogGroup",
       "logs:CreateLogStream",
       "logs:DescribeLogStreams",
       "logs:PutLogEvents"
     ]
-    resources = ["*"]
+    resources = [
+      "arn:aws:logs:${var.region}:${var.account_id}:log-group:/aws/lambda/${var.prefix}-ProvisionPostgresDatabase:*"
+    ]
   }
+
   statement {
     actions = [
       "secretsmanager:GetSecretValue",

--- a/lambdas/db-provision-user-database/variables.tf
+++ b/lambdas/db-provision-user-database/variables.tf
@@ -69,3 +69,12 @@ variable "lambda_timeouts" {
   type = map(number)
   default = {}
 }
+variable "region" {
+  description = "AWS region used in policy ARNs"
+  type        = string
+}
+
+variable "account_id" {
+  description = "AWS account ID used in policy ARNs"
+  type        = string
+}


### PR DESCRIPTION
This pull request improves the security posture of the db_provision Lambda function by removing * wildcard access in IAM policy resources.

🔧 Changes:

Replaced "*" with specific arn:aws:... log group and EC2 network interface ARNs.

Declared region and account_id variables in variables.tf for dynamic ARN generation.

Wildcard resource permissions can be overly permissive and are against least-privilege principles. This change scopes access to only the necessary AWS resources, reducing risk.

Let me know if further updates are required!