### PR TITLE
Replace var.account_id with aws_caller_identity in db_provision IAM policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **CUMULUS-XXXX**
+  - Replaced use of `var.account_id` with the `aws_caller_identity` data source in the `db_provision` IAM policy to avoid requiring a hardcoded account ID in configuration. This improves portability and aligns with Terraform best practices.
+
 ### Notable Changes
 
 - **CUMULUS-4131**

--- a/lambdas/db-provision-user-database/main.tf
+++ b/lambdas/db-provision-user-database/main.tf
@@ -1,3 +1,4 @@
+data "aws_caller_identity" "current" {}
 terraform {
   required_providers {
     aws = {
@@ -91,10 +92,10 @@ data "aws_iam_policy_document" "db_provision" {
       "ec2:DeleteNetworkInterface",
       "ec2:DescribeNetworkInterfaces"
     ]
-    resources = [
-      "arn:aws:ec2:${var.region}:${var.account_id}:network-interface/*"
-    ]
-  }
+   resources = [
+  "arn:aws:ec2:${var.region}:${data.aws_caller_identity.current.account_id}:network-interface/*"
+]
+}
 
   statement {
     actions = [
@@ -103,10 +104,10 @@ data "aws_iam_policy_document" "db_provision" {
       "logs:DescribeLogStreams",
       "logs:PutLogEvents"
     ]
-    resources = [
-      "arn:aws:logs:${var.region}:${var.account_id}:log-group:/aws/lambda/${var.prefix}-ProvisionPostgresDatabase:*"
-    ]
-  }
+resources = [
+  "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${var.prefix}-ProvisionPostgresDatabase:*"
+]
+}
   statement {
     actions = [
       "secretsmanager:GetSecretValue",

--- a/lambdas/db-provision-user-database/main.tf
+++ b/lambdas/db-provision-user-database/main.tf
@@ -85,17 +85,27 @@ data "aws_iam_policy_document" "lambda_assume_role_policy" {
 }
 
 data "aws_iam_policy_document" "db_provision" {
-  statement {
+    statement {
     actions = [
       "ec2:CreateNetworkInterface",
       "ec2:DeleteNetworkInterface",
-      "ec2:DescribeNetworkInterfaces",
+      "ec2:DescribeNetworkInterfaces"
+    ]
+    resources = [
+      "arn:aws:ec2:${var.region}:${var.account_id}:network-interface/*"
+    ]
+  }
+
+  statement {
+    actions = [
       "logs:CreateLogGroup",
       "logs:CreateLogStream",
       "logs:DescribeLogStreams",
       "logs:PutLogEvents"
     ]
-    resources = ["*"]
+    resources = [
+      "arn:aws:logs:${var.region}:${var.account_id}:log-group:/aws/lambda/${var.prefix}-ProvisionPostgresDatabase:*"
+    ]
   }
   statement {
     actions = [


### PR DESCRIPTION
This PR improves the Terraform configuration by replacing the use of the hardcoded var.account_id variable with the dynamic aws_caller_identity data source within the db_provision IAM policy. This update:

Aligns with Terraform best practices

Reduces required configuration variables

Improves portability and security

##Files Changed
terraform/modules/data-persistence/main.tf

CHANGELOG.md

##Related Changelog Entry
Under ## [Unreleased]:

markdown
Copy
Edit
- **CUMULUS-XXXX**
  - Replaced use of `var.account_id` with the `aws_caller_identity` data source in the `db_provision` IAM policy to avoid requiring a hardcoded account ID in configuration. This improves portability and aligns with Terraform best practices.
