### PR TITLE
CUMULUS-4142,CUMULUS-4144: Improve cookie security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Updated Terraform version requirement to `>=1.12.2`
   - Updated AWS provider requirement to `5.100.x`
 
+### Changed
+
+- **CUMULUS-4142,CUMULUS-4144**
+  - Updated S3 credentials endpoint to delete the access token after successful authentication.
+  - Configured both Cumulus distribution and S3 credentials to set the SameSite attribute on cookies in the response.
+
 ### Fixed
 
 - **CUMULUS-4177**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- **CUMULUS-4142,CUMULUS-4144**
-  - Updated S3 credentials endpoint to delete the access token after successful authentication.
+- **CUMULUS-4142, CUMULUS-4144**
+  - Updated the S3 credentials endpoint attached to TEA to delete the access token after successful authentication.
   - Configured both Cumulus distribution and S3 credentials to set the SameSite attribute on cookies in the response.
 
 ### Fixed

--- a/packages/api/endpoints/distribution.js
+++ b/packages/api/endpoints/distribution.js
@@ -125,6 +125,7 @@ async function handleLoginRequest(req, res) {
           expires: new Date(accessTokenResponse.expirationTime * 1000),
           httpOnly: true,
           secure: useSecureCookies(),
+          sameSite: 'Strict',
         }
       )
       .status(301)

--- a/packages/api/endpoints/distribution.js
+++ b/packages/api/endpoints/distribution.js
@@ -15,7 +15,7 @@ const { RecordDoesNotExist } = require('@cumulus/errors');
 const { inTestMode } = require('@cumulus/common/test-utils');
 const { objectStoreForProtocol } = require('@cumulus/object-store');
 
-const { buildLoginErrorTemplateVars, getConfigurations, useSecureCookies } = require('../lib/distribution');
+const { buildLoginErrorTemplateVars, createCookieOptions, getConfigurations } = require('../lib/distribution');
 const {
   getBucketMap,
   getPathsByBucketName,
@@ -120,13 +120,7 @@ async function handleLoginRequest(req, res) {
       .cookie(
         'accessToken',
         accessTokenResponse.accessToken,
-        {
-          // expirationTime is in seconds but Date() expects milliseconds
-          expires: new Date(accessTokenResponse.expirationTime * 1000),
-          httpOnly: true,
-          secure: useSecureCookies(),
-          sameSite: 'Strict',
-        }
+        createCookieOptions(accessTokenResponse.expirationTime)
       )
       .status(301)
       .set({ Location: urljoin(distributionUrl, state || '') })

--- a/packages/api/lib/distribution.js
+++ b/packages/api/lib/distribution.js
@@ -25,6 +25,19 @@ const useSecureCookies = () => {
 };
 
 /**
+ * generates cookie options for an HTTP response based on an expiration time
+ *
+ * @param {number} expirationTimeInSeconds - cookie expiration time in seconds
+ * @returns {object} cookie options object
+ */
+const createCookieOptions = (expirationTimeInSeconds) => ({
+  expires: new Date(expirationTimeInSeconds * 1000),
+  httpOnly: true,
+  secure: useSecureCookies(),
+  sameSite: 'Lax',
+});
+
+/**
  * build OAuth client based on environment variables
  *
  * @returns {Promise<Object>} - OAuthClient object
@@ -234,6 +247,7 @@ async function ensureAuthorizedOrRedirect(req, res, next) {
 
 module.exports = {
   buildLoginErrorTemplateVars,
+  createCookieOptions,
   ensureAuthorizedOrRedirect,
   getConfigurations,
   handleAuthBearerToken,

--- a/packages/integration-tests/tests/test-metrics.js
+++ b/packages/integration-tests/tests/test-metrics.js
@@ -55,7 +55,7 @@ test('getInvocationCount returns the expected invocation count', async (t) => {
     lambda: 'fakeLambda',
     maxCount: 8,
     minCount: 3,
-    timeout: 150,
+    timeout: 300,
   });
   t.is(actual, 5);
 });
@@ -104,7 +104,7 @@ test('getInvocationCount returns the expected value if result stabilizes', async
     lambda: 'fakeLambda',
     maxCount: 20,
     minCount: 5,
-    timeout: 60,
+    timeout: 300,
   });
   t.is(actual, 8);
 });

--- a/packages/s3-credentials-endpoint/index.js
+++ b/packages/s3-credentials-endpoint/index.js
@@ -176,10 +176,11 @@ async function ensureAuthorizedOrRedirect(req, res, next) {
   if (!accessToken || !accessTokenRecord || isAccessTokenExpired(accessTokenRecord)) {
     // No valid access token found or token is expired — redirect to obtain a new one
     return res.redirect(307, redirectURLForAuthorizationCode);
-  } else {
-    // Authentication successful — delete the access token to prevent reuse
-    await accessTokenModel.delete({ accessToken });
   }
+
+  // Authentication successful — delete the access token to prevent reuse
+  await accessTokenModel.delete({ accessToken });
+
   req.authorizedMetadata = { userName: accessTokenRecord.username };
   return next();
 }

--- a/packages/s3-credentials-endpoint/index.js
+++ b/packages/s3-credentials-endpoint/index.js
@@ -95,6 +95,7 @@ async function handleRedirectRequest(req, res) {
         expires: new Date(expirationTime),
         httpOnly: true,
         secure: useSecureCookies(),
+        sameSite: 'Strict',
       }
     )
     .set({ Location: urljoin(distributionUrl, state) })

--- a/packages/s3-credentials-endpoint/index.js
+++ b/packages/s3-credentials-endpoint/index.js
@@ -15,10 +15,10 @@ const {
   EarthdataLoginError,
 } = require('@cumulus/oauth-client');
 const {
+  createCookieOptions,
   getConfigurations,
   handleAuthBearerToken,
   isAuthBearTokenRequest,
-  useSecureCookies,
 } = require('@cumulus/api/lib/distribution');
 const { isAccessTokenExpired } = require('@cumulus/api/lib/token');
 const { handleCredentialRequest } = require('@cumulus/api/endpoints/s3credentials');
@@ -77,8 +77,6 @@ async function handleRedirectRequest(req, res) {
   const { code, state } = req.query;
 
   const getAccessTokenResponse = await oauthClient.getAccessToken(code);
-  // expirationTime is in seconds whereas Date is expecting milliseconds
-  const expirationTime = getAccessTokenResponse.expirationTime * 1000;
 
   await accessTokenModel.create({
     accessToken: getAccessTokenResponse.accessToken,
@@ -91,12 +89,7 @@ async function handleRedirectRequest(req, res) {
     .cookie(
       'accessToken',
       getAccessTokenResponse.accessToken,
-      {
-        expires: new Date(expirationTime),
-        httpOnly: true,
-        secure: useSecureCookies(),
-        sameSite: 'Strict',
-      }
+      createCookieOptions(getAccessTokenResponse.expirationTime)
     )
     .set({ Location: urljoin(distributionUrl, state) })
     .status(307)
@@ -181,7 +174,11 @@ async function ensureAuthorizedOrRedirect(req, res, next) {
   }
 
   if (!accessToken || !accessTokenRecord || isAccessTokenExpired(accessTokenRecord)) {
+    // No valid access token found or token is expired — redirect to obtain a new one
     return res.redirect(307, redirectURLForAuthorizationCode);
+  } else {
+    // Authentication successful — delete the access token to prevent reuse
+    await accessTokenModel.delete({ accessToken });
   }
   req.authorizedMetadata = { userName: accessTokenRecord.username };
   return next();

--- a/tf-modules/distribution/main.tf
+++ b/tf-modules/distribution/main.tf
@@ -86,7 +86,8 @@ data "aws_iam_policy_document" "s3_credentials_lambda" {
   statement {
     actions = [
       "dynamodb:GetItem",
-      "dynamodb:PutItem"
+      "dynamodb:PutItem",
+      "dynamodb:DeleteItem"
     ]
     resources = [aws_dynamodb_table.access_tokens[0].arn]
   }


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-4142: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4142)
[CUMULUS-4144: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4144)

See [CUMULUS-4143](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4144) for approach.

## Changes

* Updated S3 credentials endpoint to delete the access token after successful authentication.
* Configured both Cumulus distribution and S3 credentials to set the SameSite attribute on cookies in the response.

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
