### PR TITLE
feat: add s3 replicator arn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+- Add S3 Replicator lambda ARN to s3-replicator outputs
 
 ### Notable Changes
 

--- a/tf-modules/s3-replicator/outputs.tf
+++ b/tf-modules/s3-replicator/outputs.tf
@@ -1,0 +1,4 @@
+output "s3_replicator_arn" {
+  value = aws_lambda_function.s3_replicator.arn
+  description = "Lambda ARN for the S3 replicator"
+}


### PR DESCRIPTION
**Summary:** We are adding an event trigger to our internal bucket in one of our modules. Due to limitations with how TF works, you have to define all the event triggers at once. Our event trigger is overwritting the S3 replication trigger. We want to define them all at once in our code, but the replicator ARN is not exposed to us. 

Addresses [CUMULUS-XX: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-XXX)

## Changes

* Detailed list or prose of changes
* ...

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
