### PR TITLE
Update task to pass payload to output in-line with docs

### DIFF
--- a/tasks/add-unique-granuleID/src/index.ts
+++ b/tasks/add-unique-granuleID/src/index.ts
@@ -39,7 +39,7 @@ async function assignUniqueIds(event: HandlerEvent): Promise<HandlerOutput> {
 
   const output = { granules: granules as GranuleOutput[] };
   log.debug('Granule output', output);
-  return output;
+  return { ...event.input, ...output };
 }
 
 /**

--- a/tasks/add-unique-granuleID/tests/index.js
+++ b/tasks/add-unique-granuleID/tests/index.js
@@ -28,6 +28,30 @@ test('assignUniqueIds assigns unique granule IDs and preserves producerGranuleId
   });
 });
 
+test('assignUniqueIds retains the rest of the passed in payload', async (t) => {
+  const hashLength = 6;
+
+  const payloadKeys = {
+    pdrs: ['somePdrValue'],
+    otherKey: { other: 'value' },
+  };
+  const event = {
+    input: {
+      granules: [
+        { granuleId: 'granule1', collectionId: 'collection1' },
+        { granuleId: 'granule2', collectionId: 'collection2' },
+      ],
+      ...payloadKeys,
+    },
+    config: {
+      hashLength,
+    },
+  };
+  const result = await assignUniqueIds(event, {});
+  delete result.granules;
+  t.deepEqual(result, payloadKeys, 'Should retain all non-granule keys in the payload');
+});
+
 test('assignUniqueIds ignores granules that already have producerGranuleId assigned', async (t) => {
   const event = {
     input: {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-4028](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4028)

## Changes

* Update AddUniqueGranuleId task to output the input payload in addition to the modified granules

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
