### PR TITLE
CUMULUS-4252: fix test-multipartCopyObject failures caused by stricter validation introduced in aws-sdk 3.896.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - **CUMULUS-4200**
   - updated metrics_es_host terraform variable description and validation
   - Users should ensure that the metrics_es_host does not include `https://`
+- **CUMULUS-4252**
+  - Fixed `test-multipartCopyObject` failures caused by stricter validation introduced in
+    `@aws-sdk/lib-storage@3.896.0`
 
 ## [v21.0.0] 2025-09-09
 

--- a/packages/aws-client/tests/S3/test-multipartCopyObject.js
+++ b/packages/aws-client/tests/S3/test-multipartCopyObject.js
@@ -3,7 +3,8 @@
 const test = require('ava');
 const cryptoRandomString = require('crypto-random-string');
 const fs = require('fs');
-const { createHash } = require('crypto');
+const { createHash, randomBytes } = require('crypto');
+const { Readable } = require('stream');
 const {
   createBucket,
   multipartCopyObject,
@@ -21,7 +22,8 @@ const randomId = (prefix) =>
 
 // Create an object in with random data of the given size
 const createDummyObject = ({ Bucket, Key, size, contentType }) => {
-  const readStream = fs.createReadStream('/dev/urandom', { end: size - 1 });
+  const buffer = randomBytes(size);
+  const readStream = Readable.from(buffer);
 
   return uploadS3FileStream(
     readStream,


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-4252: Fix unit test failure caused by added validation of @aws-sdk/lib-storage@3.896.0](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4252)

## Changes

* https://github.com/aws/aws-sdk-js-v3/blob/main/lib/lib-storage/src/Upload.ts added validation, which caused the failure.
Since /dev/urandom is not seekable, the SDK can’t re-read data → AWS thinks no valid parts were uploaded.
* Updated unit test to use in-memory buffer (Readable.from(crypto.randomBytes(size))) for file upload

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
