### PR TITLE
Update TEA to latest version 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+- **CUMULUS-4576 Upgrade Cumulus to use the latest version of TEA (3.0.0)
+  ** UPGRADE NOTE: When upgrading the TEA module version, use a two-phase apply to prevent rollback failures
+  caused by Terraform destroying old lambda S3 objects before the CloudFormation stack update completes.
+
+Phase 1 — upload new S3 objects and update CF stack (keeps old S3 objects intact as rollback targets if the CF update fails):
+   ````
+   terraform apply \
+     -target=module.thin_egress_app.aws_s3_object.cloudformation_template \
+     -target=module.thin_egress_app.aws_s3_object.lambda_source \
+     -target=module.thin_egress_app.aws_s3_object.lambda_code_dependency_archive \
+     -target=module.thin_egress_app.aws_s3_bucket.lambda_source \
+     -target=module.thin_egress_app.aws_cloudformation_stack.thin_egress_app \
+     -var-file=env/sandbox.tfvars
+   ````
+Phase 2 — full apply to clean up old S3 objects and apply remaining changes:
+````terraform apply -var-file=env/sandbox.tfvars````
+
 ### Added
 
 - **CUMULUS-4706**

--- a/example/cumulus-tf/thin_egress_app.tf
+++ b/example/cumulus-tf/thin_egress_app.tf
@@ -3,6 +3,35 @@ locals {
   tea_stage_name = "DEV"
 }
 
+# UPGRADE NOTE: When upgrading the TEA module version, use a two-phase apply to
+# prevent rollback failures caused by Terraform destroying old lambda S3 objects
+# before the CloudFormation stack update completes.
+#
+# Phase 1 — upload new S3 objects and update CF stack (keeps old S3 objects intact
+#            as rollback targets if the CF update fails):
+#
+#   terraform apply \
+#     -target=module.thin_egress_app.aws_s3_object.cloudformation_template \
+#     -target=module.thin_egress_app.aws_s3_object.lambda_source \
+#     -target=module.thin_egress_app.aws_s3_object.lambda_code_dependency_archive \
+#     -target=module.thin_egress_app.aws_s3_bucket.lambda_source \
+#     -target=module.thin_egress_app.aws_cloudformation_stack.thin_egress_app \
+#     -var-file=env/sandbox.tfvars
+#
+# Phase 2 — full apply to clean up old S3 objects and apply remaining changes:
+#
+#   terraform apply -var-file=env/sandbox.tfvars
+#
+# Known issue: upgrading from 1.3.2 to 3.0.0 will fail on EgressStage with
+# "Invalid stage identifier" because CF deletes the old EgressAPIdeployment334624
+# resource before updating EgressStage, which removes the DEV API Gateway stage.
+# If this happens:
+#   1. Run continue-update-rollback skipping EgressLambda BumperLambda UpdatePolicyLambda
+#   2. Run continue-update-rollback skipping EgressStage
+#   3. Recreate the DEV stage: aws apigateway create-stage --rest-api-id <id>
+#        --stage-name DEV --deployment-id <old_deployment_id>
+#   4. Re-run Phase 1 apply above
+
 resource "aws_secretsmanager_secret" "thin_egress_urs_creds" {
   name_prefix = "${var.prefix}-tea-urs-creds-"
   description = "URS credentials for the ${var.prefix} Thin Egress App"
@@ -32,7 +61,7 @@ resource "aws_s3_bucket_object" "bucket_map_yaml" {
 }
 
 module "thin_egress_app" {
-  source = "s3::https://s3.amazonaws.com/asf.public.code/thin-egress-app/tea-terraform-build.1.3.2.zip"
+  source = "s3::https://s3.amazonaws.com/asf.public.code/thin-egress-app/tea-terraform-build.3.0.0.zip"
 
   auth_base_url                 = "https://uat.urs.earthdata.nasa.gov"
   bucket_map_file               = aws_s3_bucket_object.bucket_map_yaml.id


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-4576: Upgrade Cumulus to use the latest version of TEA](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4576)

## Changes

* Updated example terraform to latest TEA version 3.0.0

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests

---
📝 **Note:**
For most pull requests, please **Squash and merge** to maintain a clean and readable commit history.
