### PR TITLE
CUMULUS-4707: Add default values for iceberg_iceberg_s3_bucket and iceberg_namespace.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,10 @@ Phase 2 — full apply to clean up old S3 objects and apply remaining changes:
 
 ### Added
 
-- **CUMULUS-4707**
-  - Implement list of granules route in iceberg search api
 - **CUMULUS-4708**
   - Implement list of executions route in iceberg search api
+- **CUMULUS-4707**
+  - Implement list of granules route in iceberg search api
 - **CUMULUS-4534**
   - collection db model has added non-optional cmr_provider field
   - update requires db-migration to add cmr_provider to collection model

--- a/example/cumulus-tf/variables.tf
+++ b/example/cumulus-tf/variables.tf
@@ -314,11 +314,13 @@ variable "api_service_autoscaling_target_cpu" {
 variable "iceberg_s3_bucket" {
   description = "Name of the S3 bucket the Iceberg API task needs read access to"
   type        = string
+  default = ""
 }
 
 variable "iceberg_namespace" {
   description = "AWS Glue schema (database) name containing the Iceberg tables"
   type        = string
+  default = ""
 }
 
 variable "archive_api_users" {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-4707: Add default values for iceberg_iceberg_s3_bucket and iceberg_namespace.](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4707)

## Changes

* This PR add default values for iceberg_iceberg_s3_bucket and iceberg_namespace so that deployment without iceberg api in CICD can run without extra configuration.

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests

---
📝 **Note:**
For most pull requests, please **Squash and merge** to maintain a clean and readable commit history.
