### PR TITLE
CUMULUS-4710: Implement list of stats route in iceberg search api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Phase 2 — full apply to clean up old S3 objects and apply remaining changes:
 
 ### Added
 
+- **CUMULUS-4710**
+  - Implement list of stats route in iceberg search api
 - **CUMULUS-4708**
   - Implement list of executions route in iceberg search api
 - **CUMULUS-4707**

--- a/example/cumulus-tf/variables.tf
+++ b/example/cumulus-tf/variables.tf
@@ -314,13 +314,13 @@ variable "api_service_autoscaling_target_cpu" {
 variable "iceberg_s3_bucket" {
   description = "Name of the S3 bucket the Iceberg API task needs read access to"
   type        = string
-  default = ""
+  default     = ""
 }
 
 variable "iceberg_namespace" {
   description = "AWS Glue schema (database) name containing the Iceberg tables"
   type        = string
-  default = ""
+  default     = ""
 }
 
 variable "archive_api_users" {
@@ -614,6 +614,6 @@ variable "workflow_configurations" {
 
 variable "cumulus_iceberg_api_image_version" {
   description = "The version of the Cumulus Iceberg API image to use"
-  type = string
-  default = "latest"
+  type        = string
+  default     = "latest"
 }

--- a/packages/api/app/iceberg-routes.js
+++ b/packages/api/app/iceberg-routes.js
@@ -4,7 +4,7 @@ const router = require('express-promise-router')();
 const Logger = require('@cumulus/logger');
 
 const { defaultErrorHandler } = require('./middleware');
-const stats = require('../endpoints/stats');
+const stats = require('../endpoints/iceberg-stats');
 const version = require('../endpoints/version');
 
 const log = new Logger('@cumulus/api/iceberg-routes');

--- a/packages/api/endpoints/iceberg-stats.js
+++ b/packages/api/endpoints/iceberg-stats.js
@@ -1,10 +1,8 @@
-//@ts-check
-
 'use strict';
 
 const router = require('express-promise-router')();
 const get = require('lodash/get');
-const { StatsSearch } = require('@cumulus/db');
+const { StatsIcebergSearch } = require('@cumulus/db/duckdb');
 const omit = require('lodash/omit');
 const { getType } = require('../lib/statsHelpers');
 
@@ -25,7 +23,7 @@ async function summary(req, res) {
     now - 24 * 3600 * 1000
   ), 10);
   params.timestamp__to = Number.parseInt(get(params, 'timestamp__to', now), 10);
-  const stats = new StatsSearch({ queryStringParameters: params }, 'granule');
+  const stats = new StatsIcebergSearch({ queryStringParameters: params }, 'granule');
   const r = await stats.summary();
   return res.send(r);
 }
@@ -40,11 +38,16 @@ async function summary(req, res) {
 async function aggregate(req, res) {
   const type = getType(req);
   if (type) {
-    const stats = new StatsSearch({ queryStringParameters: omit(req.query, 'type') }, type);
+    const stats = new StatsIcebergSearch(
+      { queryStringParameters: omit(req.query, 'type') },
+      type
+    );
     const r = await stats.aggregate();
     return res.send(r);
   }
-  return res.boom.badRequest('Type must be included in Stats Aggregate query string parameters');
+  return res.boom.badRequest(
+    'Type must be included in Stats Aggregate query string parameters'
+  );
 }
 
 router.get('/aggregate/:type?', aggregate);

--- a/packages/api/endpoints/iceberg-stats.js
+++ b/packages/api/endpoints/iceberg-stats.js
@@ -2,9 +2,12 @@
 
 const router = require('express-promise-router')();
 const get = require('lodash/get');
+const Logger = require('@cumulus/logger');
 const { StatsIcebergSearch } = require('@cumulus/db/duckdb');
 const omit = require('lodash/omit');
 const { getType } = require('../lib/statsHelpers');
+
+const log = new Logger({ sender: '@cumulus/api/iceberg-stats' });
 
 /**
  * get summary stats
@@ -14,18 +17,29 @@ const { getType } = require('../lib/statsHelpers');
  * @returns {Promise<Object>} the promise of express response object
  */
 async function summary(req, res) {
-  const params = req.query;
+  try {
+    const params = req.query;
 
-  const now = Date.now();
-  params.timestamp__from = Number.parseInt(get(
-    params,
-    'timestamp__from',
-    now - 24 * 3600 * 1000
-  ), 10);
-  params.timestamp__to = Number.parseInt(get(params, 'timestamp__to', now), 10);
-  const stats = new StatsIcebergSearch({ queryStringParameters: params }, 'granule');
-  const r = await stats.summary();
-  return res.send(r);
+    const now = Date.now();
+    params.timestamp__from = Number.parseInt(get(
+      params,
+      'timestamp__from',
+      now - 24 * 3600 * 1000
+    ), 10);
+    params.timestamp__to = Number.parseInt(get(params, 'timestamp__to', now), 10);
+    const stats = new StatsIcebergSearch({ queryStringParameters: params }, 'granule');
+    const r = await stats.summary();
+    return res.send(r);
+  } catch (error) {
+    log.error('StatsIcebergSearch Summary Query Failed', error);
+    if (res.boom) {
+      return res.boom.badImplementation('Error querying S3/Iceberg data');
+    }
+    return res.status(500).send({
+      error: 'Internal Server Error',
+      message: 'Error querying S3/Iceberg data',
+    });
+  }
 }
 
 /**
@@ -36,18 +50,29 @@ async function summary(req, res) {
  * @returns {Promise<Object>} the promise of express response object
  */
 async function aggregate(req, res) {
-  const type = getType(req);
-  if (type) {
-    const stats = new StatsIcebergSearch(
-      { queryStringParameters: omit(req.query, 'type') },
-      type
+  try {
+    const type = getType(req);
+    if (type) {
+      const stats = new StatsIcebergSearch(
+        { queryStringParameters: omit(req.query, 'type') },
+        type
+      );
+      const r = await stats.aggregate();
+      return res.send(r);
+    }
+    return res.boom.badRequest(
+      'Type must be included in the Stats Aggregate path parameter or query string parameters'
     );
-    const r = await stats.aggregate();
-    return res.send(r);
+  } catch (error) {
+    log.error('StatsIcebergSearch Aggregate Query Failed', error);
+    if (res.boom) {
+      return res.boom.badImplementation('Error querying S3/Iceberg data');
+    }
+    return res.status(500).send({
+      error: 'Internal Server Error',
+      message: 'Error querying S3/Iceberg data',
+    });
   }
-  return res.boom.badRequest(
-    'Type must be included in Stats Aggregate query string parameters'
-  );
 }
 
 router.get('/aggregate/:type?', aggregate);

--- a/packages/api/lib/statsHelpers.js
+++ b/packages/api/lib/statsHelpers.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const get = require('lodash/get');
+
+/**
+ * Map requested stats types to supported types
+ *
+ * @param {Object} req - express request object
+ * @returns {string|undefined} returns the type of stats
+ */
+function getType(req) {
+  const supportedTypes = {
+    granules: 'granule',
+    pdrs: 'pdr',
+    collections: 'collection',
+    logs: 'logs',
+    providers: 'provider',
+    executions: 'execution',
+    reconciliationReports: 'reconciliationReport',
+  };
+
+  const typeRequested = get(req, 'params.type') || get(req, 'query.type');
+  const type = get(supportedTypes, typeRequested);
+
+  return type;
+}
+
+module.exports = { getType };

--- a/packages/api/tests/endpoints/test-iceberg-stats.js
+++ b/packages/api/tests/endpoints/test-iceberg-stats.js
@@ -13,8 +13,8 @@ const aggregate = icebergStats.__get__('aggregate');
 test.serial('summary returns badImplementation when StatsIcebergSearch summary query throws', async (t) => {
   const queryError = new Error('summary query failed');
   class MockStatsIcebergSearch {
-    async summary() {
-      throw queryError;
+    summary() {
+      return Promise.reject(queryError);
     }
   }
 
@@ -38,8 +38,8 @@ test.serial('summary returns badImplementation when StatsIcebergSearch summary q
 test.serial('aggregate returns badImplementation when StatsIcebergSearch aggregate query throws', async (t) => {
   const queryError = new Error('aggregate query failed');
   class MockStatsIcebergSearch {
-    async aggregate() {
-      throw queryError;
+    aggregate() {
+      return Promise.reject(queryError);
     }
   }
 

--- a/packages/api/tests/endpoints/test-iceberg-stats.js
+++ b/packages/api/tests/endpoints/test-iceberg-stats.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const test = require('ava');
+const sinon = require('sinon');
+const rewire = require('rewire');
+
+const { buildFakeExpressResponse } = require('./utils');
+
+const icebergStats = rewire('../../endpoints/iceberg-stats');
+const summary = icebergStats.__get__('summary');
+const aggregate = icebergStats.__get__('aggregate');
+
+test.serial('summary returns badImplementation when StatsIcebergSearch summary query throws', async (t) => {
+  const queryError = new Error('summary query failed');
+  class MockStatsIcebergSearch {
+    async summary() {
+      throw queryError;
+    }
+  }
+
+  const restoreStatsIcebergSearch = icebergStats.__set__('StatsIcebergSearch', MockStatsIcebergSearch);
+  const logErrorStub = sinon.stub();
+  const restoreLog = icebergStats.__set__('log', { error: logErrorStub });
+  t.teardown(() => {
+    restoreStatsIcebergSearch();
+    restoreLog();
+  });
+
+  const response = buildFakeExpressResponse();
+  await summary({ query: {} }, response);
+
+  t.true(logErrorStub.calledWith('StatsIcebergSearch Summary Query Failed', queryError));
+  t.true(response.boom.badImplementation.calledWith('Error querying S3/Iceberg data'));
+  t.true(response.status.notCalled);
+  t.true(response.send.notCalled);
+});
+
+test.serial('aggregate returns badImplementation when StatsIcebergSearch aggregate query throws', async (t) => {
+  const queryError = new Error('aggregate query failed');
+  class MockStatsIcebergSearch {
+    async aggregate() {
+      throw queryError;
+    }
+  }
+
+  const restoreStatsIcebergSearch = icebergStats.__set__('StatsIcebergSearch', MockStatsIcebergSearch);
+  const logErrorStub = sinon.stub();
+  const restoreLog = icebergStats.__set__('log', { error: logErrorStub });
+  t.teardown(() => {
+    restoreStatsIcebergSearch();
+    restoreLog();
+  });
+
+  const response = buildFakeExpressResponse();
+  await aggregate({ params: { type: 'granules' }, query: {} }, response);
+
+  t.true(logErrorStub.calledWith('StatsIcebergSearch Aggregate Query Failed', queryError));
+  t.true(response.boom.badImplementation.calledWith('Error querying S3/Iceberg data'));
+  t.true(response.status.notCalled);
+  t.true(response.send.notCalled);
+});

--- a/packages/db/src/iceberg-connection.ts
+++ b/packages/db/src/iceberg-connection.ts
@@ -13,9 +13,21 @@ const quoteIdent = (ident: string): string => `"${ident.replace(/"/g, '""')}"`;
 let instance: DuckDBInstance | undefined;
 let initPromise: Promise<void> | undefined;
 let dbVersionCache: string | undefined;
+let poolCacheWarmupPromise: Promise<void> | undefined;
 
 const connectionPool: DuckDBConnection[] = [];
 const MAX_POOL_SIZE = Number(process.env.DUCKDB_MAX_POOL) || 3;
+const ENABLE_CACHE_WARMUP = process.env.DUCKDB_ENABLE_CACHE_WARMUP !== 'false';
+const tableNames = [
+  'granules',
+  'collections',
+  'executions',
+  'pdrs',
+  'providers',
+  'rules',
+  'async_operations',
+  'granules_executions',
+];
 
 /**
  * Executes settings that should apply to every individual connection.
@@ -56,6 +68,54 @@ const warmupConnection = async (conn: DuckDBConnection): Promise<void> => {
 };
 
 /**
+ * Pre-populate connection-level metadata and file/cache state for known views.
+ */
+const populateConnectionCache = async (conn: DuckDBConnection): Promise<void> => {
+  for (const tableName of tableNames) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      await conn.run(`SELECT COUNT(*) FROM ${quoteIdent(tableName)};`);
+    } catch (error) {
+      log.debug(`Cache warmup skipped for table ${tableName}.`);
+    }
+  }
+};
+
+/**
+ * Start one-time background cache population for currently pooled connections.
+ */
+const startPoolCacheWarmup = (): void => {
+  if (!ENABLE_CACHE_WARMUP) {
+    log.info('DuckDB cache warmup disabled by DUCKDB_ENABLE_CACHE_WARMUP.');
+    return;
+  }
+
+  if (poolCacheWarmupPromise) return;
+
+  poolCacheWarmupPromise = (async () => {
+    log.info('Starting background cache warmup for pooled DuckDB connections...');
+    await Promise.all(connectionPool.map((conn) => populateConnectionCache(conn)));
+    log.info('Background cache warmup for pooled connections complete.');
+  })().catch((error) => {
+    log.warn('Background cache warmup encountered an error. Continuing without blocking startup.', error);
+  });
+};
+
+/**
+ * Start background cache warmup for a single connection.
+ */
+const startConnectionCacheWarmup = (conn: DuckDBConnection): void => {
+  if (!ENABLE_CACHE_WARMUP) {
+    return;
+  }
+
+  const cacheWarmupPromise = populateConnectionCache(conn);
+  cacheWarmupPromise.catch((error) => {
+    log.debug('Background cache warmup for connection failed.', error);
+  });
+};
+
+/**
  * Initialize the DuckDB Instance and load required extensions.
  */
 export const initializeDuckDb = async (): Promise<void> => {
@@ -90,11 +150,6 @@ export const initializeDuckDb = async (): Promise<void> => {
         `ATTACH '${awsAccountId}' AS glue_iceberg (TYPE iceberg, ENDPOINT_TYPE 'glue');`
       );
 
-      const tableNames = [
-        'granules', 'collections', 'executions', 'pdrs',
-        'providers', 'rules', 'async_operations', 'granules_executions',
-      ];
-
       for (const tableName of tableNames) {
         try {
           // eslint-disable-next-line no-await-in-loop
@@ -123,6 +178,8 @@ export const initializeDuckDb = async (): Promise<void> => {
         connectionPool.push(...newConns);
       }
 
+      startPoolCacheWarmup();
+
       log.info('DuckDB initialization and view creation complete.');
     } catch (error) {
       log.error('Failed to initialize DuckDB:', error);
@@ -149,6 +206,7 @@ export const acquireDuckDbConnection = async (): Promise<DuckDBConnection> => {
 
   const conn = await instance!.connect();
   await warmupConnection(conn);
+  startConnectionCacheWarmup(conn);
   return conn;
 };
 
@@ -172,4 +230,5 @@ export const destroyDuckDb = async (): Promise<void> => {
   instance = undefined;
   initPromise = undefined;
   dbVersionCache = undefined;
+  poolCacheWarmupPromise = undefined;
 };

--- a/packages/db/src/iceberg-connection.ts
+++ b/packages/db/src/iceberg-connection.ts
@@ -8,7 +8,9 @@ const log = new Logger({ sender: '@cumulus/db/iceberg-connection' });
  * by doubling them (standard SQL identifier quoting).
  * e.g. foo -> "foo", foo"bar -> "foo""bar"
  */
-const quoteIdent = (ident: string): string => `"${ident.replace(/"/g, '""')}"`;
+function quoteIdent(ident: string): string {
+  return `"${ident.replace(/"/g, '""')}"`;
+}
 
 let instance: DuckDBInstance | undefined;
 let initPromise: Promise<void> | undefined;
@@ -32,7 +34,7 @@ const tableNames = [
 /**
  * Executes settings that should apply to every individual connection.
  */
-const warmupConnection = async (conn: DuckDBConnection): Promise<void> => {
+async function warmupConnection(conn: DuckDBConnection): Promise<void> {
   const isLocal = process.env.NODE_ENV === 'development';
 
   if (isLocal) {
@@ -62,15 +64,28 @@ const warmupConnection = async (conn: DuckDBConnection): Promise<void> => {
   const region = process.env.AWS_REGION || 'us-east-1';
   await conn.run(`SET s3_region='${region}';`);
   await conn.run('SET s3_url_style=\'vhost\';');
+  // Performance and memory settings
+  // ECS_TASK_MEMORY is in MiB; use half of that for DuckDB.
+  // ECS_TASK_CPU is in CPU units (1024 = 1 vCPU); derive thread count from it.
+  const ecsMemoryMiB = Number(process.env.ECS_TASK_MEMORY) || 1024;
+  const ecsCpuUnits = Number(process.env.ECS_TASK_CPU) || 1024;
+  const memoryLimitMiB = Math.floor(ecsMemoryMiB / 2);
+  const threadCount = Math.max(1, Math.floor(ecsCpuUnits / 1024));
+  await conn.run(`SET memory_limit='${memoryLimitMiB}MB';`);
+  await conn.run(`SET threads=${threadCount};`);
+  await conn.run('SET parquet_metadata_cache=true;');
+  await conn.run('SET enable_http_metadata_cache=true;');
+  await conn.run('SET enable_object_cache=true;');
+  await conn.run('SET http_keep_alive=true;');
 
   await conn.run('CALL load_aws_credentials();');
   await conn.run('CREATE SECRET IF NOT EXISTS (TYPE S3, PROVIDER credential_chain);');
-};
+}
 
 /**
  * Pre-populate connection-level metadata and file/cache state for known views.
  */
-const populateConnectionCache = async (conn: DuckDBConnection): Promise<void> => {
+async function populateConnectionCache(conn: DuckDBConnection): Promise<void> {
   for (const tableName of tableNames) {
     try {
       // eslint-disable-next-line no-await-in-loop
@@ -79,12 +94,12 @@ const populateConnectionCache = async (conn: DuckDBConnection): Promise<void> =>
       log.debug(`Cache warmup skipped for table ${tableName}.`);
     }
   }
-};
+}
 
 /**
  * Start one-time background cache population for currently pooled connections.
  */
-const startPoolCacheWarmup = (): void => {
+function startPoolCacheWarmup(): void {
   if (!ENABLE_CACHE_WARMUP) {
     log.info('DuckDB cache warmup disabled by DUCKDB_ENABLE_CACHE_WARMUP.');
     return;
@@ -99,26 +114,26 @@ const startPoolCacheWarmup = (): void => {
   })().catch((error) => {
     log.warn('Background cache warmup encountered an error. Continuing without blocking startup.', error);
   });
-};
+}
 
 /**
  * Start background cache warmup for a single connection.
  */
-const startConnectionCacheWarmup = (conn: DuckDBConnection): void => {
+function startConnectionCacheWarmup(conn: DuckDBConnection): void {
   if (!ENABLE_CACHE_WARMUP) {
     return;
   }
 
   const cacheWarmupPromise = populateConnectionCache(conn);
   cacheWarmupPromise.catch((error) => {
-    log.debug('Background cache warmup for connection failed.', error);
+    log.warn('Background cache warmup for connection failed.', error);
   });
-};
+}
 
 /**
  * Initialize the DuckDB Instance and load required extensions.
  */
-export const initializeDuckDb = async (): Promise<void> => {
+export async function initializeDuckDb(): Promise<void> {
   if (instance) return;
   if (initPromise) {
     await initPromise;
@@ -190,12 +205,12 @@ export const initializeDuckDb = async (): Promise<void> => {
   })();
 
   await initPromise;
-};
+}
 
 /**
  * Acquire a connection from the pool or create a new one.
  */
-export const acquireDuckDbConnection = async (): Promise<DuckDBConnection> => {
+export async function acquireDuckDbConnection(): Promise<DuckDBConnection> {
   if (!instance) {
     await initializeDuckDb();
   }
@@ -208,27 +223,27 @@ export const acquireDuckDbConnection = async (): Promise<DuckDBConnection> => {
   await warmupConnection(conn);
   startConnectionCacheWarmup(conn);
   return conn;
-};
+}
 
 /**
  * Release a connection back to the pool for reuse.
  */
-export const releaseDuckDbConnection = async (conn: DuckDBConnection): Promise<void> => {
+export async function releaseDuckDbConnection(conn: DuckDBConnection): Promise<void> {
   if (connectionPool.length < MAX_POOL_SIZE) {
     connectionPool.push(conn);
   } else {
     log.debug('Pool full, discarding connection reference.');
   }
-};
+}
 
 /**
  * Cleanup function for graceful shutdown.
  */
-export const destroyDuckDb = async (): Promise<void> => {
+export async function destroyDuckDb(): Promise<void> {
   log.info('Shutting down DuckDB...');
   connectionPool.length = 0;
   instance = undefined;
   initPromise = undefined;
   dbVersionCache = undefined;
   poolCacheWarmupPromise = undefined;
-};
+}

--- a/tf-modules/iceberg_api/main.tf
+++ b/tf-modules/iceberg_api/main.tf
@@ -1,9 +1,11 @@
 locals {
-  api_env_variables  = {
-        "OAUTH_PROVIDER"      = var.oauth_provider
-        "api_config_secret_id" = var.api_config_secret_arn
-        "AWS_ACCOUNT_ID"      = var.aws_account_id
-        "ICEBERG_NAMESPACE" = var.iceberg_namespace
+  api_env_variables = {
+    "OAUTH_PROVIDER"       = var.oauth_provider
+    "api_config_secret_id" = var.api_config_secret_arn
+    "AWS_ACCOUNT_ID"       = var.aws_account_id
+    "ICEBERG_NAMESPACE"    = var.iceberg_namespace
+    "ECS_TASK_MEMORY"      = tostring(var.iceberg_api_memory)
+    "ECS_TASK_CPU"         = tostring(var.iceberg_api_cpu)
   }
 }
 
@@ -12,7 +14,7 @@ data "aws_ecr_repository" "cumulus_iceberg_api" {
 }
 
 data "aws_ssm_parameter" "private_ca" {
-  name  = "ngap_private_ca_arn"
+  name = "ngap_private_ca_arn"
 }
 
 resource "aws_cloudwatch_log_group" "iceberg_api" {
@@ -46,7 +48,7 @@ resource "aws_ecs_task_definition" "iceberg_api" {
         }
       ]
       environment = [
-        for k, v in merge(local.api_env_variables, {"auth_mode"="public"}) : {
+        for k, v in merge(local.api_env_variables, { "auth_mode" = "public" }) : {
           name  = k
           value = tostring(v)
         }
@@ -64,15 +66,15 @@ resource "aws_ecs_task_definition" "iceberg_api" {
 }
 
 resource "aws_ecs_service" "iceberg_api" {
-  name            = "${var.prefix}-IcebergApiService"
-  cluster         = var.ecs_cluster_arn
-  task_definition = aws_ecs_task_definition.iceberg_api.arn
-  desired_count   = var.api_service_autoscaling_min_capacity
+  name                              = "${var.prefix}-IcebergApiService"
+  cluster                           = var.ecs_cluster_arn
+  task_definition                   = aws_ecs_task_definition.iceberg_api.arn
+  desired_count                     = var.api_service_autoscaling_min_capacity
   health_check_grace_period_seconds = 180
-  launch_type     = "FARGATE"
+  launch_type                       = "FARGATE"
 
   network_configuration {
-    subnets          = var.ecs_cluster_instance_subnet_ids
+    subnets = var.ecs_cluster_instance_subnet_ids
 
     # Include RDS security group to allow database access
     security_groups  = [aws_security_group.iceberg_ecs_task_sg.id, var.rds_security_group_id]
@@ -103,16 +105,16 @@ resource "aws_lb" "iceberg_api" {
 }
 
 resource "aws_lb_target_group" "iceberg_api" {
-  name_prefix = substr("${var.prefix}-", 0, 6)
-  port        = 5001
-  protocol    = "HTTP"
-  vpc_id      = var.vpc_id
-  target_type = "ip"
+  name_prefix          = substr("${var.prefix}-", 0, 6)
+  port                 = 5001
+  protocol             = "HTTP"
+  vpc_id               = var.vpc_id
+  target_type          = "ip"
   deregistration_delay = 120
 
   health_check {
     path                = "/version"
-    matcher = "200-399" # Accept any success or redirect code
+    matcher             = "200-399" # Accept any success or redirect code
     interval            = 20
     timeout             = 10
     unhealthy_threshold = 6
@@ -124,7 +126,7 @@ resource "aws_lb_target_group" "iceberg_api" {
 }
 
 resource "aws_acm_certificate" "iceberg_lb_cert" {
-  domain_name       = "${var.prefix}.cumulus.earthdatacloud.nasa.gov"
+  domain_name               = "${var.prefix}.cumulus.earthdatacloud.nasa.gov"
   certificate_authority_arn = data.aws_ssm_parameter.private_ca.value
 
   lifecycle {

--- a/tf-modules/iceberg_api/main.tf
+++ b/tf-modules/iceberg_api/main.tf
@@ -95,7 +95,7 @@ resource "aws_ecs_service" "iceberg_api" {
 }
 
 resource "aws_lb" "iceberg_api" {
-  name               = "${var.prefix}-iceberg-api-alb"
+  name               = "${var.prefix}-iceberg-api"
   internal           = true
   load_balancer_type = "application"
   security_groups    = [aws_security_group.iceberg_alb_sg.id]


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-4710: Implement list of stats route in iceberg search api](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4710)

## Changes

* Implement list of stats route in iceberg search api
* Fix nsidc-cumulus-prod stack deployment in SIT
* Add background cache population for duckdb connections.

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests

---
📝 **Note:**
For most pull requests, please **Squash and merge** to maintain a clean and readable commit history.
