### PR TITLE
CUMULUS-4815: Add support for files related searches to go to the files_table in iceberg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **CUMULUS-4815**
+  - Add support for files related searches to go to the files_table in iceberg
 - **CUMULUS-4709**
   - Fix stale connections problem in iceberg API
 - **CUMULUS-4710**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - **CUMULUS-4815**
-  - Add support for files related searches to go to the files_table in iceberg
+  - Add support for file-related searches to go to the files_table in iceberg
 - **CUMULUS-4709**
   - Fix stale connections problem in iceberg API
 - **CUMULUS-4710**

--- a/packages/api/app/iceberg-routes.js
+++ b/packages/api/app/iceberg-routes.js
@@ -18,7 +18,6 @@ if (process.env.FAKE_AUTH === 'true') {
   ensureAuthorized = token.ensureAuthorized;
 }
 
-// Import the limited routers for granules and executions
 const granulesIcebergRouter = require('../endpoints/iceberg-granules');
 const executionsIcebergRouter = require('../endpoints/iceberg-executions');
 const collectionsIcebergRouter = require('../endpoints/iceberg-collections');

--- a/packages/db/src/iceberg-connection.ts
+++ b/packages/db/src/iceberg-connection.ts
@@ -6,8 +6,7 @@ const log = new Logger({ sender: '@cumulus/db/iceberg-connection' });
 let instance: DuckDBInstance | undefined;
 let initPromise: Promise<void> | undefined;
 let dbVersionCache: string | undefined;
-export interface PooledDuckDbConnection {
-  connection: DuckDBConnection;
+export interface PooledDuckDbConnection extends DuckDBConnection {
   creationTime: number;
 }
 
@@ -158,16 +157,18 @@ async function configureConnection(conn: DuckDBConnection): Promise<void> {
 async function getConnection(): Promise<PooledDuckDbConnection> {
   const connection = await instance!.connect();
   await configureConnection(connection);
-  return { connection, creationTime: Date.now() };
+
+  const pooledConn = connection as PooledDuckDbConnection;
+  pooledConn.creationTime = Date.now();
+  return pooledConn;
 }
 
 /**
  * Pre-populate connection-level metadata and file/cache state for known views.
  *
- * @param pooledConn
+ * @param conn
  */
-async function populateConnectionCache(pooledConn: PooledDuckDbConnection): Promise<void> {
-  const conn = pooledConn.connection;
+async function populateConnectionCache(conn: PooledDuckDbConnection): Promise<void> {
   for (const tableName of tableNames) {
     try {
       // eslint-disable-next-line no-await-in-loop
@@ -303,7 +304,7 @@ export async function releaseDuckDbConnection(conn: PooledDuckDbConnection): Pro
   } else {
     log.debug('Pool full, discarding connection reference.');
     try {
-      conn.connection.closeSync();
+      conn.closeSync();
     } catch (error) {
       log.warn('Error closing discarded DuckDB connection', error);
     }
@@ -339,7 +340,7 @@ export async function clearDuckDbPool(createdBefore: number): Promise<void> {
           } else {
             // Destroy old connection
             try {
-              pooledConn.connection.closeSync();
+              pooledConn.closeSync();
               removedCount += 1;
             } catch (error) {
               log.warn('Error closing pooled DuckDB connection', error);

--- a/packages/db/src/iceberg-connection.ts
+++ b/packages/db/src/iceberg-connection.ts
@@ -21,6 +21,7 @@ const tableNames = [
   'granules',
   'collections',
   'executions',
+  'files_table',
   'pdrs',
   'providers',
   'rules',

--- a/packages/db/src/iceberg-search/CollectionIcebergSearch.ts
+++ b/packages/db/src/iceberg-search/CollectionIcebergSearch.ts
@@ -49,7 +49,7 @@ export class CollectionIcebergSearch extends CollectionSearch {
 
     log.debug(`fetchGranuleStatusAggregation statsQuery: ${statsQuery?.toSQL().sql}`);
     const { sql, bindings } = statsQuery.toSQL().toNative();
-    const reader = await dbConnection.connection.runAndReadAll(
+    const reader = await dbConnection.runAndReadAll(
       sql,
       prepareBindings(bindings)
     );

--- a/packages/db/src/iceberg-search/DuckDBSearchExecutor.ts
+++ b/packages/db/src/iceberg-search/DuckDBSearchExecutor.ts
@@ -100,15 +100,15 @@ export async function executeDuckDBSearch(params: {
     };
 
     try {
-      await runNativeQueries(pooledConnection.connection);
+      await runNativeQueries(pooledConnection);
     } catch (error) {
       if (isCatalogError(error)) {
         log.warn('Catalog error detected; closing stale connection and clearing pool, then retrying query once.', error);
-        pooledConnection.connection.closeSync();
+        pooledConnection.closeSync();
         await clearDuckDbPool(queryStartTime);
         pooledConnection = await acquireDuckDbConnection();
 
-        await runNativeQueries(pooledConnection.connection);
+        await runNativeQueries(pooledConnection);
       } else {
         throw error;
       }

--- a/packages/db/src/iceberg-search/GranuleIcebergSearch.ts
+++ b/packages/db/src/iceberg-search/GranuleIcebergSearch.ts
@@ -48,7 +48,7 @@ export class GranuleIcebergSearch extends GranuleSearch {
     if (includeFullRecord) {
       //get files
       const files = await getFilesByGranuleCumulusIds({
-        connection: dbConnection.connection,
+        connection: dbConnection,
         granuleCumulusIds: cumulusIds,
         knexBuilder: knexClient,
       });
@@ -61,7 +61,7 @@ export class GranuleIcebergSearch extends GranuleSearch {
 
       //get Executions
       const executions = await getExecutionInfoByGranuleCumulusIds({
-        connection: dbConnection.connection,
+        connection: dbConnection,
         granuleCumulusIds: cumulusIds,
         knexBuilder: knexClient,
       });

--- a/packages/db/src/iceberg-search/IcebergSchemas.ts
+++ b/packages/db/src/iceberg-search/IcebergSchemas.ts
@@ -94,7 +94,7 @@ export const executionsIcebergSql = (tableName: string = 'executions') => `
         CHECK (status IN ('running', 'completed', 'failed', 'unknown'))
 );`;
 
-export const filesIcebergSql = (tableName: string = 'files') => `
+export const filesIcebergSql = (tableName: string = 'files_table') => `
   CREATE TABLE IF NOT EXISTS ${tableName} (
     cumulus_id BIGINT PRIMARY KEY,
     granule_cumulus_id BIGINT NOT NULL,

--- a/packages/db/src/iceberg-search/IcebergSchemas.ts
+++ b/packages/db/src/iceberg-search/IcebergSchemas.ts
@@ -94,7 +94,9 @@ export const executionsIcebergSql = (tableName: string = 'executions') => `
         CHECK (status IN ('running', 'completed', 'failed', 'unknown'))
 );`;
 
-export const filesIcebergSql = (tableName: string = 'files_table') => `
+export const ICEBERG_FILES_TABLE = 'files_table';
+
+export const filesIcebergSql = (tableName: string = ICEBERG_FILES_TABLE) => `
   CREATE TABLE IF NOT EXISTS ${tableName} (
     cumulus_id BIGINT PRIMARY KEY,
     granule_cumulus_id BIGINT NOT NULL,

--- a/packages/db/src/iceberg-search/StatsIcebergSearch.ts
+++ b/packages/db/src/iceberg-search/StatsIcebergSearch.ts
@@ -30,7 +30,7 @@ class StatsIcebergSearch extends StatsSearch {
     const { sql, bindings } = aggregateQuery.toSQL().toNative();
     const dbConnection = await acquireDuckDbConnection();
     try {
-      const reader = await dbConnection.connection.runAndReadAll(
+      const reader = await dbConnection.runAndReadAll(
         sql,
         prepareBindings([...bindings])
       );
@@ -51,7 +51,7 @@ class StatsIcebergSearch extends StatsSearch {
     const { sql, bindings } = searchQuery.toSQL().toNative();
     const dbConnection = await acquireDuckDbConnection();
     try {
-      const records = (await dbConnection.connection.runAndReadAll(
+      const records = (await dbConnection.runAndReadAll(
         sql,
         prepareBindings([...bindings])
       )).getRowObjectsJson() as any;

--- a/packages/db/src/iceberg-search/duckdbHelpers.ts
+++ b/packages/db/src/iceberg-search/duckdbHelpers.ts
@@ -92,6 +92,7 @@ export const getFilesByGranuleCumulusIds = async ({
     .whereIn('granule_cumulus_id', granuleCumulusIds);
 
   const { sql, bindings } = knexQuery.toSQL().toNative();
+  log.debug(`getFilesByGranuleCumulusIds query: ${sql}`);
 
   // Execute using DuckDB connection
   const reader = await connection.runAndReadAll(

--- a/packages/db/src/iceberg-search/duckdbHelpers.ts
+++ b/packages/db/src/iceberg-search/duckdbHelpers.ts
@@ -86,7 +86,7 @@ export const getFilesByGranuleCumulusIds = async ({
   columns?: string | string[];
   knexBuilder?: Knex;
 }): Promise<PostgresFileRecord[]> => {
-  const knexQuery = knexBuilder(TableNames.files)
+  const knexQuery = knexBuilder('files_table')
     .select(columns)
     .whereIn('granule_cumulus_id', granuleCumulusIds);
 

--- a/packages/db/src/iceberg-search/duckdbHelpers.ts
+++ b/packages/db/src/iceberg-search/duckdbHelpers.ts
@@ -3,6 +3,7 @@ import { knex, Knex } from 'knex';
 import Logger from '@cumulus/logger';
 import { TableNames } from '../tables';
 import { PostgresFileRecord } from '../types/file';
+import { ICEBERG_FILES_TABLE } from './IcebergSchemas';
 
 const log = new Logger({ sender: '@cumulus/db/duckdbHelpers' });
 
@@ -86,7 +87,7 @@ export const getFilesByGranuleCumulusIds = async ({
   columns?: string | string[];
   knexBuilder?: Knex;
 }): Promise<PostgresFileRecord[]> => {
-  const knexQuery = knexBuilder('files_table')
+  const knexQuery = knexBuilder(ICEBERG_FILES_TABLE)
     .select(columns)
     .whereIn('granule_cumulus_id', granuleCumulusIds);
 

--- a/packages/db/src/test-duckdb-utils.ts
+++ b/packages/db/src/test-duckdb-utils.ts
@@ -1,6 +1,6 @@
 import type { Knex } from 'knex';
 import { DuckDBInstance, DuckDBConnection } from '@duckdb/node-api';
-import { setDuckDbStateForTesting } from './iceberg-connection';
+import { setDuckDbStateForTesting, PooledDuckDbConnection } from './iceberg-connection';
 import {
   asyncOperationsIcebergSql,
   collectionsIcebergSql,
@@ -43,9 +43,10 @@ export async function setupDuckDBWithS3ForTesting(dbFilePath: string = ':memory:
     SET s3_url_style='path';
   `);
 
+  const pooledConnection = Object.assign(connection, { creationTime: Date.now() });
   setDuckDbStateForTesting({
     instance,
-    pooledConnections: [{ connection, creationTime: Date.now() }],
+    pooledConnections: [pooledConnection as PooledDuckDbConnection],
   });
 
   return { instance, connection };

--- a/packages/db/tests/iceberg-search/test-GranuleIcebergSearch.js
+++ b/packages/db/tests/iceberg-search/test-GranuleIcebergSearch.js
@@ -281,7 +281,7 @@ test.before(async (t) => {
   await stageAndLoadDuckDBTableFromData(
     connection,
     t.context.knexBuilder,
-    'files',
+    'files_table',
     filesIcebergSql,
     t.context.files,
     `${duckdbS3Prefix}files.parquet`

--- a/packages/db/tests/iceberg-search/test-GranuleIcebergSearch.js
+++ b/packages/db/tests/iceberg-search/test-GranuleIcebergSearch.js
@@ -23,6 +23,7 @@ const {
   granulesExecutionsIcebergSql,
   providersIcebergSql,
   pdrsIcebergSql,
+  ICEBERG_FILES_TABLE,
 } = require('../../dist/iceberg-search/IcebergSchemas');
 const {
   translatePostgresGranuleToApiGranuleWithoutDbQuery,
@@ -281,7 +282,7 @@ test.before(async (t) => {
   await stageAndLoadDuckDBTableFromData(
     connection,
     t.context.knexBuilder,
-    'files_table',
+    ICEBERG_FILES_TABLE,
     filesIcebergSql,
     t.context.files,
     `${duckdbS3Prefix}files.parquet`


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-4815: Add support for files related searches to go to the files_table in iceberg](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4815)

## Changes

* Add support for files related searches to go to the files_table in iceberg
* Minor refactoring of PooledDuckDbConnection

## Test

Run iceberg api locally on master or against a Sandbox stack deployed from master and reproduce the problem with the following query:
`curl -i -H "Authorization: Bearer $token" https://<iceberg api root>/granules?includeFullRecord=true`
It will return an Internal Server Error and status code of 500.

Run iceberg locally on this branch or against a Sandbox stack deployed from this branch and verify the same request now returns a 200 status code with empty result since there is no granules in the Sandbox Iceberg table.

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests

---
📝 **Note:**
For most pull requests, please **Squash and merge** to maintain a clean and readable commit history.
