### PR TITLE
CUMULUS 4789 - Upgrade Docusaurus to latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
-### CSD-104
-- `PVLNumeric` now stores the original string value as `rawValue` before converting to `Number()`, preserving precision for large numeric strings.
-- Fixed `PDRParsingError` when a PDR contains an MD5 `FILE_CKSUM_VALUE` that is an unquoted all-decimal string (e.g. `73806951753129206387143405718909`). The PVL parser previously classified such values as numeric, causing precision loss via JavaScript's `Number()` conversion. The original string is now preserved via `PVLNumeric.rawValue` and used for MD5 checksum validation.
-- MD5 checksum values are now validated as 32-character hex strings, providing a clearer error message for values that are not valid MD5 hashes.
+- **CUMULUS-4789** Update Docusaurus to latest version - 3.10
+- **CSD-104**
+  - `PVLNumeric` now stores the original string value as `rawValue` before converting to `Number()`, preserving precision for large numeric strings.
+  - Fixed `PDRParsingError` when a PDR contains an MD5 `FILE_CKSUM_VALUE` that is an unquoted all-decimal string (e.g. `73806951753129206387143405718909`). The PVL parser previously classified such values as numeric, causing precision loss via JavaScript's `Number()` conversion. The original string is now preserved via `PVLNumeric.rawValue` and used for MD5 checksum validation.
+  - MD5 checksum values are now validated as 32-character hex strings, providing a clearer error message for values that are not valid MD5 hashes.
 
 - **async-operations-update**
   - Updated Async Operation container to new version 57, `cumuluss/async-operation:57`. Users should update their references to `async-operation` with the new version.

--- a/docs/configuration/data-management-types.md
+++ b/docs/configuration/data-management-types.md
@@ -225,7 +225,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/docs/data-cookbooks/cnm-workflow.md
+++ b/docs/data-cookbooks/cnm-workflow.md
@@ -233,7 +233,7 @@ To execute this workflow, you're required to include several Lambda resources in
 
 :::note
 
-To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 :::
 

--- a/docs/development/python-best-practices.md
+++ b/docs/development/python-best-practices.md
@@ -145,4 +145,4 @@ In addition to `pytest`, developers should strongly consider using [moto](https:
 
 ## Code Documentation
 
-It is expected that whenever possible the code functionality should be documented via a README that includes critical usage and development information such as inputs, outputs, internal and external dependencies, use cases, and critical development information. In addition, the README markdown file should utilize the proper template and conform with [markdown quality standards](docs/development/quality-and-coverage.md).
+It is expected that whenever possible the code functionality should be documented via a README that includes critical usage and development information such as inputs, outputs, internal and external dependencies, use cases, and critical development information. In addition, the README markdown file should utilize the proper template and conform with [markdown quality standards](./quality-and-coverage.md).

--- a/docs/development/quality-and-coverage.md
+++ b/docs/development/quality-and-coverage.md
@@ -5,7 +5,7 @@ id: quality-and-coverage
 
 Currently, code written in this repository leverages Python or TypeScript for most logic and work. The current CI tooling and standards are based on these two languages. Specifics related to the tooling, quality, and testing can be found in the language specific best practices documentation. Python best practices and tooling expectations can be found [here](development/python-best-practices.md). Typescript best practices and tooling can be found [here](development/typescript-best-practices.md).
 
-In addition to CI pipeline quality checks, it is highly recommended for developers to install and configure [pre-commit](https://pre-commit.com) in order to find simple quality issues early. Directions on installing and configuring pre-commit locally for use with this repo can be found [here](docs/development/pre-commit-setup.md).
+In addition to CI pipeline quality checks, it is highly recommended for developers to install and configure [pre-commit](https://pre-commit.com) in order to find simple quality issues early. Directions on installing and configuring pre-commit locally for use with this repo can be found [here](./pre-commit-setup.md).
 
 ## Code Coverage
 

--- a/docs/development/typescript-best-practices.md
+++ b/docs/development/typescript-best-practices.md
@@ -41,4 +41,4 @@ report, run `nyc report --reporter html` and open the `index.html` file in the c
 
 ## Code Documentation
 
-It is expected that whenever possible the code functionality should be documented via a README that includes critical usage and development information such as inputs, outputs, internal and external dependencies, use cases, and critical development information. In addition, the README markdown file should utilize the proper template and conform with [markdown quality standards](docs/development/quality-and-coverage.md).
+It is expected that whenever possible the code functionality should be documented via a README that includes critical usage and development information such as inputs, outputs, internal and external dependencies, use cases, and critical development information. In addition, the README markdown file should utilize the proper template and conform with [markdown quality standards](./quality-and-coverage.md).

--- a/docs/features/ancillary_metadata.md
+++ b/docs/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -92,7 +92,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
 ### Developer
 
-  Those who setup deployment and workflow management for Cumulus. Sometimes referred to as an integrator. *See [integrator](#integratordeveloper)*.
+  Those who setup deployment and workflow management for Cumulus. Sometimes referred to as an integrator. *See [integrator](#integrator)*.
 
 ### ECS
 

--- a/docs/troubleshooting/README.md
+++ b/docs/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -10,6 +10,12 @@ function versionOptions() {
 }
 
 module.exports = {
+  markdown: {
+    format: 'detect',
+    hooks: {
+      onBrokenMarkdownLinks: 'log',
+    },
+  },
   title: 'Cumulus Documentation',
   tagline: 'This is a default tagline',
   url: 'https://nasa.github.io',
@@ -22,7 +28,6 @@ module.exports = {
   favicon: 'img/cumulus.ico',
   customFields: {},
   onBrokenLinks: 'log',
-  onBrokenMarkdownLinks: 'log',
   presets: [
     [
       '@docusaurus/preset-classic',

--- a/website/package.json
+++ b/website/package.json
@@ -16,12 +16,13 @@
     "clean": "git clean -d -x -e node_modules -f"
   },
   "devDependencies": {
-    "@docusaurus/core": "^2.3.0",
-    "@docusaurus/preset-classic": "^2.3.0",
-    "react": "^17.0.2"
+    "@docusaurus/core": "^3.10.0",
+    "@docusaurus/preset-classic": "^3.10.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "overrides": {
-    "webpack": "5.105.4"
+    "webpackbar": "^7.0.0"
   },
   "private": true
 }

--- a/website/versioned_docs/version-v10.0.0/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v10.0.0/configuration/data-management-types.md
@@ -214,7 +214,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v10.0.0/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v10.0.0/data-cookbooks/browse-generation.md
@@ -187,7 +187,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 **Please note**: `FakeProcessing` is the core provided browse/CMR generation lambda we're using for the example in this entry.
 

--- a/website/versioned_docs/version-v10.0.0/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v10.0.0/data-cookbooks/cnm-workflow.md
@@ -228,7 +228,7 @@ To execute this workflow, you're required to include several Lambda resources in
 - <https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/cnm_to_cma_task.tf>
 - <https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/cnm_response_task.tf>
 
-**Please note:** To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+**Please note:** To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 - `CNMToCMA`: <https://github.com/podaac/cumulus-cnm-to-granule>
 - `CnmResponse`: <https://github.com/podaac/cumulus-cnm-response-task>

--- a/website/versioned_docs/version-v10.0.0/deployment/README.md
+++ b/website/versioned_docs/version-v10.0.0/deployment/README.md
@@ -96,7 +96,7 @@ Clone the [`cumulus-template-deploy`](https://github.com/nasa/cumulus-template-d
   git clone https://github.com/nasa/cumulus-template-deploy <repository-name>
 ```
 
-We will return to [configuring this repo and using it for deployment below](#deploying-the-cumulus-instance).
+We will return to [configuring this repo and using it for deployment below](#deploy-the-cumulus-instance).
 
 <details>
   <summary>Optional: Create a new repository</summary>
@@ -561,7 +561,7 @@ From the S3 Console:
 - Open the `<prefix>-dashboard` bucket, click 'upload'. Add the contents of the 'dist' subdirectory to the upload. Then select 'Next'. On the permissions window allow the public to view. Select 'Upload'.
 
 You should be able to visit the dashboard website at `http://<prefix>-dashboard.s3-website-<region>.amazonaws.com` or find the url
-`<prefix>-dashboard` -> "Properties" -> "Static website hosting" -> "Endpoint" and login with a user that you configured for access in the [Configure and Deploy the Cumulus Stack](#configure-and-deploy-the-cumulus-stack) step.
+`<prefix>-dashboard` -> "Properties" -> "Static website hosting" -> "Endpoint" and login with a user that you configured for access in the [Configure and Deploy the Cumulus Stack](#configure-and-deploy-the-cumulus-tf-root-module) step.
 
 ---
 

--- a/website/versioned_docs/version-v10.0.0/deployment/postgres-database-deployment.md
+++ b/website/versioned_docs/version-v10.0.0/deployment/postgres-database-deployment.md
@@ -71,7 +71,7 @@ Clone the [`cumulus-template-deploy`](https://github.com/nasa/cumulus-template-d
   git clone https://github.com/nasa/cumulus-template-deploy <repository-name>
 ```
 
-We will return to [configuring this repo and using it for deployment below](#deploying-the-cumulus-instance).
+We will return to [configuring this repo and using it for deployment below](#configure-and-deploy-the-module).
 
 <details>
   <summary>Optional: Create a new repository</summary>
@@ -95,9 +95,9 @@ You can then [add/commit](https://help.github.com/articles/adding-a-file-to-a-re
 
 To deploy this module, you need to make sure that you have the following steps from the [Cumulus deployment instructions](#prepare-aws-configuration) in similar fashion *for this module*:
 
-- [Set Access Keys](#set-access-keys)
-- [Create the state bucket](#create-the-state-bucket)
-- [Create the locks table](#create-the-locks-table)
+- [Set Access Keys](./README.md#set-access-keys)
+- [Create the state bucket](./README.md#create-the-state-bucket)
+- [Create the locks table](./README.md#create-the-locks-table)
 
 --
 

--- a/website/versioned_docs/version-v10.0.0/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v10.0.0/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v10.0.0/glossary.md
+++ b/website/versioned_docs/version-v10.0.0/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v10.0.0/troubleshooting/README.md
+++ b/website/versioned_docs/version-v10.0.0/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v10.0.0/upgrade-notes/upgrade-task-file-schemas.md
+++ b/website/versioned_docs/version-v10.0.0/upgrade-notes/upgrade-task-file-schemas.md
@@ -27,7 +27,7 @@ These former properties were deprecated (with notes about how to derive the same
   - `hyrax-metadata-updates`
 - `fileStagingDir` - no longer supported
 - `url_path` - no longer supported
-- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#optional---integrate-granuleduplicates-information).
+- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#upgrading-your-workflows).
 
 ## Exceptions
 

--- a/website/versioned_docs/version-v10.0.0/workflows/lambda.md
+++ b/website/versioned_docs/version-v10.0.0/workflows/lambda.md
@@ -44,7 +44,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 
@@ -52,7 +52,7 @@ The deploy folder referenced here would contain a folder 'test_task/task/' which
 
 ### Python Lambda
 
-Python Lambdas are created the same way as the Node.js example [above](#node.js-lambda).
+Python Lambdas are created the same way as the Node.js example [above](#nodejs-lambda).
 
 ## Cumulus Message Adapter
 

--- a/website/versioned_docs/version-v10.1.0/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v10.1.0/configuration/data-management-types.md
@@ -214,7 +214,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v10.1.0/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v10.1.0/data-cookbooks/browse-generation.md
@@ -187,7 +187,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 **Please note**: `FakeProcessing` is the core provided browse/CMR generation lambda we're using for the example in this entry.
 

--- a/website/versioned_docs/version-v10.1.0/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v10.1.0/data-cookbooks/cnm-workflow.md
@@ -228,7 +228,7 @@ To execute this workflow, you're required to include several Lambda resources in
 - <https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/cnm_to_cma_task.tf>
 - <https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/cnm_response_task.tf>
 
-**Please note:** To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+**Please note:** To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 - `CNMToCMA`: <https://github.com/podaac/cumulus-cnm-to-granule>
 - `CnmResponse`: <https://github.com/podaac/cumulus-cnm-response-task>

--- a/website/versioned_docs/version-v10.1.0/deployment/README.md
+++ b/website/versioned_docs/version-v10.1.0/deployment/README.md
@@ -96,7 +96,7 @@ Clone the [`cumulus-template-deploy`](https://github.com/nasa/cumulus-template-d
   git clone https://github.com/nasa/cumulus-template-deploy <repository-name>
 ```
 
-We will return to [configuring this repo and using it for deployment below](#deploying-the-cumulus-instance).
+We will return to [configuring this repo and using it for deployment below](#deploy-the-cumulus-instance).
 
 <details>
   <summary>Optional: Create a new repository</summary>
@@ -561,7 +561,7 @@ From the S3 Console:
 - Open the `<prefix>-dashboard` bucket, click 'upload'. Add the contents of the 'dist' subdirectory to the upload. Then select 'Next'. On the permissions window allow the public to view. Select 'Upload'.
 
 You should be able to visit the dashboard website at `http://<prefix>-dashboard.s3-website-<region>.amazonaws.com` or find the url
-`<prefix>-dashboard` -> "Properties" -> "Static website hosting" -> "Endpoint" and login with a user that you configured for access in the [Configure and Deploy the Cumulus Stack](#configure-and-deploy-the-cumulus-stack) step.
+`<prefix>-dashboard` -> "Properties" -> "Static website hosting" -> "Endpoint" and login with a user that you configured for access in the [Configure and Deploy the Cumulus Stack](#configure-and-deploy-the-cumulus-tf-root-module) step.
 
 ---
 

--- a/website/versioned_docs/version-v10.1.0/deployment/postgres-database-deployment.md
+++ b/website/versioned_docs/version-v10.1.0/deployment/postgres-database-deployment.md
@@ -71,7 +71,7 @@ Clone the [`cumulus-template-deploy`](https://github.com/nasa/cumulus-template-d
   git clone https://github.com/nasa/cumulus-template-deploy <repository-name>
 ```
 
-We will return to [configuring this repo and using it for deployment below](#deploying-the-cumulus-instance).
+We will return to [configuring this repo and using it for deployment below](#configure-and-deploy-the-module).
 
 <details>
   <summary>Optional: Create a new repository</summary>
@@ -95,9 +95,9 @@ You can then [add/commit](https://help.github.com/articles/adding-a-file-to-a-re
 
 To deploy this module, you need to make sure that you have the following steps from the [Cumulus deployment instructions](#prepare-aws-configuration) in similar fashion *for this module*:
 
-- [Set Access Keys](#set-access-keys)
-- [Create the state bucket](#create-the-state-bucket)
-- [Create the locks table](#create-the-locks-table)
+- [Set Access Keys](./README.md#set-access-keys)
+- [Create the state bucket](./README.md#create-the-state-bucket)
+- [Create the locks table](./README.md#create-the-locks-table)
 
 --
 

--- a/website/versioned_docs/version-v10.1.0/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v10.1.0/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v10.1.0/glossary.md
+++ b/website/versioned_docs/version-v10.1.0/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v10.1.0/troubleshooting/README.md
+++ b/website/versioned_docs/version-v10.1.0/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v10.1.0/upgrade-notes/upgrade-task-file-schemas.md
+++ b/website/versioned_docs/version-v10.1.0/upgrade-notes/upgrade-task-file-schemas.md
@@ -27,7 +27,7 @@ These former properties were deprecated (with notes about how to derive the same
   - `hyrax-metadata-updates`
 - `fileStagingDir` - no longer supported
 - `url_path` - no longer supported
-- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#optional---integrate-granuleduplicates-information).
+- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#upgrading-your-workflows).
 
 ## Exceptions
 

--- a/website/versioned_docs/version-v10.1.0/workflows/lambda.md
+++ b/website/versioned_docs/version-v10.1.0/workflows/lambda.md
@@ -44,7 +44,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 
@@ -52,7 +52,7 @@ The deploy folder referenced here would contain a folder 'test_task/task/' which
 
 ### Python Lambda
 
-Python Lambdas are created the same way as the Node.js example [above](#node.js-lambda).
+Python Lambdas are created the same way as the Node.js example [above](#nodejs-lambda).
 
 ## Cumulus Message Adapter
 

--- a/website/versioned_docs/version-v11.0.0/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v11.0.0/configuration/data-management-types.md
@@ -214,7 +214,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v11.0.0/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v11.0.0/data-cookbooks/browse-generation.md
@@ -187,7 +187,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 **Please note**: `FakeProcessing` is the core provided browse/CMR generation lambda we're using for the example in this entry.
 

--- a/website/versioned_docs/version-v11.0.0/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v11.0.0/data-cookbooks/cnm-workflow.md
@@ -228,7 +228,7 @@ To execute this workflow, you're required to include several Lambda resources in
 - <https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/cnm_to_cma_task.tf>
 - <https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/cnm_response_task.tf>
 
-**Please note:** To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+**Please note:** To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 - `CNMToCMA`: <https://github.com/podaac/cumulus-cnm-to-granule>
 - `CnmResponse`: <https://github.com/podaac/cumulus-cnm-response-task>

--- a/website/versioned_docs/version-v11.0.0/deployment/README.md
+++ b/website/versioned_docs/version-v11.0.0/deployment/README.md
@@ -96,7 +96,7 @@ Clone the [`cumulus-template-deploy`](https://github.com/nasa/cumulus-template-d
   git clone https://github.com/nasa/cumulus-template-deploy <repository-name>
 ```
 
-We will return to [configuring this repo and using it for deployment below](#deploying-the-cumulus-instance).
+We will return to [configuring this repo and using it for deployment below](#deploy-the-cumulus-instance).
 
 <details>
   <summary>Optional: Create a new repository</summary>
@@ -529,7 +529,7 @@ From the S3 Console:
 - Open the `<prefix>-dashboard` bucket, click 'upload'. Add the contents of the 'dist' subdirectory to the upload. Then select 'Next'. On the permissions window allow the public to view. Select 'Upload'.
 
 You should be able to visit the dashboard website at `http://<prefix>-dashboard.s3-website-<region>.amazonaws.com` or find the url
-`<prefix>-dashboard` -> "Properties" -> "Static website hosting" -> "Endpoint" and login with a user that you configured for access in the [Configure and Deploy the Cumulus Stack](#configure-and-deploy-the-cumulus-stack) step.
+`<prefix>-dashboard` -> "Properties" -> "Static website hosting" -> "Endpoint" and login with a user that you configured for access in the [Configure and Deploy the Cumulus Stack](#configure-and-deploy-the-cumulus-tf-root-module) step.
 
 ---
 

--- a/website/versioned_docs/version-v11.0.0/deployment/postgres-database-deployment.md
+++ b/website/versioned_docs/version-v11.0.0/deployment/postgres-database-deployment.md
@@ -71,7 +71,7 @@ Clone the [`cumulus-template-deploy`](https://github.com/nasa/cumulus-template-d
   git clone https://github.com/nasa/cumulus-template-deploy <repository-name>
 ```
 
-We will return to [configuring this repo and using it for deployment below](#deploying-the-cumulus-instance).
+We will return to [configuring this repo and using it for deployment below](#configure-and-deploy-the-module).
 
 <details>
   <summary>Optional: Create a new repository</summary>
@@ -95,9 +95,9 @@ You can then [add/commit](https://help.github.com/articles/adding-a-file-to-a-re
 
 To deploy this module, you need to make sure that you have the following steps from the [Cumulus deployment instructions](#prepare-aws-configuration) in similar fashion *for this module*:
 
-- [Set Access Keys](#set-access-keys)
-- [Create the state bucket](#create-the-state-bucket)
-- [Create the locks table](#create-the-locks-table)
+- [Set Access Keys](./README.md#set-access-keys)
+- [Create the state bucket](./README.md#create-the-state-bucket)
+- [Create the locks table](./README.md#create-the-locks-table)
 
 --
 

--- a/website/versioned_docs/version-v11.0.0/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v11.0.0/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v11.0.0/glossary.md
+++ b/website/versioned_docs/version-v11.0.0/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v11.0.0/troubleshooting/README.md
+++ b/website/versioned_docs/version-v11.0.0/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v11.0.0/upgrade-notes/upgrade-task-file-schemas.md
+++ b/website/versioned_docs/version-v11.0.0/upgrade-notes/upgrade-task-file-schemas.md
@@ -27,7 +27,7 @@ These former properties were deprecated (with notes about how to derive the same
   - `hyrax-metadata-updates`
 - `fileStagingDir` - no longer supported
 - `url_path` - no longer supported
-- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#optional---integrate-granuleduplicates-information).
+- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#upgrading-your-workflows).
 
 ## Exceptions
 

--- a/website/versioned_docs/version-v11.0.0/workflows/lambda.md
+++ b/website/versioned_docs/version-v11.0.0/workflows/lambda.md
@@ -44,7 +44,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 
@@ -52,7 +52,7 @@ The deploy folder referenced here would contain a folder 'test_task/task/' which
 
 ### Python Lambda
 
-Python Lambdas are created the same way as the Node.js example [above](#node.js-lambda).
+Python Lambdas are created the same way as the Node.js example [above](#nodejs-lambda).
 
 ## Cumulus Message Adapter
 

--- a/website/versioned_docs/version-v11.1.0/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v11.1.0/configuration/data-management-types.md
@@ -214,7 +214,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v11.1.0/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v11.1.0/data-cookbooks/browse-generation.md
@@ -187,7 +187,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 **Please note**: `FakeProcessing` is the core provided browse/CMR generation lambda we're using for the example in this entry.
 

--- a/website/versioned_docs/version-v11.1.0/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v11.1.0/data-cookbooks/cnm-workflow.md
@@ -228,7 +228,7 @@ To execute this workflow, you're required to include several Lambda resources in
 - <https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/cnm_to_cma_task.tf>
 - <https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/cnm_response_task.tf>
 
-**Please note:** To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+**Please note:** To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 - `CNMToCMA`: <https://github.com/podaac/cumulus-cnm-to-granule>
 - `CnmResponse`: <https://github.com/podaac/cumulus-cnm-response-task>

--- a/website/versioned_docs/version-v11.1.0/deployment/README.md
+++ b/website/versioned_docs/version-v11.1.0/deployment/README.md
@@ -96,7 +96,7 @@ Clone the [`cumulus-template-deploy`](https://github.com/nasa/cumulus-template-d
   git clone https://github.com/nasa/cumulus-template-deploy <repository-name>
 ```
 
-We will return to [configuring this repo and using it for deployment below](#deploying-the-cumulus-instance).
+We will return to [configuring this repo and using it for deployment below](#deploy-the-cumulus-instance).
 
 <details>
   <summary>Optional: Create a new repository</summary>
@@ -533,7 +533,7 @@ From the S3 Console:
 - Open the `<prefix>-dashboard` bucket, click 'upload'. Add the contents of the 'dist' subdirectory to the upload. Then select 'Next'. On the permissions window allow the public to view. Select 'Upload'.
 
 You should be able to visit the dashboard website at `http://<prefix>-dashboard.s3-website-<region>.amazonaws.com` or find the url
-`<prefix>-dashboard` -> "Properties" -> "Static website hosting" -> "Endpoint" and login with a user that you configured for access in the [Configure and Deploy the Cumulus Stack](#configure-and-deploy-the-cumulus-stack) step.
+`<prefix>-dashboard` -> "Properties" -> "Static website hosting" -> "Endpoint" and login with a user that you configured for access in the [Configure and Deploy the Cumulus Stack](#configure-and-deploy-the-cumulus-tf-root-module) step.
 
 ---
 

--- a/website/versioned_docs/version-v11.1.0/deployment/postgres-database-deployment.md
+++ b/website/versioned_docs/version-v11.1.0/deployment/postgres-database-deployment.md
@@ -71,7 +71,7 @@ Clone the [`cumulus-template-deploy`](https://github.com/nasa/cumulus-template-d
   git clone https://github.com/nasa/cumulus-template-deploy <repository-name>
 ```
 
-We will return to [configuring this repo and using it for deployment below](#deploying-the-cumulus-instance).
+We will return to [configuring this repo and using it for deployment below](#configure-and-deploy-the-module).
 
 <details>
   <summary>Optional: Create a new repository</summary>
@@ -95,9 +95,9 @@ You can then [add/commit](https://help.github.com/articles/adding-a-file-to-a-re
 
 To deploy this module, you need to make sure that you have the following steps from the [Cumulus deployment instructions](#prepare-aws-configuration) in similar fashion *for this module*:
 
-- [Set Access Keys](#set-access-keys)
-- [Create the state bucket](#create-the-state-bucket)
-- [Create the locks table](#create-the-locks-table)
+- [Set Access Keys](./README.md#set-access-keys)
+- [Create the state bucket](./README.md#create-the-state-bucket)
+- [Create the locks table](./README.md#create-the-locks-table)
 
 --
 

--- a/website/versioned_docs/version-v11.1.0/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v11.1.0/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v11.1.0/glossary.md
+++ b/website/versioned_docs/version-v11.1.0/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v11.1.0/troubleshooting/README.md
+++ b/website/versioned_docs/version-v11.1.0/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v11.1.0/upgrade-notes/upgrade-task-file-schemas.md
+++ b/website/versioned_docs/version-v11.1.0/upgrade-notes/upgrade-task-file-schemas.md
@@ -27,7 +27,7 @@ These former properties were deprecated (with notes about how to derive the same
   - `hyrax-metadata-updates`
 - `fileStagingDir` - no longer supported
 - `url_path` - no longer supported
-- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#optional---integrate-granuleduplicates-information).
+- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#upgrading-your-workflows).
 
 ## Exceptions
 

--- a/website/versioned_docs/version-v11.1.0/workflows/lambda.md
+++ b/website/versioned_docs/version-v11.1.0/workflows/lambda.md
@@ -44,7 +44,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 
@@ -52,7 +52,7 @@ The deploy folder referenced here would contain a folder 'test_task/task/' which
 
 ### Python Lambda
 
-Python Lambdas are created the same way as the Node.js example [above](#node.js-lambda).
+Python Lambdas are created the same way as the Node.js example [above](#nodejs-lambda).
 
 ## Cumulus Message Adapter
 

--- a/website/versioned_docs/version-v12.0.0/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v12.0.0/configuration/data-management-types.md
@@ -214,7 +214,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v12.0.0/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v12.0.0/data-cookbooks/browse-generation.md
@@ -187,7 +187,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 **Please note**: `FakeProcessing` is the core provided browse/CMR generation lambda we're using for the example in this entry.
 

--- a/website/versioned_docs/version-v12.0.0/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v12.0.0/data-cookbooks/cnm-workflow.md
@@ -228,7 +228,7 @@ To execute this workflow, you're required to include several Lambda resources in
 - <https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/cnm_to_cma_task.tf>
 - <https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/cnm_response_task.tf>
 
-**Please note:** To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+**Please note:** To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 - `CNMToCMA`: <https://github.com/podaac/cumulus-cnm-to-granule>
 - `CnmResponse`: <https://github.com/podaac/cumulus-cnm-response-task>

--- a/website/versioned_docs/version-v12.0.0/deployment/README.md
+++ b/website/versioned_docs/version-v12.0.0/deployment/README.md
@@ -96,7 +96,7 @@ Clone the [`cumulus-template-deploy`](https://github.com/nasa/cumulus-template-d
   git clone https://github.com/nasa/cumulus-template-deploy <repository-name>
 ```
 
-We will return to [configuring this repo and using it for deployment below](#deploying-the-cumulus-instance).
+We will return to [configuring this repo and using it for deployment below](#deploy-the-cumulus-instance).
 
 <details>
   <summary>Optional: Create a new repository</summary>
@@ -533,7 +533,7 @@ From the S3 Console:
 - Open the `<prefix>-dashboard` bucket, click 'upload'. Add the contents of the 'dist' subdirectory to the upload. Then select 'Next'. On the permissions window allow the public to view. Select 'Upload'.
 
 You should be able to visit the dashboard website at `http://<prefix>-dashboard.s3-website-<region>.amazonaws.com` or find the url
-`<prefix>-dashboard` -> "Properties" -> "Static website hosting" -> "Endpoint" and login with a user that you configured for access in the [Configure and Deploy the Cumulus Stack](#configure-and-deploy-the-cumulus-stack) step.
+`<prefix>-dashboard` -> "Properties" -> "Static website hosting" -> "Endpoint" and login with a user that you configured for access in the [Configure and Deploy the Cumulus Stack](#configure-and-deploy-the-cumulus-tf-root-module) step.
 
 ---
 

--- a/website/versioned_docs/version-v12.0.0/deployment/postgres-database-deployment.md
+++ b/website/versioned_docs/version-v12.0.0/deployment/postgres-database-deployment.md
@@ -71,7 +71,7 @@ Clone the [`cumulus-template-deploy`](https://github.com/nasa/cumulus-template-d
   git clone https://github.com/nasa/cumulus-template-deploy <repository-name>
 ```
 
-We will return to [configuring this repo and using it for deployment below](#deploying-the-cumulus-instance).
+We will return to [configuring this repo and using it for deployment below](#configure-and-deploy-the-module).
 
 <details>
   <summary>Optional: Create a new repository</summary>
@@ -95,9 +95,9 @@ You can then [add/commit](https://help.github.com/articles/adding-a-file-to-a-re
 
 To deploy this module, you need to make sure that you have the following steps from the [Cumulus deployment instructions](#prepare-aws-configuration) in similar fashion *for this module*:
 
-- [Set Access Keys](#set-access-keys)
-- [Create the state bucket](#create-the-state-bucket)
-- [Create the locks table](#create-the-locks-table)
+- [Set Access Keys](./README.md#set-access-keys)
+- [Create the state bucket](./README.md#create-the-state-bucket)
+- [Create the locks table](./README.md#create-the-locks-table)
 
 --
 

--- a/website/versioned_docs/version-v12.0.0/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v12.0.0/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v12.0.0/glossary.md
+++ b/website/versioned_docs/version-v12.0.0/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v12.0.0/troubleshooting/README.md
+++ b/website/versioned_docs/version-v12.0.0/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v12.0.0/upgrade-notes/upgrade-task-file-schemas.md
+++ b/website/versioned_docs/version-v12.0.0/upgrade-notes/upgrade-task-file-schemas.md
@@ -27,7 +27,7 @@ These former properties were deprecated (with notes about how to derive the same
   - `hyrax-metadata-updates`
 - `fileStagingDir` - no longer supported
 - `url_path` - no longer supported
-- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#optional---integrate-granuleduplicates-information).
+- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#upgrading-your-workflows).
 
 ## Exceptions
 

--- a/website/versioned_docs/version-v12.0.0/workflows/lambda.md
+++ b/website/versioned_docs/version-v12.0.0/workflows/lambda.md
@@ -44,7 +44,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 
@@ -52,7 +52,7 @@ The deploy folder referenced here would contain a folder 'test_task/task/' which
 
 ### Python Lambda
 
-Python Lambdas are created the same way as the Node.js example [above](#node.js-lambda).
+Python Lambdas are created the same way as the Node.js example [above](#nodejs-lambda).
 
 ## Cumulus Message Adapter
 

--- a/website/versioned_docs/version-v13.0.0/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v13.0.0/configuration/data-management-types.md
@@ -214,7 +214,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v13.0.0/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v13.0.0/data-cookbooks/browse-generation.md
@@ -187,7 +187,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 **Please note**: `FakeProcessing` is the core provided browse/CMR generation lambda we're using for the example in this entry.
 

--- a/website/versioned_docs/version-v13.0.0/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v13.0.0/data-cookbooks/cnm-workflow.md
@@ -228,7 +228,7 @@ To execute this workflow, you're required to include several Lambda resources in
 - <https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/cnm_to_cma_task.tf>
 - <https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/cnm_response_task.tf>
 
-**Please note:** To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+**Please note:** To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 - `CNMToCMA`: <https://github.com/podaac/cumulus-cnm-to-granule>
 - `CnmResponse`: <https://github.com/podaac/cumulus-cnm-response-task>

--- a/website/versioned_docs/version-v13.0.0/deployment/README.md
+++ b/website/versioned_docs/version-v13.0.0/deployment/README.md
@@ -96,7 +96,7 @@ Clone the [`cumulus-template-deploy`](https://github.com/nasa/cumulus-template-d
   git clone https://github.com/nasa/cumulus-template-deploy <repository-name>
 ```
 
-We will return to [configuring this repo and using it for deployment below](#deploying-the-cumulus-instance).
+We will return to [configuring this repo and using it for deployment below](#deploy-the-cumulus-instance).
 
 <details>
   <summary>Optional: Create a new repository</summary>
@@ -533,7 +533,7 @@ From the S3 Console:
 - Open the `<prefix>-dashboard` bucket, click 'upload'. Add the contents of the 'dist' subdirectory to the upload. Then select 'Next'. On the permissions window allow the public to view. Select 'Upload'.
 
 You should be able to visit the dashboard website at `http://<prefix>-dashboard.s3-website-<region>.amazonaws.com` or find the url
-`<prefix>-dashboard` -> "Properties" -> "Static website hosting" -> "Endpoint" and login with a user that you configured for access in the [Configure and Deploy the Cumulus Stack](#configure-and-deploy-the-cumulus-stack) step.
+`<prefix>-dashboard` -> "Properties" -> "Static website hosting" -> "Endpoint" and login with a user that you configured for access in the [Configure and Deploy the Cumulus Stack](#configure-and-deploy-the-cumulus-tf-root-module) step.
 
 ---
 

--- a/website/versioned_docs/version-v13.0.0/deployment/postgres-database-deployment.md
+++ b/website/versioned_docs/version-v13.0.0/deployment/postgres-database-deployment.md
@@ -71,7 +71,7 @@ Clone the [`cumulus-template-deploy`](https://github.com/nasa/cumulus-template-d
   git clone https://github.com/nasa/cumulus-template-deploy <repository-name>
 ```
 
-We will return to [configuring this repo and using it for deployment below](#deploying-the-cumulus-instance).
+We will return to [configuring this repo and using it for deployment below](#configure-and-deploy-the-module).
 
 <details>
   <summary>Optional: Create a new repository</summary>
@@ -95,9 +95,9 @@ You can then [add/commit](https://help.github.com/articles/adding-a-file-to-a-re
 
 To deploy this module, you need to make sure that you have the following steps from the [Cumulus deployment instructions](#prepare-aws-configuration) in similar fashion *for this module*:
 
-- [Set Access Keys](#set-access-keys)
-- [Create the state bucket](#create-the-state-bucket)
-- [Create the locks table](#create-the-locks-table)
+- [Set Access Keys](./README.md#set-access-keys)
+- [Create the state bucket](./README.md#create-the-state-bucket)
+- [Create the locks table](./README.md#create-the-locks-table)
 
 --
 

--- a/website/versioned_docs/version-v13.0.0/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v13.0.0/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v13.0.0/glossary.md
+++ b/website/versioned_docs/version-v13.0.0/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v13.0.0/troubleshooting/README.md
+++ b/website/versioned_docs/version-v13.0.0/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v13.0.0/upgrade-notes/upgrade-task-file-schemas.md
+++ b/website/versioned_docs/version-v13.0.0/upgrade-notes/upgrade-task-file-schemas.md
@@ -27,7 +27,7 @@ These former properties were deprecated (with notes about how to derive the same
   - `hyrax-metadata-updates`
 - `fileStagingDir` - no longer supported
 - `url_path` - no longer supported
-- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#optional---integrate-granuleduplicates-information).
+- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#upgrading-your-workflows).
 
 ## Exceptions
 

--- a/website/versioned_docs/version-v13.0.0/workflows/lambda.md
+++ b/website/versioned_docs/version-v13.0.0/workflows/lambda.md
@@ -44,7 +44,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 
@@ -52,7 +52,7 @@ The deploy folder referenced here would contain a folder 'test_task/task/' which
 
 ### Python Lambda
 
-Python Lambdas are created the same way as the Node.js example [above](#node.js-lambda).
+Python Lambdas are created the same way as the Node.js example [above](#nodejs-lambda).
 
 ## Cumulus Message Adapter
 

--- a/website/versioned_docs/version-v13.4.0/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v13.4.0/configuration/data-management-types.md
@@ -214,7 +214,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v13.4.0/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v13.4.0/data-cookbooks/browse-generation.md
@@ -187,7 +187,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 **Please note**: `FakeProcessing` is the core provided browse/CMR generation lambda we're using for the example in this entry.
 

--- a/website/versioned_docs/version-v13.4.0/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v13.4.0/data-cookbooks/cnm-workflow.md
@@ -228,7 +228,7 @@ To execute this workflow, you're required to include several Lambda resources in
 - <https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/cnm_to_cma_task.tf>
 - <https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/cnm_response_task.tf>
 
-**Please note:** To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+**Please note:** To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 - `CNMToCMA`: <https://github.com/podaac/cumulus-cnm-to-granule>
 - `CnmResponse`: <https://github.com/podaac/cumulus-cnm-response-task>

--- a/website/versioned_docs/version-v13.4.0/deployment/README.md
+++ b/website/versioned_docs/version-v13.4.0/deployment/README.md
@@ -96,7 +96,7 @@ Clone the [`cumulus-template-deploy`](https://github.com/nasa/cumulus-template-d
   git clone https://github.com/nasa/cumulus-template-deploy <repository-name>
 ```
 
-We will return to [configuring this repo and using it for deployment below](#deploying-the-cumulus-instance).
+We will return to [configuring this repo and using it for deployment below](#deploy-the-cumulus-instance).
 
 <details>
   <summary>Optional: Create a new repository</summary>
@@ -533,7 +533,7 @@ From the S3 Console:
 - Open the `<prefix>-dashboard` bucket, click 'upload'. Add the contents of the 'dist' subdirectory to the upload. Then select 'Next'. On the permissions window allow the public to view. Select 'Upload'.
 
 You should be able to visit the dashboard website at `http://<prefix>-dashboard.s3-website-<region>.amazonaws.com` or find the url
-`<prefix>-dashboard` -> "Properties" -> "Static website hosting" -> "Endpoint" and login with a user that you configured for access in the [Configure and Deploy the Cumulus Stack](#configure-and-deploy-the-cumulus-stack) step.
+`<prefix>-dashboard` -> "Properties" -> "Static website hosting" -> "Endpoint" and login with a user that you configured for access in the [Configure and Deploy the Cumulus Stack](#configure-and-deploy-the-cumulus-tf-root-module) step.
 
 ---
 

--- a/website/versioned_docs/version-v13.4.0/deployment/postgres-database-deployment.md
+++ b/website/versioned_docs/version-v13.4.0/deployment/postgres-database-deployment.md
@@ -71,7 +71,7 @@ Clone the [`cumulus-template-deploy`](https://github.com/nasa/cumulus-template-d
   git clone https://github.com/nasa/cumulus-template-deploy <repository-name>
 ```
 
-We will return to [configuring this repo and using it for deployment below](#deploying-the-cumulus-instance).
+We will return to [configuring this repo and using it for deployment below](#configure-and-deploy-the-module).
 
 <details>
   <summary>Optional: Create a new repository</summary>
@@ -95,9 +95,9 @@ You can then [add/commit](https://help.github.com/articles/adding-a-file-to-a-re
 
 To deploy this module, you need to make sure that you have the following steps from the [Cumulus deployment instructions](#prepare-aws-configuration) in similar fashion *for this module*:
 
-- [Set Access Keys](#set-access-keys)
-- [Create the state bucket](#create-the-state-bucket)
-- [Create the locks table](#create-the-locks-table)
+- [Set Access Keys](./README.md#set-access-keys)
+- [Create the state bucket](./README.md#create-the-state-bucket)
+- [Create the locks table](./README.md#create-the-locks-table)
 
 --
 

--- a/website/versioned_docs/version-v13.4.0/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v13.4.0/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v13.4.0/glossary.md
+++ b/website/versioned_docs/version-v13.4.0/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v13.4.0/troubleshooting/README.md
+++ b/website/versioned_docs/version-v13.4.0/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v13.4.0/upgrade-notes/upgrade-task-file-schemas.md
+++ b/website/versioned_docs/version-v13.4.0/upgrade-notes/upgrade-task-file-schemas.md
@@ -27,7 +27,7 @@ These former properties were deprecated (with notes about how to derive the same
   - `hyrax-metadata-updates`
 - `fileStagingDir` - no longer supported
 - `url_path` - no longer supported
-- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#optional---integrate-granuleduplicates-information).
+- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#upgrading-your-workflows).
 
 ## Exceptions
 

--- a/website/versioned_docs/version-v13.4.0/workflows/lambda.md
+++ b/website/versioned_docs/version-v13.4.0/workflows/lambda.md
@@ -44,7 +44,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 
@@ -52,7 +52,7 @@ The deploy folder referenced here would contain a folder 'test_task/task/' which
 
 ### Python Lambda
 
-Python Lambdas are created the same way as the Node.js example [above](#node.js-lambda).
+Python Lambdas are created the same way as the Node.js example [above](#nodejs-lambda).
 
 ## Cumulus Message Adapter
 

--- a/website/versioned_docs/version-v14.1.0/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v14.1.0/configuration/data-management-types.md
@@ -214,7 +214,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v14.1.0/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v14.1.0/data-cookbooks/browse-generation.md
@@ -187,7 +187,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 **Please note**: `FakeProcessing` is the core provided browse/CMR generation lambda we're using for the example in this entry.
 

--- a/website/versioned_docs/version-v14.1.0/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v14.1.0/data-cookbooks/cnm-workflow.md
@@ -228,7 +228,7 @@ To execute this workflow, you're required to include several Lambda resources in
 - <https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/cnm_to_cma_task.tf>
 - <https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/cnm_response_task.tf>
 
-**Please note:** To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+**Please note:** To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 - `CNMToCMA`: <https://github.com/podaac/cumulus-cnm-to-granule>
 - `CnmResponse`: <https://github.com/podaac/cumulus-cnm-response-task>

--- a/website/versioned_docs/version-v14.1.0/deployment/postgres-database-deployment.md
+++ b/website/versioned_docs/version-v14.1.0/deployment/postgres-database-deployment.md
@@ -95,9 +95,9 @@ You can then [add/commit](https://help.github.com/articles/adding-a-file-to-a-re
 
 To deploy this module, you need to make sure that you have the following steps from the [Cumulus deployment instructions](#prepare-aws-configuration) in similar fashion *for this module*:
 
-- [Set Access Keys](#set-access-keys)
-- [Create the state bucket](#create-the-state-bucket)
-- [Create the locks table](#create-the-locks-table)
+- [Set Access Keys](./README.md#set-access-keys)
+- [Create the state bucket](./README.md#create-the-state-bucket)
+- [Create the locks table](./README.md#create-the-locks-table)
 
 --
 

--- a/website/versioned_docs/version-v14.1.0/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v14.1.0/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v14.1.0/glossary.md
+++ b/website/versioned_docs/version-v14.1.0/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v14.1.0/troubleshooting/README.md
+++ b/website/versioned_docs/version-v14.1.0/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v14.1.0/upgrade-notes/upgrade-task-file-schemas.md
+++ b/website/versioned_docs/version-v14.1.0/upgrade-notes/upgrade-task-file-schemas.md
@@ -27,7 +27,7 @@ These former properties were deprecated (with notes about how to derive the same
   - `hyrax-metadata-updates`
 - `fileStagingDir` - no longer supported
 - `url_path` - no longer supported
-- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#optional---integrate-granuleduplicates-information).
+- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#upgrading-your-workflows).
 
 ## Exceptions
 

--- a/website/versioned_docs/version-v14.1.0/workflows/lambda.md
+++ b/website/versioned_docs/version-v14.1.0/workflows/lambda.md
@@ -44,7 +44,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 
@@ -52,7 +52,7 @@ The deploy folder referenced here would contain a folder 'test_task/task/' which
 
 ### Python Lambda
 
-Python Lambdas are created the same way as the Node.js example [above](#node.js-lambda).
+Python Lambdas are created the same way as the Node.js example [above](#nodejs-lambda).
 
 ## Cumulus Message Adapter
 

--- a/website/versioned_docs/version-v15.0.2/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v15.0.2/configuration/data-management-types.md
@@ -214,7 +214,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v15.0.2/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v15.0.2/data-cookbooks/browse-generation.md
@@ -187,7 +187,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 **Please note**: `FakeProcessing` is the core provided browse/CMR generation lambda we're using for the example in this entry.
 

--- a/website/versioned_docs/version-v15.0.2/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v15.0.2/data-cookbooks/cnm-workflow.md
@@ -228,7 +228,7 @@ To execute this workflow, you're required to include several Lambda resources in
 - <https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/cnm_to_cma_task.tf>
 - <https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/cnm_response_task.tf>
 
-**Please note:** To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+**Please note:** To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 - `CNMToCMA`: <https://github.com/podaac/cumulus-cnm-to-granule>
 - `CnmResponse`: <https://github.com/podaac/cumulus-cnm-response-task>

--- a/website/versioned_docs/version-v15.0.2/deployment/postgres-database-deployment.md
+++ b/website/versioned_docs/version-v15.0.2/deployment/postgres-database-deployment.md
@@ -95,9 +95,9 @@ You can then [add/commit](https://help.github.com/articles/adding-a-file-to-a-re
 
 To deploy this module, you need to make sure that you have the following steps from the [Cumulus deployment instructions](#prepare-aws-configuration) in similar fashion *for this module*:
 
-- [Set Access Keys](#set-access-keys)
-- [Create the state bucket](#create-the-state-bucket)
-- [Create the locks table](#create-the-locks-table)
+- [Set Access Keys](./README.md#set-access-keys)
+- [Create the state bucket](./README.md#create-the-state-bucket)
+- [Create the locks table](./README.md#create-the-locks-table)
 
 --
 

--- a/website/versioned_docs/version-v15.0.2/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v15.0.2/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v15.0.2/glossary.md
+++ b/website/versioned_docs/version-v15.0.2/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v15.0.2/troubleshooting/README.md
+++ b/website/versioned_docs/version-v15.0.2/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v15.0.2/upgrade-notes/upgrade-task-file-schemas.md
+++ b/website/versioned_docs/version-v15.0.2/upgrade-notes/upgrade-task-file-schemas.md
@@ -27,7 +27,7 @@ These former properties were deprecated (with notes about how to derive the same
   - `hyrax-metadata-updates`
 - `fileStagingDir` - no longer supported
 - `url_path` - no longer supported
-- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#optional---integrate-granuleduplicates-information).
+- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#upgrading-your-workflows).
 
 ## Exceptions
 

--- a/website/versioned_docs/version-v15.0.2/workflows/lambda.md
+++ b/website/versioned_docs/version-v15.0.2/workflows/lambda.md
@@ -44,7 +44,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 
@@ -52,7 +52,7 @@ The deploy folder referenced here would contain a folder 'test_task/task/' which
 
 ### Python Lambda
 
-Python Lambdas are created the same way as the Node.js example [above](#node.js-lambda).
+Python Lambdas are created the same way as the Node.js example [above](#nodejs-lambda).
 
 ## Cumulus Message Adapter
 

--- a/website/versioned_docs/version-v16.0.0/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v16.0.0/configuration/data-management-types.md
@@ -214,7 +214,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v16.0.0/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v16.0.0/data-cookbooks/browse-generation.md
@@ -187,7 +187,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 **Please note**: `FakeProcessing` is the core provided browse/CMR generation lambda we're using for the example in this entry.
 

--- a/website/versioned_docs/version-v16.0.0/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v16.0.0/data-cookbooks/cnm-workflow.md
@@ -228,7 +228,7 @@ To execute this workflow, you're required to include several Lambda resources in
 - <https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/cnm_to_cma_task.tf>
 - <https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/cnm_response_task.tf>
 
-**Please note:** To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+**Please note:** To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 - `CNMToCMA`: <https://github.com/podaac/cumulus-cnm-to-granule>
 - `CnmResponse`: <https://github.com/podaac/cumulus-cnm-response-task>

--- a/website/versioned_docs/version-v16.0.0/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v16.0.0/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v16.0.0/glossary.md
+++ b/website/versioned_docs/version-v16.0.0/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v16.0.0/troubleshooting/README.md
+++ b/website/versioned_docs/version-v16.0.0/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v16.0.0/upgrade-notes/upgrade-task-file-schemas.md
+++ b/website/versioned_docs/version-v16.0.0/upgrade-notes/upgrade-task-file-schemas.md
@@ -27,7 +27,7 @@ These former properties were deprecated (with notes about how to derive the same
   - `hyrax-metadata-updates`
 - `fileStagingDir` - no longer supported
 - `url_path` - no longer supported
-- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#optional---integrate-granuleduplicates-information).
+- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#upgrading-your-workflows).
 
 ## Exceptions
 

--- a/website/versioned_docs/version-v16.0.0/workflows/lambda.md
+++ b/website/versioned_docs/version-v16.0.0/workflows/lambda.md
@@ -44,7 +44,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 
@@ -52,7 +52,7 @@ The deploy folder referenced here would contain a folder 'test_task/task/' which
 
 ### Python Lambda
 
-Python Lambdas are created the same way as the Node.js example [above](#node.js-lambda).
+Python Lambdas are created the same way as the Node.js example [above](#nodejs-lambda).
 
 ## Cumulus Message Adapter
 

--- a/website/versioned_docs/version-v16.1.3/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v16.1.3/configuration/data-management-types.md
@@ -225,7 +225,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v16.1.3/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v16.1.3/data-cookbooks/browse-generation.md
@@ -195,7 +195,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 :::note
 

--- a/website/versioned_docs/version-v16.1.3/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v16.1.3/data-cookbooks/cnm-workflow.md
@@ -230,7 +230,7 @@ To execute this workflow, you're required to include several Lambda resources in
 
 :::note
 
-To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 :::
 

--- a/website/versioned_docs/version-v16.1.3/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v16.1.3/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v16.1.3/glossary.md
+++ b/website/versioned_docs/version-v16.1.3/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v16.1.3/troubleshooting/README.md
+++ b/website/versioned_docs/version-v16.1.3/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v16.1.3/upgrade-notes/upgrade-task-file-schemas.md
+++ b/website/versioned_docs/version-v16.1.3/upgrade-notes/upgrade-task-file-schemas.md
@@ -27,7 +27,7 @@ These former properties were deprecated (with notes about how to derive the same
   - `hyrax-metadata-updates`
 - `fileStagingDir` - no longer supported
 - `url_path` - no longer supported
-- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#optional---integrate-granuleduplicates-information).
+- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#upgrading-your-workflows).
 
 ## Exceptions
 

--- a/website/versioned_docs/version-v16.1.3/workflows/lambda.md
+++ b/website/versioned_docs/version-v16.1.3/workflows/lambda.md
@@ -48,7 +48,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 

--- a/website/versioned_docs/version-v17.0.0/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v17.0.0/configuration/data-management-types.md
@@ -220,7 +220,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v17.0.0/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v17.0.0/data-cookbooks/browse-generation.md
@@ -195,7 +195,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 :::note
 

--- a/website/versioned_docs/version-v17.0.0/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v17.0.0/data-cookbooks/cnm-workflow.md
@@ -230,7 +230,7 @@ To execute this workflow, you're required to include several Lambda resources in
 
 :::note
 
-To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 :::
 

--- a/website/versioned_docs/version-v17.0.0/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v17.0.0/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v17.0.0/glossary.md
+++ b/website/versioned_docs/version-v17.0.0/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v17.0.0/troubleshooting/README.md
+++ b/website/versioned_docs/version-v17.0.0/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v17.0.0/upgrade-notes/upgrade-task-file-schemas.md
+++ b/website/versioned_docs/version-v17.0.0/upgrade-notes/upgrade-task-file-schemas.md
@@ -27,7 +27,7 @@ These former properties were deprecated (with notes about how to derive the same
   - `hyrax-metadata-updates`
 - `fileStagingDir` - no longer supported
 - `url_path` - no longer supported
-- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#optional---integrate-granuleduplicates-information).
+- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#upgrading-your-workflows).
 
 ## Exceptions
 

--- a/website/versioned_docs/version-v17.0.0/workflows/lambda.md
+++ b/website/versioned_docs/version-v17.0.0/workflows/lambda.md
@@ -48,7 +48,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 

--- a/website/versioned_docs/version-v18.0.0/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v18.0.0/configuration/data-management-types.md
@@ -220,7 +220,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v18.0.0/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v18.0.0/data-cookbooks/browse-generation.md
@@ -195,7 +195,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 :::note
 

--- a/website/versioned_docs/version-v18.0.0/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v18.0.0/data-cookbooks/cnm-workflow.md
@@ -230,7 +230,7 @@ To execute this workflow, you're required to include several Lambda resources in
 
 :::note
 
-To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 :::
 

--- a/website/versioned_docs/version-v18.0.0/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v18.0.0/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v18.0.0/glossary.md
+++ b/website/versioned_docs/version-v18.0.0/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v18.0.0/troubleshooting/README.md
+++ b/website/versioned_docs/version-v18.0.0/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v18.0.0/upgrade-notes/upgrade-task-file-schemas.md
+++ b/website/versioned_docs/version-v18.0.0/upgrade-notes/upgrade-task-file-schemas.md
@@ -27,7 +27,7 @@ These former properties were deprecated (with notes about how to derive the same
   - `hyrax-metadata-updates`
 - `fileStagingDir` - no longer supported
 - `url_path` - no longer supported
-- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#optional---integrate-granuleduplicates-information).
+- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#upgrading-your-workflows).
 
 ## Exceptions
 

--- a/website/versioned_docs/version-v18.0.0/workflows/lambda.md
+++ b/website/versioned_docs/version-v18.0.0/workflows/lambda.md
@@ -48,7 +48,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 

--- a/website/versioned_docs/version-v18.1.0/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v18.1.0/configuration/data-management-types.md
@@ -225,7 +225,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v18.1.0/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v18.1.0/data-cookbooks/browse-generation.md
@@ -195,7 +195,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 :::note
 

--- a/website/versioned_docs/version-v18.1.0/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v18.1.0/data-cookbooks/cnm-workflow.md
@@ -230,7 +230,7 @@ To execute this workflow, you're required to include several Lambda resources in
 
 :::note
 
-To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 :::
 

--- a/website/versioned_docs/version-v18.1.0/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v18.1.0/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v18.1.0/glossary.md
+++ b/website/versioned_docs/version-v18.1.0/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v18.1.0/troubleshooting/README.md
+++ b/website/versioned_docs/version-v18.1.0/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v18.1.0/upgrade-notes/upgrade-task-file-schemas.md
+++ b/website/versioned_docs/version-v18.1.0/upgrade-notes/upgrade-task-file-schemas.md
@@ -27,7 +27,7 @@ These former properties were deprecated (with notes about how to derive the same
   - `hyrax-metadata-updates`
 - `fileStagingDir` - no longer supported
 - `url_path` - no longer supported
-- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#optional---integrate-granuleduplicates-information).
+- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#upgrading-your-workflows).
 
 ## Exceptions
 

--- a/website/versioned_docs/version-v18.1.0/workflows/lambda.md
+++ b/website/versioned_docs/version-v18.1.0/workflows/lambda.md
@@ -48,7 +48,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 

--- a/website/versioned_docs/version-v18.2.0/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v18.2.0/configuration/data-management-types.md
@@ -225,7 +225,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v18.2.0/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v18.2.0/data-cookbooks/browse-generation.md
@@ -195,7 +195,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 :::note
 

--- a/website/versioned_docs/version-v18.2.0/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v18.2.0/data-cookbooks/cnm-workflow.md
@@ -230,7 +230,7 @@ To execute this workflow, you're required to include several Lambda resources in
 
 :::note
 
-To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 :::
 

--- a/website/versioned_docs/version-v18.2.0/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v18.2.0/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v18.2.0/glossary.md
+++ b/website/versioned_docs/version-v18.2.0/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v18.2.0/troubleshooting/README.md
+++ b/website/versioned_docs/version-v18.2.0/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v18.2.0/upgrade-notes/upgrade-task-file-schemas.md
+++ b/website/versioned_docs/version-v18.2.0/upgrade-notes/upgrade-task-file-schemas.md
@@ -27,7 +27,7 @@ These former properties were deprecated (with notes about how to derive the same
   - `hyrax-metadata-updates`
 - `fileStagingDir` - no longer supported
 - `url_path` - no longer supported
-- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#optional---integrate-granuleduplicates-information).
+- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#upgrading-your-workflows).
 
 ## Exceptions
 

--- a/website/versioned_docs/version-v18.2.0/workflows/lambda.md
+++ b/website/versioned_docs/version-v18.2.0/workflows/lambda.md
@@ -48,7 +48,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 

--- a/website/versioned_docs/version-v18.3.4/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v18.3.4/configuration/data-management-types.md
@@ -225,7 +225,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v18.3.4/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v18.3.4/data-cookbooks/browse-generation.md
@@ -195,7 +195,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 :::note
 

--- a/website/versioned_docs/version-v18.3.4/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v18.3.4/data-cookbooks/cnm-workflow.md
@@ -235,7 +235,7 @@ To execute this workflow, you're required to include several Lambda resources in
 
 :::note
 
-To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 :::
 

--- a/website/versioned_docs/version-v18.3.4/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v18.3.4/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v18.3.4/glossary.md
+++ b/website/versioned_docs/version-v18.3.4/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v18.3.4/troubleshooting/README.md
+++ b/website/versioned_docs/version-v18.3.4/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v18.3.4/upgrade-notes/upgrade-task-file-schemas.md
+++ b/website/versioned_docs/version-v18.3.4/upgrade-notes/upgrade-task-file-schemas.md
@@ -27,7 +27,7 @@ These former properties were deprecated (with notes about how to derive the same
   - `hyrax-metadata-updates`
 - `fileStagingDir` - no longer supported
 - `url_path` - no longer supported
-- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#optional---integrate-granuleduplicates-information).
+- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#upgrading-your-workflows).
 
 ## Exceptions
 

--- a/website/versioned_docs/version-v18.3.4/workflows/lambda.md
+++ b/website/versioned_docs/version-v18.3.4/workflows/lambda.md
@@ -48,7 +48,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 

--- a/website/versioned_docs/version-v18.4.0/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v18.4.0/configuration/data-management-types.md
@@ -225,7 +225,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v18.4.0/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v18.4.0/data-cookbooks/browse-generation.md
@@ -195,7 +195,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 :::note
 

--- a/website/versioned_docs/version-v18.4.0/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v18.4.0/data-cookbooks/cnm-workflow.md
@@ -235,7 +235,7 @@ To execute this workflow, you're required to include several Lambda resources in
 
 :::note
 
-To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 :::
 

--- a/website/versioned_docs/version-v18.4.0/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v18.4.0/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v18.4.0/glossary.md
+++ b/website/versioned_docs/version-v18.4.0/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v18.4.0/troubleshooting/README.md
+++ b/website/versioned_docs/version-v18.4.0/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v18.4.0/upgrade-notes/upgrade-task-file-schemas.md
+++ b/website/versioned_docs/version-v18.4.0/upgrade-notes/upgrade-task-file-schemas.md
@@ -27,7 +27,7 @@ These former properties were deprecated (with notes about how to derive the same
   - `hyrax-metadata-updates`
 - `fileStagingDir` - no longer supported
 - `url_path` - no longer supported
-- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#optional---integrate-granuleduplicates-information).
+- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#upgrading-your-workflows).
 
 ## Exceptions
 

--- a/website/versioned_docs/version-v18.4.0/workflows/lambda.md
+++ b/website/versioned_docs/version-v18.4.0/workflows/lambda.md
@@ -48,7 +48,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 

--- a/website/versioned_docs/version-v18.5.0/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v18.5.0/configuration/data-management-types.md
@@ -225,7 +225,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v18.5.0/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v18.5.0/data-cookbooks/browse-generation.md
@@ -195,7 +195,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 :::note
 

--- a/website/versioned_docs/version-v18.5.0/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v18.5.0/data-cookbooks/cnm-workflow.md
@@ -235,7 +235,7 @@ To execute this workflow, you're required to include several Lambda resources in
 
 :::note
 
-To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 :::
 

--- a/website/versioned_docs/version-v18.5.0/deployment/choosing_configuring_rds.md
+++ b/website/versioned_docs/version-v18.5.0/deployment/choosing_configuring_rds.md
@@ -26,7 +26,7 @@ load.
 
 On the other hand, serverless databases are designed precisely to **scale in response to load**.
 While the ability of serverless databases to scale is quite useful, there can be complexity in
-setting the scaling configuration to achieve the best results. Recommendations for Aurora serverless database scaling configuration are provided in the section [below](#recommended-scaling-configuration-for-aurora-serverless).
+setting the scaling configuration to achieve the best results. Recommendations for Aurora serverless database scaling configuration are provided in the section [below](#aurora-serverless-v2-capacity-range).
 
 To decide whether a provisioned or a serverless database is appropriate for your ingest
 operations, you should consider the pattern of your data ingests.

--- a/website/versioned_docs/version-v18.5.0/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v18.5.0/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v18.5.0/glossary.md
+++ b/website/versioned_docs/version-v18.5.0/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v18.5.0/troubleshooting/README.md
+++ b/website/versioned_docs/version-v18.5.0/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v18.5.0/upgrade-notes/upgrade-task-file-schemas.md
+++ b/website/versioned_docs/version-v18.5.0/upgrade-notes/upgrade-task-file-schemas.md
@@ -27,7 +27,7 @@ These former properties were deprecated (with notes about how to derive the same
   - `hyrax-metadata-updates`
 - `fileStagingDir` - no longer supported
 - `url_path` - no longer supported
-- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#optional---integrate-granuleduplicates-information).
+- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#upgrading-your-workflows).
 
 ## Exceptions
 

--- a/website/versioned_docs/version-v18.5.0/workflows/lambda.md
+++ b/website/versioned_docs/version-v18.5.0/workflows/lambda.md
@@ -48,7 +48,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 

--- a/website/versioned_docs/version-v19.0.0/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v19.0.0/configuration/data-management-types.md
@@ -225,7 +225,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v19.0.0/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v19.0.0/data-cookbooks/browse-generation.md
@@ -195,7 +195,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 :::note
 

--- a/website/versioned_docs/version-v19.0.0/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v19.0.0/data-cookbooks/cnm-workflow.md
@@ -235,7 +235,7 @@ To execute this workflow, you're required to include several Lambda resources in
 
 :::note
 
-To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 :::
 

--- a/website/versioned_docs/version-v19.0.0/deployment/choosing_configuring_rds.md
+++ b/website/versioned_docs/version-v19.0.0/deployment/choosing_configuring_rds.md
@@ -26,7 +26,7 @@ load.
 
 On the other hand, serverless databases are designed precisely to **scale in response to load**.
 While the ability of serverless databases to scale is quite useful, there can be complexity in
-setting the scaling configuration to achieve the best results. Recommendations for Aurora serverless database scaling configuration are provided in the section [below](#recommended-scaling-configuration-for-aurora-serverless).
+setting the scaling configuration to achieve the best results. Recommendations for Aurora serverless database scaling configuration are provided in the section [below](#aurora-serverless-v2-capacity-range).
 
 To decide whether a provisioned or a serverless database is appropriate for your ingest
 operations, you should consider the pattern of your data ingests.

--- a/website/versioned_docs/version-v19.0.0/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v19.0.0/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v19.0.0/glossary.md
+++ b/website/versioned_docs/version-v19.0.0/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v19.0.0/troubleshooting/README.md
+++ b/website/versioned_docs/version-v19.0.0/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v19.0.0/upgrade-notes/upgrade-task-file-schemas.md
+++ b/website/versioned_docs/version-v19.0.0/upgrade-notes/upgrade-task-file-schemas.md
@@ -27,7 +27,7 @@ These former properties were deprecated (with notes about how to derive the same
   - `hyrax-metadata-updates`
 - `fileStagingDir` - no longer supported
 - `url_path` - no longer supported
-- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#optional---integrate-granuleduplicates-information).
+- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#upgrading-your-workflows).
 
 ## Exceptions
 

--- a/website/versioned_docs/version-v19.0.0/workflows/lambda.md
+++ b/website/versioned_docs/version-v19.0.0/workflows/lambda.md
@@ -48,7 +48,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 

--- a/website/versioned_docs/version-v19.1.0/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v19.1.0/configuration/data-management-types.md
@@ -225,7 +225,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v19.1.0/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v19.1.0/data-cookbooks/browse-generation.md
@@ -195,7 +195,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 :::note
 

--- a/website/versioned_docs/version-v19.1.0/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v19.1.0/data-cookbooks/cnm-workflow.md
@@ -235,7 +235,7 @@ To execute this workflow, you're required to include several Lambda resources in
 
 :::note
 
-To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 :::
 

--- a/website/versioned_docs/version-v19.1.0/deployment/choosing_configuring_rds.md
+++ b/website/versioned_docs/version-v19.1.0/deployment/choosing_configuring_rds.md
@@ -26,7 +26,7 @@ load.
 
 On the other hand, serverless databases are designed precisely to **scale in response to load**.
 While the ability of serverless databases to scale is quite useful, there can be complexity in
-setting the scaling configuration to achieve the best results. Recommendations for Aurora serverless database scaling configuration are provided in the section [below](#recommended-scaling-configuration-for-aurora-serverless).
+setting the scaling configuration to achieve the best results. Recommendations for Aurora serverless database scaling configuration are provided in the section [below](#aurora-serverless-v2-capacity-range).
 
 To decide whether a provisioned or a serverless database is appropriate for your ingest
 operations, you should consider the pattern of your data ingests.

--- a/website/versioned_docs/version-v19.1.0/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v19.1.0/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v19.1.0/glossary.md
+++ b/website/versioned_docs/version-v19.1.0/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v19.1.0/troubleshooting/README.md
+++ b/website/versioned_docs/version-v19.1.0/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v19.1.0/upgrade-notes/upgrade-task-file-schemas.md
+++ b/website/versioned_docs/version-v19.1.0/upgrade-notes/upgrade-task-file-schemas.md
@@ -27,7 +27,7 @@ These former properties were deprecated (with notes about how to derive the same
   - `hyrax-metadata-updates`
 - `fileStagingDir` - no longer supported
 - `url_path` - no longer supported
-- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#optional---integrate-granuleduplicates-information).
+- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#upgrading-your-workflows).
 
 ## Exceptions
 

--- a/website/versioned_docs/version-v19.1.0/workflows/lambda.md
+++ b/website/versioned_docs/version-v19.1.0/workflows/lambda.md
@@ -48,7 +48,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 

--- a/website/versioned_docs/version-v20.0.0/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v20.0.0/configuration/data-management-types.md
@@ -225,7 +225,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v20.0.0/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v20.0.0/data-cookbooks/browse-generation.md
@@ -195,7 +195,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 :::note
 

--- a/website/versioned_docs/version-v20.0.0/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v20.0.0/data-cookbooks/cnm-workflow.md
@@ -235,7 +235,7 @@ To execute this workflow, you're required to include several Lambda resources in
 
 :::note
 
-To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 :::
 

--- a/website/versioned_docs/version-v20.0.0/deployment/choosing_configuring_rds.md
+++ b/website/versioned_docs/version-v20.0.0/deployment/choosing_configuring_rds.md
@@ -26,7 +26,7 @@ load.
 
 On the other hand, serverless databases are designed precisely to **scale in response to load**.
 While the ability of serverless databases to scale is quite useful, there can be complexity in
-setting the scaling configuration to achieve the best results. Recommendations for Aurora serverless database scaling configuration are provided in the section [below](#recommended-scaling-configuration-for-aurora-serverless).
+setting the scaling configuration to achieve the best results. Recommendations for Aurora serverless database scaling configuration are provided in the section [below](#aurora-serverless-v2-capacity-range).
 
 To decide whether a provisioned or a serverless database is appropriate for your ingest
 operations, you should consider the pattern of your data ingests.

--- a/website/versioned_docs/version-v20.0.0/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v20.0.0/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v20.0.0/glossary.md
+++ b/website/versioned_docs/version-v20.0.0/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v20.0.0/troubleshooting/README.md
+++ b/website/versioned_docs/version-v20.0.0/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v20.0.0/upgrade-notes/upgrade-task-file-schemas.md
+++ b/website/versioned_docs/version-v20.0.0/upgrade-notes/upgrade-task-file-schemas.md
@@ -27,7 +27,7 @@ These former properties were deprecated (with notes about how to derive the same
   - `hyrax-metadata-updates`
 - `fileStagingDir` - no longer supported
 - `url_path` - no longer supported
-- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#optional---integrate-granuleduplicates-information).
+- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#upgrading-your-workflows).
 
 ## Exceptions
 

--- a/website/versioned_docs/version-v20.0.0/workflows/lambda.md
+++ b/website/versioned_docs/version-v20.0.0/workflows/lambda.md
@@ -48,7 +48,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 

--- a/website/versioned_docs/version-v20.1.1/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v20.1.1/configuration/data-management-types.md
@@ -225,7 +225,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v20.1.1/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v20.1.1/data-cookbooks/browse-generation.md
@@ -195,7 +195,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 :::note
 

--- a/website/versioned_docs/version-v20.1.1/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v20.1.1/data-cookbooks/cnm-workflow.md
@@ -235,7 +235,7 @@ To execute this workflow, you're required to include several Lambda resources in
 
 :::note
 
-To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 :::
 

--- a/website/versioned_docs/version-v20.1.1/deployment/choosing_configuring_rds.md
+++ b/website/versioned_docs/version-v20.1.1/deployment/choosing_configuring_rds.md
@@ -26,7 +26,7 @@ load.
 
 On the other hand, serverless databases are designed precisely to **scale in response to load**.
 While the ability of serverless databases to scale is quite useful, there can be complexity in
-setting the scaling configuration to achieve the best results. Recommendations for Aurora serverless database scaling configuration are provided in the section [below](#recommended-scaling-configuration-for-aurora-serverless).
+setting the scaling configuration to achieve the best results. Recommendations for Aurora serverless database scaling configuration are provided in the section [below](#aurora-serverless-v2-capacity-range).
 
 To decide whether a provisioned or a serverless database is appropriate for your ingest
 operations, you should consider the pattern of your data ingests.

--- a/website/versioned_docs/version-v20.1.1/development/release.md
+++ b/website/versioned_docs/version-v20.1.1/development/release.md
@@ -173,7 +173,7 @@ If there is exists a PR in the cumulus-dashboard repo with a name containing: "V
 
 ### 4. Publish async_operations image to Docker Hub
 
-For consistency and security reasons, a [new docker image for async_operations should be created and published](../../packages/api/ecs/async-operation/README.md) for each release and pushed to Docker Hub and possibly AWS ECR. Make sure to follow the instructions for **Updating the Cumulus deployment configuration**
+For consistency and security reasons, a [new docker image for async_operations should be created and published](https://github.com/nasa/cumulus/blob/master/packages/api/ecs/async-operation/README.md) for each release and pushed to Docker Hub and possibly AWS ECR. Make sure to follow the instructions for **Updating the Cumulus deployment configuration**
 
 ### 5. Update CHANGELOG.md
 

--- a/website/versioned_docs/version-v20.1.1/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v20.1.1/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v20.1.1/glossary.md
+++ b/website/versioned_docs/version-v20.1.1/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v20.1.1/troubleshooting/README.md
+++ b/website/versioned_docs/version-v20.1.1/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v20.1.1/upgrade-notes/upgrade-task-file-schemas.md
+++ b/website/versioned_docs/version-v20.1.1/upgrade-notes/upgrade-task-file-schemas.md
@@ -27,7 +27,7 @@ These former properties were deprecated (with notes about how to derive the same
   - `hyrax-metadata-updates`
 - `fileStagingDir` - no longer supported
 - `url_path` - no longer supported
-- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#optional---integrate-granuleduplicates-information).
+- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#upgrading-your-workflows).
 
 ## Exceptions
 

--- a/website/versioned_docs/version-v20.1.1/workflows/lambda.md
+++ b/website/versioned_docs/version-v20.1.1/workflows/lambda.md
@@ -48,7 +48,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 

--- a/website/versioned_docs/version-v20.1.2/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v20.1.2/configuration/data-management-types.md
@@ -225,7 +225,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v20.1.2/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v20.1.2/data-cookbooks/browse-generation.md
@@ -195,7 +195,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 :::note
 

--- a/website/versioned_docs/version-v20.1.2/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v20.1.2/data-cookbooks/cnm-workflow.md
@@ -235,7 +235,7 @@ To execute this workflow, you're required to include several Lambda resources in
 
 :::note
 
-To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 :::
 

--- a/website/versioned_docs/version-v20.1.2/deployment/choosing_configuring_rds.md
+++ b/website/versioned_docs/version-v20.1.2/deployment/choosing_configuring_rds.md
@@ -26,7 +26,7 @@ load.
 
 On the other hand, serverless databases are designed precisely to **scale in response to load**.
 While the ability of serverless databases to scale is quite useful, there can be complexity in
-setting the scaling configuration to achieve the best results. Recommendations for Aurora serverless database scaling configuration are provided in the section [below](#recommended-scaling-configuration-for-aurora-serverless).
+setting the scaling configuration to achieve the best results. Recommendations for Aurora serverless database scaling configuration are provided in the section [below](#aurora-serverless-v2-capacity-range).
 
 To decide whether a provisioned or a serverless database is appropriate for your ingest
 operations, you should consider the pattern of your data ingests.

--- a/website/versioned_docs/version-v20.1.2/development/release.md
+++ b/website/versioned_docs/version-v20.1.2/development/release.md
@@ -173,7 +173,7 @@ If there is exists a PR in the cumulus-dashboard repo with a name containing: "V
 
 ### 4. Publish async_operations image to Docker Hub
 
-For consistency and security reasons, a [new docker image for async_operations should be created and published](../../packages/api/ecs/async-operation/README.md) for each release and pushed to Docker Hub and possibly AWS ECR. Make sure to follow the instructions for **Updating the Cumulus deployment configuration**
+For consistency and security reasons, a [new docker image for async_operations should be created and published](https://github.com/nasa/cumulus/blob/master/packages/api/ecs/async-operation/README.md) for each release and pushed to Docker Hub and possibly AWS ECR. Make sure to follow the instructions for **Updating the Cumulus deployment configuration**
 
 ### 5. Update CHANGELOG.md
 

--- a/website/versioned_docs/version-v20.1.2/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v20.1.2/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v20.1.2/glossary.md
+++ b/website/versioned_docs/version-v20.1.2/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v20.1.2/troubleshooting/README.md
+++ b/website/versioned_docs/version-v20.1.2/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v20.1.2/upgrade-notes/upgrade-task-file-schemas.md
+++ b/website/versioned_docs/version-v20.1.2/upgrade-notes/upgrade-task-file-schemas.md
@@ -27,7 +27,7 @@ These former properties were deprecated (with notes about how to derive the same
   - `hyrax-metadata-updates`
 - `fileStagingDir` - no longer supported
 - `url_path` - no longer supported
-- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#optional---integrate-granuleduplicates-information).
+- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#upgrading-your-workflows).
 
 ## Exceptions
 

--- a/website/versioned_docs/version-v20.1.2/workflows/lambda.md
+++ b/website/versioned_docs/version-v20.1.2/workflows/lambda.md
@@ -48,7 +48,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 

--- a/website/versioned_docs/version-v20.2.0/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v20.2.0/configuration/data-management-types.md
@@ -225,7 +225,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v20.2.0/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v20.2.0/data-cookbooks/browse-generation.md
@@ -195,7 +195,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 :::note
 

--- a/website/versioned_docs/version-v20.2.0/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v20.2.0/data-cookbooks/cnm-workflow.md
@@ -235,7 +235,7 @@ To execute this workflow, you're required to include several Lambda resources in
 
 :::note
 
-To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 :::
 

--- a/website/versioned_docs/version-v20.2.0/deployment/choosing_configuring_rds.md
+++ b/website/versioned_docs/version-v20.2.0/deployment/choosing_configuring_rds.md
@@ -26,7 +26,7 @@ load.
 
 On the other hand, serverless databases are designed precisely to **scale in response to load**.
 While the ability of serverless databases to scale is quite useful, there can be complexity in
-setting the scaling configuration to achieve the best results. Recommendations for Aurora serverless database scaling configuration are provided in the section [below](#recommended-scaling-configuration-for-aurora-serverless).
+setting the scaling configuration to achieve the best results. Recommendations for Aurora serverless database scaling configuration are provided in the section [below](#aurora-serverless-v2-capacity-range).
 
 To decide whether a provisioned or a serverless database is appropriate for your ingest
 operations, you should consider the pattern of your data ingests.

--- a/website/versioned_docs/version-v20.2.0/development/release.md
+++ b/website/versioned_docs/version-v20.2.0/development/release.md
@@ -173,7 +173,7 @@ If there is exists a PR in the cumulus-dashboard repo with a name containing: "V
 
 ### 4. Publish async_operations image to Docker Hub
 
-For consistency and security reasons, a [new docker image for async_operations should be created and published](../../packages/api/ecs/async-operation/README.md) for each release and pushed to Docker Hub and possibly AWS ECR. Make sure to follow the instructions for **Updating the Cumulus deployment configuration**
+For consistency and security reasons, a [new docker image for async_operations should be created and published](https://github.com/nasa/cumulus/blob/master/packages/api/ecs/async-operation/README.md) for each release and pushed to Docker Hub and possibly AWS ECR. Make sure to follow the instructions for **Updating the Cumulus deployment configuration**
 
 ### 5. Update CHANGELOG.md
 

--- a/website/versioned_docs/version-v20.2.0/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v20.2.0/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v20.2.0/glossary.md
+++ b/website/versioned_docs/version-v20.2.0/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v20.2.0/troubleshooting/README.md
+++ b/website/versioned_docs/version-v20.2.0/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v20.2.0/upgrade-notes/upgrade-task-file-schemas.md
+++ b/website/versioned_docs/version-v20.2.0/upgrade-notes/upgrade-task-file-schemas.md
@@ -27,7 +27,7 @@ These former properties were deprecated (with notes about how to derive the same
   - `hyrax-metadata-updates`
 - `fileStagingDir` - no longer supported
 - `url_path` - no longer supported
-- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#optional---integrate-granuleduplicates-information).
+- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#upgrading-your-workflows).
 
 ## Exceptions
 

--- a/website/versioned_docs/version-v20.2.0/workflows/lambda.md
+++ b/website/versioned_docs/version-v20.2.0/workflows/lambda.md
@@ -48,7 +48,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 

--- a/website/versioned_docs/version-v20.3.0/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v20.3.0/configuration/data-management-types.md
@@ -225,7 +225,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v20.3.0/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v20.3.0/data-cookbooks/browse-generation.md
@@ -195,7 +195,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 :::note
 

--- a/website/versioned_docs/version-v20.3.0/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v20.3.0/data-cookbooks/cnm-workflow.md
@@ -235,7 +235,7 @@ To execute this workflow, you're required to include several Lambda resources in
 
 :::note
 
-To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 :::
 

--- a/website/versioned_docs/version-v20.3.0/deployment/choosing_configuring_rds.md
+++ b/website/versioned_docs/version-v20.3.0/deployment/choosing_configuring_rds.md
@@ -26,7 +26,7 @@ load.
 
 On the other hand, serverless databases are designed precisely to **scale in response to load**.
 While the ability of serverless databases to scale is quite useful, there can be complexity in
-setting the scaling configuration to achieve the best results. Recommendations for Aurora serverless database scaling configuration are provided in the section [below](#recommended-scaling-configuration-for-aurora-serverless).
+setting the scaling configuration to achieve the best results. Recommendations for Aurora serverless database scaling configuration are provided in the section [below](#aurora-serverless-v2-capacity-range).
 
 To decide whether a provisioned or a serverless database is appropriate for your ingest
 operations, you should consider the pattern of your data ingests.

--- a/website/versioned_docs/version-v20.3.0/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v20.3.0/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v20.3.0/glossary.md
+++ b/website/versioned_docs/version-v20.3.0/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v20.3.0/troubleshooting/README.md
+++ b/website/versioned_docs/version-v20.3.0/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v20.3.0/upgrade-notes/upgrade-task-file-schemas.md
+++ b/website/versioned_docs/version-v20.3.0/upgrade-notes/upgrade-task-file-schemas.md
@@ -27,7 +27,7 @@ These former properties were deprecated (with notes about how to derive the same
   - `hyrax-metadata-updates`
 - `fileStagingDir` - no longer supported
 - `url_path` - no longer supported
-- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#optional---integrate-granuleduplicates-information).
+- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#upgrading-your-workflows).
 
 ## Exceptions
 

--- a/website/versioned_docs/version-v20.3.0/workflows/lambda.md
+++ b/website/versioned_docs/version-v20.3.0/workflows/lambda.md
@@ -48,7 +48,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 

--- a/website/versioned_docs/version-v21.0.0/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v21.0.0/configuration/data-management-types.md
@@ -225,7 +225,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v21.0.0/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v21.0.0/data-cookbooks/browse-generation.md
@@ -195,7 +195,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 :::note
 

--- a/website/versioned_docs/version-v21.0.0/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v21.0.0/data-cookbooks/cnm-workflow.md
@@ -235,7 +235,7 @@ To execute this workflow, you're required to include several Lambda resources in
 
 :::note
 
-To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 :::
 

--- a/website/versioned_docs/version-v21.0.0/deployment/choosing_configuring_rds.md
+++ b/website/versioned_docs/version-v21.0.0/deployment/choosing_configuring_rds.md
@@ -26,7 +26,7 @@ load.
 
 On the other hand, serverless databases are designed precisely to **scale in response to load**.
 While the ability of serverless databases to scale is quite useful, there can be complexity in
-setting the scaling configuration to achieve the best results. Recommendations for Aurora serverless database scaling configuration are provided in the section [below](#recommended-scaling-configuration-for-aurora-serverless).
+setting the scaling configuration to achieve the best results. Recommendations for Aurora serverless database scaling configuration are provided in the section [below](#aurora-serverless-v2-capacity-range).
 
 To decide whether a provisioned or a serverless database is appropriate for your ingest
 operations, you should consider the pattern of your data ingests.

--- a/website/versioned_docs/version-v21.0.0/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v21.0.0/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v21.0.0/glossary.md
+++ b/website/versioned_docs/version-v21.0.0/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v21.0.0/troubleshooting/README.md
+++ b/website/versioned_docs/version-v21.0.0/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v21.0.0/upgrade-notes/upgrade-task-file-schemas.md
+++ b/website/versioned_docs/version-v21.0.0/upgrade-notes/upgrade-task-file-schemas.md
@@ -27,7 +27,7 @@ These former properties were deprecated (with notes about how to derive the same
   - `hyrax-metadata-updates`
 - `fileStagingDir` - no longer supported
 - `url_path` - no longer supported
-- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#optional---integrate-granuleduplicates-information).
+- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#upgrading-your-workflows).
 
 ## Exceptions
 

--- a/website/versioned_docs/version-v21.0.0/workflows/lambda.md
+++ b/website/versioned_docs/version-v21.0.0/workflows/lambda.md
@@ -48,7 +48,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 

--- a/website/versioned_docs/version-v21.2.0/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v21.2.0/configuration/data-management-types.md
@@ -225,7 +225,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v21.2.0/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v21.2.0/data-cookbooks/browse-generation.md
@@ -195,7 +195,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 :::note
 

--- a/website/versioned_docs/version-v21.2.0/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v21.2.0/data-cookbooks/cnm-workflow.md
@@ -235,7 +235,7 @@ To execute this workflow, you're required to include several Lambda resources in
 
 :::note
 
-To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 :::
 

--- a/website/versioned_docs/version-v21.2.0/deployment/choosing_configuring_rds.md
+++ b/website/versioned_docs/version-v21.2.0/deployment/choosing_configuring_rds.md
@@ -26,7 +26,7 @@ load.
 
 On the other hand, serverless databases are designed precisely to **scale in response to load**.
 While the ability of serverless databases to scale is quite useful, there can be complexity in
-setting the scaling configuration to achieve the best results. Recommendations for Aurora serverless database scaling configuration are provided in the section [below](#recommended-scaling-configuration-for-aurora-serverless).
+setting the scaling configuration to achieve the best results. Recommendations for Aurora serverless database scaling configuration are provided in the section [below](#aurora-serverless-v2-capacity-range).
 
 To decide whether a provisioned or a serverless database is appropriate for your ingest
 operations, you should consider the pattern of your data ingests.

--- a/website/versioned_docs/version-v21.2.0/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v21.2.0/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v21.2.0/glossary.md
+++ b/website/versioned_docs/version-v21.2.0/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v21.2.0/troubleshooting/README.md
+++ b/website/versioned_docs/version-v21.2.0/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v21.2.0/upgrade-notes/upgrade-task-file-schemas.md
+++ b/website/versioned_docs/version-v21.2.0/upgrade-notes/upgrade-task-file-schemas.md
@@ -27,7 +27,7 @@ These former properties were deprecated (with notes about how to derive the same
   - `hyrax-metadata-updates`
 - `fileStagingDir` - no longer supported
 - `url_path` - no longer supported
-- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#optional---integrate-granuleduplicates-information).
+- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#upgrading-your-workflows).
 
 ## Exceptions
 

--- a/website/versioned_docs/version-v21.2.0/workflows/lambda.md
+++ b/website/versioned_docs/version-v21.2.0/workflows/lambda.md
@@ -48,7 +48,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 

--- a/website/versioned_docs/version-v21.3.0/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v21.3.0/configuration/data-management-types.md
@@ -225,7 +225,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v21.3.0/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v21.3.0/data-cookbooks/browse-generation.md
@@ -195,7 +195,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 :::note
 

--- a/website/versioned_docs/version-v21.3.0/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v21.3.0/data-cookbooks/cnm-workflow.md
@@ -235,7 +235,7 @@ To execute this workflow, you're required to include several Lambda resources in
 
 :::note
 
-To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 :::
 

--- a/website/versioned_docs/version-v21.3.0/deployment/choosing_configuring_rds.md
+++ b/website/versioned_docs/version-v21.3.0/deployment/choosing_configuring_rds.md
@@ -26,7 +26,7 @@ load.
 
 On the other hand, serverless databases are designed precisely to **scale in response to load**.
 While the ability of serverless databases to scale is quite useful, there can be complexity in
-setting the scaling configuration to achieve the best results. Recommendations for Aurora serverless database scaling configuration are provided in the section [below](#recommended-scaling-configuration-for-aurora-serverless).
+setting the scaling configuration to achieve the best results. Recommendations for Aurora serverless database scaling configuration are provided in the section [below](#aurora-serverless-v2-capacity-range).
 
 To decide whether a provisioned or a serverless database is appropriate for your ingest
 operations, you should consider the pattern of your data ingests.

--- a/website/versioned_docs/version-v21.3.0/development/python-best-practices.md
+++ b/website/versioned_docs/version-v21.3.0/development/python-best-practices.md
@@ -145,4 +145,4 @@ In addition to `pytest`, developers should strongly consider using [moto](https:
 
 ## Code Documentation
 
-It is expected that whenever possible the code functionality should be documented via a README that includes critical usage and development information such as inputs, outputs, internal and external dependencies, use cases, and critical development information. In addition, the README markdown file should utilize the proper template and conform with [markdown quality standards](docs/development/quality-and-coverage.md).
+It is expected that whenever possible the code functionality should be documented via a README that includes critical usage and development information such as inputs, outputs, internal and external dependencies, use cases, and critical development information. In addition, the README markdown file should utilize the proper template and conform with [markdown quality standards](./quality-and-coverage.md).

--- a/website/versioned_docs/version-v21.3.0/development/quality-and-coverage.md
+++ b/website/versioned_docs/version-v21.3.0/development/quality-and-coverage.md
@@ -5,7 +5,7 @@ id: quality-and-coverage
 
 Currently, code written in this repository leverages Python or TypeScript for most logic and work. The current CI tooling and standards are based on these two languages. Specifics related to the tooling, quality, and testing can be found in the language specific best practices documentation. Python best practices and tooling expectations can be found [here](development/python-best-practices.md). Typescript best practices and tooling can be found [here](development/typescript-best-practices.md).
 
-In addition to CI pipeline quality checks, it is highly recommended for developers to install and configure [pre-commit](https://pre-commit.com) in order to find simple quality issues early. Directions on installing and configuring pre-commit locally for use with this repo can be found [here](docs/development/pre-commit-setup.md).
+In addition to CI pipeline quality checks, it is highly recommended for developers to install and configure [pre-commit](https://pre-commit.com) in order to find simple quality issues early. Directions on installing and configuring pre-commit locally for use with this repo can be found [here](./pre-commit-setup.md).
 
 ## Code Coverage
 

--- a/website/versioned_docs/version-v21.3.0/development/typescript-best-practices.md
+++ b/website/versioned_docs/version-v21.3.0/development/typescript-best-practices.md
@@ -41,4 +41,4 @@ report, run `nyc report --reporter html` and open the `index.html` file in the c
 
 ## Code Documentation
 
-It is expected that whenever possible the code functionality should be documented via a README that includes critical usage and development information such as inputs, outputs, internal and external dependencies, use cases, and critical development information. In addition, the README markdown file should utilize the proper template and conform with [markdown quality standards](docs/development/quality-and-coverage.md).
+It is expected that whenever possible the code functionality should be documented via a README that includes critical usage and development information such as inputs, outputs, internal and external dependencies, use cases, and critical development information. In addition, the README markdown file should utilize the proper template and conform with [markdown quality standards](./quality-and-coverage.md).

--- a/website/versioned_docs/version-v21.3.0/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v21.3.0/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v21.3.0/glossary.md
+++ b/website/versioned_docs/version-v21.3.0/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v21.3.0/troubleshooting/README.md
+++ b/website/versioned_docs/version-v21.3.0/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v21.3.0/upgrade-notes/upgrade-task-file-schemas.md
+++ b/website/versioned_docs/version-v21.3.0/upgrade-notes/upgrade-task-file-schemas.md
@@ -27,7 +27,7 @@ These former properties were deprecated (with notes about how to derive the same
   - `hyrax-metadata-updates`
 - `fileStagingDir` - no longer supported
 - `url_path` - no longer supported
-- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#optional---integrate-granuleduplicates-information).
+- `duplicate_found` - This property is no longer supported, however `sync-granule` and `move-granules` now produce a separate `granuleDuplicates` object as part of their output. The `granuleDuplicates` object is a map of granules by granule ID which includes the files that encountered duplicates during processing. [Guidance on how to integrate `granuleDuplicates` information into your workflow configuration is provided below](#upgrading-your-workflows).
 
 ## Exceptions
 

--- a/website/versioned_docs/version-v21.3.0/workflows/lambda.md
+++ b/website/versioned_docs/version-v21.3.0/workflows/lambda.md
@@ -48,7 +48,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 

--- a/website/versioned_docs/version-v21.3.2/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v21.3.2/configuration/data-management-types.md
@@ -225,7 +225,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v21.3.2/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v21.3.2/data-cookbooks/cnm-workflow.md
@@ -233,7 +233,7 @@ To execute this workflow, you're required to include several Lambda resources in
 
 :::note
 
-To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 :::
 

--- a/website/versioned_docs/version-v21.3.2/development/python-best-practices.md
+++ b/website/versioned_docs/version-v21.3.2/development/python-best-practices.md
@@ -145,4 +145,4 @@ In addition to `pytest`, developers should strongly consider using [moto](https:
 
 ## Code Documentation
 
-It is expected that whenever possible the code functionality should be documented via a README that includes critical usage and development information such as inputs, outputs, internal and external dependencies, use cases, and critical development information. In addition, the README markdown file should utilize the proper template and conform with [markdown quality standards](docs/development/quality-and-coverage.md).
+It is expected that whenever possible the code functionality should be documented via a README that includes critical usage and development information such as inputs, outputs, internal and external dependencies, use cases, and critical development information. In addition, the README markdown file should utilize the proper template and conform with [markdown quality standards](./quality-and-coverage.md).

--- a/website/versioned_docs/version-v21.3.2/development/quality-and-coverage.md
+++ b/website/versioned_docs/version-v21.3.2/development/quality-and-coverage.md
@@ -5,7 +5,7 @@ id: quality-and-coverage
 
 Currently, code written in this repository leverages Python or TypeScript for most logic and work. The current CI tooling and standards are based on these two languages. Specifics related to the tooling, quality, and testing can be found in the language specific best practices documentation. Python best practices and tooling expectations can be found [here](development/python-best-practices.md). Typescript best practices and tooling can be found [here](development/typescript-best-practices.md).
 
-In addition to CI pipeline quality checks, it is highly recommended for developers to install and configure [pre-commit](https://pre-commit.com) in order to find simple quality issues early. Directions on installing and configuring pre-commit locally for use with this repo can be found [here](docs/development/pre-commit-setup.md).
+In addition to CI pipeline quality checks, it is highly recommended for developers to install and configure [pre-commit](https://pre-commit.com) in order to find simple quality issues early. Directions on installing and configuring pre-commit locally for use with this repo can be found [here](./pre-commit-setup.md).
 
 ## Code Coverage
 

--- a/website/versioned_docs/version-v21.3.2/development/typescript-best-practices.md
+++ b/website/versioned_docs/version-v21.3.2/development/typescript-best-practices.md
@@ -41,4 +41,4 @@ report, run `nyc report --reporter html` and open the `index.html` file in the c
 
 ## Code Documentation
 
-It is expected that whenever possible the code functionality should be documented via a README that includes critical usage and development information such as inputs, outputs, internal and external dependencies, use cases, and critical development information. In addition, the README markdown file should utilize the proper template and conform with [markdown quality standards](docs/development/quality-and-coverage.md).
+It is expected that whenever possible the code functionality should be documented via a README that includes critical usage and development information such as inputs, outputs, internal and external dependencies, use cases, and critical development information. In addition, the README markdown file should utilize the proper template and conform with [markdown quality standards](./quality-and-coverage.md).

--- a/website/versioned_docs/version-v21.3.2/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v21.3.2/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v21.3.2/glossary.md
+++ b/website/versioned_docs/version-v21.3.2/glossary.md
@@ -92,7 +92,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
 ### Developer
 
-  Those who setup deployment and workflow management for Cumulus. Sometimes referred to as an integrator. *See [integrator](#integratordeveloper)*.
+  Those who setup deployment and workflow management for Cumulus. Sometimes referred to as an integrator. *See [integrator](#integrator)*.
 
 ### ECS
 
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v21.3.2/troubleshooting/README.md
+++ b/website/versioned_docs/version-v21.3.2/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v21.3.3/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v21.3.3/configuration/data-management-types.md
@@ -225,7 +225,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v21.3.3/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v21.3.3/data-cookbooks/cnm-workflow.md
@@ -233,7 +233,7 @@ To execute this workflow, you're required to include several Lambda resources in
 
 :::note
 
-To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 :::
 

--- a/website/versioned_docs/version-v21.3.3/development/python-best-practices.md
+++ b/website/versioned_docs/version-v21.3.3/development/python-best-practices.md
@@ -145,4 +145,4 @@ In addition to `pytest`, developers should strongly consider using [moto](https:
 
 ## Code Documentation
 
-It is expected that whenever possible the code functionality should be documented via a README that includes critical usage and development information such as inputs, outputs, internal and external dependencies, use cases, and critical development information. In addition, the README markdown file should utilize the proper template and conform with [markdown quality standards](docs/development/quality-and-coverage.md).
+It is expected that whenever possible the code functionality should be documented via a README that includes critical usage and development information such as inputs, outputs, internal and external dependencies, use cases, and critical development information. In addition, the README markdown file should utilize the proper template and conform with [markdown quality standards](./quality-and-coverage.md).

--- a/website/versioned_docs/version-v21.3.3/development/quality-and-coverage.md
+++ b/website/versioned_docs/version-v21.3.3/development/quality-and-coverage.md
@@ -5,7 +5,7 @@ id: quality-and-coverage
 
 Currently, code written in this repository leverages Python or TypeScript for most logic and work. The current CI tooling and standards are based on these two languages. Specifics related to the tooling, quality, and testing can be found in the language specific best practices documentation. Python best practices and tooling expectations can be found [here](development/python-best-practices.md). Typescript best practices and tooling can be found [here](development/typescript-best-practices.md).
 
-In addition to CI pipeline quality checks, it is highly recommended for developers to install and configure [pre-commit](https://pre-commit.com) in order to find simple quality issues early. Directions on installing and configuring pre-commit locally for use with this repo can be found [here](docs/development/pre-commit-setup.md).
+In addition to CI pipeline quality checks, it is highly recommended for developers to install and configure [pre-commit](https://pre-commit.com) in order to find simple quality issues early. Directions on installing and configuring pre-commit locally for use with this repo can be found [here](./pre-commit-setup.md).
 
 ## Code Coverage
 

--- a/website/versioned_docs/version-v21.3.3/development/typescript-best-practices.md
+++ b/website/versioned_docs/version-v21.3.3/development/typescript-best-practices.md
@@ -41,4 +41,4 @@ report, run `nyc report --reporter html` and open the `index.html` file in the c
 
 ## Code Documentation
 
-It is expected that whenever possible the code functionality should be documented via a README that includes critical usage and development information such as inputs, outputs, internal and external dependencies, use cases, and critical development information. In addition, the README markdown file should utilize the proper template and conform with [markdown quality standards](docs/development/quality-and-coverage.md).
+It is expected that whenever possible the code functionality should be documented via a README that includes critical usage and development information such as inputs, outputs, internal and external dependencies, use cases, and critical development information. In addition, the README markdown file should utilize the proper template and conform with [markdown quality standards](./quality-and-coverage.md).

--- a/website/versioned_docs/version-v21.3.3/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v21.3.3/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v21.3.3/glossary.md
+++ b/website/versioned_docs/version-v21.3.3/glossary.md
@@ -92,7 +92,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
 ### Developer
 
-  Those who setup deployment and workflow management for Cumulus. Sometimes referred to as an integrator. *See [integrator](#integratordeveloper)*.
+  Those who setup deployment and workflow management for Cumulus. Sometimes referred to as an integrator. *See [integrator](#integrator)*.
 
 ### ECS
 
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v21.3.3/troubleshooting/README.md
+++ b/website/versioned_docs/version-v21.3.3/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v9.0.0/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v9.0.0/configuration/data-management-types.md
@@ -208,7 +208,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v9.0.0/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v9.0.0/data-cookbooks/browse-generation.md
@@ -187,7 +187,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 **Please note**: `FakeProcessing` is the core provided browse/CMR generation lambda we're using for the example in this entry.
 

--- a/website/versioned_docs/version-v9.0.0/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v9.0.0/data-cookbooks/cnm-workflow.md
@@ -228,7 +228,7 @@ To execute this workflow, you're required to include several Lambda resources in
 - <https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/cnm_to_cma_task.tf>
 - <https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/cnm_response_task.tf>
 
-**Please note:** To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+**Please note:** To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
 
 - `CNMToCMA`: <https://github.com/podaac/cumulus-cnm-to-granule>
 - `CnmResponse`: <https://github.com/podaac/cumulus-cnm-response-task>

--- a/website/versioned_docs/version-v9.0.0/deployment/README.md
+++ b/website/versioned_docs/version-v9.0.0/deployment/README.md
@@ -96,7 +96,7 @@ Clone the [`cumulus-template-deploy`](https://github.com/nasa/cumulus-template-d
   git clone https://github.com/nasa/cumulus-template-deploy <repository-name>
 ```
 
-We will return to [configuring this repo and using it for deployment below](#deploying-the-cumulus-instance).
+We will return to [configuring this repo and using it for deployment below](#deploy-the-cumulus-instance).
 
 <details>
   <summary>Optional: Create a new repository</summary>
@@ -542,7 +542,7 @@ From the S3 Console:
 - Open the `<prefix>-dashboard` bucket, click 'upload'. Add the contents of the 'dist' subdirectory to the upload. Then select 'Next'. On the permissions window allow the public to view. Select 'Upload'.
 
 You should be able to visit the dashboard website at `http://<prefix>-dashboard.s3-website-<region>.amazonaws.com` or find the url
-`<prefix>-dashboard` -> "Properties" -> "Static website hosting" -> "Endpoint" and login with a user that you configured for access in the [Configure and Deploy the Cumulus Stack](#configure-and-deploy-the-cumulus-stack) step.
+`<prefix>-dashboard` -> "Properties" -> "Static website hosting" -> "Endpoint" and login with a user that you configured for access in the [Configure and Deploy the Cumulus Stack](#configure-and-deploy-the-cumulus-tf-root-module) step.
 
 ---
 

--- a/website/versioned_docs/version-v9.0.0/deployment/postgres-database-deployment.md
+++ b/website/versioned_docs/version-v9.0.0/deployment/postgres-database-deployment.md
@@ -71,7 +71,7 @@ Clone the [`cumulus-template-deploy`](https://github.com/nasa/cumulus-template-d
   git clone https://github.com/nasa/cumulus-template-deploy <repository-name>
 ```
 
-We will return to [configuring this repo and using it for deployment below](#deploying-the-cumulus-instance).
+We will return to [configuring this repo and using it for deployment below](#configure-and-deploy-the-module).
 
 <details>
   <summary>Optional: Create a new repository</summary>
@@ -95,9 +95,9 @@ You can then [add/commit](https://help.github.com/articles/adding-a-file-to-a-re
 
 To deploy this module, you need to make sure that you have the following steps from the [Cumulus deployment instructions](#prepare-aws-configuration) in similar fashion *for this module*:
 
-- [Set Access Keys](#set-access-keys)
-- [Create the state bucket](#create-the-state-bucket)
-- [Create the locks table](#create-the-locks-table)
+- [Set Access Keys](./README.md#set-access-keys)
+- [Create the state bucket](./README.md#create-the-state-bucket)
+- [Create the locks table](./README.md#create-the-locks-table)
 
 --
 

--- a/website/versioned_docs/version-v9.0.0/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v9.0.0/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v9.0.0/glossary.md
+++ b/website/versioned_docs/version-v9.0.0/glossary.md
@@ -125,7 +125,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v9.0.0/troubleshooting/README.md
+++ b/website/versioned_docs/version-v9.0.0/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v9.0.0/workflows/lambda.md
+++ b/website/versioned_docs/version-v9.0.0/workflows/lambda.md
@@ -44,7 +44,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 
@@ -52,7 +52,7 @@ The deploy folder referenced here would contain a folder 'test_task/task/' which
 
 ### Python Lambda
 
-Python Lambdas are created the same way as the Node.js example [above](#node.js-lambda).
+Python Lambdas are created the same way as the Node.js example [above](#nodejs-lambda).
 
 ## Cumulus Message Adapter
 

--- a/website/versioned_docs/version-v9.9.0/configuration/data-management-types.md
+++ b/website/versioned_docs/version-v9.9.0/configuration/data-management-types.md
@@ -208,7 +208,7 @@ Rules are used by to start processing workflows and the transformation process. 
 
 The `rule - value` entry depends on the type of run:
 
-- If this is a onetime rule this can be left blank. [Example](data-cookbooks/hello-world.md/#execution)
+- If this is a onetime rule this can be left blank. [Example](../data-cookbooks/hello-world.md#execution)
 - If this is a scheduled rule this field must hold a valid [cron-type expression or rate expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
 - If this is a kinesis rule, this must be a configured `${Kinesis_stream_ARN}`. [Example](data-cookbooks/cnm-workflow.md#rule-configuration)
 - If this is an sns rule, this must be an existing `${SNS_Topic_Arn}`. [Example](https://github.com/nasa/cumulus/blob/master/example/spec/parallel/testAPI/snsRuleDef.json)

--- a/website/versioned_docs/version-v9.9.0/data-cookbooks/browse-generation.md
+++ b/website/versioned_docs/version-v9.9.0/data-cookbooks/browse-generation.md
@@ -187,7 +187,7 @@ Note that, in the task, the `CmrStep.Parameters.cma.task_config.cmr` key will co
 },
 ```
 
-If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
+If you're not ingesting mock data matching the example, or would like to use modify the example to ingest your own data please see the [build-lambda](#build-processing-lambda) section below. You will need to configure a different lambda entry for your lambda and utilize it in place of the `Resource` defined in the example workflow.
 
 **Please note**: `FakeProcessing` is the core provided browse/CMR generation lambda we're using for the example in this entry.
 

--- a/website/versioned_docs/version-v9.9.0/data-cookbooks/cnm-workflow.md
+++ b/website/versioned_docs/version-v9.9.0/data-cookbooks/cnm-workflow.md
@@ -228,7 +228,7 @@ To execute this workflow, you're required to include several Lambda resources in
 - <https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/cnm_to_cma_task.tf>
 - <https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/cnm_response_task.tf>
 
-**Please note:** To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-cumulus-message-adapter-layer) for more details on how to deploy a CMA layer.
+**Please note:** To utilize these tasks you need to ensure you have a compatible CMA layer. See the [deployment instructions](../deployment/README.md#deploy-the-cumulus-message-adapter-layer-deprecated) for more details on how to deploy a CMA layer.
 
 - `CNMToCMA`: <https://github.com/podaac/cumulus-cnm-to-granule>
 - `CnmResponse`: <https://github.com/podaac/cumulus-cnm-response-task>

--- a/website/versioned_docs/version-v9.9.0/deployment/README.md
+++ b/website/versioned_docs/version-v9.9.0/deployment/README.md
@@ -96,7 +96,7 @@ Clone the [`cumulus-template-deploy`](https://github.com/nasa/cumulus-template-d
   git clone https://github.com/nasa/cumulus-template-deploy <repository-name>
 ```
 
-We will return to [configuring this repo and using it for deployment below](#deploying-the-cumulus-instance).
+We will return to [configuring this repo and using it for deployment below](#deploy-the-cumulus-instance).
 
 <details>
   <summary>Optional: Create a new repository</summary>
@@ -561,7 +561,7 @@ From the S3 Console:
 - Open the `<prefix>-dashboard` bucket, click 'upload'. Add the contents of the 'dist' subdirectory to the upload. Then select 'Next'. On the permissions window allow the public to view. Select 'Upload'.
 
 You should be able to visit the dashboard website at `http://<prefix>-dashboard.s3-website-<region>.amazonaws.com` or find the url
-`<prefix>-dashboard` -> "Properties" -> "Static website hosting" -> "Endpoint" and login with a user that you configured for access in the [Configure and Deploy the Cumulus Stack](#configure-and-deploy-the-cumulus-stack) step.
+`<prefix>-dashboard` -> "Properties" -> "Static website hosting" -> "Endpoint" and login with a user that you configured for access in the [Configure and Deploy the Cumulus Stack](#configure-and-deploy-the-cumulus-tf-root-module) step.
 
 ---
 

--- a/website/versioned_docs/version-v9.9.0/deployment/postgres-database-deployment.md
+++ b/website/versioned_docs/version-v9.9.0/deployment/postgres-database-deployment.md
@@ -71,7 +71,7 @@ Clone the [`cumulus-template-deploy`](https://github.com/nasa/cumulus-template-d
   git clone https://github.com/nasa/cumulus-template-deploy <repository-name>
 ```
 
-We will return to [configuring this repo and using it for deployment below](#deploying-the-cumulus-instance).
+We will return to [configuring this repo and using it for deployment below](#configure-and-deploy-the-module).
 
 <details>
   <summary>Optional: Create a new repository</summary>
@@ -95,9 +95,9 @@ You can then [add/commit](https://help.github.com/articles/adding-a-file-to-a-re
 
 To deploy this module, you need to make sure that you have the following steps from the [Cumulus deployment instructions](#prepare-aws-configuration) in similar fashion *for this module*:
 
-- [Set Access Keys](#set-access-keys)
-- [Create the state bucket](#create-the-state-bucket)
-- [Create the locks table](#create-the-locks-table)
+- [Set Access Keys](./README.md#set-access-keys)
+- [Create the state bucket](./README.md#create-the-state-bucket)
+- [Create the locks table](./README.md#create-the-locks-table)
 
 --
 

--- a/website/versioned_docs/version-v9.9.0/features/ancillary_metadata.md
+++ b/website/versioned_docs/version-v9.9.0/features/ancillary_metadata.md
@@ -25,5 +25,5 @@ This feature utilizes the `type` key on a files object in a Cumulus [granule](ht
 ### [Move Granules](../workflow_tasks/move_granules)
 
   Uses the granule file `type` key to update UMM/ECHO 10 CMR files passed in as candidates to the task. This task adds the external facing URLs to the CMR metadata file based on the `type`.
-  See the [file tracking data cookbook](../data-cookbooks/tracking-files#publish-to-cmr) for a detailed mapping.
+  See the [file tracking data cookbook](../data-cookbooks/tracking-files#cmr-metadata) for a detailed mapping.
   If a non-CNM `type` is specified, the task assumes it is a 'data' file.

--- a/website/versioned_docs/version-v9.9.0/glossary.md
+++ b/website/versioned_docs/version-v9.9.0/glossary.md
@@ -122,7 +122,7 @@ For terms/items from Amazon/AWS not mentioned in this glossary, please refer to 
 
   For more information, see [AWS IAMs](https://aws.amazon.com/iam/).
 
-### Integrator/Developer
+### Integrator/Developer {#integrator}
 
   Those who work within Cumulus and AWS for deployments and to manage workflows.
 

--- a/website/versioned_docs/version-v9.9.0/troubleshooting/README.md
+++ b/website/versioned_docs/version-v9.9.0/troubleshooting/README.md
@@ -10,7 +10,7 @@ While Cumulus is a complex system, there is a focus on maintaining the integrity
 
 Cumulus has backup and restore functionality built-in to protect Cumulus data and allow recovery of a Cumulus stack. This is currently limited to Cumulus data and not full S3 archive data. Backup and restore is not enabled by default and must be enabled and configured to take advantage of this feature.
 
-For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws).
+For more information, read the [Backup and Restore documentation](../features/backup_and_restore.md#backup-and-restore-with-aws-rds).
 
 ## Elasticsearch reindexing
 

--- a/website/versioned_docs/version-v9.9.0/workflows/lambda.md
+++ b/website/versioned_docs/version-v9.9.0/workflows/lambda.md
@@ -44,7 +44,7 @@ Make sure to include a `vpc_config` that matches the information you've provided
 
 ### Java Lambda
 
-Java Lambdas are created in much the same way as the Node.js example [above](#node.js-lambda).
+Java Lambdas are created in much the same way as the Node.js example [above](#nodejs-lambda).
 
 The source points to a folder with the compiled .class files and dependency libraries in the Lambda Java zip folder structure (details [here](https://docs.aws.amazon.com/lambda/latest/dg/create-deployment-pkg-zip-java.html)), not an uber-jar.
 
@@ -52,7 +52,7 @@ The deploy folder referenced here would contain a folder 'test_task/task/' which
 
 ### Python Lambda
 
-Python Lambdas are created the same way as the Node.js example [above](#node.js-lambda).
+Python Lambdas are created the same way as the Node.js example [above](#nodejs-lambda).
 
 ## Cumulus Message Adapter
 


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-4789: Upgrade Docusaurus to the latest version](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4789)

## Changes

* Updated docusaurs to 3.10.0 in package.json
* Update/fixed broken links caused by the upgrade

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests

---
📝 **Note:**
For most pull requests, please **Squash and merge** to maintain a clean and readable commit history.
