### PR TITLE
CUMULUS-4829: Add background job to refresh stale DuckDB connections for iceberg API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **CUMULUS-4829**
+  - Add background job to refresh stale DuckDB connections for iceberg API
 - **CUMULUS-4815**
   - Add support for file-related searches to go to the files_table in iceberg
 - **CUMULUS-4709**

--- a/packages/db/src/iceberg-connection.ts
+++ b/packages/db/src/iceberg-connection.ts
@@ -12,11 +12,15 @@ export interface PooledDuckDbConnection extends DuckDBConnection {
 
 let poolCacheWarmupPromise: Promise<void> | undefined;
 let isPoolCacheWarmupComplete = false;
-let clearPoolPromise: Promise<void> | undefined;
+let backgroundRefreshInterval: NodeJS.Timeout | undefined;
+let refreshPoolPromise: Promise<void> | undefined;
 
 const connectionPool: PooledDuckDbConnection[] = [];
 const MAX_POOL_SIZE = Number(process.env.DUCKDB_MAX_POOL) || 3;
 const ENABLE_CACHE_WARMUP = process.env.DUCKDB_ENABLE_CACHE_WARMUP !== 'false';
+const STALE_CONNECTION_THRESHOLD_MS = 5 * 60 * 60 * 1000; // 5 hours
+const BACKGROUND_CHECK_INTERVAL_MS =
+  Number(process.env.DUCKDB_POOL_CHECK_INTERVAL) || 10 * 60 * 1000; // 10 minutes
 const tableNames = [
   'granules',
   'collections',
@@ -181,6 +185,19 @@ async function populateConnectionCache(conn: PooledDuckDbConnection): Promise<vo
 }
 
 /**
+ * Creates and returns a new DuckDB connection that has cache warmup initiated.
+ */
+export async function replaceDuckDbConnection(): Promise<PooledDuckDbConnection> {
+  const newConn = await getConnection();
+  if (ENABLE_CACHE_WARMUP) {
+    populateConnectionCache(newConn).catch((error: unknown) => {
+      log.warn('Background cache warmup for connection failed.', error);
+    });
+  }
+  return newConn;
+}
+
+/**
  * Start one-time background cache population for currently pooled connections.
  */
 function startPoolCacheWarmup(): void {
@@ -222,6 +239,77 @@ function startConnectionCacheWarmup(conn: PooledDuckDbConnection): void {
 }
 
 /**
+ * Core logic for checking stale connections and replenishing the pool.
+ */
+async function performConnectionRefresh(): Promise<void> {
+  const startTime = Date.now();
+  let removedCount = 0;
+
+  log.info('Starting background check for stale DuckDB connections...');
+  const staleThreshold = startTime - STALE_CONNECTION_THRESHOLD_MS;
+  for (let i = connectionPool.length - 1; i >= 0; i -= 1) {
+    const pooledConn = connectionPool[i];
+    if (pooledConn.creationTime < staleThreshold) {
+      connectionPool.splice(i, 1);
+      try {
+        pooledConn.closeSync();
+        removedCount += 1;
+      } catch (error) {
+        log.warn('Error closing stale DuckDB connection', error);
+      }
+    }
+  }
+
+  const warmupPromises: Promise<void>[] = [];
+  for (let i = 0; i < removedCount; i += 1) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const newConn = await getConnection();
+      if (ENABLE_CACHE_WARMUP) {
+        warmupPromises.push(
+          populateConnectionCache(newConn).catch((error: unknown) => {
+            log.warn('Background cache warmup for connection failed.', error);
+          })
+        );
+      }
+      connectionPool.push(newConn);
+    } catch (e) {
+      log.error('Failed to create replacement DuckDB connection', e);
+    }
+  }
+  await Promise.all(warmupPromises);
+  log.info(
+    'Background check for stale DuckDB connections complete. '
+    + `${removedCount} stale DuckDB connections replaced in ${Date.now() - startTime}ms.`
+  );
+}
+
+/**
+ * Refresh any connections older than the threshold.
+ */
+async function refreshStaleConnections(): Promise<void> {
+  if (refreshPoolPromise) {
+    await refreshPoolPromise;
+    return;
+  }
+
+  refreshPoolPromise = performConnectionRefresh().finally(() => {
+    refreshPoolPromise = undefined;
+  });
+  await refreshPoolPromise;
+}
+
+/**
+ * Start the background job to periodically refresh stale connections.
+ */
+function startBackgroundConnectionRefresh(): void {
+  if (backgroundRefreshInterval) return;
+  backgroundRefreshInterval = setInterval(() => {
+    refreshStaleConnections().catch((e) => log.error('Error during connection refresh', e));
+  }, BACKGROUND_CHECK_INTERVAL_MS);
+}
+
+/**
  * Initialize the DuckDB Instance and load required extensions.
  */
 export async function initializeDuckDb(): Promise<void> {
@@ -244,6 +332,7 @@ export async function initializeDuckDb(): Promise<void> {
       }
 
       startPoolCacheWarmup();
+      startBackgroundConnectionRefresh();
 
       log.info(`DuckDB initialized with a pool of ${connectionPool.length}/${MAX_POOL_SIZE} connections.`);
     } catch (error) {
@@ -313,73 +402,6 @@ export async function releaseDuckDbConnection(conn: PooledDuckDbConnection): Pro
 }
 
 /**
- * Clear and close connections in the pool that were created older than
- * REFRESH_INTERVAL_MS before the given timestamp.
- * Useful when connections become stale and need to be selectively flushed.
- *
- * @param createdBefore - Timestamp in milliseconds. Only connections created
- * REFRESH_INTERVAL_MS before this time are closed.
- */
-export async function clearDuckDbPool(createdBefore: number): Promise<void> {
-  if (clearPoolPromise) {
-    return clearPoolPromise;
-  }
-
-  clearPoolPromise = (async () => {
-    try {
-      const startTime = Date.now();
-      const keepingConnections: PooledDuckDbConnection[] = [];
-      const staleThreshold = createdBefore - REFRESH_INTERVAL_MS;
-      let removedCount = 1; // Start at 1 to account for the connection that triggered the clear
-
-      while (connectionPool.length > 0) {
-        const pooledConn = connectionPool.pop();
-        if (pooledConn) {
-          if (pooledConn.creationTime >= staleThreshold) {
-            // Keep newly created connection
-            keepingConnections.push(pooledConn);
-          } else {
-            // Destroy old connection
-            try {
-              pooledConn.closeSync();
-              removedCount += 1;
-            } catch (error) {
-              log.warn('Error closing pooled DuckDB connection', error);
-            }
-          }
-        }
-      }
-
-      // Return preserved connections to pool
-      connectionPool.push(...keepingConnections);
-
-      // Immediately replace cleared connections to maintain pool size
-      const warmupPromises: Promise<void>[] = [];
-      for (let i = 0; i < removedCount; i += 1) {
-        // eslint-disable-next-line no-await-in-loop
-        const newConn = await getConnection();
-        if (ENABLE_CACHE_WARMUP) {
-          warmupPromises.push(
-            populateConnectionCache(newConn).catch((error: unknown) => {
-              log.warn('Background cache warmup for connection failed.', error);
-            })
-          );
-        }
-        connectionPool.push(newConn);
-      }
-      await Promise.all(warmupPromises);
-      if (removedCount > 0) {
-        log.info(`Cleared and replaced ${removedCount} stale DuckDB connections in ${Date.now() - startTime}ms.`);
-      }
-    } finally {
-      clearPoolPromise = undefined;
-    }
-  })();
-
-  return clearPoolPromise;
-}
-
-/**
  * Check if DuckDB is initialized and ready without acquiring a connection.
  * Used for lightweight health checks to avoid pool contention.
  *
@@ -394,11 +416,14 @@ export function isDuckDbReady(): boolean {
  */
 export async function destroyDuckDb(): Promise<void> {
   log.info('Shutting down DuckDB...');
+  if (backgroundRefreshInterval) {
+    clearInterval(backgroundRefreshInterval);
+    backgroundRefreshInterval = undefined;
+  }
   connectionPool.length = 0;
   instance = undefined;
   initPromise = undefined;
   dbVersionCache = undefined;
   poolCacheWarmupPromise = undefined;
-  clearPoolPromise = undefined;
   isPoolCacheWarmupComplete = false;
 }

--- a/packages/db/src/iceberg-connection.ts
+++ b/packages/db/src/iceberg-connection.ts
@@ -243,17 +243,18 @@ function startConnectionCacheWarmup(conn: PooledDuckDbConnection): void {
  */
 async function performConnectionRefresh(): Promise<void> {
   const startTime = Date.now();
-  let removedCount = 0;
+  let staleRemovedCount = 0;
+  let replacementSuccessCount = 0;
 
-  log.info('Starting background check for stale DuckDB connections...');
+  log.debug('Starting background check for stale DuckDB connections...');
   const staleThreshold = startTime - STALE_CONNECTION_THRESHOLD_MS;
   for (let i = connectionPool.length - 1; i >= 0; i -= 1) {
     const pooledConn = connectionPool[i];
     if (pooledConn.creationTime < staleThreshold) {
       connectionPool.splice(i, 1);
+      staleRemovedCount += 1;
       try {
         pooledConn.closeSync();
-        removedCount += 1;
       } catch (error) {
         log.warn('Error closing stale DuckDB connection', error);
       }
@@ -261,7 +262,7 @@ async function performConnectionRefresh(): Promise<void> {
   }
 
   const warmupPromises: Promise<void>[] = [];
-  for (let i = 0; i < removedCount; i += 1) {
+  for (let i = 0; i < staleRemovedCount; i += 1) {
     try {
       // eslint-disable-next-line no-await-in-loop
       const newConn = await getConnection();
@@ -273,6 +274,7 @@ async function performConnectionRefresh(): Promise<void> {
         );
       }
       connectionPool.push(newConn);
+      replacementSuccessCount += 1;
     } catch (e) {
       log.error('Failed to create replacement DuckDB connection', e);
     }
@@ -280,7 +282,8 @@ async function performConnectionRefresh(): Promise<void> {
   await Promise.all(warmupPromises);
   log.info(
     'Background check for stale DuckDB connections complete. '
-    + `${removedCount} stale DuckDB connections replaced in ${Date.now() - startTime}ms.`
+    + `${staleRemovedCount} stale removed, ${replacementSuccessCount} replaced, `
+    + `in ${Date.now() - startTime}ms.`
   );
 }
 

--- a/packages/db/src/iceberg-search/DuckDBSearchExecutor.ts
+++ b/packages/db/src/iceberg-search/DuckDBSearchExecutor.ts
@@ -26,6 +26,30 @@ export function isCatalogError(error: unknown): boolean {
 }
 
 /**
+ * Returns true for recoverable S3/HTTP data-access failures that can be fixed
+ * by rebuilding a stale DuckDB connection and retrying once.
+ *
+ * @param error - value to evaluate
+ * @returns true when the error matches S3 parquet HTTP 400 access failure
+ */
+export function isRecoverableS3HttpError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+
+  const message = error.message;
+  const s3ParquetHttp400Pattern = new RegExp(
+    [
+      'http get error on \'https?:\\/\\/[^\']*\\.s3\\.[^\']*amazonaws\\.com\\/[^\']*\\.parquet\'',
+      ' \\(http 400\\)',
+    ].join(''),
+    'i'
+  );
+  return (
+    // Intentionally strict: mirrors the observed DuckDB error text for S3 parquet GET HTTP 400.
+    s3ParquetHttp400Pattern.test(message)
+  );
+}
+
+/**
  * Shared helper that builds queries, acquires a DuckDB connection, executes,
  * and releases the connection when done.
  *
@@ -101,8 +125,8 @@ export async function executeDuckDBSearch(params: {
     try {
       await runNativeQueries(pooledConnection);
     } catch (error) {
-      if (isCatalogError(error)) {
-        log.warn('Catalog error detected; closing stale connection and retrying query once.', error);
+      if (isCatalogError(error) || isRecoverableS3HttpError(error)) {
+        log.warn('Recoverable DuckDB connection error detected; closing stale connection and retrying query once.', error);
         pooledConnection.closeSync();
         pooledConnection = await replaceDuckDbConnection();
         await runNativeQueries(pooledConnection);

--- a/packages/db/src/iceberg-search/DuckDBSearchExecutor.ts
+++ b/packages/db/src/iceberg-search/DuckDBSearchExecutor.ts
@@ -5,7 +5,7 @@ import Logger from '@cumulus/logger';
 import { prepareBindings } from './duckdbHelpers';
 import { Meta } from '../search/BaseSearch';
 import { DbQueryParameters } from '../types/search';
-import { acquireDuckDbConnection, releaseDuckDbConnection, clearDuckDbPool, PooledDuckDbConnection } from '../iceberg-connection';
+import { acquireDuckDbConnection, releaseDuckDbConnection, replaceDuckDbConnection, PooledDuckDbConnection } from '../iceberg-connection';
 
 const log = new Logger({ sender: '@cumulus/db/DuckDBSearchExecutor' });
 
@@ -74,7 +74,6 @@ export async function executeDuckDBSearch(params: {
       return { key: config.key, sql, bindings };
     });
 
-  const queryStartTime = Date.now();
   let pooledConnection: PooledDuckDbConnection = await acquireDuckDbConnection();
 
   try {
@@ -103,11 +102,9 @@ export async function executeDuckDBSearch(params: {
       await runNativeQueries(pooledConnection);
     } catch (error) {
       if (isCatalogError(error)) {
-        log.warn('Catalog error detected; closing stale connection and clearing pool, then retrying query once.', error);
+        log.warn('Catalog error detected; closing stale connection and retrying query once.', error);
         pooledConnection.closeSync();
-        await clearDuckDbPool(queryStartTime);
-        pooledConnection = await acquireDuckDbConnection();
-
+        pooledConnection = await replaceDuckDbConnection();
         await runNativeQueries(pooledConnection);
       } else {
         throw error;

--- a/packages/db/tests/iceberg-search/test-DuckDBSearchExecutor.js
+++ b/packages/db/tests/iceberg-search/test-DuckDBSearchExecutor.js
@@ -2,7 +2,7 @@
 
 const test = require('ava');
 
-const { isCatalogError } = require('../../dist/iceberg-search/DuckDBSearchExecutor');
+const { isCatalogError, isRecoverableS3HttpError } = require('../../dist/iceberg-search/DuckDBSearchExecutor');
 
 test('isCatalogError returns true for DuckDB missing table catalog error', (t) => {
   const error = new Error('Catalog Error: Table with name granules does not exist!\nDid you mean "pg_tables"?');
@@ -22,4 +22,20 @@ test('isCatalogError returns false for non-catalog error', (t) => {
 test('isCatalogError returns false for non-Error values', (t) => {
   t.false(isCatalogError({ message: 'Catalog Error: Table with name granules does not exist!' }));
   t.false(isCatalogError(undefined));
+});
+
+test('isRecoverableS3HttpError returns true for DuckDB S3 HTTP 400 GET error', (t) => {
+  const error = new Error('HTTP Error: HTTP GET error on \'https://bucket.s3.us-east-1.amazonaws.com/file.parquet\' (HTTP 400)');
+  t.true(isRecoverableS3HttpError(error));
+});
+
+test('isRecoverableS3HttpError returns false when URL is not an S3 parquet path', (t) => {
+  t.false(isRecoverableS3HttpError(new Error('HTTP Error: HTTP GET error on \'https://bucket.s3.us-east-1.amazonaws.com/file.csv\' (HTTP 400)')));
+  t.false(isRecoverableS3HttpError(new Error('HTTP Error: HTTP GET error on \'https://example.com/file.parquet\' (HTTP 400)')));
+});
+
+test('isRecoverableS3HttpError returns false for non-recoverable errors', (t) => {
+  t.false(isRecoverableS3HttpError(new Error('Binder Error: Referenced column not found')));
+  t.false(isRecoverableS3HttpError(new Error('ExpiredToken: The provided token has expired')));
+  t.false(isRecoverableS3HttpError(undefined));
 });

--- a/packages/db/tests/test-iceberg-connection.js
+++ b/packages/db/tests/test-iceberg-connection.js
@@ -7,6 +7,7 @@ const sinon = require('sinon');
 // noCallThru prevents proxyquire from loading the real @duckdb/node-api binary,
 // which requires native addons not available in the test environment.
 const proxyquire = require('proxyquire').noCallThru();
+const loadedIcebergModules = [];
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -60,10 +61,14 @@ const makeDuckDBStub = (instanceOverride) => {
  * Load a fresh, isolated copy of iceberg-connection with the supplied DuckDB stub.
  * Each call produces independent module-level state (instance, pool, flags).
  */
-const loadIcebergModule = (duckdbModule) =>
-  proxyquire('../dist/iceberg-connection', {
+const loadIcebergModule = (duckdbModule) => {
+  const icebergModule = proxyquire('../dist/iceberg-connection', {
     '@duckdb/node-api': duckdbModule,
   });
+
+  loadedIcebergModules.push(icebergModule);
+  return icebergModule;
+};
 
 // ---------------------------------------------------------------------------
 // Shared env setup – use development mode so getConnection skips
@@ -81,6 +86,16 @@ test.after(() => {
   delete process.env.AWS_ACCOUNT_ID;
   delete process.env.ICEBERG_NAMESPACE;
   delete process.env.AWS_REGION;
+});
+
+test.afterEach.always(async () => {
+  while (loadedIcebergModules.length > 0) {
+    const icebergModule = loadedIcebergModules.pop();
+    if (icebergModule?.destroyDuckDb) {
+      // eslint-disable-next-line no-await-in-loop
+      await icebergModule.destroyDuckDb();
+    }
+  }
 });
 
 // ---------------------------------------------------------------------------
@@ -152,7 +167,6 @@ test.serial('releaseDuckDbConnection discards connections when pool is at MAX_PO
     initializeDuckDb,
     acquireDuckDbConnection,
     releaseDuckDbConnection,
-    destroyDuckDb,
   } = loadIcebergModule(duckdbModule);
 
   await initializeDuckDb();
@@ -184,8 +198,6 @@ test.serial('releaseDuckDbConnection discards connections when pool is at MAX_PO
     connectCallsBefore,
     'no new connection should be created – pool was already full before the extra release'
   );
-
-  await destroyDuckDb();
 });
 
 // ---------------------------------------------------------------------------
@@ -213,15 +225,13 @@ test.serial('failed initializeDuckDb resets instance so a subsequent call retrie
 
   // First stub: always fails
   const failingModule = { DuckDBInstance: { create: failStub } };
-  const { initializeDuckDb: initFailing, destroyDuckDb } = loadIcebergModule(failingModule);
+  const { initializeDuckDb: initFailing } = loadIcebergModule(failingModule);
 
   await t.throwsAsync(
     () => initFailing(),
     { message: initError.message },
     'initializeDuckDb should propagate the underlying error'
   );
-
-  await destroyDuckDb();
 });
 
 test.serial('after init failure, a second initializeDuckDb attempt calls DuckDBInstance.create again', async (t) => {
@@ -331,6 +341,4 @@ test.serial('background connection refresh replaces stale connections', async (t
     maxPool * 2,
     'New connections should be created to replace stale ones'
   );
-
-  await icebergModule.destroyDuckDb();
 });

--- a/packages/db/tests/test-iceberg-connection.js
+++ b/packages/db/tests/test-iceberg-connection.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const isFunction = require('lodash/isFunction');
+const noop = require('lodash/noop');
 const test = require('ava');
 const sinon = require('sinon');
 // noCallThru prevents proxyquire from loading the real @duckdb/node-api binary,
@@ -16,6 +17,7 @@ const makeFakeConnection = () => {
   let glueAttached = false;
 
   return {
+    closeSync: noop,
     run: sinon.stub().callsFake((sql) => {
       if (/duckdb_databases\(\)/i.test(sql)) {
         return {
@@ -297,4 +299,38 @@ test.serial('initializeDuckDb throws if ICEBERG_NAMESPACE is missing', async (t)
     () => initializeDuckDb(),
     { message: /ICEBERG_NAMESPACE environment variable is required/ }
   );
+});
+
+// ---------------------------------------------------------------------------
+// 7. Background connection refresh
+// ---------------------------------------------------------------------------
+
+test.serial('background connection refresh replaces stale connections', async (t) => {
+  const clock = sinon.useFakeTimers({
+    now: Date.now(),
+    shouldAdvanceTime: true,
+  });
+  t.teardown(() => clock.restore());
+
+  const fakeInst = makeFakeInstance();
+  const { duckdbModule } = makeDuckDBStub(fakeInst);
+  const icebergModule = loadIcebergModule(duckdbModule);
+
+  await icebergModule.initializeDuckDb();
+
+  const maxPool = Number(process.env.DUCKDB_MAX_POOL) || 3;
+  t.is(fakeInst.connect.callCount, maxPool, 'Initial connections created');
+
+  // Advance time past the 5-hour threshold and wait for setInterval callbacks
+  // 6 hours in milliseconds
+  await clock.tickAsync(6 * 60 * 60 * 1000);
+
+  // Stale connections should be removed and replaced by new connections
+  t.is(
+    fakeInst.connect.callCount,
+    maxPool * 2,
+    'New connections should be created to replace stale ones'
+  );
+
+  await icebergModule.destroyDuckDb();
 });


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-4829: Add background job to refresh stale DuckDB connections for iceberg API](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4829)

## Changes

* Add background job to refresh stale DuckDB connections for iceberg API

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests

---
📝 **Note:**
For most pull requests, please **Squash and merge** to maintain a clean and readable commit history.
