### PR TITLE
CUMULUS-4844: Fix BaseSearch.shouldEstimateRowcount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Added prefix to IAM resource names to prevent collisions from multiple deployments in sandbox environment
 - **CUMULUS-4844**
   - Fixed `@cumulus/db` `BaseSearch.shouldEstimateRowcount()` to compare against SQL generated
-    by buildBasicQuery() instead of a hardcoded query string, ensuring accurate detection of table count queries.
+    by `baseCountQuery()` instead of a hardcoded query string, ensuring accurate detection of table count queries.
 
 ## [v21.3.3] 2026-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     are loaded after the handler invocation to circumvent `InvalidSignatureException` errors that were being reported
 - **CUMULUS-4606**
   - Added prefix to IAM resource names to prevent collisions from multiple deployments in sandbox environment
+- **CUMULUS-4844**
+  - Fixed `@cumulus/db` `BaseSearch.shouldEstimateRowcount()` to compare against SQL generated
+    by buildBasicQuery() instead of a hardcoded query string, ensuring accurate detection of table count queries.
 
 ## [v21.3.3] 2026-04-10
 

--- a/packages/db/src/search/BaseSearch.ts
+++ b/packages/db/src/search/BaseSearch.ts
@@ -123,12 +123,22 @@ abstract class BaseSearch {
   /**
    * Determine if an estimated row count should be returned
    *
+   * @param knex - DB client
    * @param countSql - sql statement for count
    * @returns whether an estimated row count should be returned
    */
-  protected shouldEstimateRowcount(countSql: string): boolean {
-    const isBasicQuery = (countSql === `select count(* as count) from "${this.tableName}"`);
-    return this.dbQueryParameters.estimateTableRowCount === true && isBasicQuery;
+  protected shouldEstimateRowcount(
+    knex: Knex,
+    countSql: string
+  ): boolean {
+    const { countQuery } = this.buildBasicQuery(knex);
+
+    const basicQuerySql = countQuery?.toSQL().sql;
+
+    return (
+      this.dbQueryParameters.estimateTableRowCount === true
+      && countSql === basicQuerySql
+    );
   }
 
   /**
@@ -592,10 +602,10 @@ abstract class BaseSearch {
     const knex = testKnex ?? await getKnexClient();
     const { countQuery, searchQuery } = this.buildSearch(knex);
 
-    const shouldEstimateRowcount = countQuery
-      ? this.shouldEstimateRowcount(countQuery?.toSQL().sql)
+    const estimateRowcount = countQuery
+      ? this.shouldEstimateRowcount(knex, countQuery?.toSQL().sql)
       : false;
-    const getEstimate = shouldEstimateRowcount
+    const getEstimate = estimateRowcount
       ? this.getEstimatedRowcount({ knex })
       : undefined;
     const shouldReturnCountOnly = this.dbQueryParameters.countOnly === true;
@@ -608,7 +618,7 @@ abstract class BaseSearch {
       const meta = this._metaTemplate();
       meta.limit = this.dbQueryParameters.limit;
       meta.page = this.dbQueryParameters.page;
-      meta.count = shouldEstimateRowcount ? countResult : Number(countResult[0]?.count ?? 0);
+      meta.count = estimateRowcount ? countResult : Number(countResult[0]?.count ?? 0);
 
       const apiRecords = await this.translatePostgresRecordsToApiRecords(pgRecords, knex);
 

--- a/packages/db/src/search/BaseSearch.ts
+++ b/packages/db/src/search/BaseSearch.ts
@@ -131,8 +131,7 @@ abstract class BaseSearch {
     knex: Knex,
     countSql: string
   ): boolean {
-    const { countQuery } = this.buildBasicQuery(knex);
-
+    const countQuery = this.baseCountQuery(knex);
     const basicQuerySql = countQuery?.toSQL().sql;
 
     return (
@@ -205,6 +204,17 @@ abstract class BaseSearch {
   }
 
   /**
+   * Builds the base count query for rowcount estimation.
+   * Subclasses should use this method for consistent rowcount behavior.
+   *
+   * @param knex - DB client
+   * @returns Knex count query builder
+   */
+  protected baseCountQuery(knex: Knex) {
+    return knex(this.tableName).count('* as count');
+  }
+
+  /**
    * Build basic query
    *
    * @param knex - DB client
@@ -214,8 +224,7 @@ abstract class BaseSearch {
     countQuery?: Knex.QueryBuilder,
     searchQuery: Knex.QueryBuilder,
   } {
-    const countQuery = knex(this.tableName)
-      .count('* as count');
+    const countQuery = this.baseCountQuery(knex);
 
     const searchQuery = knex(this.tableName)
       .select(`${this.tableName}.*`);

--- a/packages/db/src/search/ExecutionSearch.ts
+++ b/packages/db/src/search/ExecutionSearch.ts
@@ -85,8 +85,7 @@ export class ExecutionSearch extends BaseSearch {
       searchQuery.select({ parentArn: `${executionsTable}_parent.arn` });
     }
 
-    const countQuery = knex(this.tableName)
-      .count('* as count');
+    const countQuery = this.baseCountQuery(knex);
 
     if (this.searchCollection()) {
       countQuery.innerJoin(collectionsTable, `${this.tableName}.collection_cumulus_id`, `${collectionsTable}.cumulus_id`);

--- a/packages/db/src/search/GranuleSearch.ts
+++ b/packages/db/src/search/GranuleSearch.ts
@@ -52,8 +52,7 @@ export class GranuleSearch extends BaseSearch {
       providers: providersTable,
       pdrs: pdrsTable,
     } = TableNames;
-    const countQuery = knex(this.tableName)
-      .count('* as count');
+    const countQuery = this.baseCountQuery(knex);
 
     const searchQuery = knex(this.tableName)
       .select(`${this.tableName}.*`)

--- a/packages/db/src/search/PdrSearch.ts
+++ b/packages/db/src/search/PdrSearch.ts
@@ -44,8 +44,7 @@ export class PdrSearch extends BaseSearch {
       providers: providersTable,
       executions: executionsTable,
     } = TableNames;
-    const countQuery = knex(this.tableName)
-      .count('* as count');
+    const countQuery = this.baseCountQuery(knex);
 
     const searchQuery = knex(this.tableName)
       .select(`${this.tableName}.*`)

--- a/packages/db/src/search/ReconciliationReportSearch.ts
+++ b/packages/db/src/search/ReconciliationReportSearch.ts
@@ -33,8 +33,7 @@ export class ReconciliationReportSearch extends BaseSearch {
     const {
       reconciliationReports: reconciliationReportsTable,
     } = TableNames;
-    const countQuery = knex(this.tableName)
-      .count('* as count');
+    const countQuery = this.baseCountQuery(knex);
 
     const searchQuery = knex(this.tableName)
       .select(`${this.tableName}.*`)

--- a/packages/db/src/search/RuleSearch.ts
+++ b/packages/db/src/search/RuleSearch.ts
@@ -40,8 +40,7 @@ export class RuleSearch extends BaseSearch {
       providers: providersTable,
     } = TableNames;
 
-    const countQuery = knex(this.tableName)
-      .count('* as count');
+    const countQuery = this.baseCountQuery(knex);
 
     const searchQuery = knex(this.tableName)
       .select(`${this.tableName}.*`)

--- a/packages/db/tests/iceberg-search/test-ExecutionIcebergSearch.js
+++ b/packages/db/tests/iceberg-search/test-ExecutionIcebergSearch.js
@@ -5,6 +5,7 @@ const knex = require('knex');
 const cryptoRandomString = require('crypto-random-string');
 const omit = require('lodash/omit');
 const range = require('lodash/range');
+const sinon = require('sinon');
 const { s3 } = require('@cumulus/aws-client/services');
 const { recursivelyDeleteS3Bucket } = require('@cumulus/aws-client/S3');
 const { constructCollectionId } = require('@cumulus/message/Collections');
@@ -630,14 +631,18 @@ test.serial('ExecutionIcebergSearch includeFullRecord', async (t) => {
   t.deepEqual(results.results[40], expectedResponse40);
 });
 
-test.serial('ExecutionIcebergSearch estimates the rowcount of the table by default', async (t) => {
+test('ExecutionIcebergSearch does not call getEstimatedRowcount', async (t) => {
   const { connection } = t.context;
   const queryStringParameters = {
     limit: 50,
   };
   const dbSearch = new ExecutionIcebergSearch({ queryStringParameters }, connection);
+  const estimateSpy = sinon.spy(dbSearch, 'getEstimatedRowcount');
   const response = await dbSearch.query();
-  t.true(response.meta.count > 0, 'Expected response.meta.count to be greater than 0');
+
+  t.true(estimateSpy.notCalled);
+
+  t.is(response.meta.count, 50);
   t.is(response.results?.length, 50);
 });
 

--- a/packages/db/tests/iceberg-search/test-ExecutionIcebergSearch.js
+++ b/packages/db/tests/iceberg-search/test-ExecutionIcebergSearch.js
@@ -631,7 +631,7 @@ test.serial('ExecutionIcebergSearch includeFullRecord', async (t) => {
   t.deepEqual(results.results[40], expectedResponse40);
 });
 
-test('ExecutionIcebergSearch does not call getEstimatedRowcount', async (t) => {
+test.serial('ExecutionIcebergSearch does not call getEstimatedRowcount', async (t) => {
   const { connection } = t.context;
   const queryStringParameters = {
     limit: 50,

--- a/packages/db/tests/iceberg-search/test-GranuleIcebergSearch.js
+++ b/packages/db/tests/iceberg-search/test-GranuleIcebergSearch.js
@@ -1036,7 +1036,7 @@ test.serial('GranuleIcebergSearch supports search which checks existence of erro
   t.is(response.results?.length, 50);
 });
 
-test('GranuleIcebergSearch does not call getEstimatedRowcount', async (t) => {
+test.serial('GranuleIcebergSearch does not call getEstimatedRowcount', async (t) => {
   const { connection } = t.context;
   const queryStringParameters = {
     limit: 50,

--- a/packages/db/tests/iceberg-search/test-GranuleIcebergSearch.js
+++ b/packages/db/tests/iceberg-search/test-GranuleIcebergSearch.js
@@ -6,6 +6,7 @@ const cryptoRandomString = require('crypto-random-string');
 const omit = require('lodash/omit');
 const random = require('lodash/random');
 const range = require('lodash/range');
+const sinon = require('sinon');
 const { s3 } = require('@cumulus/aws-client/services');
 const { recursivelyDeleteS3Bucket } = require('@cumulus/aws-client/S3');
 const { constructCollectionId } = require('@cumulus/message/Collections');
@@ -1035,14 +1036,18 @@ test.serial('GranuleIcebergSearch supports search which checks existence of erro
   t.is(response.results?.length, 50);
 });
 
-test.serial('GranuleIcebergSearch estimates the rowcount of the table by default', async (t) => {
+test('GranuleIcebergSearch does not call getEstimatedRowcount', async (t) => {
   const { connection } = t.context;
   const queryStringParameters = {
     limit: 50,
   };
   const dbSearch = new GranuleIcebergSearch({ queryStringParameters }, connection);
+  const estimateSpy = sinon.spy(dbSearch, 'getEstimatedRowcount');
   const response = await dbSearch.query();
-  t.true(response.meta.count > 0, 'Expected response.meta.count to be greater than 0');
+
+  t.true(estimateSpy.notCalled);
+
+  t.is(response.meta.count, 100);
   t.is(response.results?.length, 50);
 });
 

--- a/packages/db/tests/search/test-ExecutionSearch.js
+++ b/packages/db/tests/search/test-ExecutionSearch.js
@@ -3,6 +3,7 @@
 const test = require('ava');
 const cryptoRandomString = require('crypto-random-string');
 const range = require('lodash/range');
+const sinon = require('sinon');
 const { constructCollectionId } = require('@cumulus/message/Collections');
 const { ExecutionSearch } = require('../../dist/search/ExecutionSearch');
 
@@ -616,6 +617,48 @@ test('ExecutionSearch estimates the rowcount of the table by default', async (t)
   const response = await dbSearch.query(knex);
   t.true(response.meta.count > 0, 'Expected response.meta.count to be greater than 0');
   t.is(response.results?.length, 50);
+});
+
+test('ExecutionSearch calls getEstimatedRowcount for table count when estimateTableRowCount is enabled', async (t) => {
+  const { knex } = t.context;
+
+  const queryStringParameters = {
+    limit: 50,
+  };
+
+  const dbSearch = new ExecutionSearch({ queryStringParameters });
+
+  const estimateStub = sinon.stub(dbSearch, 'getEstimatedRowcount')
+    .resolves(9999);
+
+  const response = await dbSearch.query(knex);
+
+  t.true(estimateStub.calledOnce);
+
+  t.true(
+    estimateStub.calledWithMatch({
+      knex,
+    })
+  );
+
+  t.is(response.meta.count, 9999);
+  t.is(response.results.length, 50);
+});
+
+test('ExecutionSearch does not estimate rowcount when disabled', async (t) => {
+  const { knex } = t.context;
+
+  const dbSearch = new ExecutionSearch({
+    queryStringParameters: {
+      estimateTableRowCount: 'false',
+    },
+  });
+
+  const estimateSpy = sinon.spy(dbSearch, 'getEstimatedRowcount');
+
+  await dbSearch.query(knex);
+
+  t.true(estimateSpy.notCalled);
 });
 
 test('ExecutionSearch only returns count if countOnly is set to true', async (t) => {

--- a/packages/db/tests/search/test-GranuleSearch.js
+++ b/packages/db/tests/search/test-GranuleSearch.js
@@ -2,6 +2,7 @@ const test = require('ava');
 const cryptoRandomString = require('crypto-random-string');
 const omit = require('lodash/omit');
 const range = require('lodash/range');
+const sinon = require('sinon');
 
 const { constructCollectionId } = require('@cumulus/message/Collections');
 const { sleep } = require('@cumulus/common');
@@ -969,6 +970,48 @@ test('GranuleSearch estimates the rowcount of the table by default', async (t) =
   const response = await dbSearch.query(knex);
   t.true(response.meta.count > 0, 'Expected response.meta.count to be greater than 0');
   t.is(response.results?.length, 50);
+});
+
+test('GranuleSearch calls getEstimatedRowcount for table count when estimateTableRowCount is enabled', async (t) => {
+  const { knex } = t.context;
+
+  const queryStringParameters = {
+    limit: 50,
+  };
+
+  const dbSearch = new GranuleSearch({ queryStringParameters });
+
+  const estimateStub = sinon.stub(dbSearch, 'getEstimatedRowcount')
+    .resolves(9999);
+
+  const response = await dbSearch.query(knex);
+
+  t.true(estimateStub.calledOnce);
+
+  t.true(
+    estimateStub.calledWithMatch({
+      knex,
+    })
+  );
+
+  t.is(response.meta.count, 9999);
+  t.is(response.results.length, 50);
+});
+
+test('GranuleSearch does not estimate rowcount when disabled', async (t) => {
+  const { knex } = t.context;
+
+  const dbSearch = new GranuleSearch({
+    queryStringParameters: {
+      estimateTableRowCount: 'false',
+    },
+  });
+
+  const estimateSpy = sinon.spy(dbSearch, 'getEstimatedRowcount');
+
+  await dbSearch.query(knex);
+
+  t.true(estimateSpy.notCalled);
 });
 
 test('GranuleSearch only returns count if countOnly is set to true', async (t) => {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-4844: `estimateTableRowCount` flag ignored in BaseSearch](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4844)

## Changes

* Fixed `@cumulus/db` `BaseSearch.shouldEstimateRowcount()` to compare against SQL generated
  by `baseCountQuery()` instead of a hardcoded query string, ensuring accurate detection of table count queries.

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests

---
📝 **Note:**
For most pull requests, please **Squash and merge** to maintain a clean and readable commit history.
