### PR TITLE
CUMULUS-4883: Add script to build Iceberg API docker image and push it to ECR as part of the build process.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **CUMULUS-4883**
+  - Add script to build Iceberg API docker image and push it to ECR as part of the build process
 - **CUMULUS-4705**
   - Add Fargate task to cleanup old Iceberg table snapshots on a schedule
 - **CUMULUS-4711**

--- a/bamboo/bootstrap-tf-deployment.sh
+++ b/bamboo/bootstrap-tf-deployment.sh
@@ -58,9 +58,9 @@ echo "Deploying Cumulus data-persistence module to $DEPLOYMENT"
   -var "subnet_ids=[\"$AWS_SUBNET\"]" \
   -var "vpc_id=$VPC_ID" \
   -var "rds_admin_access_secret_arn=$RDS_ADMIN_ACCESS_SECRET_ARN" \
-  -var "rds_security_group=$RDS_SECURITY_GROUP"\
-  -var "permissions_boundary_arn=arn:aws:iam::$AWS_ACCOUNT_ID:policy/$ROLE_BOUNDARY"\
-  -var "cumulus_iceberg_api_image_version=$ICEBERG_IMAGE_VERSION"\
+  -var "rds_security_group=$RDS_SECURITY_GROUP" \
+  -var "permissions_boundary_arn=arn:aws:iam::$AWS_ACCOUNT_ID:policy/$ROLE_BOUNDARY" \
+  -var "cumulus_iceberg_api_image_version=$ICEBERG_IMAGE_VERSION" \
   -var "deploy_iceberg_api=$DEPLOY_ICEBERG_API"
 
 cd ../cumulus-tf

--- a/bamboo/bootstrap-tf-deployment.sh
+++ b/bamboo/bootstrap-tf-deployment.sh
@@ -42,8 +42,9 @@ else
   ROLE_BOUNDARY=NGAPShNonProdRoleBoundary
 fi
 
+set_iceberg_image_version
+
 DEPLOY_ICEBERG_API="${DEPLOY_ICEBERG_API:-false}"
-ICEBERG_IMAGE_VERSION="${ICEBERG_IMAGE_VERSION:-latest}"
 echo "Deploy Iceberg API: ${DEPLOY_ICEBERG_API}"
 echo "Using Iceberg API image version ${ICEBERG_IMAGE_VERSION}"
 

--- a/bamboo/bootstrap-tf-deployment.sh
+++ b/bamboo/bootstrap-tf-deployment.sh
@@ -42,6 +42,11 @@ else
   ROLE_BOUNDARY=NGAPShNonProdRoleBoundary
 fi
 
+DEPLOY_ICEBERG_API="${DEPLOY_ICEBERG_API:-false}"
+ICEBERG_IMAGE_VERSION="${ICEBERG_IMAGE_VERSION:-latest}"
+echo "Deploy Iceberg API: ${DEPLOY_ICEBERG_API}"
+echo "Using Iceberg API image version ${ICEBERG_IMAGE_VERSION}"
+
 # Deploy data-persistence-tf via terraform
 echo "Deploying Cumulus data-persistence module to $DEPLOYMENT"
 ../terraform apply \
@@ -54,7 +59,9 @@ echo "Deploying Cumulus data-persistence module to $DEPLOYMENT"
   -var "vpc_id=$VPC_ID" \
   -var "rds_admin_access_secret_arn=$RDS_ADMIN_ACCESS_SECRET_ARN" \
   -var "rds_security_group=$RDS_SECURITY_GROUP"\
-  -var "permissions_boundary_arn=arn:aws:iam::$AWS_ACCOUNT_ID:policy/$ROLE_BOUNDARY"
+  -var "permissions_boundary_arn=arn:aws:iam::$AWS_ACCOUNT_ID:policy/$ROLE_BOUNDARY"\
+  -var "cumulus_iceberg_api_image_version=$ICEBERG_IMAGE_VERSION"\
+  -var "deploy_iceberg_api=$DEPLOY_ICEBERG_API"
 
 cd ../cumulus-tf
 # Ensure remote state is configured for the deployment

--- a/bamboo/bootstrap-tf-deployment.sh
+++ b/bamboo/bootstrap-tf-deployment.sh
@@ -42,12 +42,6 @@ else
   ROLE_BOUNDARY=NGAPShNonProdRoleBoundary
 fi
 
-set_iceberg_image_version
-
-DEPLOY_ICEBERG_API="${DEPLOY_ICEBERG_API:-false}"
-echo "Deploy Iceberg API: ${DEPLOY_ICEBERG_API}"
-echo "Using Iceberg API image version ${ICEBERG_IMAGE_VERSION}"
-
 # Deploy data-persistence-tf via terraform
 echo "Deploying Cumulus data-persistence module to $DEPLOYMENT"
 ../terraform apply \
@@ -60,9 +54,7 @@ echo "Deploying Cumulus data-persistence module to $DEPLOYMENT"
   -var "vpc_id=$VPC_ID" \
   -var "rds_admin_access_secret_arn=$RDS_ADMIN_ACCESS_SECRET_ARN" \
   -var "rds_security_group=$RDS_SECURITY_GROUP" \
-  -var "permissions_boundary_arn=arn:aws:iam::$AWS_ACCOUNT_ID:policy/$ROLE_BOUNDARY" \
-  -var "cumulus_iceberg_api_image_version=$ICEBERG_IMAGE_VERSION" \
-  -var "deploy_iceberg_api=$DEPLOY_ICEBERG_API"
+  -var "permissions_boundary_arn=arn:aws:iam::$AWS_ACCOUNT_ID:policy/$ROLE_BOUNDARY"
 
 cd ../cumulus-tf
 # Ensure remote state is configured for the deployment
@@ -78,6 +70,12 @@ echo "terraform {
 # Initialize deployment
 ../terraform init \
   -input=false
+
+set_iceberg_image_version
+
+DEPLOY_ICEBERG_API="${DEPLOY_ICEBERG_API:-false}"
+echo "Deploy Iceberg API: ${DEPLOY_ICEBERG_API}"
+echo "Using Iceberg API image version ${ICEBERG_IMAGE_VERSION}"
 
 # Deploy cumulus-tf via terraform
 echo "Deploying Cumulus example to $DEPLOYMENT"
@@ -109,3 +107,5 @@ echo "Deploying Cumulus example to $DEPLOYMENT"
   -var "metrics_es_host=$METRICS_ES_HOST" \
   -var "metrics_es_username=$METRICS_ES_USER" \
   -var "metrics_es_password=$METRICS_ES_PASS" \
+  -var "cumulus_iceberg_api_image_version=$ICEBERG_IMAGE_VERSION" \
+  -var "deploy_iceberg_api=$DEPLOY_ICEBERG_API"

--- a/bamboo/deploy-dev-integration-test-stack.sh
+++ b/bamboo/deploy-dev-integration-test-stack.sh
@@ -28,19 +28,4 @@ npm install
 npm run ci:bootstrap
 npm run package
 
-echo "***Bamboo plan revision: $bamboo_plan_revision"
-if [[ $PUBLISH_FLAG == true ]]; then
-  ICEBERG_IMAGE_VERSION=$(jq --raw-output .version lerna.json)
-else
-  ICEBERG_IMAGE_VERSION=$(echo $bamboo_plan_revision | cut -c1-7)
-fi
-
-echo "***ICEBERG_IMAGE_VERSION: $ICEBERG_IMAGE_VERSION"
-
-if [[ -z $ICEBERG_IMAGE_VERSION ]]; then
-  echo "Error: ICEBERG_IMAGE_VERSION is not set (PUBLISH_FLAG=${PUBLISH_FLAG}). Expected bamboo_plan_revision." >&2
-  exit 1
-fi
-export ICEBERG_IMAGE_VERSION
-. ./bamboo/deploy-iceberg-api-image.sh
 . ./bamboo/deploy-integration-stack.sh

--- a/bamboo/deploy-dev-integration-test-stack.sh
+++ b/bamboo/deploy-dev-integration-test-stack.sh
@@ -28,15 +28,17 @@ npm install
 npm run ci:bootstrap
 npm run package
 
-echo "***Bamboo build number: $bamboo_buildNumber"
+echo "***Bamboo plan revision: $bamboo_plan_revision"
 if [[ $PUBLISH_FLAG == true ]]; then
   ICEBERG_IMAGE_VERSION=$(jq --raw-output .version lerna.json)
 else
-  ICEBERG_IMAGE_VERSION=${bamboo_buildNumber}
+  ICEBERG_IMAGE_VERSION=$(echo $bamboo_plan_revision | cut -c1-7)
 fi
 
+echo "***ICEBERG_IMAGE_VERSION: $ICEBERG_IMAGE_VERSION"
+
 if [[ -z $ICEBERG_IMAGE_VERSION ]]; then
-  echo "Error: ICEBERG_IMAGE_VERSION is not set (PUBLISH_FLAG=${PUBLISH_FLAG}). Expected bamboo_buildNumber." >&2
+  echo "Error: ICEBERG_IMAGE_VERSION is not set (PUBLISH_FLAG=${PUBLISH_FLAG}). Expected bamboo_plan_revision." >&2
   exit 1
 fi
 export ICEBERG_IMAGE_VERSION

--- a/bamboo/deploy-dev-integration-test-stack.sh
+++ b/bamboo/deploy-dev-integration-test-stack.sh
@@ -28,4 +28,17 @@ npm install
 npm run ci:bootstrap
 npm run package
 
+echo "***Bamboo build number: $bamboo_buildNumber"
+if [[ $PUBLISH_FLAG == true ]]; then
+  ICEBERG_IMAGE_VERSION=$(jq --raw-output .version lerna.json)
+else
+  ICEBERG_IMAGE_VERSION=${bamboo_buildNumber}
+fi
+
+if [[ -z $ICEBERG_IMAGE_VERSION ]]; then
+  echo "Error: ICEBERG_IMAGE_VERSION is not set (PUBLISH_FLAG=${PUBLISH_FLAG}). Expected bamboo_buildNumber." >&2
+  exit 1
+fi
+export ICEBERG_IMAGE_VERSION
+. ./bamboo/deploy-iceberg-api-image.sh
 . ./bamboo/deploy-integration-stack.sh

--- a/bamboo/deploy-iceberg-api-image.sh
+++ b/bamboo/deploy-iceberg-api-image.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -ex
+. ./bamboo/use-working-directory.sh
+. ./bamboo/set-bamboo-env-variables.sh
+
+if [[ "$DEPLOY_ICEBERG_API" != "true" ]]; then
+  echo "Skipping deploy Iceberg API Image step (DEPLOY_ICEBERG_API=$DEPLOY_ICEBERG_API)" >&2
+  exit 0
+fi
+
+if [[ -z $ICEBERG_IMAGE_VERSION ]]; then
+  echo "Error: ICEBERG_IMAGE_VERSION is not set." >&2
+  exit 1
+fi
+
+image="cumulus-iceberg-api"
+aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin "https://${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+# Create ECR repo if it doesn't exist
+aws ecr describe-repositories --repository-names ${image} || aws ecr create-repository --repository-name ${image}
+
+IMAGE_NAME=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$image:$ICEBERG_IMAGE_VERSION
+
+echo "Building Iceberg API image with name=${IMAGE_NAME}"
+docker build --platform linux/arm64 -f packages/api/app/Dockerfile -t "$IMAGE_NAME" .
+
+echo "Publishing Docker image to ECR with name=${IMAGE_NAME}"
+docker push "$IMAGE_NAME"

--- a/bamboo/deploy-iceberg-api-image.sh
+++ b/bamboo/deploy-iceberg-api-image.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -ex
+
 . ./bamboo/use-working-directory.sh
 . ./bamboo/set-bamboo-env-variables.sh
 
@@ -8,19 +9,26 @@ if [[ "$DEPLOY_ICEBERG_API" != "true" ]]; then
   exit 0
 fi
 
-if [[ -z $ICEBERG_IMAGE_VERSION ]]; then
-  echo "Error: ICEBERG_IMAGE_VERSION is not set." >&2
-  exit 1
+if ! command -v docker >/dev/null 2>&1; then
+  apt-get update && apt-get install -y docker.io
 fi
 
-apt-get update && apt-get install -y docker.io
+set_iceberg_image_version
 
 image="cumulus-iceberg-api"
-aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin "https://${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+registry_host="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+aws ecr get-login-password --region "${AWS_REGION}" | docker login --username AWS --password-stdin "${registry_host}"
 # Create ECR repo if it doesn't exist
-aws ecr describe-repositories --repository-names ${image} || aws ecr create-repository --repository-name ${image}
+if ! aws ecr describe-repositories --repository-names "${image}" >/dev/null 2>&1; then
+  if aws ecr describe-repositories --repository-names "${image}" 2>&1 | grep -q RepositoryNotFoundException; then
+    aws ecr create-repository --repository-name "${image}" >/dev/null
+  else
+    echo "Error: unable to verify ECR repository ${image}." >&2
+    exit 1
+  fi
+fi
 
-IMAGE_NAME=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$image:$ICEBERG_IMAGE_VERSION
+IMAGE_NAME="${registry_host}/${image}:${ICEBERG_IMAGE_VERSION}"
 
 echo "Building Iceberg API image with name=${IMAGE_NAME}"
 docker build --platform linux/arm64 -f packages/api/app/Dockerfile -t "$IMAGE_NAME" .

--- a/bamboo/deploy-iceberg-api-image.sh
+++ b/bamboo/deploy-iceberg-api-image.sh
@@ -8,6 +8,7 @@ if [[ "$DEPLOY_ICEBERG_API" != "true" ]]; then
   echo "Skipping deploy Iceberg API Image step (DEPLOY_ICEBERG_API=$DEPLOY_ICEBERG_API)" >&2
   exit 0
 fi
+echo "***Deploying Iceberg API image"
 
 if ! command -v docker >/dev/null 2>&1; then
   apt-get update && apt-get install -y docker.io

--- a/bamboo/deploy-iceberg-api-image.sh
+++ b/bamboo/deploy-iceberg-api-image.sh
@@ -13,6 +13,8 @@ if [[ -z $ICEBERG_IMAGE_VERSION ]]; then
   exit 1
 fi
 
+apt-get update && apt-get install -y docker.io
+
 image="cumulus-iceberg-api"
 aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin "https://${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
 # Create ECR repo if it doesn't exist

--- a/bamboo/set-bamboo-env-variables.sh
+++ b/bamboo/set-bamboo-env-variables.sh
@@ -58,6 +58,7 @@ declare -a param_list=(
   "bamboo_USE_TERRAFORM_ZIPS"
   "bamboo_VERSION_FLAG"
   "bamboo_CUMULUS_BASE_IMAGE"
+  "bamboo_DEPLOY_ICEBERG_API"
 )
 
 ## Strip 'bamboo_SECRET_' from secret keys

--- a/bamboo/set-bamboo-env-variables.sh
+++ b/bamboo/set-bamboo-env-variables.sh
@@ -203,3 +203,22 @@ else
 fi
 export CUMULUS_UNIT_TEST_DATA=/tmp/cumulus_unit_test_data
 export TS_BUILD_CACHE_FILE=ts-build-cache.tgz
+
+## Function to set ICEBERG_IMAGE_VERSION based on PUBLISH_FLAG
+set_iceberg_image_version() {
+  echo "***Bamboo plan revision: $bamboo_plan_revision"
+  if [[ $PUBLISH_FLAG == true ]]; then
+    ICEBERG_IMAGE_VERSION=$(jq --raw-output .version lerna.json)
+  else
+    ICEBERG_IMAGE_VERSION=$(echo $bamboo_plan_revision | cut -c1-7)
+  fi
+
+  echo "***ICEBERG_IMAGE_VERSION: $ICEBERG_IMAGE_VERSION"
+
+  if [[ -z $ICEBERG_IMAGE_VERSION ]]; then
+    echo "Error: ICEBERG_IMAGE_VERSION is not set (PUBLISH_FLAG=${PUBLISH_FLAG}). Expected bamboo_plan_revision." >&2
+    exit 1
+  fi
+
+  export ICEBERG_IMAGE_VERSION
+}

--- a/example/deployments/cumulus/sandbox.tfvars
+++ b/example/deployments/cumulus/sandbox.tfvars
@@ -56,3 +56,6 @@ saml_launchpad_metadata_url = "https://auth.launchpad-sbx.nasa.gov/unauth/metada
 thin_egress_jwt_secret_name = "cumulus_sandbox_jwt_tea_secret"
 
 orca_default_bucket = "cumulus-test-sandbox-orca-glacier"
+
+iceberg_s3_bucket = "sandbox-ci-iceberg"
+iceberg_namespace = "sandbox_ci"

--- a/example/deployments/cumulus/yliu10-ci-tf.tfvars
+++ b/example/deployments/cumulus/yliu10-ci-tf.tfvars
@@ -1,5 +1,3 @@
 prefix = "yliu10-ci-tf"
 
 deploy_iceberg_api = true
-iceberg_s3_bucket = "yliu-sandbox-test-iceberg"
-iceberg_namespace = "yliu_test"

--- a/tf-modules/iceberg_api/main.tf
+++ b/tf-modules/iceberg_api/main.tf
@@ -96,9 +96,6 @@ resource "aws_ecs_service" "iceberg_api" {
   }
 
   force_new_deployment = true
-  triggers = {
-    redeployment = sha256(jsonencode(aws_ecs_task_definition.iceberg_api))
-  }
 }
 
 resource "aws_lb" "iceberg_api" {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-4883: Add script to build Iceberg API docker image and push it to ECR as part of the build process](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4883)

## Changes

* Add script to build Iceberg API docker image and push it to ECR as part of the build process.
* Added a `Build Iceberg API Docker Image` build step in `Deploy Dev Integration Stack` build stage. The new build step will build the Iceberg API image with the PR branch and push the image to the Sandbox ECR and update the ECS Iceberg API task to run with the newly built image.

See https://ci.earthdata.nasa.gov/browse/CUM-CBA4796 for the CI build.
You can use AWS console to verify the Iceberg API image that is built by the CICD is indeed pushed to ECR and deployed to ECS.
Verify that Iceberg api queries return the expected results.

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests

---
📝 **Note:**
For most pull requests, please **Squash and merge** to maintain a clean and readable commit history.
