### PR TITLE
mikedorfman/CUMULUS-4873

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     which is a map from CMR provider to TEA base URL. Collections whose CMR provider is not in the map fall
     back to the existing single `tea_distribution_url`, so single-deployment configurations continue to work unchanged.
   - One precondition for consolidating deployments is that every S3 bucket name in the merged bucket map must be globally unique.
+- **CUMULUS-4873**
+  - Set max_locks_per_transaction database parameter to 256 to support better performance with new partitioning setup.
 
 ### Changed
 - **CUMULUS-4776** Split iceberg replication into separate services and add support for partitioned tables

--- a/tf-modules/cumulus-rds-tf/variables.tf
+++ b/tf-modules/cumulus-rds-tf/variables.tf
@@ -248,9 +248,14 @@ variable "db_parameters" {
       apply_method = "pending-reboot"
     },
     {
-      name  = "rds.logical_replication"
-      value = "1"
-      apply_method = "pending-reboot"  # Requires restart
+      name         = "rds.logical_replication"
+      value        = "1"
+      apply_method = "pending-reboot" # Requires restart
+    },
+    {
+      name         = "max_locks_per_transaction"
+      value        = "256"
+      apply_method = "pending-reboot" # Requires restart
     },
   ]
 }


### PR DESCRIPTION
**Summary:** Update max_locks_per_transaction to 256 to support better performance

Addresses [CUMULUS-4873: Update max_locks_per_transaction to 256 in Terraform
](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4873)

## Changes

* Added new parameter group override, specifying max_locks_per_transaction of 256.  The default, when this is not specified, is 64 which results in errors at load with the new partitioning setup.

## PR Checklist

- [X] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests

---
📝 **Note:**
For most pull requests, please **Squash and merge** to maintain a clean and readable commit history.
