### PR TITLE
CUMULUS-4882-2: Passed resolved db_partition_config fallback values to child module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Optimized `@cumulus/db` `granule.upsert` and `@cumulus/api/lib` `write-granule` to perform
     cross-collection collision checks only on actual unique constraint conflicts during ingest.
   - Updated the `db_partition_config` variable in `tf-modules/data-persistence` to accept null
-    values and automatically fall back to defaults.
+    values, automatically fall back to defaults, and pass resolved fallback values to the child module.
 
 ## [v22.1.1] 2026-05-28
 

--- a/tf-modules/data-persistence/variables.tf
+++ b/tf-modules/data-persistence/variables.tf
@@ -78,6 +78,9 @@ variable "db_partition_config" {
     - files_count: The number of hash/bigint-based partitions to create for the 'files' table.
   EOT
 
+  # Force Terraform to drop incoming null values and use the default block instead
+  nullable = false
+
   # Fallback if the user completely omits the db_partition_config block
   default = {
     executions_total_years = 2


### PR DESCRIPTION
…prevent attribute evaluation errors

**Summary:** Summary of changes

Addresses [CUMULUS-4882: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4882)

Fix the error when db_partition_config is set to null in example/data-persistence-tf

```
Error: Attempt to get attribute from null value
--
│
│   on ../../lambdas/db-migration/main.tf line 80, in resource "aws_lambda_function" "db_migration":
 │   80:       EXECUTIONS_PARTITION_TOTAL_YEARS = var.db_partition_config.executions_total_years
│     ├────────────────
│     │ var.db_partition_config is null
```


## Changes

* Updated the `db_partition_config` variable in `tf-modules/data-persistence` to have nullable = false

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests

---
📝 **Note:**
For most pull requests, please **Squash and merge** to maintain a clean and readable commit history.
