### PR TITLE
CUMULUS-4953: Shorten Iceberg API load balancer name suffix to accommodate a longer prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     values, automatically fall back to defaults, and pass resolved fallback values to the child module.
 - **CUMULUS-4918**
   - Add release number tag to Iceberg APi image if applicable
+- **CUMULUS-4953**
+  - Shorten Iceberg API load balancer name suffix to accommodate a longer prefix
 
 ## [v22.1.1] 2026-05-28
 

--- a/tf-modules/iceberg_api/main.tf
+++ b/tf-modules/iceberg_api/main.tf
@@ -99,7 +99,7 @@ resource "aws_ecs_service" "iceberg_api" {
 }
 
 resource "aws_lb" "iceberg_api" {
-  name               = "${var.prefix}-iceberg-api"
+  name               = "${var.prefix}-iceberg"
   internal           = true
   load_balancer_type = "application"
   security_groups    = [aws_security_group.iceberg_alb_sg.id]


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-4953: Shorten Iceberg API load balancer name suffix to accommodate a longer prefix](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4953)

## Changes

* Shorten Iceberg API load balancer name suffix to accommodate a longer prefix

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests

---
📝 **Note:**
For most pull requests, please **Squash and merge** to maintain a clean and readable commit history.
