### PR TITLE
Cumulus 4694 add iceberg enabled flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### FIXED
+- **CUMULUS-4694**
+  - Fixed issue with references to `module.cluster` in the Iceberg replication terraform code
 - **CSD-113**
   - Fixed issue with with bulk granule deletion where CMR records were not being removed
 

--- a/tf-modules/rds-iceberg-replication/main.tf
+++ b/tf-modules/rds-iceberg-replication/main.tf
@@ -87,12 +87,12 @@ module "replication_services" {
   volume_size_in_gb         = var.volume_size_in_gb
   admin_db_login_secret_arn = var.admin_db_login_secret_arn
   pg_db                     = var.pg_db
-  ecs_infrastructure_role   = module.cluster.ecs_infrastructure_role
-  ecs_task_execution_role   = module.cluster.task_execution_role
-  fargate_task_role         = module.cluster.fargate_task_role
+  ecs_infrastructure_role   = module.cluster[0].ecs_infrastructure_role
+  ecs_task_execution_role   = module.cluster[0].task_execution_role
+  fargate_task_role         = module.cluster[0].fargate_task_role
   rds_security_group        = var.rds_security_group
-  task_security_group_id    = module.cluster.no_ingress_all_egress_security_group.id
-  ecs_cluster               = module.cluster.replication_ecs_cluster
+  task_security_group_id    = module.cluster[0].no_ingress_all_egress_security_group.id
+  ecs_cluster               = module.cluster[0].replication_ecs_cluster
   compaction_interval_sec   = var.compaction_interval_sec
   region                    = var.region
 }
@@ -107,9 +107,9 @@ module "cleanup_service" {
   memory                   = var.snapshot_cleanup_memory
   cpu                      = var.snapshot_cleanup_cpu
   cpu_architecture         = var.cpu_architecture
-  ecs_task_execution_role  = module.cluster.task_execution_role
-  task_security_group_id   = module.cluster.no_ingress_all_egress_security_group.id
-  ecs_cluster              = module.cluster.replication_ecs_cluster
+  ecs_task_execution_role  = module.cluster[0].task_execution_role
+  task_security_group_id   = module.cluster[0].no_ingress_all_egress_security_group.id
+  ecs_cluster              = module.cluster[0].replication_ecs_cluster
   iceberg_cleanup_image    = var.iceberg_cleanup_image
   table_include_list       = var.snapshot_table_include_list
   cleanup_interval_minutes = var.snapshot_cleanup_interval_minutes

--- a/tf-modules/rds-iceberg-replication/outputs.tf
+++ b/tf-modules/rds-iceberg-replication/outputs.tf
@@ -1,4 +1,4 @@
 output "iceberg_replication_cluster_arn" {
   description = "ARN of the ECS Fargate cluster used for Iceberg replication"
-  value       = module.cluster.replication_ecs_cluster.arn
+  value       = module.cluster[0].replication_ecs_cluster.arn
 }


### PR DESCRIPTION
Change module lookups to use an index since they became lists after using the `count` terraform trick to enable/disable with a variable.


## Changes
Changed `module.cluster` everywhere to `moudle.cluster[0]`, because that module is now a list after using the terraform `count` trick to enable/disable the module with a variable. The deployment was broken before this change. 

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests

---
📝 **Note:**
For most pull requests, please **Squash and merge** to maintain a clean and readable commit history.
