### PR TITLE
CUMULUS-4520: Make Iceberg documentation show up in sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - **CUMULUS-4520**
-  - Add Iceberg documentation
+  - Add Iceberg design and troubleshooting documentation
 
 ### Changed
 

--- a/docs/features/iceberg.md
+++ b/docs/features/iceberg.md
@@ -1,6 +1,7 @@
 ---
-id: Iceberg
-title: Iceberg design
+id: iceberg
+title: Iceberg Design
+hide_title: false
 ---
 
 ## Rationale

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -174,6 +174,7 @@ const sidebars = {
         'features/granule_uniquification',
         'features/change_granule_collection',
         'features/record_archival',
+        'features/iceberg',
       ],
     },
     {
@@ -189,6 +190,7 @@ const sidebars = {
         'troubleshooting/rerunning-workflow-executions',
         'troubleshooting/reindex-elasticsearch',
         'troubleshooting/troubleshooting-database-migrations',
+        'troubleshooting/troubleshooting-iceberg',
       ],
     },
     {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-4520: Make Iceberg documentation show up in sidebar](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4520)

## Changes

* Make Iceberg documentation show up in sidebar

## Test
npm run docs-install
npm run docs-serve

http://localhost:3000/cumulus/

Verify you can see the "Iceberg Design" link in the sidebar of the page under Features.
Verify you can see the "Troubleshooting Iceberg" link in the sidebar of the page under Troubleshooting.
Verify the info on the Iceberg design and troubleshooting documentation pages is appropriate.

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests

---
📝 **Note:**
For most pull requests, please **Squash and merge** to maintain a clean and readable commit history.
