### PR TITLE
CUMULUS-4694: Fix iceberg terraform output when `enable_iceberg_replication`  is `false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - **CUMULUS-4694**
   - Fixed issue with references to `module.cluster` in the Iceberg replication terraform code
+  - Fixed iceberg terraform output value
 
 ## [v22.2.3] 2026-06-15
 

--- a/tf-modules/rds-iceberg-replication/outputs.tf
+++ b/tf-modules/rds-iceberg-replication/outputs.tf
@@ -1,4 +1,4 @@
 output "iceberg_replication_cluster_arn" {
   description = "ARN of the ECS Fargate cluster used for Iceberg replication"
-  value       = module.cluster[0].replication_ecs_cluster.arn
+  value       = var.enable_iceberg_replication ? module.cluster[0].replication_ecs_cluster.arn : null
 }


### PR DESCRIPTION
**Summary:** Summary of changes

The deployment would fail when `enable_iceberg_replication`  was `false`, because it was trying to take the 0th index of an empty tuple. I changed it to return `null` instead.

## Changes

* iceberg replication terraform output now returns null instead of erroring when  `enable_iceberg_replication`  is `false`

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests

---
📝 **Note:**
For most pull requests, please **Squash and merge** to maintain a clean and readable commit history.
