### PR TITLE
CUMULUS-5033: Remove unused tf resource and other changes to support deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+- **CUMULUS-5033**
+  - Fix bootstrap service to handle empty RDS tables
+  - Add SQL to grant privileges to allow disabling replication
+  - Change Iceberg setup code to correctly compute the number of workers based on CPU
+  - Remove unused terraform resource for Iceberg API
+
 - **CSD-121**
   - Updates the CMR.js CMR client object to *not* store the CMR provider and update all class methods to require
     a provider method parameter.    Update all tasks/related callers to provide expected input

--- a/example/deployments/cumulus/sandbox.tfvars
+++ b/example/deployments/cumulus/sandbox.tfvars
@@ -59,3 +59,6 @@ orca_default_bucket = "cumulus-test-sandbox-orca-glacier"
 
 iceberg_s3_bucket = "sandbox-ci-iceberg"
 iceberg_namespace = "sandbox_ci"
+
+cumulus_iceberg_api_image_version        = "22.2.5"
+cumulus_iceberg_api_image_repository_url = "ghcr.io/nasa/cumulus-iceberg-api"

--- a/packages/iceberg-replication/scripts/bootstrap.sh
+++ b/packages/iceberg-replication/scripts/bootstrap.sh
@@ -124,6 +124,7 @@ psql \
   <<EOF
 CREATE EXTENSION IF NOT EXISTS pglogical;
 GRANT rds_replication TO $USER;
+GRANT USAGE ON SCHEMA pglogical TO $USER;
 EOF
 
 psql \

--- a/packages/iceberg-replication/scripts/bulk_load_self_managed_iceberg.py
+++ b/packages/iceberg-replication/scripts/bulk_load_self_managed_iceberg.py
@@ -18,6 +18,7 @@ import psycopg2
 import pyarrow as pa
 import pyarrow.compute as pc
 import pyarrow.csv as pv
+import requests
 from botocore.exceptions import ClientError
 from create_staging_branch import create_staging_branches
 from pyiceberg.catalog import load_catalog
@@ -78,6 +79,28 @@ ICEBERG_RESERVED_TABLE_NAMES = {
 }
 
 
+def _get_container_cpu_limit():
+    metadata_url = os.getenv("ECS_CONTAINER_METADATA_URI_V4")
+    if not metadata_url:
+        return None
+    resp = requests.get(f"{metadata_url}/task", timeout=2)
+    resp.raise_for_status()
+    data = resp.json()
+    # CPU is in vCPU units (1024 = 1 vCPU)
+    cpu_units = data.get("Limits", {}).get("CPU")
+    if cpu_units is None:
+        return None
+    return cpu_units  # already in vCPUs for task-level limits
+
+
+def _get_n_workers(default=4):
+    cpu = _get_container_cpu_limit()
+    if cpu is None:
+        return default
+    # never use more than 4 workers
+    return min(4, max(1, int(cpu)))
+
+
 @dataclass
 class Config:
     """Runtime configuration loaded from environment variables."""
@@ -129,7 +152,7 @@ def init_config() -> Config:
         warehouse=f"s3://{os.environ['ICEBERG_S3_BUCKET']}/{os.getenv('ICEBERG_S3_PREFIX', 'warehouse')}",  # noqa: E501
         target_buffer_size=768 * 1024 * 1024,
         block_size=16 * 1024 * 1024,
-        n_workers=int(os.getenv("N_WORKERS", "4")),
+        n_workers=_get_n_workers(),
     )
 
 

--- a/packages/iceberg-replication/scripts/create_staging_branch.py
+++ b/packages/iceberg-replication/scripts/create_staging_branch.py
@@ -44,10 +44,6 @@ def create_staging_branches(cat, namespace, tables):
         table = cat.load_table(full_name)
         refs = table.refs()
 
-        if "staging" in refs:
-            print(f"  WARNING: staging branch already exists for {full_name}, skipping")
-            continue
-
         if "main" not in refs:
             # Table has no snapshots yet (empty table) — create an empty snapshot
             # so that main branch exists and staging branch can be created from it
@@ -56,29 +52,37 @@ def create_staging_branches(cat, namespace, tables):
             from pyiceberg.io.pyarrow import schema_to_pyarrow  # noqa: PLC0415
 
             pa_schema = schema_to_pyarrow(table.schema())
+
+            # Rebuild schema honoring required (non-nullable) fields
+            fields = []
+            for iceberg_field, pa_field in zip(table.schema().fields, pa_schema):
+                nullable = not iceberg_field.required
+                fields.append(pa_field.with_nullable(nullable))
+            pa_schema = pa.schema(fields)
+
             empty = pa.table(
                 {
                     f.name: pa.array([], type=pa_schema.field(f.name).type)
                     for f in table.schema().fields
                 },
-                schema=pa_schema,  # <-- this enforces nullability on each field
+                schema=pa_schema,
             )
             table.append(empty)
+
             # Reload to get updated refs
             table = cat.load_table(full_name)
             refs = table.refs()
 
         if "main" not in refs:
-            print(
-                f"  ERROR: 'main' branch still not found for {full_name} after empty snapshot"  # noqa: E501
-            )
+            print(f"  ERROR: 'main' branch still not found for {full_name}")
             continue
 
-        main_snapshot_id = refs["main"].snapshot_id
-
-        table.manage_snapshots().create_branch(main_snapshot_id, "staging").commit()
-
-        print(f"  Created staging branch at snapshot {main_snapshot_id}")
+        if "staging" not in refs:
+            main_snapshot_id = refs["main"].snapshot_id
+            table.manage_snapshots().create_branch(main_snapshot_id, "staging").commit()
+            print(f"  Created staging branch at snapshot {main_snapshot_id}")
+        else:
+            print(f"  staging branch already exists for {full_name}")
 
     print("done")
 

--- a/tf-modules/iceberg_api/main.tf
+++ b/tf-modules/iceberg_api/main.tf
@@ -37,7 +37,7 @@ resource "aws_ecs_task_definition" "iceberg_api" {
   container_definitions = jsonencode([
     {
       name      = "iceberg-api-container"
-      image     = "${coalesce(var.cumulus_iceberg_api_image_repository_url, data.aws_ecr_repository.cumulus_iceberg_api.repository_url)}:${var.cumulus_iceberg_api_image_version}"
+      image     = "${var.cumulus_iceberg_api_image_repository_url}:${var.cumulus_iceberg_api_image_version}"
       essential = true
       portMappings = [
         {

--- a/tf-modules/iceberg_api/main.tf
+++ b/tf-modules/iceberg_api/main.tf
@@ -11,10 +11,6 @@ locals {
   }
 }
 
-data "aws_ecr_repository" "cumulus_iceberg_api" {
-  name = "cumulus-iceberg-api"
-}
-
 data "aws_ssm_parameter" "private_ca" {
   name = "ngap_private_ca_arn"
 }

--- a/tf-modules/rds-iceberg-replication/modules/replication-service/main.tf
+++ b/tf-modules/rds-iceberg-replication/modules/replication-service/main.tf
@@ -39,10 +39,6 @@ resource "aws_efs_access_point" "kafka_data" {
 resource "aws_efs_file_system" "kafka_data" {
   encrypted = true
   tags      = merge(var.tags, { Name = "${local.full_name}-kafka-data" })
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "aws_efs_mount_target" "kafka_data" {


### PR DESCRIPTION
Addresses [CUMULUS-5033:Iceberg replication cannot be disabled via terraform once enabled](https://bugs.earthdata.nasa.gov/browse/CUMULUS-5033)

## Changes

* Fix bootstrap service to handle empty RDS tables
* Add SQL to grant privileges to allow disabling replication
* Change Iceberg setup code to correctly compute the number of workers based on CPU
* Remove unused terraform resource for Iceberg API

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests

---
📝 **Note:**
For most pull requests, please **Squash and merge** to maintain a clean and readable commit history.
