### PR TITLE
CUMULUS-5112: Change Iceberg API image release tagging to be based on lerna.json update

### DIFF
--- a/.github/workflows/build-and-push-iceberg-api-image.yml
+++ b/.github/workflows/build-and-push-iceberg-api-image.yml
@@ -50,11 +50,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           short_sha="${SOURCE_SHA:0:7}"
-          source_branch="${GITHUB_HEAD_REF:-}"
           target_branch="${GITHUB_BASE_REF:-${GITHUB_REF_NAME}}"
+          lerna_updated_in_merge="false"
 
           if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
             target_branch="${GITHUB_REF_NAME}"
+
+            if git diff --name-only "${GITHUB_SHA}^" "${GITHUB_SHA}" | grep --quiet --line-regexp 'lerna.json'; then
+              lerna_updated_in_merge="true"
+            fi
 
             if [[ "$target_branch" == "master" ]]; then
               pr_response="$(curl --silent --show-error \
@@ -62,7 +66,6 @@ jobs:
                 --header "Accept: application/vnd.github+json" \
                 "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls")"
 
-              source_branch="$(echo "$pr_response" | jq --raw-output 'if type == "array" then .[0].head.ref // empty else empty end')"
               pr_base_branch="$(echo "$pr_response" | jq --raw-output 'if type == "array" then .[0].base.ref // empty else empty end')"
 
               if [[ -n "$pr_base_branch" ]]; then
@@ -72,12 +75,11 @@ jobs:
           fi
 
           {
-            echo "source_branch=${source_branch}"
             echo "target_branch=${target_branch}"
             echo "tags<<EOF"
             echo "${REGISTRY}/${IMAGE_NAME}:${short_sha}"
 
-            if [[ "$target_branch" == "master" && "$source_branch" =~ ^release-[0-9]+\.[0-9]+\.x$ ]]; then
+            if [[ "$target_branch" == "master" && "$lerna_updated_in_merge" == "true" ]]; then
               release_tag="$(jq --raw-output .version lerna.json)"
               echo "${REGISTRY}/${IMAGE_NAME}:${release_tag}"
             fi
@@ -90,7 +92,6 @@ jobs:
           echo "event=${GITHUB_EVENT_NAME}"
           echo "ref_name=${GITHUB_REF_NAME}"
           echo "manual_push_input=${{ github.event.inputs.push_image || 'n/a' }}"
-          echo "resolved_source=${{ steps.tag.outputs.source_branch }}"
           echo "resolved_target=${{ steps.tag.outputs.target_branch }}"
           echo "tags=${{ steps.tag.outputs.tags }}"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+- **CUMULUS-5112**
+  - Change Iceberg API image release tagging to be based on lerna.json update
+
 - **CUMULUS-5033**
   - Fix bootstrap service to handle empty RDS tables
   - Add SQL to grant privileges to allow disabling replication


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-5112: Change Iceberg API image release tagging to be based on lerna.json update](https://bugs.earthdata.nasa.gov/browse/CUMULUS-5112)

## Changes

* Change Iceberg API image release tagging to be based on lerna.json update

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests

---
📝 **Note:**
For most pull requests, please **Squash and merge** to maintain a clean and readable commit history.
