### PR TITLE
docs: fix stale file links in ingest and common package READMEs

### DIFF
--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -20,12 +20,12 @@ Cumulus is a cloud-based data ingest, archive, distribution and management proto
   setup, testing, and credential management, code should obtain AWS client
   objects from helpers in this module.
 * [@cumulus/common/concurrency](./concurrency.js) - Utilities for writing concurrent code
-* [@cumulus/common/errors](./errors.js) - Classes for thrown errors
-* [@cumulus/common/log](./log.js) - muting or potentially shipping logs to
+* [@cumulus/common/errors](./src/errors.ts) - Classes for thrown errors
+* [@cumulus/common/log](./src/log.ts) - muting or potentially shipping logs to
   alternative locations
 * [@cumulus/common/string](./docs/API.md#module_string) - Utilities for
   manipulating strings
-* [@cumulus/common/test-utils](./test-utils.js) - Utilities for writing tests
+* [@cumulus/common/test-utils](./src/test-utils.ts) - Utilities for writing tests
 * [@cumulus/common/URLUtils](./docs/API.md#module_URLUtils) - a collection of
   utilities for working with URLs
 * [@cumulus/common/util](./docs/API.md#module_util) - Other misc general

--- a/packages/ingest/README.md
+++ b/packages/ingest/README.md
@@ -37,8 +37,8 @@ All modules are accessible using require: `require('@cumulus/ingest/<MODULE_NAME
 - [`log`](./log.js) - stringifies JS object logs for ElasticSearch indexing
 - [`parse-pdr`](./parse-pdr.js) - tools for validating PDRs and generating PDRD and PAN messages
 - [`pdr`](./pdr.js) - discovers and ingests pdrs
-- [`queue`](./queue.js) - creates queues for ingesting data
-- [`recursion`](./recursion.js) - handles recursion of a FTP/SFTP list operation
+- [`queue`](./src/queue.js) - creates queues for ingesting data
+- [`recursion`](./src/recursion.ts) - handles recursion of a FTP/SFTP list operation
 - [`sftp`](./sftp.js) - for accessing SFTP servers
 
 ## Contributing


### PR DESCRIPTION
## Summary

Fixes five stale module links that predate the TypeScript/src-layout migration (each new target verified to exist):

- `packages/ingest/README.md` — `./queue.js` → `./src/queue.js`; `./recursion.js` → `./src/recursion.ts`
- `packages/common/README.md` — `./errors.js`, `./log.js`, `./test-utils.js` → `./src/errors.ts`, `./src/log.ts`, `./src/test-utils.ts`

Also found but **not** fixed (no in-package successor — the modules appear to have moved to other packages, e.g. `@cumulus/aws-client`; flagging rather than guessing):
- `packages/ingest/README.md` — `./sftp.js`
- `packages/common/README.md` — `./aws.js`, `./concurrency.js`

Docs only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)