### PR TITLE
HARMONY-5217: Fix Iceberg API image build failure in github workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **CUMULUS-5217**
+  - Fix Iceberg API image build failure in github workflow
+
 - **CUMULUS-5033**
   - Catch crashed spark server and restart for Iceberg
 

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -3,5 +3,8 @@
   "pass-enoaudit": true,
   "retry-count": 20,
   "allowlist": [
+    "GHSA-3jxr-9vmj-r5cp",
+    "GHSA-mh99-v99m-4gvg",
+    "GHSA-52cp-r559-cp3m"
   ]
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -123,6 +123,7 @@
   "devDependencies": {
     "@cumulus/test-data": "22.3.3",
     "aws-sdk-client-mock": "^3.0.1",
+    "@ljharb/tsconfig": "^0.2.3",
     "proxyquire": "^2.1.3"
   }
 }

--- a/packages/api/src/lib/granule-delete.ts
+++ b/packages/api/src/lib/granule-delete.ts
@@ -13,7 +13,7 @@ import {
   ProviderPgModel,
 } from '@cumulus/db';
 import { DeletePublishedGranule, errorify } from '@cumulus/errors';
-import { ApiFile } from '@cumulus/types';
+import type { ApiFile } from '@cumulus/types';
 import Logger from '@cumulus/logger';
 const { publishGranuleDeleteSnsMessage } = require('../../lib/publishSnsMessageUtils');
 const FileUtils = require('../../lib/FileUtils');


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-5217: Fix Iceberg API image build failure in github workflow](https://bugs.earthdata.nasa.gov/browse/CUMULUS-5217)

## Changes

* This adds @ljharb/tsconfig as a dev dependency in api package so that it will be available in builds.

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests

---
📝 **Note:**
For most pull requests, please **Squash and merge** to maintain a clean and readable commit history.
