### PR TITLE
Updating boolean logic for allowProviderMismatchOnRuleFilter field in RulesHelper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **CUMULUS-5026**
+  - Fix boolean logic for allowProviderMismatch flag to handle true evaluations correctly
+
 - **CUMULUS-5033**
   - Fix bootstrap service to handle empty RDS tables
   - Add SQL to grant privileges to allow disabling replication

--- a/packages/api/lib/rulesHelpers.js
+++ b/packages/api/lib/rulesHelpers.js
@@ -114,7 +114,7 @@ const filterRulesByRuleParams = (rules, ruleParams) => rules.filter(
     const typeMatch = ruleParams.type ? get(ruleParams, 'type') === rule.rule.type : true;
     const collectionMatch = collectionRuleMatcher(rule, ruleParams);
     const skipMismatch = ruleParams?.allowProviderMismatchOnRuleFilter
-      ?? rule.meta?.allowProviderMismatchOnRuleFilter ?? false;
+      || rule.meta?.allowProviderMismatchOnRuleFilter || false;
     const providerMatch = rule.provider && ruleParams.provider && !skipMismatch
       ? ruleParams.provider === rule.provider
       : true;

--- a/packages/api/tests/lib/rules/test-rulesHelpers.js
+++ b/packages/api/tests/lib/rules/test-rulesHelpers.js
@@ -55,6 +55,7 @@ const {
   createRuleTrigger,
   deleteRuleResources,
   updateRuleTrigger,
+  filterRulesByRuleParams,
 } = require('../../../lib/rulesHelpers');
 const { getSnsTriggerPermissionId } = require('../../../lib/snsRuleHelpers');
 
@@ -2520,4 +2521,49 @@ test.serial('Enabling a disabled SNS rule and passing rule.arn throws specific e
   t.teardown(() => {
     snsStub.restore();
   });
+});
+
+test('keeps rule when ruleParams is true, short-circuiting rule.meta', (t) => {
+  const rules = [{ rule: {}, provider: 'providerB', meta: { allowProviderMismatchOnRuleFilter: false } }];
+  const ruleParams = { provider: 'providerA', allowProviderMismatchOnRuleFilter: true };
+
+  const result = filterRulesByRuleParams(rules, ruleParams);
+
+  t.is(result.length, 1);
+});
+
+test('keeps rule when ruleParams is false but rule.meta is true (|| behavior)', (t) => {
+  const rules = [{ rule: {}, provider: 'providerB', meta: { allowProviderMismatchOnRuleFilter: true } }];
+  const ruleParams = { provider: 'providerA', allowProviderMismatchOnRuleFilter: false };
+
+  const result = filterRulesByRuleParams(rules, ruleParams);
+
+  t.is(result.length, 1);
+});
+
+test('filters rule when both ruleParams and rule.meta are explicitly false', (t) => {
+  const rules = [{ rule: {}, provider: 'providerB', meta: { allowProviderMismatchOnRuleFilter: false } }];
+  const ruleParams = { provider: 'providerA', allowProviderMismatchOnRuleFilter: false };
+
+  const result = filterRulesByRuleParams(rules, ruleParams);
+
+  t.is(result.length, 0);
+});
+
+test('keeps rule when ruleParams is undefined and rule.meta is true', (t) => {
+  const rules = [{ rule: {}, provider: 'providerB', meta: { allowProviderMismatchOnRuleFilter: true } }];
+  const ruleParams = { provider: 'providerA' }; // undefined flag
+
+  const result = filterRulesByRuleParams(rules, ruleParams);
+
+  t.is(result.length, 1);
+});
+
+test('filters rule when the flag is undefined in both ruleParams and rule.meta', (t) => {
+  const rules = [{ rule: {}, provider: 'providerB' }]; // no meta defined
+  const ruleParams = { provider: 'providerA' }; // no flag defined
+
+  const result = filterRulesByRuleParams(rules, ruleParams);
+
+  t.is(result.length, 0);
 });


### PR DESCRIPTION
… RulesHelper (#4544)

* Updating boolean logic for allowProviderMismatchOnRuleFilter field in ruleHelpers

* adding test coverage to rulesHelpers filterRulesByRuleParams

* [pre-commit.ci] auto fixes from pre-commit.com hooks

for more information, see https://pre-commit.ci

---------
**Summary:** Updating boolean logic in RulesHelpers so that allowProviderMismatch fields can accurately account for boolean logic from different fields.

Addresses [CUMULUS-5026: Cumulus rule level allowProviderMismatchOnRuleFilter not allowing as expected](https://bugs.earthdata.nasa.gov/browse/CUMULUS-5026)

Extension of user PR: https://github.com/nasa/cumulus/pull/4544

## Changes

* Trading '??' opperands for '||'
  * Unlike the logical OR operator (||) which checks for "truthy" or "falsy" values, the nullish coalescing operator (??) only moves to the right side if the left side is exactly null or undefined. This means if Field 1 is false, it stops evaluating and returns false.
  
---
**Evaluate: ruleParams?.allowProviderMismatchOnRuleFilter || rule.meta?.allowProviderMismatchOnRuleFilter || false =**

Result is all combinations give us intended behavior.  This table reflects the PR update.

| Field 1 (ruleParams) | Field 2 (rule.meta) | Field 3 (Default) | Result | Why did this happen? |
| :--- | :--- | :--- | :--- | :--- |
| true | true | false | true | Field 1 is truthy, so evaluation stops and returns true. |
| true | false | false | true | Field 1 is truthy, so evaluation stops and returns true. |
| true | null | false | true | Field 1 is truthy, so evaluation stops and returns true. |
| false | true | false | true | Field 1 is falsy (false), so it evaluates Field 2. Field 2 is truthy, so it returns true. |
| false | false | false | false | Fields 1 and 2 are falsy, so it falls back to Field 3 and returns false. |
| false | null | false | false | Fields 1 and 2 are falsy, so it falls back to Field 3 and returns false. |
| null | true | false | true | Field 1 is falsy (null), so it evaluates Field 2. Field 2 is truthy, so it returns true. |
| null | false | false | false | Fields 1 and 2 are both falsy, so it falls back to Field 3 and returns false. |
| null | null | false | false | All fields are falsy, so it falls back to Field 3 and returns false. |

**Evaluate: ruleParams?.allowProviderMismatchOnRuleFilter ?? rule.meta?.allowProviderMismatchOnRuleFilter ?? false =**

Result is one combination give us incorrect behavior.  In the scenario (false ?? true ?? false) evaluates to false when it should be true.  This table reflects the current repo code.



| Field 1 (ruleParams) | Field 2 (rule.meta) | Field 3 (Default) | Result | Why did this happen? |
| :--- | :--- | :--- | :--- | :--- |
| true | true | false | true | Field 1 is not null/undefined, so evaluation stops and returns true. |
| true | false | false | true | Field 1 is not null/undefined, so evaluation stops and returns true. |
| true | null | false | true | Field 1 is not null/undefined, so evaluation stops and returns true. |
| false | true | false | false | Field 1 is not null/undefined (false is a valid boolean), so evaluation stops and returns false. |
| false | false | false | false | Field 1 is not null/undefined, so evaluation stops and returns false. |
| false | null | false | false | Field 1 is not null/undefined, so evaluation stops and returns false. |
| null | true | false | true | Field 1 is null, so it evaluates Field 2. Field 2 is not null/undefined, so it returns true. |
| null | false | false | false | Field 1 is null, so it evaluates Field 2. Field 2 is not null/undefined (false), so it returns false. |
| null | null | false | false | Fields 1 and 2 are both null, so it falls back to Field 3 and returns false. |




## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests


