### PR TITLE
docs: fix broken JSDoc links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ We ask that you follow these guidelines with your contributions:
 
 ### Documentation
 
-Anything exported by a module must be documented using [JSDoc](http://usejsdoc.org/).
+Anything exported by a module must be documented using [JSDoc](https://jsdoc.app/).
 
 The following JSDoc rules are enforced by our [eslint](https://eslint.org/)
 configuration:
@@ -39,7 +39,7 @@ configuration:
 - Functions that explicitly return should have a `@returns` tag that has a type.
   Example: `@returns {string}`
 - Parameter names must match those in the function declaration
-- Tags must be valid [JSDoc 3 Block Tags](http://usejsdoc.org/#block-tags)
+- Tags must be valid [JSDoc 3 Block Tags](https://jsdoc.app/#block-tags)
 
 ### Tests
 


### PR DESCRIPTION
**Summary:**
Fixes broken/outdated HTTP JSDoc documentation URLs in CONTRIBUTING.md and updates them to the active HTTPS documentation site.

## Related Issue
Closes #4558

## Changes

* Updated outdated JSDoc homepage URL `http://usejsdoc.org/` to `https://jsdoc.app/`
* Updated broken block tags URL `http://usejsdoc.org/#block-tags` to `https://jsdoc.app/#block-tags`

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests
