### PR TITLE
CUMULUS-5455 Fix Core Vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **CUMULUS-5455**
+  - Added `pacote` override (`^21.5.1`) to address https://github.com/advisories/GHSA-w4pp-8pjf-rmxw (CVE-2026-9496)
+
 ### Added
 
 - **CUMULUS-5256**

--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
     "minimatch@7": "^7.4.9",
     "minimatch@9": "^9.0.9",
     "minimatch@10": "^10.2.6",
+    "pacote": "^21.5.1",
     "request": {
       "qs": "^6.14.1"
     },


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-5455: Fix Core Vulnerability](https://bugs.earthdata.nasa.gov/browse/CUMULUS-5455)

## Changes

* Added `pacote` override (`^21.5.1`) to address https://github.com/advisories/GHSA-w4pp-8pjf-rmxw (CVE-2026-9496)

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Ad-hoc testing - Deploy changes and test manually
- [ ] Integration tests

---
📝 **Note:**
For most pull requests, please **Squash and merge** to maintain a clean and readable commit history.
